### PR TITLE
Issue 59  coerce

### DIFF
--- a/odl/__init__.py
+++ b/odl/__init__.py
@@ -33,26 +33,23 @@ __all__ = ('diagnostics', 'discr', 'operator', 'set', 'space', 'solvers',
 # Propagate names defined in __all__ of all submodules into the top-level
 # module
 
-from . import diagnostics
-
-from . import discr
-from .discr import *
-__all__ += discr.__all__
+# Import modules in order of dependency
+from . import set
+from .set import *
+__all__ += set.__all__
 
 from . import operator
 from .operator import *
 __all__ += operator.__all__
 
-from . import set
-from .set import *
-__all__ += set.__all__
-
 from . import space
 from .space import *
 __all__ += space.__all__
 
-from . import trafos
-from .trafos import *
-__all__ += trafos.__all__
+from . import discr
+from .discr import *
+__all__ += discr.__all__
 
+from . import trafos
+from . import diagnostics
 from . import solvers

--- a/odl/discr/discretization.py
+++ b/odl/discr/discretization.py
@@ -270,7 +270,7 @@ class RawDiscretizationVector(NtuplesBaseVector):
         """Create an identical (deep) copy of this vector."""
         return self.space.element(self.ntuple.copy())
 
-    def asarray(self, out=None):
+    def asarray(self, *args, **kwargs):
         """Extract the data of this array as a numpy array.
 
         Parameters
@@ -279,7 +279,7 @@ class RawDiscretizationVector(NtuplesBaseVector):
             Array in which the result should be written in-place.
             Has to be contiguous and of the correct dtype.
         """
-        return self.ntuple.asarray(out=out)
+        return self.ntuple.asarray(*args, **kwargs)
 
     def __eq__(self, other):
         """``vec.__eq__(other) <==> vec == other``.

--- a/odl/discr/lp_discr.py
+++ b/odl/discr/lp_discr.py
@@ -149,7 +149,7 @@ class DiscreteLp(Discretization):
             if arr.ndim > 1 and arr.shape != self.grid.shape:
                 raise ValueError('input shape {} does not match grid shape {}'
                                  ''.format(arr.shape, self.grid.shape))
-            arr = arr.flatten(order=self.order)
+            arr = arr.ravel(order=self.order)
             return self.element_type(self, self.dspace.element(arr))
 
     @property
@@ -229,7 +229,7 @@ class DiscreteLpVector(DiscretizationVector):
     """Representation of a `DiscreteLp` element."""
 
     def asarray(self, out=None):
-        """Extract the data of this array as a numpy array.
+        """Extract the data of this vector as a numpy array.
 
         Parameters
         ----------
@@ -237,6 +237,17 @@ class DiscreteLpVector(DiscretizationVector):
             Array in which the result should be written in-place.
             Has to be contiguous and of the correct dtype and
             shape.
+
+        Returns
+        -------
+        out : `numpy.ndarray`
+            This vector as an array, if ``out`` parameter was given, they are
+            equal.
+
+        See also
+        --------
+        asflatarray
+        FnBaseVector.asarray
         """
         if out is None:
             return super().asarray().reshape(self.space.grid.shape,
@@ -266,14 +277,49 @@ class DiscreteLpVector(DiscretizationVector):
             super().asarray(out=out.ravel(order=self.space.order))
             return out
 
+    def asflatarray(self, *args, **kwargs):
+        """Extract the data of this vector as a 1d numpy array.
+
+        Parameters
+        ----------
+        out : `numpy.ndarray`, optional
+            Array in which the result should be written in-place.
+            Has to be contiguous and of the correct dtype.
+
+        Returns
+        -------
+        out : `numpy.ndarray`
+            This vector as an array, if ``out`` parameter was given, they are
+            equal.
+
+        See also
+        --------
+        asarray
+        FnBaseVector.asflatarray
+        """
+        return super().asarray(*args, **kwargs)
+
     @property
     def ndim(self):
-        """Number of dimensions."""
+        """Number of dimensions.
+
+        See also
+        --------
+        TensorGrid.ndim
+        """
         return self.space.grid.ndim
 
     @property
     def shape(self):
-        # override shape
+        """Size in each dimension
+
+        For example, a 3d space can have size (3, 5, 10), indicating that it
+        is 3 elements big in the "x" direction, 5 in the "y" and "10" in the z.
+
+        See also
+        --------
+        TensorGrid.shape
+        """
         return self.space.grid.shape
 
     def __setitem__(self, indices, values):

--- a/odl/operator/__init__.py
+++ b/odl/operator/__init__.py
@@ -33,3 +33,7 @@ __all__ += operator.__all__
 from . import pspace_ops
 from .pspace_ops import *
 __all__ += pspace_ops.__all__
+
+from . import embedding
+from .embedding import *
+__all__ += embedding.__all__

--- a/odl/operator/embedding.py
+++ b/odl/operator/embedding.py
@@ -1,0 +1,105 @@
+# Copyright 2014, 2015 Jonas Adler
+#
+# This file is part of ODL.
+#
+# ODL is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# ODL is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with ODL.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Operators to cast between spaces."""
+
+# Imports for common Python 2/3 codebase
+from __future__ import print_function, division, absolute_import
+from future import standard_library
+standard_library.install_aliases()
+from builtins import super
+
+from odl.operator.operator import Operator
+
+__all__ = ('Embedding', 'EmbeddingFnInFn', 'EmbeddingPowerSpaceInFn',
+           'EmbeddingFnInPowerSpace')
+
+
+class Embedding(Operator):
+    """An operators to cast between spaces."""
+    def __init__(self, target, origin):
+        super().__init__(origin, target)
+
+
+class EmbeddingFnInFn(Embedding):
+    """ Embed a `Fn` space into another """
+
+    def __init__(self, target, origin):
+        # TODO: tests goes here
+
+        super().__init__(target, origin)
+
+    def _apply(self, x, out):
+        out[:] = x.asflatarray()
+
+    def _call(self, x):
+        return self.range.element(x.asflatarray())
+
+    @property
+    def adjoint(self):
+        return EmbeddingFnInFn(self.domain, self.range)
+
+
+class EmbeddingPowerSpaceInFn(Embedding):
+    """ Embed a `PowerSpace` of `Fn` space into a `Fn` """
+
+    def __init__(self, target, origin):
+        # TODO: tests goes here
+
+        super().__init__(target, origin)
+
+    def _apply(self, x, out):
+        out[:] = x.asflatarray()
+
+    def _call(self, x):
+        return self.range.element(x.asflatarray())
+
+    @property
+    def adjoint(self):
+        return EmbeddingFnInPowerSpace(self.domain, self.range)
+
+
+class EmbeddingFnInPowerSpace(Embedding):
+    """ Embed a `Fn` into `PowerSpace` of `Fn`'s"""
+
+    def __init__(self, target, origin):
+        # TODO: tests goes here
+
+        super().__init__(target, origin)
+
+    def _apply(self, x, out):
+        index = 0
+        for sub_vec in out:
+            sub_vec[:] = x.asflatarray(index, index + sub_vec.size)
+            index += sub_vec.size
+
+    def _call(self, x):
+        out = self.range.element()
+        index = 0
+        for sub_vec in out:
+            sub_vec[:] = x.asflatarray(index, index + sub_vec.size)
+            index += sub_vec.size
+        return out
+
+    @property
+    def adjoint(self):
+        return EmbeddingPowerSpaceInFn(self.domain, self.range)
+
+
+if __name__ == '__main__':
+    from doctest import testmod, NORMALIZE_WHITESPACE
+    testmod(optionflags=NORMALIZE_WHITESPACE)

--- a/odl/operator/embedding.py
+++ b/odl/operator/embedding.py
@@ -23,6 +23,9 @@ from future import standard_library
 standard_library.install_aliases()
 from builtins import super
 
+from odl.space.base_ntuples import FnBase
+from odl.discr.lp_discr import DiscreteLp
+from odl.set.pspace import ProductSpace
 from odl.operator.operator import Operator
 
 __all__ = ('Embedding', 'EmbeddingFnInFn', 'EmbeddingPowerSpaceInFn',
@@ -31,17 +34,21 @@ __all__ = ('Embedding', 'EmbeddingFnInFn', 'EmbeddingPowerSpaceInFn',
 
 class Embedding(Operator):
     """An operators to cast between spaces."""
-    def __init__(self, target, origin):
+
+    # TODO: is this needed?
+
+    def __init__(self, origin, target):
         super().__init__(origin, target)
 
 
 class EmbeddingFnInFn(Embedding):
-    """ Embed a `Fn` space into another """
+    """ Embed a `FnBase` space into another """
 
-    def __init__(self, target, origin):
-        # TODO: tests goes here
+    def __init__(self, origin, target):
+        assert isinstance(origin, FnBase)
+        assert isinstance(target, FnBase)
 
-        super().__init__(target, origin)
+        super().__init__(origin, target)
 
     def _apply(self, x, out):
         out[:] = x.asflatarray()
@@ -51,16 +58,37 @@ class EmbeddingFnInFn(Embedding):
 
     @property
     def adjoint(self):
-        return EmbeddingFnInFn(self.domain, self.range)
+        return EmbeddingFnInFn(self.range, self.domain)
+
+
+class EmbeddingDiscreteLpInDiscreteLp(Embedding):
+    """ Embed a `DiscreteLp` space into another """
+
+    def __init__(self, origin, target):
+        assert isinstance(origin, DiscreteLp)
+        assert isinstance(target, DiscreteLp)
+        assert origin.grid.shape == target.grid.shape
+
+        super().__init__(origin, target)
+
+    def _apply(self, x, out):
+        out[:] = x.asarray()
+
+    def _call(self, x):
+        return self.range.element(x.asarray())
+
+    @property
+    def adjoint(self):
+        return EmbeddingDiscreteLpInDiscreteLp(self.range, self.domain)
 
 
 class EmbeddingPowerSpaceInFn(Embedding):
-    """ Embed a `PowerSpace` of `Fn` space into a `Fn` """
+    """ Embed a `PowerSpace` of `FnBase` space into a `FnBase` """
 
-    def __init__(self, target, origin):
+    def __init__(self, origin, target):
         # TODO: tests goes here
 
-        super().__init__(target, origin)
+        super().__init__(origin, target)
 
     def _apply(self, x, out):
         out[:] = x.asflatarray()
@@ -70,16 +98,16 @@ class EmbeddingPowerSpaceInFn(Embedding):
 
     @property
     def adjoint(self):
-        return EmbeddingFnInPowerSpace(self.domain, self.range)
+        return EmbeddingFnInPowerSpace(self.range, self.domain)
 
 
 class EmbeddingFnInPowerSpace(Embedding):
-    """ Embed a `Fn` into `PowerSpace` of `Fn`'s"""
+    """ Embed a `FnBase` into `PowerSpace` of `FnBase`'s"""
 
-    def __init__(self, target, origin):
+    def __init__(self, origin, target):
         # TODO: tests goes here
 
-        super().__init__(target, origin)
+        super().__init__(origin, target)
 
     def _apply(self, x, out):
         index = 0
@@ -97,7 +125,7 @@ class EmbeddingFnInPowerSpace(Embedding):
 
     @property
     def adjoint(self):
-        return EmbeddingPowerSpaceInFn(self.domain, self.range)
+        return EmbeddingPowerSpaceInFn(self.range, self.domain)
 
 
 if __name__ == '__main__':

--- a/odl/set/pspace.py
+++ b/odl/set/pspace.py
@@ -523,10 +523,10 @@ class ProductSpaceVector(LinearSpaceVector):
         index = 0
         for part in self.parts:
             if isinstance(part, ProductSpaceVector):
-                out[index:index+part.total_size] = part.asarray()
+                out[index:index + part.total_size] = part.asarray()
                 index += part.total_size
             else:
-                out[index:index+part.size] = part.asarray()
+                out[index:index + part.size] = part.asarray()
                 index += part.size
 
         return out

--- a/odl/set/pspace.py
+++ b/odl/set/pspace.py
@@ -531,6 +531,20 @@ class ProductSpaceVector(LinearSpaceVector):
 
         return out
 
+    def asflatarray(self, *args, **kwargs):
+        """Representation as linear numpy array.
+
+        Returns
+        -------
+        asarray : `numpy.ndarray`
+            Array representation
+
+        See also
+        --------
+        asarray
+        """
+        return self.asarray(*args, **kwargs)
+
     def __eq__(self, other):
         """``ps.__eq__(other) <==> ps == other``.
 

--- a/odl/space/base_ntuples.py
+++ b/odl/space/base_ntuples.py
@@ -229,6 +229,14 @@ class NtuplesBaseVector(with_metaclass(ABCMeta, object)):
             Numpy array of the same type as the space.
         """
 
+    def asflatarray(self, *args):
+        """Returns the data as a flat (1d) array.
+
+        For "linear" spaces such as Rn this is equal to asarray. In higher
+        dimensional spaces they may differ.
+        """
+        return self.asarray(*args).ravel()
+
     def __len__(self):
         """``v.__len__() <==> len(v)``.
 

--- a/odl/space/cu_ntuples.py
+++ b/odl/space/cu_ntuples.py
@@ -1578,7 +1578,7 @@ class CudaFnCustomInnerProduct(FnWeightingBase):
             instance with the same inner product, `False` otherwise.
         """
         return (isinstance(other, CudaFnCustomInnerProduct) and
-                self.inner == other.inner and
+                self._inner_impl == other._inner_impl and
                 super().__eq__(other))
 
     def __repr__(self):
@@ -1643,7 +1643,7 @@ class CudaFnCustomNorm(FnWeightingBase):
             instance with the same norm, `False` otherwise.
         """
         return (isinstance(other, CudaFnCustomNorm) and
-                self.norm == other.norm and
+                self._norm_impl == other._norm_impl and
                 super().__eq__(other))
 
     def __repr__(self):
@@ -1707,7 +1707,7 @@ class CudaFnCustomDist(FnWeightingBase):
             instance with the same norm, `False` otherwise.
         """
         return (isinstance(other, CudaFnCustomDist) and
-                self.dist == other.dist)
+                self._dist_impl == other._dist_impl)
 
     def __repr__(self):
         """``w.__repr__() <==> repr(w)``."""

--- a/test/operator/embedding_test.py
+++ b/test/operator/embedding_test.py
@@ -1,0 +1,155 @@
+# Copyright 2014, 2015 The ODL development group
+#
+# This file is part of ODL.
+#
+# ODL is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# ODL is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with ODL.  If not, see <http://www.gnu.org/licenses/>.
+
+
+# Imports for common Python 2/3 codebase
+from __future__ import print_function, division, absolute_import
+from future import standard_library
+standard_library.install_aliases()
+
+# External module imports
+import numpy as np
+import pytest
+
+# ODL imports
+import odl
+from odl.util.testutils import (all_equal, all_almost_equal, almost_equal,
+                                skip_if_no_cuda)
+
+
+@skip_if_no_cuda
+def test_CudaRnToRn():
+    r3 = odl.Rn(3)
+    cur3 = odl.CudaRn(3)
+
+    cast = odl.EmbeddingFnInFn(r3, cur3)
+
+    x = cur3.element([1, 2, 3])
+    y = cast(x)
+    assert y in r3
+    assert all_almost_equal(x, y)
+
+    # adjoint
+    assert isinstance(cast.adjoint, odl.EmbeddingFnInFn)
+
+    z = cast.adjoint(y)
+    assert z in cur3
+    assert all_almost_equal(z, x)
+
+
+def test_LpToRn():
+    L2 = odl.FunctionSpace(odl.Rectangle([0, 0], [1, 1]))
+    discr = odl.uniform_discr(L2, [3, 3])
+
+    r9 = odl.Rn(9)
+
+    cast = odl.EmbeddingFnInFn(r9, discr)
+
+    x = discr.element([[1, 2, 3],
+                       [4, 5, 6],
+                       [7, 8, 9]])
+    y = cast(x)
+    assert y in r9
+    assert all_almost_equal(x, y)
+
+    # adjoint
+    assert isinstance(cast.adjoint, odl.EmbeddingFnInFn)
+
+    z = cast.adjoint(y)
+    assert z in discr
+    assert all_almost_equal(z, x)
+
+
+@skip_if_no_cuda
+def test_LpToRn_cuda():
+    L2 = odl.FunctionSpace(odl.Rectangle([0, 0], [1, 1]))
+    discr = odl.uniform_discr(L2, [3, 3], impl='cuda')
+
+    r9 = odl.Rn(9)
+
+    cast = odl.EmbeddingFnInFn(r9, discr)
+
+    x = discr.element([[1, 2, 3],
+                       [4, 5, 6],
+                       [7, 8, 9]])
+    y = cast(x)
+    assert y in r9
+    assert all_almost_equal(y, [1, 2, 3, 4, 5, 6, 7, 8, 9])
+
+    # adjoint
+    assert isinstance(cast.adjoint, odl.EmbeddingFnInFn)
+
+    z = cast.adjoint(y)
+    assert z in discr
+    assert all_almost_equal(z, x)
+
+
+def test_LpToRn_forder():
+    L2 = odl.FunctionSpace(odl.Rectangle([0, 0], [1, 1]))
+    discr = odl.uniform_discr(L2, [3, 3], order='F')
+
+    r9 = odl.Rn(9)
+
+    cast = odl.EmbeddingFnInFn(r9, discr)
+
+    x = discr.element([[1, 2, 3],
+                       [4, 5, 6],
+                       [7, 8, 9]])
+
+    # Call
+    y = cast(x)
+    assert y in r9
+    assert all_almost_equal(y, [1, 4, 7, 2, 5, 8, 3, 6, 9])
+
+    # Zero overhead
+    assert x.ntuple.data.ctypes.data == y.data.ctypes.data
+
+    # adjoint
+    assert isinstance(cast.adjoint, odl.EmbeddingFnInFn)
+
+    z = cast.adjoint(y)
+    assert z in discr
+    assert all_almost_equal(z, x)
+
+    # Zero overhead
+    assert z.ntuple.data.ctypes.data == y.data.ctypes.data
+
+
+def test_PSpaceInFn():
+    r3x2 = odl.ProductSpace(odl.Rn(3), 2)
+    r6 = odl.Rn(6)
+
+    cast = odl.EmbeddingPowerSpaceInFn(r6, r3x2)
+
+    x = r3x2.element([[1, 2, 3],
+                      [4, 5, 6]])
+
+    # Call
+    y = cast(x)
+    assert y in r6
+    assert all_almost_equal(y, [1, 2, 3, 4, 5, 6])
+
+    # adjoint
+    assert isinstance(cast.adjoint, odl.EmbeddingFnInPowerSpace)
+
+    z = cast.adjoint(y)
+    assert z in r3x2
+    assert all_almost_equal(z, x)
+
+
+if __name__ == '__main__':
+    pytest.main(str(__file__.replace('\\', '/') + ' -v'))

--- a/test/operator/embedding_test.py
+++ b/test/operator/embedding_test.py
@@ -36,7 +36,7 @@ def test_CudaRnToRn():
     r3 = odl.Rn(3)
     cur3 = odl.CudaRn(3)
 
-    cast = odl.EmbeddingFnInFn(r3, cur3)
+    cast = odl.EmbeddingFnInFn(cur3, r3)
 
     x = cur3.element([1, 2, 3])
     y = cast(x)
@@ -57,7 +57,7 @@ def test_LpToRn():
 
     r9 = odl.Rn(9)
 
-    cast = odl.EmbeddingFnInFn(r9, discr)
+    cast = odl.EmbeddingFnInFn(discr, r9)
 
     x = discr.element([[1, 2, 3],
                        [4, 5, 6],
@@ -81,7 +81,7 @@ def test_LpToRn_cuda():
 
     r9 = odl.Rn(9)
 
-    cast = odl.EmbeddingFnInFn(r9, discr)
+    cast = odl.EmbeddingFnInFn(discr, r9)
 
     x = discr.element([[1, 2, 3],
                        [4, 5, 6],
@@ -104,7 +104,7 @@ def test_LpToRn_forder():
 
     r9 = odl.Rn(9)
 
-    cast = odl.EmbeddingFnInFn(r9, discr)
+    cast = odl.EmbeddingFnInFn(discr, r9)
 
     x = discr.element([[1, 2, 3],
                        [4, 5, 6],
@@ -133,7 +133,7 @@ def test_PSpaceInFn():
     r3x2 = odl.ProductSpace(odl.Rn(3), 2)
     r6 = odl.Rn(6)
 
-    cast = odl.EmbeddingPowerSpaceInFn(r6, r3x2)
+    cast = odl.EmbeddingPowerSpaceInFn(r3x2, r6)
 
     x = r3x2.element([[1, 2, 3],
                       [4, 5, 6]])

--- a/test/set/pspace_test.py
+++ b/test/set/pspace_test.py
@@ -395,5 +395,87 @@ def test_vector_setitem_fancy():
     assert x[[0, 2]][1] is x3_new
 
 
+def test_vector_size():
+    H = odl.ProductSpace(odl.Rn(1), odl.Rn(2), odl.Rn(3))
+    x = H.element()
+    assert x.size == 3
+
+
+def test_vector_len():
+    H = odl.ProductSpace(odl.Rn(1), odl.Rn(2), odl.Rn(3))
+    x = H.element()
+    assert len(x) == 3
+
+
+def test_vector_total_size():
+    H = odl.ProductSpace(odl.Rn(1), odl.Rn(2), odl.Rn(3))
+    x = H.element()
+    assert x.total_size == 6
+
+
+def test_vector_total_size_nestled():
+    H = odl.ProductSpace(odl.Rn(1),
+                         odl.ProductSpace(odl.Rn(2), odl.Rn(3)))
+    x = H.element()
+    assert x.total_size == 6
+
+
+def test_vector_shape():
+    H = odl.ProductSpace(odl.Rn(1), odl.Rn(2), odl.Rn(3))
+    x = H.element()
+    assert x.shape == (3,)
+
+
+def test_vector_ndim():
+    H = odl.ProductSpace(odl.Rn(1), odl.Rn(2), odl.Rn(3))
+    x = H.element()
+    assert x.ndim == 1
+
+
+def test_vector_dtype():
+    H = odl.ProductSpace(odl.Rn(1), odl.Rn(2), odl.Rn(3))
+    x = H.element()
+    assert x.dtype == float
+
+    H = odl.ProductSpace(odl.Rn(1, dtype='float32'), odl.Rn(2), odl.Rn(3))
+    x = H.element()
+    assert x.dtype == float
+
+
+def test_vector_asarray():
+    H = odl.ProductSpace(odl.Rn(1), odl.Rn(2), odl.Rn(3))
+    x = H.element([[0],
+                   [1, 2],
+                   [3, 4, 5]])
+
+    arr = x.asarray()
+    assert isinstance(arr, np.ndarray)
+    assert arr.dtype == np.dtype(float)
+    assert all_equal(arr, [0, 1, 2, 3, 4, 5])
+
+
+def test_vector_asarray_out():
+    H = odl.ProductSpace(odl.Rn(1), odl.Rn(2), odl.Rn(3))
+    x = H.element([[0],
+                   [1, 2],
+                   [3, 4, 5]])
+
+    out = np.empty(6)
+    arr = x.asarray(out=out)
+    assert arr is out
+    assert all_equal(arr, [0, 1, 2, 3, 4, 5])
+
+
+def test_vector_asarray_nestled():
+    H = odl.ProductSpace(odl.Rn(1),
+                         odl.ProductSpace(odl.Rn(2), odl.Rn(3)))
+    x = H.element([[0],
+                   [[1, 2], [3, 4, 5]]])
+
+    arr = x.asarray()
+    assert isinstance(arr, np.ndarray)
+    assert arr.dtype == np.dtype(float)
+    assert all_equal(arr, [0, 1, 2, 3, 4, 5])
+
 if __name__ == '__main__':
     pytest.main(str(__file__.replace('\\', '/') + ' -v'))


### PR DESCRIPTION
Initial attempt at issue #59. Not ready for pull.

Some points of discussion/additions
- Verify `DiscreteLp` <-> `DiscreteLp` especially if they have different data orders.
- Look into optimizations (should be able to be zero overhead in some situations).
- I was forced to add a method `FnBaseVector.asflatarray`. I highly dislike this, but it shows a problem we have in `DiscreteLpVector.asarray`, namely `x.asarray()[index] != x[index]`, imo this doesnt make much sense. I would suggest we move the current behaviour to a method called `DiscreteLpVector.asvoxels()` (or preferably some better name), and leave the `asarray` behaviour to match that of `Discretization`.

Edit: Also solved issue #83 since it was "needed" for this.
