### PR TITLE
Issue 65  wavelet trafo

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -8,8 +8,11 @@ omit =
     odl/diagnostics/*
     odl/util/*
     
-    # Omit untill coveralls supports cuda.
+    # Omit until coveralls supports cuda.
     odl/space/cu_ntuples.py
+    
+    # Omit until coveralls supports pywt.
+    odl/trafos/wavelet.py
 
 [report]
 # Regexes for lines to exclude from consideration

--- a/conftest.py
+++ b/conftest.py
@@ -21,8 +21,12 @@ from __future__ import print_function, division, absolute_import
 from future import standard_library
 standard_library.install_aliases()
 
-from odl import CUDA_AVAILABLE
+from odl.space.cu_ntuples import CUDA_AVAILABLE
+from odl.trafos.wavelet import WAVELET_AVAILABLE
+
 collect_ignore = ['setup.py', 'run_tests.py']
+
 if not CUDA_AVAILABLE:
     collect_ignore.append('odl/space/cu_ntuples.py')
-    #collect_ignore.append('test/space/cu_ntuples_test.py')
+if not WAVELET_AVAILABLE:
+    collect_ignore.append('odl/trafos/wavelet.py')

--- a/odl/__init__.py
+++ b/odl/__init__.py
@@ -52,8 +52,5 @@ from .space import *
 __all__ += space.__all__
 
 from . import trafos
-from .trafos import *
-__all__ += trafos.__all__
-
 from . import solvers
 from . import tomo

--- a/odl/trafos/wavelet.py
+++ b/odl/trafos/wavelet.py
@@ -36,8 +36,8 @@ try:
 except ImportError:
     WAVELET_AVAILABLE = False
 
-__all__ = ('DiscreteWaveletTrafo', 'DiscreteWaveletTrafoAdjoint',
-           'DiscreteWaveletTrafoInverse', 'WAVELET_AVAILABLE')
+__all__ = ('DiscreteWaveletTrafo', 'DiscreteWaveletTrafoInverse',
+           'WAVELET_AVAILABLE')
 
 
 _SUPPORTED_IMPL = ('pywt',)
@@ -46,10 +46,9 @@ _SUPPORTED_IMPL = ('pywt',)
 def list_of_coeff_sizes(shape, nscale, wbasis, mode):
     """Construct a size list from given wavelet coefficients.
 
-    Construct a list containing the sizes of the wavelet approximation
-    and detail coefficients when wavelet basis, number of scaling levels
-    and the shape of the original image are given.
-    Related to 2D and 3D multidimensional wavelet transform.
+    Related to 2D and 3D multidimensional wavelet transforms that utilize
+    `PyWavelets
+    <http://www.pybytes.com/pywavelets/>`_.
 
     Parameters
     ----------
@@ -57,7 +56,8 @@ def list_of_coeff_sizes(shape, nscale, wbasis, mode):
         Number of pixels/voxels in the image. Its lenght must be 2 or 3.
     nscale : `int`
         Number of scales in the multidimensional wavelet
-        transform
+        transform.  This parameter is checked against the maximum number of
+        scales returned by ``pywt.dwt_max_level``.
     wbasis : ``_pywt.Wavelet``
         Describes properties of a selected wavelet basis
     mode : `str`
@@ -82,10 +82,6 @@ def list_of_coeff_sizes(shape, nscale, wbasis, mode):
         size_list[n] = size of the detailed coefficients at the finest level
         size_list[n+1] = size of original image
         n = number of scaling levels = nscale
-
-    See also
-    --------
-    pywt : http://www.pybytes.com/pywavelets/
     """
     if len(shape) not in (2, 3):
         raise ValueError('shape must have length 2 or 3, got {}.'
@@ -93,7 +89,9 @@ def list_of_coeff_sizes(shape, nscale, wbasis, mode):
     P = np.zeros(shape)
     max_level = pywt.dwt_max_level(shape[0], filter_len=wbasis.dec_len)
     if nscale >= max_level:
-        raise ValueError('Too many scaling levels')
+        raise ValueError('Too many scaling levels, got {}, maximum useful'
+                         ' level is {}'
+                         ''.format(nscale, max_level))
 
     if len(shape) == 2:
         W = pywt.wavedec2(P, wbasis, mode, level=nscale)
@@ -113,7 +111,8 @@ def list_of_coeff_sizes(shape, nscale, wbasis, mode):
 
 
 def pywt_coeff_to_array2d(coeff, size_list, nscales):
-    """Convert a pywt coefficient into a flat array.
+    """Convert a `pywt
+    <http://www.pybytes.com/pywavelets/>`_ coefficient into a flat array.
 
     Related to 2D multilevel discrete wavelet transform.
 
@@ -158,17 +157,13 @@ def pywt_coeff_to_array2d(coeff, size_list, nscales):
         be transformed and on the chosen wavelet basis.
         If the size of the input image is 2^n x 2^n, the lenght of the
         wavelet coefficient array is the same.
-
-    See also
-    --------
-    pywt : http://www.pybytes.com/pywavelets/
     """
     # TODO: outsource to an own helper?
     size_flatCoeff = np.prod(size_list[0])
     for kk in range(1, nscales+1):
         size_flatCoeff = size_flatCoeff + 3*np.prod(size_list[kk])
 
-    flat_coeff = np.zeros((size_flatCoeff))
+    flat_coeff = np.zeros(size_flatCoeff)
     aa = coeff[0]
     aa = aa.ravel()
     stop = np.prod(size_list[0])
@@ -189,12 +184,13 @@ def pywt_coeff_to_array2d(coeff, size_list, nscales):
 
 
 def array_to_pywt_coeff2d(coeff, size_list, nscales):
-    """Convert a flat array into a pywt coefficient list.
+    """Convert a flat array into a `pywt
+    <http://www.pybytes.com/pywavelets/>`_ coefficient list.
     For multilevel 2D discrete wavelet transform
 
     Parameters
     ----------
-    coeff :  :class:`DiscreteLp.Vector`
+    coeff : `DiscreteLp.Vector`
         A flat coefficient vector containing the approximation,
         horizontal detail, vertical detail and diagonal detail
         coefficients in the following order,
@@ -228,7 +224,7 @@ def array_to_pywt_coeff2d(coeff, size_list, nscales):
 
     Returns
     -------
-    :attr:`coeff_list` : `list`
+    coeff_list : `list`
         A list of coefficient organized in the following way
         [aaN, (adN, daN, ddN), ... (ad1, da1, dd1)],
 
@@ -243,10 +239,6 @@ def array_to_pywt_coeff2d(coeff, size_list, nscales):
         dd = detail on 1st dim, detail on 2nd dim (diaginal)
 
         N = the level of decomposition/number of scales.
-
-    See also
-    --------
-    pywt : http://www.pybytes.com/pywavelets/
     """
     size1 = np.prod(size_list[0])
     aa_flat = coeff[0:size1]
@@ -277,7 +269,8 @@ def array_to_pywt_coeff2d(coeff, size_list, nscales):
 
 
 def pywt_coeff_to_array3d(coeff, size_list, nscales):
-    """Convert a pywt coefficient into a flat array.
+    """Convert a `pywt
+    <http://www.pybytes.com/pywavelets/>`_ coefficient into a flat array.
 
     Related to 3D multilevel discrete wavelet transform.
 
@@ -331,10 +324,6 @@ def pywt_coeff_to_array3d(coeff, size_list, nscales):
         be transformed and on the chosen wavelet basis.
         If the size of the input image is 2^n x 2^n, the lenght of the
         wavelet coefficient array is the same.
-
-    See also
-    --------
-    pywt : http://www.pybytes.com/pywavelets/
     """
     size_flatCoeff = np.prod(size_list[0])
     for kk in range(1, nscales+1):
@@ -374,13 +363,14 @@ def pywt_coeff_to_array3d(coeff, size_list, nscales):
 
 
 def array_to_pywt_coeff3d(coeff, size_list, nscales):
-    """Convert a flat array into a pywt coefficient list.
+    """Convert a flat array into a `pywt
+    <http://www.pybytes.com/pywavelets/>`_ coefficient list.
 
     For multilevel 3D discrete wavelet transform
 
     Parameters
     ----------
-    coeff :  :class:`DiscreteLp.Vector`
+    coeff : `DiscreteLp.Vector`
         A flat coefficient vector containing the approximation,
         and detail coefficients in the following order
         [aaaN, aadN, adaN, addN, daaN, dadN, ddaN, dddN, ...
@@ -404,7 +394,7 @@ def array_to_pywt_coeff3d(coeff, size_list, nscales):
 
     Returns
     -------
-    :attr:`coeff_list` : `list`
+    coeff_list : `list`
         A list of coefficient organized in the following way
         [aaaN, (aadN, adaN, addN, daaN, dadN, ddaN, dddN), ...
         (aad1, ada1, add1, daa1, dad1, dda1, ddd1)].
@@ -427,10 +417,6 @@ def array_to_pywt_coeff3d(coeff, size_list, nscales):
         ddd = detail on 1st dim, detail on 2nd dim, detail on 3rd dim,
 
         N = the number of scaling levels
-
-    See also
-    --------
-    pywt : http://www.pybytes.com/pywavelets/
     """
 
     size1 = np.prod(size_list[0])
@@ -478,22 +464,26 @@ def wavelet_decomposition3d(x, wbasis, mode, nscales):
 
     Compute the discrete 3D multiresolution wavelet decomposition
     at the given level (nscales) for a given 3D image.
-    Utilizes a PyWavelet function ``pywt.dwtn``.
+    Utilizes a `PyWavelet
+    <http://www.pybytes.com/pywavelets/ref/other-functions.html>`_
+    function ``pywt.dwtn``.
 
     Parameters
     ----------
-        x : `DiscreteLp.Vector`
-        wbasis:  ``_pywt.Wavelet``
+    x : `DiscreteLp.Vector`
+    wbasis:  ``_pywt.Wavelet``
             Describes properties of a selected wavelet basis
-        mode : `str`
-            Signal extention mode. For possible extensions see
-            ``pywt.MODES.modes``
-        nscales : `int`
+    mode : `str`
+            Signal extention mode. For possible extensions see the signal
+            extenstion `modes
+        <http://www.pybytes.com/pywavelets/ref/signal-extension-modes.html>`_
+            of PyWavelets.
+    nscales : `int`
             Number of scales in the coefficient list
 
     Returns
     -------
-        :attr:`coeff_list` : `list`
+    coeff_list : `list`
         A list of coefficient organized in the following way
          [aaaN, (aadN, adaN, addN, daaN, dadN, ddaN, dddN), ...
          (aad1, ada1, add1, daa1, dad1, dda1, ddd1)] .
@@ -516,10 +506,6 @@ def wavelet_decomposition3d(x, wbasis, mode, nscales):
          ddd = detail on 1st dim, detail on 2nd dim, detail on 3rd dim,
 
          N = the number of scaling levels
-
-    See also
-    --------
-    pywt : http://www.pybytes.com/pywavelets/
     """
 
     wcoeffs = pywt.dwtn(x, wbasis, mode)
@@ -560,11 +546,13 @@ def wavelet_reconstruction3d(coeff_list, wbasis, mode, nscales):
 
     Compute a discrete 3D multiresolution wavelet reconstruction
     from a given wavelet coefficient list.
-    Utilizes a PyWavelet function ``pywt.dwtn``
+    Utilizes a `PyWavelet
+    <http://www.pybytes.com/pywavelets/ref/other-functions.html>`_
+    function ``pywt.dwtn``
 
     Parameters
     ----------
-        coeff_list: : `list`
+    coeff_list : `list`
             A list of wavelet approximation and detail coefficients
             organized in the following way
             [caaaN, (aadN, adaN, addN, daaN, dadN, ddaN, dddN), ...
@@ -588,17 +576,19 @@ def wavelet_reconstruction3d(coeff_list, wbasis, mode, nscales):
             ddd = detail on 1st dim, detail on 2nd dim, detail on 3rd dim,
 
             N = the number of scaling levels
-        wbasis :  ``_pywt.Wavelet``
-            Describes properties of a selected wavelet basis
-        mode : `str`
-            Signal extention mode. For possible extensions see
-            ``pywt.MODES.modes``
-        nscales : `int`
+    wbasis :  ``_pywt.Wavelet``
+            Describes properties of a selected wavelet basisodl.discr.lp_discr.
+    mode : `str`
+            Signal extention mode. For possible extensions see the signal
+            extenstion `modes
+        <http://www.pybytes.com/pywavelets/ref/signal-extension-modes.html>`_
+            of PyWavelets.
+    nscales : `int`
             Number of scales in the coefficient list
 
     Returns
     -------
-        x : `numpy.ndarray`.
+    x : `numpy.ndarray`.
         A wavalet reconstruction.
 
     See also
@@ -629,7 +619,7 @@ class DiscreteWaveletTrafo(Operator):
 
         Parameters
         ----------
-        dom : :class:`~odl.discr.lp_discr.DiscreteLp`
+        dom : `DiscreteLp`
             Domain of the wavelet transform (the "image domain").
             The exponent :math:`p` of the discrete :math:`L^p`
             space must be equal to 2.0.
@@ -638,8 +628,9 @@ class DiscreteWaveletTrafo(Operator):
         wbasis :  ``_pywt.Wavelet``
             Describes properties of a selected wavelet basis
         mode : `str`
-            Signal extention mode. For possible extensions see
+            Signal extension mode. For possible extensions see
             ``pywt.MODES.modes``
+            http://www.pybytes.com/pywavelets/ref/signal-extension-modes.html
 
         See also
         --------
@@ -648,6 +639,17 @@ class DiscreteWaveletTrafo(Operator):
         self.nscales = int(nscales)
         self.wbasis = wbasis
         self.mode = str(mode).lower()
+
+        if not isinstance(dom, DiscreteLp):
+            raise TypeError('domain {!r} is not a `DiscreteLp` instance.'
+                            ''.format(dom))
+
+        if dom.exponent != 2.0:
+            raise ValueError('domain Lp exponent is {} instead of 2.0.'
+                             ''.format(dom.exponent))
+#        if not np.all(dom.grid.stride == 1):
+#            raise NotImplementedError('non-uniform grid cell sizes not yet '
+#                                      'supported.')
 
         max_level = pywt.dwt_max_level(dom.grid.shape[0],
                                        filter_len=self.wbasis.dec_len)
@@ -672,17 +674,6 @@ class DiscreteWaveletTrafo(Operator):
         # TODO: Maybe allow other ranges like Besov spaces (yet to be crated)
         ran = dom.dspace_type(ran_size, dtype=dom.dtype)
         super().__init__(dom, ran)
-
-        if not isinstance(dom, DiscreteLp):
-            raise TypeError('domain {!r} is not a `DiscreteLp` instance.'
-                            ''.format(dom))
-
-        if dom.exponent != 2.0:
-            raise ValueError('domain Lp exponent is {} instead of 2.0.'
-                             ''.format(dom.exponent))
-#        if not np.all(dom.grid.stride == 1):
-#            raise NotImplementedError('non-uniform grid cell sizes not yet '
-#                                      'supported.')
 
     @property
     def is_orthogonal(self):
@@ -739,10 +730,6 @@ class DiscreteWaveletTrafo(Operator):
                                            wbasis=self.wbasis, mode=self.mode)
 
 
-class DiscreteWaveletTrafoAdjoint(Operator):
-    pass
-
-
 class DiscreteWaveletTrafoInverse(Operator):
 
     """Discrete inverse wavelet trafo between discrete L2 spaces."""
@@ -752,7 +739,7 @@ class DiscreteWaveletTrafoInverse(Operator):
 
         Parameters
         ----------
-        ran : `odl.discr.lp_discr.DiscreteLp`
+        ran : `DiscreteLp`
             Domain of the wavelet transform (the "image domain").
             The exponent `p` of the discrete :math:`L^p`
             space must be equal to 2.0.
@@ -761,7 +748,7 @@ class DiscreteWaveletTrafoInverse(Operator):
         wbasis :  ``_pywt.Wavelet``
             Describes properties of a selected wavelet basis
         mode : `str`
-            Signal extention mode. For possible extensions see
+            Signal extension mode. For possible extensions see
             ``pywt.MODES.modes``
         See also
         --------
@@ -770,6 +757,17 @@ class DiscreteWaveletTrafoInverse(Operator):
         self.nscales = int(nscales)
         self.wbasis = wbasis
         self.mode = str(mode).lower()
+
+        if not isinstance(ran, DiscreteLp):
+            raise TypeError('range {!r} is not a `DiscreteLp` instance.'
+                            ''.format(ran))
+
+        if ran.exponent != 2.0:
+            raise ValueError('range Lp exponent is {} instead of 2.0.'
+                             ''.format(ran.exponent))
+#        if not np.all(dom.grid.stride == 1):
+#            raise NotImplementedError('non-uniform grid cell sizes not yet '
+#                                      'supported.')
 
         max_level = pywt.dwt_max_level(ran.grid.shape[0],
                                        filter_len=self.wbasis.dec_len)
@@ -793,17 +791,6 @@ class DiscreteWaveletTrafoInverse(Operator):
         # TODO: Maybe allow other ranges like Besov spaces (yet to be created)
         dom = ran.dspace_type(dom_size, dtype=ran.dtype)
         super().__init__(dom, ran)
-
-        if not isinstance(ran, DiscreteLp):
-            raise TypeError('range {!r} is not a `DiscreteLp` instance.'
-                            ''.format(dom))
-
-        if ran.exponent != 2.0:
-            raise ValueError('range Lp exponent is {} instead of 2.0.'
-                             ''.format(ran.exponent))
-#        if not np.all(dom.grid.stride == 1):
-#            raise NotImplementedError('non-uniform grid cell sizes not yet '
-#                                      'supported.')
 
     @property
     def is_orthogonal(self):

--- a/odl/trafos/wavelet.py
+++ b/odl/trafos/wavelet.py
@@ -25,15 +25,19 @@ from builtins import range, str, super
 
 # External
 import numpy as np
-import pywt
 
 # Internal
 from odl.discr.lp_discr import DiscreteLp
 from odl.operator.operator import Operator
 
+try:
+    import pywt
+    WAVELET_AVAILABLE = True
+except ImportError:
+    WAVELET_AVAILABLE = False
 
 __all__ = ('DiscreteWaveletTrafo', 'DiscreteWaveletTrafoAdjoint',
-           'DiscreteWaveletTrafoInverse')
+           'DiscreteWaveletTrafoInverse', 'WAVELET_AVAILABLE')
 
 
 _SUPPORTED_IMPL = ('pywt',)

--- a/odl/trafos/wavelet.py
+++ b/odl/trafos/wavelet.py
@@ -43,7 +43,7 @@ __all__ = ('DiscreteWaveletTrafo', 'DiscreteWaveletTrafoInverse',
 _SUPPORTED_IMPL = ('pywt',)
 
 
-def list_of_coeff_sizes(shape, nscale, wbasis, mode):
+def coeff_size_list(shape, nscale, wbasis, mode):
     """Construct a size list from given wavelet coefficients.
 
     Related to 2D and 3D multidimensional wavelet transforms that utilize
@@ -614,7 +614,7 @@ class DiscreteWaveletTrafo(Operator):
             raise ValueError('Cannot use more than {} scaling levels, '
                              'got {}.'.format(max_level, self.nscales))
 
-        self.size_list = list_of_coeff_sizes(dom.grid.shape, self.nscales,
+        self.size_list = coeff_size_list(dom.grid.shape, self.nscales,
                                              self.wbasis, self.mode)
 
         ran_size = np.prod(self.size_list[0])
@@ -736,7 +736,7 @@ class DiscreteWaveletTrafoInverse(Operator):
             raise ValueError('Cannot use more than {} scaling levels, '
                              'got {}.'.format(max_level, self.nscales))
 
-        self.size_list = list_of_coeff_sizes(ran.grid.shape, self.nscales,
+        self.size_list = coeff_size_list(ran.grid.shape, self.nscales,
                                              self.wbasis, self.mode)
 
         dom_size = np.prod(self.size_list[0])

--- a/odl/trafos/wavelet.py
+++ b/odl/trafos/wavelet.py
@@ -28,6 +28,8 @@ import numpy as np
 import pywt
 
 # Internal
+from odl.discr.lp_discr import DiscreteLp
+from odl.operator.operator import Operator
 
 
 __all__ = ('DiscreteWaveletTrafo', 'DiscreteWaveletTrafoAdjoint',
@@ -41,18 +43,20 @@ def list_of_coeff_sizes(shape, nscale, wbasis, mode):
     """Construct a size list from given wavelet coefficients.
 
     Construct a list containing the sizes of the wavelet approximation
-    and detail coefficients. Related to 2D multidimensional wavelet transform.
+    and detail coefficients when wavelet basis, number of scaling levels
+    and the shape of the original image are given.
+    Related to 2D and 3D multidimensional wavelet transform.
 
     Parameters
     ----------
     shape : `tuple`
-        Number of pixels in the image. Its lenght must be 2.
-    nscale: int
+        Number of pixels/voxels in the image. Its lenght must be 2 or 3.
+    nscale : `int`
         Number of scales in the multidimensional wavelet
         transform
-    wbasis: ``_pywt.Wavelet``
+    wbasis : ``_pywt.Wavelet``
         Describes properties of a selected wavelet basis
-    mode: `str`
+    mode : `str`
         Signal extention mode. Possible extension modes are
         'zpd' - zero-padding: signal is extended by adding zero samples
         'cpd' - constant padding: border values are replicated
@@ -65,65 +69,81 @@ def list_of_coeff_sizes(shape, nscale, wbasis, mode):
 
     Returns
     -------
-    S: `list`
+    size_list : `list`
         A list containing the sizes of the wavelet (approximation
         and detail) coefficients at different scaling levels
-        S[0] = size of approximation coefficients at the coarsest level
-              size of cAn
-        S[1] = size of the detailed coefficients at the coarsest level
-              size of cHn/cVn/cDn
-        S[n] = size of the detailed coefficients at the finest level
-              size of cH1/cV1/cD1, n = nscales
-        S[n+1] = size of original image
+        size_list[0] = size of approximation coefficients at the coarsest level
+        size_list[1] = size of the detailed coefficients at the coarsest level
+        ...
+        size_list[n] = size of the detailed coefficients at the finest level
+        size_list[n+1] = size of original image
+        n = number of scaling levels = nscale
 
     See also
     --------
     pywt : http://www.pybytes.com/pywavelets/
     """
-    if len(shape) != 2:
-        raise ValueError('shape must have length 2, got {}.'
+    if len(shape) not in (2, 3):
+        raise ValueError('shape must have length 2 or 3, got {}.'
                          ''.format(len(shape)))
     P = np.zeros(shape)
     max_level = pywt.dwt_max_level(shape[0], filter_len=wbasis.dec_len)
     if nscale >= max_level:
         raise ValueError('Too many scaling levels')
 
-    W = pywt.wavedec2(P, wbasis, mode, level=nscale)
-    S = []
+    if len(shape) == 2:
+        W = pywt.wavedec2(P, wbasis, mode, level=nscale)
+    if len(shape) == 3:
+        W = wavelet_decomposition3d(P, wbasis, mode, nscale)
+
+    size_list = []
     a = np.shape(W[0])
-    S.append(a)
+    size_list.append(a)
     for kk in range(1, nscale+1):
-        (wave_horz, wave_vert, wave_diag) = W[kk]
-        a = np.shape(wave_horz)
-        S.append(a)
-    S.append(shape)
-    return S
+        a = np.shape(W[kk])
+        a = a[1:]
+        size_list.append(a)
+
+    size_list.append(shape)
+    return size_list
 
 
 def pywt_coeff_to_array2d(coeff, size_list, nscales):
     """Convert a pywt coefficient into a flat array.
+
     Related to 2D multilevel discrete wavelet transform.
 
     Parameters
     ----------
     coeff : `list`
         Coefficient are organized in the list in the following way
-        [cAn, (cHn, cVn, cDn), ... (cH1, cV1, cD1)]
-        where  cA, cH, cV, cD denote approximation, horizontal detail,
-        vertical detail and diagonal detail coefficients respectively
-        and n denotes the level of decomposition/number of scales.
-    size_list: `list`
+        [aaN, (adN, daN, ddN), ... (ad1, da1, dd1)]
+        The appreviations refer to,
+
+        aa = approx. on 1st dim, approx. on 2nd dim (approximation),
+
+        ad = approx. on 1st dim, detail on 2nd dim (horizontal),
+
+        da = detail on 1st dim, approx. on 2nd dim (vertical),
+
+        dd = detail on 1st dim, detail on 2nd dim (diaginal),
+
+        N = the level of decomposition i.e. number of scales.
+
+    size_list : `list`
         A list containing the sizes of the wavelet (approximation
-        and detail) coefficients at different scaling levels
+        and detail) coefficients at different scaling levels,
+
         size_list[0] = size of approximation coefficients at
-            the coarsest level, i.e. size of cAn
+            the coarsest level, i.e. size of aaN,
         size_list[1] = size of the detailed coefficients at
-            the coarsest level, i.e.  size of cHn/cVn/cDn
-        size_list[n] = size of the detailed coefficients at
-            the finest level, i.e. size of cH1/cV1/cD1,
-            n = nscales
-        size_list[n+1] = size of original image
-    nscales : int
+            the coarsest level, i.e.  size of adN/daN/ddN,
+        size_list[N] = size of the detailed coefficients at
+            the finest level, i.e. size of ad1/da1/dd1,
+        size_list[N+1] = size of original image,
+        N = nscales
+
+    nscales : `int`
         Number of scales in the coefficient list
 
     Returns
@@ -145,21 +165,21 @@ def pywt_coeff_to_array2d(coeff, size_list, nscales):
         size_flatCoeff = size_flatCoeff + 3*np.prod(size_list[kk])
 
     flat_coeff = np.zeros((size_flatCoeff))
-    approx = coeff[0]
-    approx = approx.ravel()
+    aa = coeff[0]
+    aa = aa.ravel()
     stop = np.prod(size_list[0])
-    flat_coeff[0:stop] = approx
+    flat_coeff[0:stop] = aa
     start = stop
     for kk in range(1, nscales+1):
-        (wave_horz, wave_vert, wave_diag) = coeff[kk]
+        (ad, da, dd) = coeff[kk]
         stop = start + np.prod(size_list[kk])
-        flat_coeff[start:stop] = wave_horz.ravel()
+        flat_coeff[start:stop] = ad.ravel()
         start = stop
         stop = start + np.prod(size_list[kk])
-        flat_coeff[start:stop] = wave_vert.ravel()
+        flat_coeff[start:stop] = da.ravel()
         start = stop
         stop = start + np.prod(size_list[kk])
-        flat_coeff[start:stop] = wave_diag.ravel()
+        flat_coeff[start:stop] = dd.ravel()
         start = stop
     return flat_coeff
 
@@ -170,55 +190,80 @@ def array_to_pywt_coeff2d(coeff, size_list, nscales):
 
     Parameters
     ----------
-    coeff:  :class:`DiscreteLp.Vector`
+    coeff :  :class:`DiscreteLp.Vector`
         A flat coefficient vector containing the approximation,
-        horizontal detail, vertical detail and
-        diagonal detail coefficients in the following order
-        [cAn, cHn, cVn, cDn, ... cH1, cV1, cD1]
-    size_list: list
-       A list of coefficient sizes such that
-       size_list[0] = size of approximation coefficients at the coarsest level
-       size_list[1] = size of the detailed coefficients at the coarsest level
-       size_list[n] = size of the detailed coefficients at the finest level
-                  n = nscales
-       size_list[n+1] = size of original image
-    nscales : int
+        horizontal detail, vertical detail and diagonal detail
+        coefficients in the following order,
+        [aaN, adN, daN, ddN, ... ad1, da1, dd1],
+
+        The appreviations refer to,
+
+        aa = approx. on 1st dim, approx. on 2nd dim (approximation)
+
+        ad = approx. on 1st dim, detail on 2nd dim (horizontal)
+
+        da = detail on 1st dim, approx. on 2nd dim (vertical)
+
+        dd = detail on 1st dim, detail on 2nd dim (diagonal)
+
+    size_list : `list`
+       A list of coefficient sizes such that,
+
+       size_list[0] = size of approximation coefficients at the coarsest level,
+
+       size_list[1] = size of the detailed coefficients at the coarsest level,
+
+       size_list[N] = size of the detailed coefficients at the finest level,
+
+       size_list[N+1] = size of original image,
+
+       N = nscales
+
+    nscales : `int`
         Number of scales in the coefficient list
 
     Returns
     -------
     :attr:`coeff_list` : `list`
         A list of coefficient organized in the following way
-        [cAn, (cHn, cVn, cDn), ... (cH1, cV1, cD1)]
-        where  cA, cH, cV, cD denote approximation, horizontal detail,
-        vertical detail and diagonal detail coefficients respectively
-        and n denotes the level of decomposition/number of scales.
+        [aaN, (adN, daN, ddN), ... (ad1, da1, dd1)],
+
+        The appreviations refer to
+
+        aa = approx. on 1st dim, approx. on 2nd dim
+
+        ad = approx. on 1st dim, detail on 2nd dim (horizontal)
+
+        da = detail on 1st dim, approx. on 2nd dim (vertical)
+
+        dd = detail on 1st dim, detail on 2nd dim (diaginal)
+
+        N = the level of decomposition/number of scales.
 
     See also
     --------
     pywt : http://www.pybytes.com/pywavelets/
     """
-    size1 = size_list[0][0] * size_list[0][1]
-    approx_flat = coeff[0:size1]
-    approx = np.asarray(approx_flat).reshape(
-        [size_list[0][0], size_list[0][1]])
+    size1 = np.prod(size_list[0])
+    aa_flat = coeff[0:size1]
+    aa = np.asarray(aa_flat).reshape(size_list[0])
     kk = 1
     coeff_list = []
-    coeff_list.append(approx)
+    coeff_list.append(aa)
 
     while kk <= nscales:
         detail_shape = size_list[kk]
-        size2 = size_list[kk][0] * size_list[kk][1]
-        wave_horz_flat = coeff[size1:size1+size2]
-        wave_horz = np.asarray(wave_horz_flat).reshape(detail_shape)
+        size2 = np.prod(size_list[kk])
+        ad_flat = coeff[size1:size1+size2]
+        ad = np.asarray(ad_flat).reshape(detail_shape)
 
-        wave_vert_flat = coeff[size1+size2:size1+2*size2]
-        wave_vert = np.asarray(wave_vert_flat).reshape(detail_shape)
+        da_flat = coeff[size1+size2:size1+2*size2]
+        da = np.asarray(da_flat).reshape(detail_shape)
 
-        wave_diag_flat = coeff[size1+2*size2:size1 + 3*size1]
-        wave_diag = np.asarray(wave_diag_flat).reshape(detail_shape)
+        dd_flat = coeff[size1+2*size2:size1 + 3*size1]
+        dd = np.asarray(dd_flat).reshape(detail_shape)
 
-        details = (wave_horz, wave_vert, wave_diag)
+        details = (ad, da, dd)
         coeff_list.append(details)
 
         kk = kk + 1
@@ -227,24 +272,368 @@ def array_to_pywt_coeff2d(coeff, size_list, nscales):
     return coeff_list
 
 
-class DiscreteWaveletTrafo(odl.Operator):
+def pywt_coeff_to_array3d(coeff, size_list, nscales):
+    """Convert a pywt coefficient into a flat array.
 
-    """Discrete 2D wavelet trafo between discrete L2 spaces."""
+    Related to 3D multilevel discrete wavelet transform.
+
+    Parameters
+    ----------
+    coeff : `list`
+        Coefficient are organized in the list in the following way
+        [aaaN, (aadN, adaN, addN, daaN, dadN, ddaN, dddN), ...
+        (aad1, ada1, add1, daa1, dad1, dda1, ddd1)].
+        The appreviations refer to
+
+        aaa = approx. on 1st dim, approx. on 2nd dim, approx. on 3rd dim,
+
+        aad = approx. on 1st dim, approx. on 2nd dim, detail on 3rd dim,
+
+        ada = approx. on 1st dim, detail on 3nd dim, approx. on 3rd dim,
+
+        add = approx. on 1st dim, detail on 3nd dim, detail on 3rd dim,
+
+        daa = detail on 1st dim, approx. on 2nd dim, approx. on 3rd dim,
+
+        dad = detail on 1st dim, approx. on 2nd dim, detail on 3rd dim,
+
+        dda = detail on 1st dim, detail on 2nd dim, approx. on 3rd dim,
+
+        ddd = detail on 1st dim, detail on 2nd dim, detail on 3rd dim,
+
+        N =  the number of scaling levels
+
+    size_list : `list`
+        A list containing the sizes of the wavelet (approximation
+        and detail) coefficients at different scaling levels
+
+        size_list[0] = size of approximation coefficients at
+            the coarsest level,
+        size_list[1] = size of the detailed coefficients at
+            the coarsest level,
+        size_list[N] = size of the detailed coefficients at
+            the finest level,
+        size_list[N+1] = size of original image,
+        N = number of scales
+
+    nscales : `int`
+        Number of scales in the coefficient list
+
+    Returns
+    -------
+    arr : `numpy.ndarray`
+        Flattened and concatenated coefficient array
+        The length of the array depends on the size of input image to
+        be transformed and on the chosen wavelet basis.
+        If the size of the input image is 2^n x 2^n, the lenght of the
+        wavelet coefficient array is the same.
+
+    See also
+    --------
+    pywt : http://www.pybytes.com/pywavelets/
+    """
+    size_flatCoeff = np.prod(size_list[0])
+    for kk in range(1, nscales+1):
+        size_flatCoeff = size_flatCoeff + 7*np.prod(size_list[kk])
+
+    flat_coeff = np.zeros((size_flatCoeff))
+    approx = coeff[0]
+    approx = approx.ravel()
+    stop = np.prod(size_list[0])
+    flat_coeff[0:stop] = approx
+    start = stop
+    for kk in range(1, nscales+1):
+        (aad, ada, add, daa, dad, dda, ddd) = coeff[kk]
+        stop = start + np.prod(size_list[kk])
+        flat_coeff[start:stop] = aad.ravel()
+        start = stop
+        stop = start + np.prod(size_list[kk])
+        flat_coeff[start:stop] = ada.ravel()
+        start = stop
+        stop = start + np.prod(size_list[kk])
+        flat_coeff[start:stop] = add.ravel()
+        start = stop
+        stop = start + np.prod(size_list[kk])
+        flat_coeff[start:stop] = daa.ravel()
+        start = stop
+        stop = start + np.prod(size_list[kk])
+        flat_coeff[start:stop] = dad.ravel()
+        start = stop
+        stop = start + np.prod(size_list[kk])
+        flat_coeff[start:stop] = dda.ravel()
+        start = stop
+        stop = start + np.prod(size_list[kk])
+        flat_coeff[start:stop] = ddd.ravel()
+        start = stop
+
+    return flat_coeff
+
+
+def array_to_pywt_coeff3d(coeff, size_list, nscales):
+    """Convert a flat array into a pywt coefficient list.
+
+    For multilevel 3D discrete wavelet transform
+
+    Parameters
+    ----------
+    coeff :  :class:`DiscreteLp.Vector`
+        A flat coefficient vector containing the approximation,
+        and detail coefficients in the following order
+        [aaaN, aadN, adaN, addN, daaN, dadN, ddaN, dddN, ...
+        aad1, ada1, add1, daa1, dad1, dda1, ddd1]
+
+    size_list : list
+       A list of coefficient sizes such that,
+
+       size_list[0] = size of approximation coefficients at the coarsest level,
+
+       size_list[1] = size of the detailed coefficients at the coarsest level,
+
+       size_list[N] = size of the detailed coefficients at the finest level,
+
+       size_list[N+1] = size of original image,
+
+       N = nscales
+
+    nscales : int
+        Number of scales in the coefficient list
+
+    Returns
+    -------
+    :attr:`coeff_list` : `list`
+        A list of coefficient organized in the following way
+        [aaaN, (aadN, adaN, addN, daaN, dadN, ddaN, dddN), ...
+        (aad1, ada1, add1, daa1, dad1, dda1, ddd1)].
+        The appreviations refer to,
+
+        aaa = approx. on 1st dim, approx. on 2nd dim, approx. on 3rd dim,
+
+        aad = approx. on 1st dim, approx. on 2nd dim, detail on 3rd dim,
+
+        ada = approx. on 1st dim, detail on 3nd dim, approx. on 3rd dim,
+
+        add = approx. on 1st dim, detail on 3nd dim, detail on 3rd dim,
+
+        daa = detail on 1st dim, approx. on 2nd dim, approx. on 3rd dim,
+
+        dad = detail on 1st dim, approx. on 2nd dim, detail on 3rd dim,
+
+        dda = detail on 1st dim, detail on 2nd dim, approx. on 3rd dim,
+
+        ddd = detail on 1st dim, detail on 2nd dim, detail on 3rd dim,
+
+        N = the number of scaling levels
+
+    See also
+    --------
+    pywt : http://www.pybytes.com/pywavelets/
+    """
+
+    size1 = np.prod(size_list[0])
+    approx_flat = coeff[0:size1]
+    approx = np.asarray(approx_flat).reshape(size_list[0])
+    kk = 1
+    coeff_list = []
+    coeff_list.append(approx)
+
+    while kk <= nscales:
+        detail_shape = size_list[kk]
+        size2 = np.prod(size_list[kk])
+        aad_flat = coeff[size1:size1+size2]
+        aad = np.asarray(aad_flat).reshape(detail_shape)
+
+        ada_flat = coeff[size1+size2:size1+2*size2]
+        ada = np.asarray(ada_flat).reshape(detail_shape)
+
+        add_flat = coeff[size1+2*size2:size1 + 3*size1]
+        add = np.asarray(add_flat).reshape(detail_shape)
+
+        daa_flat = coeff[size1+3*size2:size1 + 4*size1]
+        daa = np.asarray(daa_flat).reshape(detail_shape)
+
+        dad_flat = coeff[size1+4*size2:size1 + 5*size1]
+        dad = np.asarray(dad_flat).reshape(detail_shape)
+
+        dda_flat = coeff[size1+5*size2:size1 + 6*size1]
+        dda = np.asarray(dda_flat).reshape(detail_shape)
+
+        ddd_flat = coeff[size1+6*size2:size1 + 7*size1]
+        ddd = np.asarray(ddd_flat).reshape(detail_shape)
+
+        details = (aad, ada, add, daa, dad, dda, ddd)
+        coeff_list.append(details)
+
+        kk = kk + 1
+        size1 = size1 + 7*size2
+
+    return coeff_list
+
+
+def wavelet_decomposition3d(x, wbasis, mode, nscales):
+    """Discrete 3D multiresolution wavelet decomposition.
+
+    Compute the discrete 3D multiresolution wavelet decomposition
+    at the given level (nscales) for a given 3D image.
+    Utilizes a PyWavelet function ``pywt.dwtn``.
+
+    Parameters
+    ----------
+        x : `DiscreteLp.Vector`
+        wbasis:  ``_pywt.Wavelet``
+            Describes properties of a selected wavelet basis
+        mode : `str`
+            Signal extention mode. For possible extensions see
+            ``pywt.MODES.modes``
+        nscales : `int`
+            Number of scales in the coefficient list
+
+    Returns
+    -------
+        :attr:`coeff_list` : `list`
+        A list of coefficient organized in the following way
+         [aaaN, (aadN, adaN, addN, daaN, dadN, ddaN, dddN), ...
+         (aad1, ada1, add1, daa1, dad1, dda1, ddd1)] .
+         The appreviations refer to,
+
+         aaa = approx. on 1st dim, approx. on 2nd dim, approx. on 3rd dim,
+
+         aad = approx. on 1st dim, approx. on 2nd dim, detail on 3rd dim,
+
+         ada = approx. on 1st dim, detail on 3nd dim, approx. on 3rd dim,
+
+         add = approx. on 1st dim, detail on 3nd dim, detail on 3rd dim,
+
+         daa = detail on 1st dim, approx. on 2nd dim, approx. on 3rd dim,
+
+         dad = detail on 1st dim, approx. on 2nd dim, detail on 3rd dim,
+
+         dda = detail on 1st dim, detail on 2nd dim, approx. on 3rd dim,
+
+         ddd = detail on 1st dim, detail on 2nd dim, detail on 3rd dim,
+
+         N = the number of scaling levels
+
+    See also
+    --------
+    pywt : http://www.pybytes.com/pywavelets/
+    """
+
+    wcoeffs = pywt.dwtn(x, wbasis, mode)
+    aaa = wcoeffs['aaa']
+    aad = wcoeffs['aad']
+    ada = wcoeffs['ada']
+    add = wcoeffs['add']
+    daa = wcoeffs['daa']
+    dad = wcoeffs['dad']
+    dda = wcoeffs['dda']
+    ddd = wcoeffs['ddd']
+
+    details = (aad, ada, add, daa, dad, dda, ddd)
+    coeff_list = []
+    coeff_list.append(details)
+
+    for kk in range(1, nscales):
+        wcoeffs = pywt.dwtn(aaa, wbasis, mode)
+        aaa = wcoeffs['aaa']
+        aad = wcoeffs['aad']
+        ada = wcoeffs['ada']
+        add = wcoeffs['add']
+        daa = wcoeffs['daa']
+        dad = wcoeffs['dad']
+        dda = wcoeffs['dda']
+        ddd = wcoeffs['ddd']
+        details = (aad, ada, add, daa, dad, dda, ddd)
+        coeff_list.append(details)
+
+    coeff_list.append(aaa)
+    coeff_list.reverse()
+
+    return coeff_list
+
+
+def wavelet_reconstruction3d(coeff_list, wbasis, mode, nscales):
+    """Discrete 3D multiresolution wavelet reconstruction
+
+    Compute a discrete 3D multiresolution wavelet reconstruction
+    from a given wavelet coefficient list.
+    Utilizes a PyWavelet function ``pywt.dwtn``
+
+    Parameters
+    ----------
+        coeff_list: : `list`
+            A list of wavelet approximation and detail coefficients
+            organized in the following way
+            [caaaN, (aadN, adaN, addN, daaN, dadN, ddaN, dddN), ...
+            (aad1, ada1, add1, daa1, dad1, dda1, ddd1)].
+            The appreviations refer to,
+
+            aaa = approx. on 1st dim, approx. on 2nd dim, approx. on 3rd dim,
+
+            aad = approx. on 1st dim, approx. on 2nd dim, detail on 3rd dim,
+
+            ada = approx. on 1st dim, detail on 3nd dim, approx. on 3rd dim,
+
+            add = approx. on 1st dim, detail on 3nd dim, detail on 3rd dim,
+
+            daa = detail on 1st dim, approx. on 2nd dim, approx. on 3rd dim,
+
+            dad = detail on 1st dim, approx. on 2nd dim, detail on 3rd dim,
+
+            dda = detail on 1st dim, detail on 2nd dim, approx. on 3rd dim,
+
+            ddd = detail on 1st dim, detail on 2nd dim, detail on 3rd dim,
+
+            N = the number of scaling levels
+        wbasis :  ``_pywt.Wavelet``
+            Describes properties of a selected wavelet basis
+        mode : `str`
+            Signal extention mode. For possible extensions see
+            ``pywt.MODES.modes``
+        nscales : `int`
+            Number of scales in the coefficient list
+
+    Returns
+    -------
+        x : `numpy.ndarray`.
+        A wavalet reconstruction.
+
+    See also
+    --------
+    pywt : http://www.pybytes.com/pywavelets/
+    """
+    aaa = coeff_list[0]
+    k = 1
+    (aad, ada, add, daa, dad, dda, ddd) = coeff_list[k]
+    coeff_dict = {'aaa': aaa, 'aad': aad, 'ada': ada, 'add': add,
+                  'daa': daa, 'dad': dad, 'dda': dda, 'ddd': ddd}
+    for k in range(2, nscales+1):
+        aaa = pywt.idwtn(coeff_dict, wbasis, mode)
+        (aad, ada, add, daa, dad, dda, ddd) = coeff_list[k]
+        coeff_dict = {'aaa': aaa, 'aad': aad, 'ada': ada, 'add': add,
+                      'daa': daa, 'dad': dad, 'dda': dda, 'ddd': ddd}
+
+    x = pywt.idwtn(coeff_dict, wbasis, mode)
+    return x
+
+
+class DiscreteWaveletTrafo(Operator):
+
+    """Discrete wavelet trafo between discrete L2 spaces."""
 
     def __init__(self, dom, nscales, wbasis, mode):
         """Initialize a new instance.
 
         Parameters
         ----------
-        dom : :class:`~odl.DiscreteLp`
+        dom : :class:`~odl.discr.lp_discr.DiscreteLp`
             Domain of the wavelet transform (the "image domain").
             The exponent :math:`p` of the discrete :math:`L^p`
             space must be equal to 2.0.
         nscales : `int`
             Number of scales in the coefficient list
-        wbasis:  ``_pywt.Wavelet``
+        wbasis :  ``_pywt.Wavelet``
             Describes properties of a selected wavelet basis
-        mode: `str`
+        mode : `str`
             Signal extention mode. For possible extensions see
             ``pywt.MODES.modes``
 
@@ -268,21 +657,25 @@ class DiscreteWaveletTrafo(odl.Operator):
                                              self.wbasis, self.mode)
 
         ran_size = np.prod(self.size_list[0])
-        ran_size += sum(3 * np.prod(shape) for shape in self.size_list[1:-1])
-        #`pywt` does not handle complex values
-        # >>ComplexWarning: Casting complex values to real discards the imaginary part
+
+        if len(dom.grid.shape) == 2:
+            ran_size += sum(3 * np.prod(shape) for shape in
+                            self.size_list[1:-1])
+        if len(dom.grid.shape) == 3:
+            ran_size += sum(7 * np.prod(shape) for shape in
+                            self.size_list[1:-1])
 
         # TODO: Maybe allow other ranges like Besov spaces (yet to be crated)
         ran = dom.dspace_type(ran_size, dtype=dom.dtype)
         super().__init__(dom, ran)
 
-        if not isinstance(dom, odl.DiscreteL2):
+        if not isinstance(dom, DiscreteLp):
             raise TypeError('domain {!r} is not a `DiscreteLp` instance.'
                             ''.format(dom))
 
-#        if dom.exponent != 2.0:
-#            raise ValueError('domain Lp exponent is {} instead of 2.0.'
-#                             ''.format(dom.exponent))
+        if dom.exponent != 2.0:
+            raise ValueError('domain Lp exponent is {} instead of 2.0.'
+                             ''.format(dom.exponent))
 #        if not np.all(dom.grid.stride == 1):
 #            raise NotImplementedError('non-uniform grid cell sizes not yet '
 #                                      'supported.')
@@ -298,10 +691,10 @@ class DiscreteWaveletTrafo(odl.Operator):
         return self.wbasis.biorthogonal
 
     def _call(self, x):
-        """Compute the discrete 2D multiresolution wavelet transform
+        """Compute the discrete 2D and 3D multiresolution wavelet transform
         Parameters
         ----------
-        x: `DiscreteLp.Vector`
+        x : `DiscreteLp.Vector`
 
         Returns
         -------
@@ -309,14 +702,20 @@ class DiscreteWaveletTrafo(odl.Operator):
             Flattened and concatenated coefficient array
             The length of the array depends on the size of input image to
             be transformed and on the chosen wavelet basis.
-            If the size of the input image is 2^n x 2^n, the lenght of the
-            wavelet coefficient array is the same.
         """
-        # TODO: check if one needs to write x.asarray()
-        coeff_list = pywt.wavedec2(x, self.wbasis, self.mode, self.nscales)
-        coeff_arr = pywt_coeff_to_array2d(coeff_list, self.size_list,
-                                          self.nscales)
-        return self.range.element(coeff_arr)
+        if len(x.shape) == 2:
+            coeff_list = pywt.wavedec2(x, self.wbasis, self.mode, self.nscales)
+            coeff_arr = pywt_coeff_to_array2d(coeff_list, self.size_list,
+                                              self.nscales)
+            return self.range.element(coeff_arr)
+
+        if len(x.shape) == 3:
+            coeff_dict = wavelet_decomposition3d(x, self.wbasis, self.mode,
+                                                 self.nscales)
+            coeff_arr = pywt_coeff_to_array3d(coeff_dict, self.size_list,
+                                              self.nscales)
+
+            return self.range.element(coeff_arr)
 
     @property
     def adjoint(self):
@@ -336,11 +735,11 @@ class DiscreteWaveletTrafo(odl.Operator):
                                            wbasis=self.wbasis, mode=self.mode)
 
 
-class DiscreteWaveletTrafoAdjoint(odl.Operator):
+class DiscreteWaveletTrafoAdjoint(Operator):
     pass
 
 
-class DiscreteWaveletTrafoInverse(odl.Operator):
+class DiscreteWaveletTrafoInverse(Operator):
 
     """Discrete inverse wavelet trafo between discrete L2 spaces."""
 
@@ -349,15 +748,15 @@ class DiscreteWaveletTrafoInverse(odl.Operator):
 
         Parameters
         ----------
-        ran : `odl.DiscreteLp`
+        ran : `odl.discr.lp_discr.DiscreteLp`
             Domain of the wavelet transform (the "image domain").
             The exponent `p` of the discrete :math:`L^p`
             space must be equal to 2.0.
-        nscales : int
+        nscales : `int`
             Number of scales in the coefficient list
-        wbasis:  ``_pywt.Wavelet``
+        wbasis :  ``_pywt.Wavelet``
             Describes properties of a selected wavelet basis
-        mode: `str`
+        mode : `str`
             Signal extention mode. For possible extensions see
             ``pywt.MODES.modes``
         See also
@@ -380,22 +779,24 @@ class DiscreteWaveletTrafoInverse(odl.Operator):
                                              self.wbasis, self.mode)
 
         dom_size = np.prod(self.size_list[0])
-        dom_size += sum(3 * np.prod(shape) for shape in self.size_list[1:-1])
-        # TODO: Check if complex spaces work
+        if len(ran.grid.shape) == 2:
+            dom_size += sum(3 * np.prod(shape) for shape in
+                            self.size_list[1:-1])
+        if len(ran.grid.shape) == 3:
+            dom_size += sum(7 * np.prod(shape) for shape in
+                            self.size_list[1:-1])
+
         # TODO: Maybe allow other ranges like Besov spaces (yet to be created)
         dom = ran.dspace_type(dom_size, dtype=ran.dtype)
         super().__init__(dom, ran)
 
-        if not isinstance(ran, odl.DiscreteL2):
+        if not isinstance(ran, DiscreteLp):
             raise TypeError('range {!r} is not a `DiscreteLp` instance.'
                             ''.format(dom))
-#
-#        if dom.exponent != 2.0:
-#            raise ValueError('domain Lp exponent is {} instead of 2.0.'
-#                             ''.format(dom.exponent))
-#        if ran.exponent != 2.0:
-#            raise ValueError('range Lp exponent is {} instead of 2.0.'
-#                             ''.format(ran.exponent))
+
+        if ran.exponent != 2.0:
+            raise ValueError('range Lp exponent is {} instead of 2.0.'
+                             ''.format(ran.exponent))
 #        if not np.all(dom.grid.stride == 1):
 #            raise NotImplementedError('non-uniform grid cell sizes not yet '
 #                                      'supported.')
@@ -411,21 +812,29 @@ class DiscreteWaveletTrafoInverse(odl.Operator):
         return self.wbasis.biorthogonal
 
     def _call(self, coeff):
-        """Compute the discrete 2D inverse multiresolution wavelet transform
+        """Compute the discrete 2D and 3D inverse
+        multiresolution wavelet transform
 
         Parameters
         ----------
-        coeff: class:`DiscreteLp.Vector` (or `list`??)
+        coeff : class:`DiscreteLp.Vector`
 
         Returns
         -------
-        arr : `numpy.ndarray` or `DiscreteLp.Vector`
+        arr : `DiscreteLp.Vector`
 
         """
-        coeff_list = array_to_pywt_coeff2d(coeff, self.size_list, self.nscales)
-        x = pywt.waverec2(coeff_list, self.wbasis, self.mode)
-        return self.range.element(x)
-
+        if len(self.range.grid.shape) == 2:
+            coeff_list = array_to_pywt_coeff2d(coeff, self.size_list,
+                                               self.nscales)
+            x = pywt.waverec2(coeff_list, self.wbasis, self.mode)
+            return self.range.element(x)
+        if len(self.range.grid.shape) == 3:
+            coeff_dict = array_to_pywt_coeff3d(coeff, self.size_list,
+                                               self.nscales)
+            x = wavelet_reconstruction3d(coeff_dict, self.wbasis, self.mode,
+                                         self.nscales)
+            return self.range.element(x)
 
     @property
     def adjoint(self):
@@ -439,6 +848,5 @@ class DiscreteWaveletTrafoInverse(odl.Operator):
     @property
     def inverse(self):
         """The inverse wavelet transform."""
-
-        return DiscreteWaveletTrafo(dom=self.range, nscales = self.nscales,
-                                    wbasis = self.wbasis, mode = self.mode)
+        return DiscreteWaveletTrafo(dom=self.range, nscales=self.nscales,
+                                    wbasis=self.wbasis, mode=self.mode)

--- a/odl/trafos/wavelet.py
+++ b/odl/trafos/wavelet.py
@@ -21,9 +21,424 @@
 from __future__ import print_function, division, absolute_import
 from future import standard_library
 standard_library.install_aliases()
+from builtins import range, str, super
 
 # External
+import numpy as np
+import pywt
 
 # Internal
 
-__all__ = ()
+
+__all__ = ('DiscreteWaveletTrafo', 'DiscreteWaveletTrafoAdjoint',
+           'DiscreteWaveletTrafoInverse')
+
+
+_SUPPORTED_IMPL = ('pywt',)
+
+
+def list_of_coeff_sizes(shape, nscale, wbasis, mode):
+    """Construct a size list from given wavelet coefficients.
+
+    Construct a list containing the sizes of the wavelet approximation
+    and detail coefficients. Related to 2D multidimensional wavelet transform.
+
+    Parameters
+    ----------
+    shape : `tuple`
+        Number of pixels in the image. Its lenght must be 2.
+    nscale: int
+        Number of scales in the multidimensional wavelet
+        transform
+    wbasis: ``_pywt.Wavelet``
+        Describes properties of a selected wavelet basis
+    mode: `str`
+        Signal extention mode. Possible extension modes are
+        'zpd' - zero-padding: signal is extended by adding zero samples
+        'cpd' - constant padding: border values are replicated
+        'sym' - symmetric padding: signal extension by mirroring samples
+        'ppd' - periodic padding: signal is trated as a periodic one
+        'sp1' - smooth padding: signal is extended according to the
+        first derivatives calculated on the edges (straight line)
+        'per' - periodization: like periodic-padding but gives the
+        smallest possible number of decomposition coefficients.
+
+    Returns
+    -------
+    S: `list`
+        A list containing the sizes of the wavelet (approximation
+        and detail) coefficients at different scaling levels
+        S[0] = size of approximation coefficients at the coarsest level
+              size of cAn
+        S[1] = size of the detailed coefficients at the coarsest level
+              size of cHn/cVn/cDn
+        S[n] = size of the detailed coefficients at the finest level
+              size of cH1/cV1/cD1, n = nscales
+        S[n+1] = size of original image
+
+    See also
+    --------
+    pywt : http://www.pybytes.com/pywavelets/
+    """
+    if len(shape) != 2:
+        raise ValueError('shape must have length 2, got {}.'
+                         ''.format(len(shape)))
+    P = np.zeros(shape)
+    max_level = pywt.dwt_max_level(shape[0], filter_len=wbasis.dec_len)
+    if nscale >= max_level:
+        raise ValueError('Too many scaling levels')
+
+    W = pywt.wavedec2(P, wbasis, mode, level=nscale)
+    S = []
+    a = np.shape(W[0])
+    S.append(a)
+    for kk in range(1, nscale+1):
+        (wave_horz, wave_vert, wave_diag) = W[kk]
+        a = np.shape(wave_horz)
+        S.append(a)
+    S.append(shape)
+    return S
+
+
+def pywt_coeff_to_array2d(coeff, size_list, nscales):
+    """Convert a pywt coefficient into a flat array.
+    Related to 2D multilevel discrete wavelet transform.
+
+    Parameters
+    ----------
+    coeff : `list`
+        Coefficient are organized in the list in the following way
+        [cAn, (cHn, cVn, cDn), ... (cH1, cV1, cD1)]
+        where  cA, cH, cV, cD denote approximation, horizontal detail,
+        vertical detail and diagonal detail coefficients respectively
+        and n denotes the level of decomposition/number of scales.
+    size_list: `list`
+        A list containing the sizes of the wavelet (approximation
+        and detail) coefficients at different scaling levels
+        size_list[0] = size of approximation coefficients at
+            the coarsest level, i.e. size of cAn
+        size_list[1] = size of the detailed coefficients at
+            the coarsest level, i.e.  size of cHn/cVn/cDn
+        size_list[n] = size of the detailed coefficients at
+            the finest level, i.e. size of cH1/cV1/cD1,
+            n = nscales
+        size_list[n+1] = size of original image
+    nscales : int
+        Number of scales in the coefficient list
+
+    Returns
+    -------
+    arr : `numpy.ndarray`
+        Flattened and concatenated coefficient array
+        The length of the array depends on the size of input image to
+        be transformed and on the chosen wavelet basis.
+        If the size of the input image is 2^n x 2^n, the lenght of the
+        wavelet coefficient array is the same.
+
+    See also
+    --------
+    pywt : http://www.pybytes.com/pywavelets/
+    """
+    # TODO: outsource to an own helper?
+    size_flatCoeff = np.prod(size_list[0])
+    for kk in range(1, nscales+1):
+        size_flatCoeff = size_flatCoeff + 3*np.prod(size_list[kk])
+
+    flat_coeff = np.zeros((size_flatCoeff))
+    approx = coeff[0]
+    approx = approx.ravel()
+    stop = np.prod(size_list[0])
+    flat_coeff[0:stop] = approx
+    start = stop
+    for kk in range(1, nscales+1):
+        (wave_horz, wave_vert, wave_diag) = coeff[kk]
+        stop = start + np.prod(size_list[kk])
+        flat_coeff[start:stop] = wave_horz.ravel()
+        start = stop
+        stop = start + np.prod(size_list[kk])
+        flat_coeff[start:stop] = wave_vert.ravel()
+        start = stop
+        stop = start + np.prod(size_list[kk])
+        flat_coeff[start:stop] = wave_diag.ravel()
+        start = stop
+    return flat_coeff
+
+
+def array_to_pywt_coeff2d(coeff, size_list, nscales):
+    """Convert a flat array into a pywt coefficient list.
+    For multilevel 2D discrete wavelet transform
+
+    Parameters
+    ----------
+    coeff:  :class:`DiscreteLp.Vector`
+        A flat coefficient vector containing the approximation,
+        horizontal detail, vertical detail and
+        diagonal detail coefficients in the following order
+        [cAn, cHn, cVn, cDn, ... cH1, cV1, cD1]
+    size_list: list
+       A list of coefficient sizes such that
+       size_list[0] = size of approximation coefficients at the coarsest level
+       size_list[1] = size of the detailed coefficients at the coarsest level
+       size_list[n] = size of the detailed coefficients at the finest level
+                  n = nscales
+       size_list[n+1] = size of original image
+    nscales : int
+        Number of scales in the coefficient list
+
+    Returns
+    -------
+    :attr:`coeff_list` : `list`
+        A list of coefficient organized in the following way
+        [cAn, (cHn, cVn, cDn), ... (cH1, cV1, cD1)]
+        where  cA, cH, cV, cD denote approximation, horizontal detail,
+        vertical detail and diagonal detail coefficients respectively
+        and n denotes the level of decomposition/number of scales.
+
+    See also
+    --------
+    pywt : http://www.pybytes.com/pywavelets/
+    """
+    size1 = size_list[0][0] * size_list[0][1]
+    approx_flat = coeff[0:size1]
+    approx = np.asarray(approx_flat).reshape(
+        [size_list[0][0], size_list[0][1]])
+    kk = 1
+    coeff_list = []
+    coeff_list.append(approx)
+
+    while kk <= nscales:
+        detail_shape = size_list[kk]
+        size2 = size_list[kk][0] * size_list[kk][1]
+        wave_horz_flat = coeff[size1:size1+size2]
+        wave_horz = np.asarray(wave_horz_flat).reshape(detail_shape)
+
+        wave_vert_flat = coeff[size1+size2:size1+2*size2]
+        wave_vert = np.asarray(wave_vert_flat).reshape(detail_shape)
+
+        wave_diag_flat = coeff[size1+2*size2:size1 + 3*size1]
+        wave_diag = np.asarray(wave_diag_flat).reshape(detail_shape)
+
+        details = (wave_horz, wave_vert, wave_diag)
+        coeff_list.append(details)
+
+        kk = kk + 1
+        size1 = size1 + 3*size2
+
+    return coeff_list
+
+
+class DiscreteWaveletTrafo(odl.Operator):
+
+    """Discrete 2D wavelet trafo between discrete L2 spaces."""
+
+    def __init__(self, dom, nscales, wbasis, mode):
+        """Initialize a new instance.
+
+        Parameters
+        ----------
+        dom : :class:`~odl.DiscreteLp`
+            Domain of the wavelet transform (the "image domain").
+            The exponent :math:`p` of the discrete :math:`L^p`
+            space must be equal to 2.0.
+        nscales : `int`
+            Number of scales in the coefficient list
+        wbasis:  ``_pywt.Wavelet``
+            Describes properties of a selected wavelet basis
+        mode: `str`
+            Signal extention mode. For possible extensions see
+            ``pywt.MODES.modes``
+
+        See also
+        --------
+        pywt : http://www.pybytes.com/pywavelets/
+        """
+        self.nscales = int(nscales)
+        self.wbasis = wbasis
+        self.mode = str(mode).lower()
+
+        max_level = pywt.dwt_max_level(dom.grid.shape[0],
+                                       filter_len=self.wbasis.dec_len)
+        # TODO: maybe the error message could tell how to calculate the
+        # max number of levels
+        if self.nscales >= max_level:
+            raise ValueError('Cannot use more than {} scaling levels, '
+                             'got {}.'.format(max_level, self.nscales))
+
+        self.size_list = list_of_coeff_sizes(dom.grid.shape, self.nscales,
+                                             self.wbasis, self.mode)
+
+        ran_size = np.prod(self.size_list[0])
+        ran_size += sum(3 * np.prod(shape) for shape in self.size_list[1:-1])
+        #`pywt` does not handle complex values
+        # >>ComplexWarning: Casting complex values to real discards the imaginary part
+
+        # TODO: Maybe allow other ranges like Besov spaces (yet to be crated)
+        ran = dom.dspace_type(ran_size, dtype=dom.dtype)
+        super().__init__(dom, ran)
+
+        if not isinstance(dom, odl.DiscreteL2):
+            raise TypeError('domain {!r} is not a `DiscreteLp` instance.'
+                            ''.format(dom))
+
+#        if dom.exponent != 2.0:
+#            raise ValueError('domain Lp exponent is {} instead of 2.0.'
+#                             ''.format(dom.exponent))
+#        if not np.all(dom.grid.stride == 1):
+#            raise NotImplementedError('non-uniform grid cell sizes not yet '
+#                                      'supported.')
+
+    @property
+    def is_orthogonal(self):
+        """Whether or not the wavelet basis is orthogonal."""
+        return self.wbasis.orthogonal
+
+    @property
+    def is_biorthogonal(self):
+        """Whether or not the wavelet basis is bi-orthogonal."""
+        return self.wbasis.biorthogonal
+
+    def _call(self, x):
+        """Compute the discrete 2D multiresolution wavelet transform
+        Parameters
+        ----------
+        x: `DiscreteLp.Vector`
+
+        Returns
+        -------
+        arr : `numpy.ndarray`
+            Flattened and concatenated coefficient array
+            The length of the array depends on the size of input image to
+            be transformed and on the chosen wavelet basis.
+            If the size of the input image is 2^n x 2^n, the lenght of the
+            wavelet coefficient array is the same.
+        """
+        # TODO: check if one needs to write x.asarray()
+        coeff_list = pywt.wavedec2(x, self.wbasis, self.mode, self.nscales)
+        coeff_arr = pywt_coeff_to_array2d(coeff_list, self.size_list,
+                                          self.nscales)
+        return self.range.element(coeff_arr)
+
+    @property
+    def adjoint(self):
+        """The adjoint wavelet transform."""
+        if self.is_orthogonal:
+            return self.inverse
+        else:
+            # TODO: put adjoint here
+            return None
+
+    @property
+    def inverse(self):
+        """The inverse wavelet transform."""
+
+        return DiscreteWaveletTrafoInverse(ran=self.domain,
+                                           nscales=self.nscales,
+                                           wbasis=self.wbasis, mode=self.mode)
+
+
+class DiscreteWaveletTrafoAdjoint(odl.Operator):
+    pass
+
+
+class DiscreteWaveletTrafoInverse(odl.Operator):
+
+    """Discrete inverse wavelet trafo between discrete L2 spaces."""
+
+    def __init__(self, ran, nscales, wbasis, mode):
+        """Initialize a new instance.
+
+        Parameters
+        ----------
+        ran : `odl.DiscreteLp`
+            Domain of the wavelet transform (the "image domain").
+            The exponent `p` of the discrete :math:`L^p`
+            space must be equal to 2.0.
+        nscales : int
+            Number of scales in the coefficient list
+        wbasis:  ``_pywt.Wavelet``
+            Describes properties of a selected wavelet basis
+        mode: `str`
+            Signal extention mode. For possible extensions see
+            ``pywt.MODES.modes``
+        See also
+        --------
+        pywt : http://www.pybytes.com/pywavelets/
+        """
+        self.nscales = int(nscales)
+        self.wbasis = wbasis
+        self.mode = str(mode).lower()
+
+        max_level = pywt.dwt_max_level(ran.grid.shape[0],
+                                       filter_len=self.wbasis.dec_len)
+        # TODO: maybe the error message could tell how to calculate the
+        # max number of levels
+        if self.nscales >= max_level:
+            raise ValueError('Cannot use more than {} scaling levels, '
+                             'got {}.'.format(max_level, self.nscales))
+
+        self.size_list = list_of_coeff_sizes(ran.grid.shape, self.nscales,
+                                             self.wbasis, self.mode)
+
+        dom_size = np.prod(self.size_list[0])
+        dom_size += sum(3 * np.prod(shape) for shape in self.size_list[1:-1])
+        # TODO: Check if complex spaces work
+        # TODO: Maybe allow other ranges like Besov spaces (yet to be created)
+        dom = ran.dspace_type(dom_size, dtype=ran.dtype)
+        super().__init__(dom, ran)
+
+        if not isinstance(ran, odl.DiscreteL2):
+            raise TypeError('range {!r} is not a `DiscreteLp` instance.'
+                            ''.format(dom))
+#
+#        if dom.exponent != 2.0:
+#            raise ValueError('domain Lp exponent is {} instead of 2.0.'
+#                             ''.format(dom.exponent))
+#        if ran.exponent != 2.0:
+#            raise ValueError('range Lp exponent is {} instead of 2.0.'
+#                             ''.format(ran.exponent))
+#        if not np.all(dom.grid.stride == 1):
+#            raise NotImplementedError('non-uniform grid cell sizes not yet '
+#                                      'supported.')
+
+    @property
+    def is_orthogonal(self):
+        """Whether or not the wavelet basis is orthogonal."""
+        return self.wbasis.orthogonal
+
+    @property
+    def is_biorthogonal(self):
+        """Whether or not the wavelet basis is bi-orthogonal."""
+        return self.wbasis.biorthogonal
+
+    def _call(self, coeff):
+        """Compute the discrete 2D inverse multiresolution wavelet transform
+
+        Parameters
+        ----------
+        coeff: class:`DiscreteLp.Vector` (or `list`??)
+
+        Returns
+        -------
+        arr : `numpy.ndarray` or `DiscreteLp.Vector`
+
+        """
+        coeff_list = array_to_pywt_coeff2d(coeff, self.size_list, self.nscales)
+        x = pywt.waverec2(coeff_list, self.wbasis, self.mode)
+        return self.range.element(x)
+
+
+    @property
+    def adjoint(self):
+        """The adjoint wavelet transform."""
+        if self.is_orthogonal:
+            return self.inverse
+        else:
+            # TODO: put adjoint here
+            return None
+
+    @property
+    def inverse(self):
+        """The inverse wavelet transform."""
+
+        return DiscreteWaveletTrafo(dom=self.range, nscales = self.nscales,
+                                    wbasis = self.wbasis, mode = self.mode)

--- a/odl/util/testutils.py
+++ b/odl/util/testutils.py
@@ -31,8 +31,9 @@ from numpy import ravel_multi_index, prod
 import sys
 from time import time
 
-__all__ = ('almost_equal', 'all_equal', 'all_almost_equal',
-           'Timer', 'timeit', 'ProgressBar', 'ProgressRange')
+__all__ = ('almost_equal', 'all_equal', 'all_almost_equal', 'skip_if_no_cuda',
+           'Timer', 'timeit', 'ProgressBar', 'ProgressRange',
+           'skip_if_no_wavelet')
 
 
 def _places(a, b, default=5):
@@ -148,12 +149,12 @@ try:
     import pytest
     skip_if_no_cuda = pytest.mark.skipif("not odl.CUDA_AVAILABLE",
                                          reason='CUDA not available')
-    skip_if_no_wavelet = pytest.mark.skipif("not odl.tomo.WAVELET_AVILABLE",
-                                         reason='Wavelet not available')
+    skip_if_no_wavelet = pytest.mark.skipif("not odl.trafos.wavelet.WAVELET_AVILABLE",
+                                            reason='Wavelet not available')
 except ImportError:
     def do_nothing(function):
         return function
-    skip_if_no_cuda = skip_if_no_wavelet = do_nothing    
+    skip_if_no_cuda = skip_if_no_wavelet = do_nothing
 
 
 class FailCounter(object):

--- a/odl/util/testutils.py
+++ b/odl/util/testutils.py
@@ -148,9 +148,12 @@ try:
     import pytest
     skip_if_no_cuda = pytest.mark.skipif("not odl.CUDA_AVAILABLE",
                                          reason='CUDA not available')
+    skip_if_no_wavelet = pytest.mark.skipif("not odl.tomo.WAVELET_AVILABLE",
+                                         reason='Wavelet not available')
 except ImportError:
-    def skip_if_no_cuda(function):
+    def do_nothing(function):
         return function
+    skip_if_no_cuda = skip_if_no_wavelet = do_nothing    
 
 
 class FailCounter(object):

--- a/odl/util/testutils.py
+++ b/odl/util/testutils.py
@@ -149,8 +149,9 @@ try:
     import pytest
     skip_if_no_cuda = pytest.mark.skipif("not odl.CUDA_AVAILABLE",
                                          reason='CUDA not available')
-    skip_if_no_wavelet = pytest.mark.skipif("not odl.trafos.wavelet.WAVELET_AVAILABLE",
-                                            reason='Wavelet not available')
+    skip_if_no_wavelet = pytest.mark.skipif(
+        "not odl.trafos.wavelet.WAVELET_AVAILABLE",
+        reason='Wavelet not available')
 except ImportError:
     def do_nothing(function):
         return function

--- a/odl/util/testutils.py
+++ b/odl/util/testutils.py
@@ -149,7 +149,7 @@ try:
     import pytest
     skip_if_no_cuda = pytest.mark.skipif("not odl.CUDA_AVAILABLE",
                                          reason='CUDA not available')
-    skip_if_no_wavelet = pytest.mark.skipif("not odl.trafos.wavelet.WAVELET_AVILABLE",
+    skip_if_no_wavelet = pytest.mark.skipif("not odl.trafos.wavelet.WAVELET_AVAILABLE",
                                             reason='Wavelet not available')
 except ImportError:
     def do_nothing(function):

--- a/test/trafos/wavelet_test.py
+++ b/test/trafos/wavelet_test.py
@@ -79,7 +79,7 @@ def test_wavelet_decomposition3d_et_reconstruction3d():
     wbasis = pywt.Wavelet('db1')
     nscales = 3
     wavelet_coeffs = wavelet_decomposition3d(x, wbasis, mode, nscales)
-    shape_true = (nscales+1, )
+    shape_true = (nscales + 1, )
     assert all_equal(np.shape(wavelet_coeffs), shape_true)
 
     reconstruction = wavelet_reconstruction3d(wavelet_coeffs, wbasis, mode,
@@ -134,7 +134,7 @@ def test_pywt_coeff_to_array_et_array_to_pywt_coeff3d():
 
 @skip_if_no_wavelet
 def test_DiscreteWaveletTrafo():
-    #Verify that the operator works as axpected
+    # Verify that the operator works as axpected
     # 2D test
     n = 16
     x = np.zeros((n, n))
@@ -157,7 +157,7 @@ def test_DiscreteWaveletTrafo():
     # Compute the discrete wavelet transform of discrete imput image
     coeffs = Wop(disc_phantom)
 
-    #Determine the correct range for Wop and verify that coeffs
+    # Determine the correct range for Wop and verify that coeffs
     # is an element of it
     ran_size = np.prod(size_list[0])
     ran_size += sum(3 * np.prod(shape) for shape in size_list[1:-1])

--- a/test/trafos/wavelet_test.py
+++ b/test/trafos/wavelet_test.py
@@ -147,7 +147,7 @@ def test_DiscreteWaveletTrafo():
     # Define a discretized domain
     domain = odl.FunctionSpace(odl.Rectangle([-1, -1], [1, 1]))
     nPoints = np.array([n, n])
-    disc_domain = odl.uniform_discr(domain, nPoints)
+    disc_domain = odl.uniform_discr_fromspace(domain, nPoints)
     disc_phantom = disc_domain.element(x)
 
     # Create the discrete wavelet transform operator.
@@ -190,7 +190,7 @@ def test_DiscreteWaveletTrafo():
     # Define a discretized domain
     domain = odl.FunctionSpace(odl.Cuboid([-1, -1, -1], [1, 1, 1]))
     nPoints = np.array([n, n, n])
-    disc_domain = odl.uniform_discr(domain, nPoints)
+    disc_domain = odl.uniform_discr_fromspace(domain, nPoints)
     disc_phantom = disc_domain.element(x)
 
     # Create the discrete wavelet transform operator related to 3D transform.

--- a/test/trafos/wavelet_test.py
+++ b/test/trafos/wavelet_test.py
@@ -24,7 +24,11 @@ standard_library.install_aliases()
 # External module imports
 import pytest
 import numpy as np
-import pywt
+from odl.trafos.wavelet import WAVELET_AVAILABLE
+if WAVELET_AVAILABLE:
+    import pywt
+else:
+    pywt = None
 
 # ODL imports
 import odl
@@ -32,9 +36,10 @@ from odl.trafos.wavelet import (list_of_coeff_sizes, pywt_coeff_to_array2d,
                                 array_to_pywt_coeff2d, pywt_coeff_to_array3d,
                                 array_to_pywt_coeff3d, wavelet_decomposition3d,
                                 wavelet_reconstruction3d, DiscreteWaveletTrafo)
-from odl.util.testutils import all_almost_equal, all_equal
+from odl.util.testutils import all_almost_equal, all_equal, skip_if_no_wavelet
 
 
+@skip_if_no_wavelet
 def test_list_of_coeffs_sizes():
     # Verify that the helper function does indeed work as expected
     shape = (64, 64)
@@ -50,6 +55,7 @@ def test_list_of_coeffs_sizes():
     assert all_equal(size_list3d, S3d)
 
 
+@skip_if_no_wavelet
 def test_wavelet_decomposition3d_et_reconstruction3d():
     # Test 3D wavelet decomposition and reconstruction and verify that
     # they perform as expected
@@ -81,6 +87,7 @@ def test_wavelet_decomposition3d_et_reconstruction3d():
     assert all_almost_equal(reconstruction, x)
 
 
+@skip_if_no_wavelet
 def test_pywt_coeff_to_array_et_array_to_pywt_coeff2d():
     # Verify that the helper function does indeed work as expected
     wbasis = pywt.Wavelet('db1')
@@ -102,6 +109,7 @@ def test_pywt_coeff_to_array_et_array_to_pywt_coeff2d():
     assert all_almost_equal(reconstruction, x)
 
 
+@skip_if_no_wavelet
 def test_pywt_coeff_to_array_et_array_to_pywt_coeff3d():
     # Verify that the helper function does indeed work as expected
     wbasis = pywt.Wavelet('db1')
@@ -124,6 +132,7 @@ def test_pywt_coeff_to_array_et_array_to_pywt_coeff3d():
     assert all_almost_equal(reconstruction, x)
 
 
+@skip_if_no_wavelet
 def test_DiscreteWaveletTrafo():
     #Verify that the operator works as axpected
     # 2D test

--- a/test/trafos/wavelet_test.py
+++ b/test/trafos/wavelet_test.py
@@ -197,7 +197,7 @@ def test_DiscreteWaveletTrafo():
     Wop = DiscreteWaveletTrafo(disc_domain, nscales, wbasis, mode)
     # Compute the discrete wavelet transform of discrete imput image
     coeffs = Wop(disc_phantom)
-    #Determine the correct range for Wop and verify that coeffs
+    # Determine the correct range for Wop and verify that coeffs
     # is an element of it
     ran_size = np.prod(size_list[0])
     ran_size += sum(7 * np.prod(shape) for shape in size_list[1:-1])

--- a/test/trafos/wavelet_test.py
+++ b/test/trafos/wavelet_test.py
@@ -1,0 +1,213 @@
+# Copyright 2014, 2015 The ODL development group
+#
+# This file is part of ODL.
+#
+# ODL is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# ODL is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with ODL.  If not, see <http://www.gnu.org/licenses/>.
+
+
+# Imports for common Python 2/3 codebase
+from __future__ import print_function, division, absolute_import
+from future import standard_library
+standard_library.install_aliases()
+
+# External module imports
+import pytest
+import numpy as np
+import pywt
+
+# ODL imports
+import odl
+from odl.trafos.wavelet import (list_of_coeff_sizes, pywt_coeff_to_array2d,
+                                array_to_pywt_coeff2d, pywt_coeff_to_array3d,
+                                array_to_pywt_coeff3d, wavelet_decomposition3d,
+                                wavelet_reconstruction3d, DiscreteWaveletTrafo)
+from odl.util.testutils import all_almost_equal, all_equal
+
+
+def test_list_of_coeffs_sizes():
+    # Verify that the helper function does indeed work as expected
+    shape = (64, 64)
+    nscale = 3
+    wbasis = pywt.Wavelet('db2')
+    mode = 'per'
+    size_list = list_of_coeff_sizes(shape, nscale, wbasis, mode)
+    S2d = [(8, 8), (8, 8), (16, 16), (32, 32), (64, 64)]
+    shape = (64, 64, 64)
+    size_list3d = list_of_coeff_sizes(shape, nscale, wbasis, mode)
+    S3d = [(8, 8, 8), (8, 8, 8), (16, 16, 16), (32, 32, 32), (64, 64, 64)]
+    assert all_equal(size_list, S2d)
+    assert all_equal(size_list3d, S3d)
+
+
+def test_wavelet_decomposition3d_et_reconstruction3d():
+    # Test 3D wavelet decomposition and reconstruction and verify that
+    # they perform as expected
+    x = np.random.rand(16, 16, 16)
+    mode = 'sym'
+    wbasis = pywt.Wavelet('db5')
+    nscales = 1
+    wavelet_coeffs = wavelet_decomposition3d(x, wbasis, mode, nscales)
+    aaa = wavelet_coeffs[0]
+    reference = pywt.dwtn(x, wbasis, mode)
+    aaa_reference = reference['aaa']
+    assert all_almost_equal(aaa, aaa_reference)
+
+    reconstruction = wavelet_reconstruction3d(wavelet_coeffs, wbasis, mode,
+                                              nscales)
+    reconstruction_reference = pywt.idwtn(reference, wbasis, mode)
+    assert all_almost_equal(reconstruction, reconstruction_reference)
+    assert all_almost_equal(reconstruction, x)
+    assert all_almost_equal(reconstruction_reference, x)
+
+    wbasis = pywt.Wavelet('db1')
+    nscales = 3
+    wavelet_coeffs = wavelet_decomposition3d(x, wbasis, mode, nscales)
+    shape_true = (nscales+1, )
+    assert all_equal(np.shape(wavelet_coeffs), shape_true)
+
+    reconstruction = wavelet_reconstruction3d(wavelet_coeffs, wbasis, mode,
+                                              nscales)
+    assert all_almost_equal(reconstruction, x)
+
+
+def test_pywt_coeff_to_array_et_array_to_pywt_coeff2d():
+    # Verify that the helper function does indeed work as expected
+    wbasis = pywt.Wavelet('db1')
+    mode = 'zpd'
+    nscales = 2
+    n = 16
+    size_list = list_of_coeff_sizes((n, n), nscales, wbasis, mode)
+    x = np.random.rand(n, n)
+    coeff_list = pywt.wavedec2(x, wbasis, mode, nscales)
+    coeff_arr = pywt_coeff_to_array2d(coeff_list, size_list, nscales)
+    assert isinstance(coeff_arr, (np.ndarray))
+    length_of_array = np.prod(size_list[0])
+    length_of_array += sum(3 * np.prod(shape) for shape in size_list[1:-1])
+    assert all_equal(len(coeff_arr), length_of_array)
+
+    coeff_list2 = array_to_pywt_coeff2d(coeff_arr, size_list, nscales)
+    assert all_equal(coeff_list, coeff_list2)
+    reconstruction = pywt.waverec2(coeff_list2, wbasis, mode)
+    assert all_almost_equal(reconstruction, x)
+
+
+def test_pywt_coeff_to_array_et_array_to_pywt_coeff3d():
+    # Verify that the helper function does indeed work as expected
+    wbasis = pywt.Wavelet('db1')
+    mode = 'ppd'
+    nscales = 2
+    n = 16
+    size_list = list_of_coeff_sizes((n, n, n), nscales, wbasis, mode)
+    x = np.random.rand(n, n, n)
+    coeff_dict = wavelet_decomposition3d(x, wbasis, mode, nscales)
+    coeff_arr = pywt_coeff_to_array3d(coeff_dict, size_list, nscales)
+    assert isinstance(coeff_arr, (np.ndarray))
+    length_of_array = np.prod(size_list[0])
+    length_of_array += sum(7 * np.prod(shape) for shape in size_list[1:-1])
+    assert all_equal(len(coeff_arr), length_of_array)
+
+    coeff_dict2 = array_to_pywt_coeff3d(coeff_arr, size_list, nscales)
+    reconstruction = wavelet_reconstruction3d(coeff_dict2, wbasis, mode,
+                                              nscales)
+    assert all_equal(coeff_dict, coeff_dict)
+    assert all_almost_equal(reconstruction, x)
+
+
+def test_DiscreteWaveletTrafo():
+    #Verify that the operator works as axpected
+    # 2D test
+    n = 16
+    x = np.zeros((n, n))
+    x[5:10, 5:10] = 1
+    wbasis = pywt.Wavelet('db1')
+    nscales = 2
+    mode = 'sym'
+    size_list = list_of_coeff_sizes((n, n), nscales, wbasis, mode)
+
+    # Define a discretized domain
+    domain = odl.FunctionSpace(odl.Rectangle([-1, -1], [1, 1]))
+    nPoints = np.array([n, n])
+    disc_domain = odl.uniform_discr(domain, nPoints)
+    disc_phantom = disc_domain.element(x)
+
+    # Create the discrete wavelet transform operator.
+    # Only the domain of the operator needs to be defined
+    Wop = DiscreteWaveletTrafo(disc_domain, nscales, wbasis, mode)
+
+    # Compute the discrete wavelet transform of discrete imput image
+    coeffs = Wop(disc_phantom)
+
+    #Determine the correct range for Wop and verify that coeffs
+    # is an element of it
+    ran_size = np.prod(size_list[0])
+    ran_size += sum(3 * np.prod(shape) for shape in size_list[1:-1])
+    disc_range = disc_domain.dspace_type(ran_size, dtype=disc_domain.dtype)
+    assert coeffs in disc_range
+
+    # Compute the inverse wavelet transform
+    reconstruction1 = Wop.inverse(coeffs)
+    # With othogonal wavelets the inverse is the adjoint
+    reconstruction2 = Wop.adjoint(coeffs)
+    # Verify that the output of Wop.inverse and Wop.adjoint are the same
+    assert all_almost_equal(reconstruction1.asarray(),
+                            reconstruction2.asarray())
+
+    # Verify that reconstructions lie in correct discretized domain
+    assert reconstruction1 in disc_domain
+    assert reconstruction2 in disc_domain
+    assert all_almost_equal(reconstruction1.asarray(), x)
+    assert all_almost_equal(reconstruction2.asarray(), x)
+
+    # 3D test
+    n = 16
+    x = np.zeros((n, n, n))
+    x[5:10, 5:10, 5:10] = 1
+    wbasis = pywt.Wavelet('db2')
+    nscales = 1
+    mode = 'per'
+    size_list = list_of_coeff_sizes((n, n, n), nscales, wbasis, mode)
+
+    # Define a discretized domain
+    domain = odl.FunctionSpace(odl.Cuboid([-1, -1, -1], [1, 1, 1]))
+    nPoints = np.array([n, n, n])
+    disc_domain = odl.uniform_discr(domain, nPoints)
+    disc_phantom = disc_domain.element(x)
+
+    # Create the discrete wavelet transform operator related to 3D transform.
+    Wop = DiscreteWaveletTrafo(disc_domain, nscales, wbasis, mode)
+    # Compute the discrete wavelet transform of discrete imput image
+    coeffs = Wop(disc_phantom)
+    #Determine the correct range for Wop and verify that coeffs
+    # is an element of it
+    ran_size = np.prod(size_list[0])
+    ran_size += sum(7 * np.prod(shape) for shape in size_list[1:-1])
+    disc_range = disc_domain.dspace_type(ran_size, dtype=disc_domain.dtype)
+    assert coeffs in disc_range
+
+    # Compute the inverse wavelet transform
+    reconstruction1 = Wop.inverse(coeffs)
+    # With othogonal wavelets the inverse is the adjoint
+    reconstruction2 = Wop.adjoint(coeffs)
+
+    # Verify that the output of Wop.inverse and Wop.adjoint are the same
+    assert all_almost_equal(reconstruction1, reconstruction2)
+
+    # Verify that reconstructions lie in correct discretized domain
+    assert reconstruction1 in disc_domain
+    assert reconstruction2 in disc_domain
+    assert all_almost_equal(reconstruction1.asarray(), x)
+    assert all_almost_equal(reconstruction2, disc_phantom)
+
+if __name__ == '__main__':
+    pytest.main(str(__file__.replace('\\', '/') + ' -v'))

--- a/test/trafos/wavelet_test.py
+++ b/test/trafos/wavelet_test.py
@@ -32,7 +32,7 @@ else:
 
 # ODL imports
 import odl
-from odl.trafos.wavelet import (list_of_coeff_sizes, pywt_coeff_to_array2d,
+from odl.trafos.wavelet import (coeff_size_list, pywt_coeff_to_array2d,
                                 array_to_pywt_coeff2d, pywt_coeff_to_array3d,
                                 array_to_pywt_coeff3d, wavelet_decomposition3d,
                                 wavelet_reconstruction3d, DiscreteWaveletTrafo)
@@ -40,23 +40,23 @@ from odl.util.testutils import all_almost_equal, all_equal, skip_if_no_wavelet
 
 
 @skip_if_no_wavelet
-def test_list_of_coeffs_sizes():
+def test_coeff_size_list():
     # Verify that the helper function does indeed work as expected
     shape = (64, 64)
     nscale = 3
     wbasis = pywt.Wavelet('db2')
     mode = 'per'
-    size_list = list_of_coeff_sizes(shape, nscale, wbasis, mode)
+    size_list = coeff_size_list(shape, nscale, wbasis, mode)
     S2d = [(8, 8), (8, 8), (16, 16), (32, 32), (64, 64)]
     shape = (64, 64, 64)
-    size_list3d = list_of_coeff_sizes(shape, nscale, wbasis, mode)
+    size_list3d = coeff_size_list(shape, nscale, wbasis, mode)
     S3d = [(8, 8, 8), (8, 8, 8), (16, 16, 16), (32, 32, 32), (64, 64, 64)]
     assert all_equal(size_list, S2d)
     assert all_equal(size_list3d, S3d)
 
 
 @skip_if_no_wavelet
-def test_wavelet_decomposition3d_et_reconstruction3d():
+def test_wavelet_decomposition3d_and_reconstruction3d():
     # Test 3D wavelet decomposition and reconstruction and verify that
     # they perform as expected
     x = np.random.rand(16, 16, 16)
@@ -88,13 +88,13 @@ def test_wavelet_decomposition3d_et_reconstruction3d():
 
 
 @skip_if_no_wavelet
-def test_pywt_coeff_to_array_et_array_to_pywt_coeff2d():
+def test_pywt_coeff_to_array_and_array_to_pywt_coeff2d():
     # Verify that the helper function does indeed work as expected
     wbasis = pywt.Wavelet('db1')
     mode = 'zpd'
     nscales = 2
     n = 16
-    size_list = list_of_coeff_sizes((n, n), nscales, wbasis, mode)
+    size_list = coeff_size_list((n, n), nscales, wbasis, mode)
     x = np.random.rand(n, n)
     coeff_list = pywt.wavedec2(x, wbasis, mode, nscales)
     coeff_arr = pywt_coeff_to_array2d(coeff_list, size_list, nscales)
@@ -110,13 +110,13 @@ def test_pywt_coeff_to_array_et_array_to_pywt_coeff2d():
 
 
 @skip_if_no_wavelet
-def test_pywt_coeff_to_array_et_array_to_pywt_coeff3d():
+def test_pywt_coeff_to_array_and_array_to_pywt_coeff3d():
     # Verify that the helper function does indeed work as expected
     wbasis = pywt.Wavelet('db1')
     mode = 'ppd'
     nscales = 2
     n = 16
-    size_list = list_of_coeff_sizes((n, n, n), nscales, wbasis, mode)
+    size_list = coeff_size_list((n, n, n), nscales, wbasis, mode)
     x = np.random.rand(n, n, n)
     coeff_dict = wavelet_decomposition3d(x, wbasis, mode, nscales)
     coeff_arr = pywt_coeff_to_array3d(coeff_dict, size_list, nscales)
@@ -142,7 +142,7 @@ def test_DiscreteWaveletTrafo():
     wbasis = pywt.Wavelet('db1')
     nscales = 2
     mode = 'sym'
-    size_list = list_of_coeff_sizes((n, n), nscales, wbasis, mode)
+    size_list = coeff_size_list((n, n), nscales, wbasis, mode)
 
     # Define a discretized domain
     domain = odl.FunctionSpace(odl.Rectangle([-1, -1], [1, 1]))
@@ -185,7 +185,7 @@ def test_DiscreteWaveletTrafo():
     wbasis = pywt.Wavelet('db2')
     nscales = 1
     mode = 'per'
-    size_list = list_of_coeff_sizes((n, n, n), nscales, wbasis, mode)
+    size_list = coeff_size_list((n, n, n), nscales, wbasis, mode)
 
     # Define a discretized domain
     domain = odl.FunctionSpace(odl.Cuboid([-1, -1, -1], [1, 1, 1]))


### PR DESCRIPTION
Implement 2D and 3D wavelet transforms. These depend on [PyWavelets] (http://www.pybytes.com/pywavelets/) which is a free Open Source wavelet transform software for Python, i.e. in order to work  *pywt* needs to be installed first.

The `DiscreteWaveletTrafo` (and its adjoint and inverse) takes as input and gives as output a `DiscreteLp.Vectors`. They call for helper functions given in the `wavelet.py` file. The helper functions `pywt_coeff_to_array2d` and `pywt_coeff_to_array3d` convert a *pywt* coefficient `list` into a flat array. Reverse is done by `array_to_pywt_coeff2d` and `array_to_pywt_coeff3d`. Helper function `list_of_coeff_sizes` construct a `list` containing the sizes of the wavelet approximation and detail coefficients when a desired wavelet basis, number of scaling levels and the shape of the original image are given. The function `wavelet_decomposition3d` computes the discrete 3D multiresolution wavelet decomposition at the given level for a given `DiscreteLp.Vector`. Its pair `wavelet_reconstruction3d` computes a discrete 3D multiresolution wavelet reconstruction from a given wavelet coefficient `list`.

The `DiscreteWaveletTrafo` is implemented such that the user need only to define the domain for the operator `~odl.discr.lp_discr.DiscreteLp` (the "image domain"), the correct range is determined from the given inputs. 

