### PR TITLE
Issue 64  profile

### DIFF
--- a/odl/diagnostics/examples.py
+++ b/odl/diagnostics/examples.py
@@ -121,7 +121,7 @@ def vector_examples(space):
                 inside = np.logical_and(inside, points < mean + std)
                 inside = np.logical_and(inside, mean - std < points)
 
-            return inside.astype(space.dtype)
+            return inside.astype(space.dtype, copy=False)
 
         yield ('Cube', element(_cube_fun))
 
@@ -132,7 +132,7 @@ def vector_examples(space):
 
                 for points, mean, std in zip(args, means, stds):
                     r += (points - mean) ** 2 / std ** 2
-                return (r < 1.0).astype(space.dtype)
+                return (r < 1.0).astype(space.dtype, copy=False)
 
             yield ('Sphere', element(_sphere_fun))
 

--- a/odl/discr/discr_mappings.py
+++ b/odl/discr/discr_mappings.py
@@ -104,7 +104,7 @@ class FunctionSetMapping(with_metaclass(ABCMeta, Operator)):
 
         dom = fset if map_type == 'restriction' else dspace
         ran = dspace if map_type == 'restriction' else fset
-        super().__init__(dom, ran, linear=linear)
+        Operator.__init__(self, dom, ran, linear=linear)
         self._grid = grid
         self._order = order
 

--- a/odl/discr/discr_mappings.py
+++ b/odl/discr/discr_mappings.py
@@ -23,10 +23,8 @@ from __future__ import print_function, division, absolute_import
 from future import standard_library
 standard_library.install_aliases()
 from builtins import super, str, zip
-from odl.util.utility import with_metaclass
 
 # External imports
-from abc import ABCMeta
 import numpy as np
 from scipy.interpolate import interpnd
 from scipy.interpolate.interpnd import _ndim_coords_from_arrays
@@ -44,7 +42,7 @@ __all__ = ('FunctionSetMapping',
            'NearestInterpolation', 'LinearInterpolation')
 
 
-class FunctionSetMapping(with_metaclass(ABCMeta, Operator)):
+class FunctionSetMapping(Operator):
 
     """Abstract base class for function set discretization mappings."""
 

--- a/odl/discr/discr_mappings.py
+++ b/odl/discr/discr_mappings.py
@@ -148,7 +148,7 @@ class RawGridCollocation(FunctionSetMapping):
     used by all core discretization classes.
     """
 
-    def __init__(self, ip_fset, grid, dspace, order='C'):
+    def __init__(self, ip_fset, grid, dspace, order='C', linear=False):
         """Initialize a new instance.
 
         Parameters
@@ -169,7 +169,8 @@ class RawGridCollocation(FunctionSetMapping):
             means the first grid axis varies fastest, the last most
             slowly, 'F' vice versa.
         """
-        super().__init__('restriction', ip_fset, grid, dspace, order)
+        FunctionSetMapping.__init__(self, 'restriction', ip_fset, grid, dspace,
+                                    order, linear)
 
         # TODO: remove this requirement depending on the vectorization
         # solution
@@ -258,7 +259,7 @@ class RawGridCollocation(FunctionSetMapping):
         return self.range.element(values)
 
 
-class GridCollocation(RawGridCollocation, FunctionSetMapping):
+class GridCollocation(RawGridCollocation):
 
     """Function evaluation at grid points.
 
@@ -289,16 +290,15 @@ class GridCollocation(RawGridCollocation, FunctionSetMapping):
             means the first grid axis varies fastest, the last most
             slowly, 'F' vice versa.
         """
-        RawGridCollocation.__init__(self, ip_fspace, grid, dspace, order)
-        FunctionSetMapping.__init__(self, 'restriction', ip_fspace,
-                                    grid, dspace, order, linear=True)
+        RawGridCollocation.__init__(self, ip_fspace, grid, dspace, order,
+                                    linear=True)
 
 
 class RawNearestInterpolation(FunctionSetMapping):
 
     """Nearest neighbor interpolation as a raw `Operator`."""
 
-    def __init__(self, ip_fset, grid, dspace, order='C'):
+    def __init__(self, ip_fset, grid, dspace, order='C', linear=False):
         """Initialize a new `RawNearestInterpolation` instance.
 
         Parameters
@@ -319,7 +319,8 @@ class RawNearestInterpolation(FunctionSetMapping):
             means the first grid axis varies fastest, the last most
             slowly, 'F' vice versa.
         """
-        super().__init__('extension', ip_fset, grid, dspace, order)
+        FunctionSetMapping.__init__(self, 'extension', ip_fset, grid, dspace,
+                                    order, linear)
 
         # TODO: remove this requirement depending on the vectorization
         # solution
@@ -411,8 +412,7 @@ class RawNearestInterpolation(FunctionSetMapping):
         return self.range.element(func)
 
 
-class NearestInterpolation(RawNearestInterpolation,
-                           FunctionSetMapping):
+class NearestInterpolation(RawNearestInterpolation):
 
     """Nearest neighbor interpolation as a linear operator."""
 
@@ -472,9 +472,8 @@ class NearestInterpolation(RawNearestInterpolation,
         >>> function(0.3, 0.6)  # closest to index (1, 1) -> 3
         (3+4j)
         """
-        RawNearestInterpolation.__init__(self, ip_fspace, grid, dspace, order)
-        FunctionSetMapping.__init__(self, 'extension', ip_fspace,
-                                    grid, dspace, order, linear=True)
+        RawNearestInterpolation.__init__(self, ip_fspace, grid, dspace, order,
+                                         linear=True)
 
 
 class LinearInterpolation(FunctionSetMapping):

--- a/odl/discr/discretization.py
+++ b/odl/discr/discretization.py
@@ -23,18 +23,13 @@ from __future__ import print_function, division, absolute_import
 from future import standard_library
 standard_library.install_aliases()
 from builtins import super
-from odl.util.utility import with_metaclass
-
-# External
-from abc import ABCMeta
 
 # ODL
 from odl.util.utility import arraynd_repr, arraynd_str
 from odl.operator.operator import Operator
 from odl.space.base_ntuples import (NtuplesBase, NtuplesBaseVector,
                                     FnBase, FnBaseVector)
-from odl.space.ntuples import (Ntuples, NtuplesVector, Fn, FnVector,
-                               Rn, RnVector, Cn, CnVector)
+from odl.space.ntuples import Ntuples, Fn, Rn, Cn
 from odl.set.sets import Set, RealNumbers, ComplexNumbers
 from odl.set.space import LinearSpace
 from odl.space import CUDA_AVAILABLE
@@ -51,7 +46,7 @@ __all__ = ('RawDiscretization', 'RawDiscretizationVector',
            'Discretization', 'DiscretizationVector')
 
 
-class RawDiscretization(with_metaclass(ABCMeta, NtuplesBase)):
+class RawDiscretization(NtuplesBase):
 
     """Abstract raw discretization class.
 

--- a/odl/discr/grid.py
+++ b/odl/discr/grid.py
@@ -118,7 +118,7 @@ class TensorGrid(Set):
         if not coord_vectors:
             raise ValueError('No coordinate vectors given.')
 
-        vecs = tuple(np.atleast_1d(vec).astype(float)
+        vecs = tuple(np.atleast_1d(vec).astype('float64')
                      for vec in coord_vectors)
         for i, vec in enumerate(vecs):
 
@@ -785,9 +785,9 @@ class RegularGrid(TensorGrid):
         >>> rg.ndim, rg.ntotal
         (2, 6)
         """
-        min_pt = np.atleast_1d(min_pt).astype(np.float64)
-        max_pt = np.atleast_1d(max_pt).astype(np.float64)
-        shape = np.atleast_1d(shape).astype(np.int64)
+        min_pt = np.atleast_1d(min_pt).astype('float64')
+        max_pt = np.atleast_1d(max_pt).astype('float64')
+        shape = np.atleast_1d(shape).astype('int64')
 
         if any(x.ndim != 1 for x in (min_pt, max_pt, shape)):
             raise ValueError('input arrays have dimensions {}, {}, {} '
@@ -1134,7 +1134,7 @@ def uniform_sampling(intv_prod, num_nodes, as_midp=True):
     >>> grid.coord_vectors
     (array([-1.5, -0.5]), array([ 2.  ,  2.25,  2.5 ,  2.75,  3.  ]))
     """
-    num_nodes = np.atleast_1d(num_nodes).astype(np.int64)
+    num_nodes = np.atleast_1d(num_nodes).astype('int64')
 
     if not isinstance(intv_prod, IntervalProd):
         raise TypeError('interval product {!r} not an `IntervalProd` instance.'

--- a/odl/discr/grid.py
+++ b/odl/discr/grid.py
@@ -825,7 +825,7 @@ class RegularGrid(TensorGrid):
 
         coord_vecs = [np.linspace(mi, ma, num, endpoint=True, dtype=np.float64)
                       for mi, ma, num in zip(min_pt, max_pt, shape)]
-        super().__init__(*coord_vecs, **kwargs)
+        TensorGrid.__init__(self, *coord_vecs, **kwargs)
         self._center = (self.max_pt + self.min_pt) / 2
         self._stride = np.ones(len(shape), dtype='float64')
         idcs = np.where(shape > 1)

--- a/odl/discr/lp_discr.py
+++ b/odl/discr/lp_discr.py
@@ -106,7 +106,7 @@ class DiscreteLp(Discretization):
         else:
             raise NotImplementedError
 
-        super().__init__(fspace, dspace, restriction, extension)
+        Discretization.__init__(self, fspace, dspace, restriction, extension)
 
         self._exponent = float(exponent)
         if (hasattr(self.dspace, 'exponent') and

--- a/odl/operator/operator.py
+++ b/odl/operator/operator.py
@@ -122,12 +122,6 @@ class _OperatorMeta(ABCMeta):
     def __call__(cls, *args, **kwargs):
         """Create a new class ``cls`` from given arguments."""
         obj = ABCMeta.__call__(cls, *args, **kwargs)
-        if not hasattr(obj, 'domain'):
-            raise NotImplementedError('`Operator` instances must have a '
-                                      '`Operator.domain` attribute.')
-        if not hasattr(obj, 'range'):
-            raise NotImplementedError('`Operator` instances must have a '
-                                      '`Operator.range` attribute.')
         if not hasattr(obj, '_call') and not hasattr(obj, '_apply'):
             raise NotImplementedError('`Operator` instances must either '
                                       'have `_call` or `_apply` as '

--- a/odl/operator/operator.py
+++ b/odl/operator/operator.py
@@ -25,7 +25,6 @@ from builtins import object, super
 from odl.util.utility import with_metaclass
 
 # External module imports
-from abc import ABCMeta
 from numbers import Number, Integral
 
 # ODL imports
@@ -97,7 +96,7 @@ def _default_apply(self, x, out, *args, **kwargs):
     out.assign(self._call(x, *args, **kwargs))
 
 
-class _OperatorMeta(ABCMeta):
+class _OperatorMeta(type):
 
     """Metaclass used by `Operator` to ensure correct methods.
 
@@ -121,7 +120,7 @@ class _OperatorMeta(ABCMeta):
 
     def __call__(cls, *args, **kwargs):
         """Create a new class ``cls`` from given arguments."""
-        obj = ABCMeta.__call__(cls, *args, **kwargs)
+        obj = type.__call__(cls, *args, **kwargs)
         if not hasattr(obj, '_call') and not hasattr(obj, '_apply'):
             raise NotImplementedError('`Operator` instances must either '
                                       'have `_call` or `_apply` as '

--- a/odl/set/domain.py
+++ b/odl/set/domain.py
@@ -59,8 +59,8 @@ class IntervalProd(Set):
         >>> rbox
         IntervalProd([-1.0, 2.5, 70.0], [-0.5, 10.0, 75.0])
         """
-        self._begin = np.atleast_1d(begin).astype(np.float64)
-        self._end = np.atleast_1d(end).astype(np.float64)
+        self._begin = np.atleast_1d(begin).astype('float64')
+        self._end = np.atleast_1d(end).astype('float64')
 
         if self._begin.ndim > 1:
             raise ValueError('begin {} is {}- instead of 1-dimensional.'

--- a/odl/set/sets.py
+++ b/odl/set/sets.py
@@ -239,7 +239,7 @@ class Strings(Set):
         return 'Strings({})'.format(self.length)
 
 
-class Field(with_metaclass(ABCMeta, Set)):
+class Field(Set):
     """Any set that satisfies the field axioms
 
     For example `RealNumbers`, `ComplexNumbers` or

--- a/odl/set/space.py
+++ b/odl/set/space.py
@@ -168,7 +168,7 @@ class LinearSpace(Set):
         This is the strict default where spaces must be equal.
         Subclasses may choose to implement a less strict check.
         """
-        return isinstance(other, LinearSpaceVector) and other.space == self
+        return getattr(other, 'space', None) == self
 
     # Error checking variant of methods
     def lincomb(self, a, x1, b=None, x2=None, out=None):

--- a/odl/set/space.py
+++ b/odl/set/space.py
@@ -36,10 +36,9 @@ from __future__ import print_function, division, absolute_import
 from builtins import object, range, str
 from future import standard_library
 standard_library.install_aliases()
-from odl.util.utility import with_metaclass
 
 # External module imports
-from abc import ABCMeta, abstractmethod, abstractproperty
+from abc import abstractmethod
 import math as m
 
 # ODL imports
@@ -392,7 +391,7 @@ class LinearSpace(Set):
         return LinearSpaceVector
 
 
-class LinearSpaceVector(with_metaclass(ABCMeta, object)):
+class LinearSpaceVector(object):
     """Abstract `LinearSpace` element.
 
     Not intended for creation of vectors, use the space's

--- a/odl/space/base_ntuples.py
+++ b/odl/space/base_ntuples.py
@@ -22,7 +22,7 @@ from __future__ import print_function, division, absolute_import
 
 from future import standard_library
 standard_library.install_aliases()
-from builtins import int, super
+from builtins import int
 
 # External module imports
 from abc import ABCMeta, abstractmethod
@@ -346,7 +346,7 @@ class FnBase(NtuplesBase, LinearSpace):
             objects or as string.
             Only scalar data types (numbers) are allowed.
         """
-        super().__init__(size, dtype)
+        NtuplesBase.__init__(self, size, dtype)
         if not is_scalar_dtype(self.dtype):
             raise TypeError('{!r} is not a scalar data type.'.format(dtype))
 

--- a/odl/space/base_ntuples.py
+++ b/odl/space/base_ntuples.py
@@ -295,7 +295,7 @@ class NtuplesBaseVector(with_metaclass(ABCMeta, object)):
         if dtype is None:
             return self.asarray()
         else:
-            return self.asarray().astype(dtype)
+            return self.asarray().astype(dtype, copy=False)
 
     def __array_wrap__(self, obj):
         """Return a new vector from the data in obj.

--- a/odl/space/base_ntuples.py
+++ b/odl/space/base_ntuples.py
@@ -151,7 +151,7 @@ class NtuplesBase(with_metaclass(ABCMeta, Set)):
         return NtuplesBaseVector
 
 
-class NtuplesBaseVector(with_metaclass(ABCMeta, object)):
+class NtuplesBaseVector(object):
 
     """Abstract class for representation of `NtuplesBase` elements.
 
@@ -397,7 +397,7 @@ class FnBaseVector(NtuplesBaseVector, LinearSpaceVector):
         return LinearSpaceVector.copy(self)
 
 
-class FnWeightingBase(with_metaclass(ABCMeta, object)):
+class FnWeightingBase(object):
 
     """Abstract base class for weighting of `FnBase` spaces.
 

--- a/odl/space/ntuples.py
+++ b/odl/space/ntuples.py
@@ -33,6 +33,7 @@ from future.utils import native
 # External module imports
 # pylint: disable=no-name-in-module
 import ctypes
+from numbers import Integral
 from functools import partial
 from math import sqrt
 import numpy as np
@@ -342,12 +343,11 @@ class NtuplesVector(NtuplesBaseVector):
         >>> x[1:3].space
         Ntuples(2, '<U6')
         """
-        try:
-            return self.data[int(indices)]  # single index
-        except TypeError:
+        if isinstance(indices, Integral):
+            return self.data[indices]  # single index
+        else:
             arr = self.data[indices]
-            return type(self.space)(
-                len(arr), dtype=self.dtype).element(arr)
+            return type(self.space)(len(arr), dtype=self.dtype).element(arr)
 
     def __setitem__(self, indices, values):
         """Set values of this vector.
@@ -2131,8 +2131,8 @@ class FnConstWeighting(FnWeightingBase):
 
             Can only be used if ``exponent`` is 2.0.
         """
-        super().__init__(impl='numpy', exponent=exponent,
-                         dist_using_inner=dist_using_inner)
+        FnWeightingBase.__init__(self, impl='numpy', exponent=exponent,
+                                 dist_using_inner=dist_using_inner)
         self._const = float(constant)
         if self.const <= 0:
             raise ValueError('constant {} is not positive.'.format(constant))
@@ -2327,8 +2327,8 @@ class FnNoWeighting(FnConstWeighting):
 
             Can only be used if ``exponent`` is 2.0.
         """
-        super().__init__(constant=1.0, exponent=exponent,
-                         dist_using_inner=dist_using_inner)
+        FnConstWeighting.__init__(self, constant=1.0, exponent=exponent,
+                                  dist_using_inner=dist_using_inner)
 
     def __repr__(self):
         """``w.__repr__() <==> repr(w)``."""

--- a/odl/space/ntuples.py
+++ b/odl/space/ntuples.py
@@ -182,7 +182,7 @@ class NtuplesVector(NtuplesBaseVector):
 
         self._data = data
 
-        super().__init__(space)
+        NtuplesBaseVector.__init__(self, space)
 
     @property
     def data(self):
@@ -676,7 +676,7 @@ class Fn(FnBase, Ntuples):
 
                 Default: `False`.
         """
-        super().__init__(size, dtype)
+        FnBase.__init__(self, size, dtype)
 
         dist = kwargs.pop('dist', None)
         norm = kwargs.pop('norm', None)
@@ -1021,7 +1021,7 @@ class FnVector(FnBaseVector, NtuplesVector):
         if not isinstance(space, Fn):
             raise TypeError('{!r} not an `Fn` instance.'
                             ''.format(space))
-        super().__init__(space, data)
+        NtuplesVector.__init__(self, space, data)
 
     @property
     def real(self):
@@ -1204,7 +1204,7 @@ class Cn(Fn):
         kwargs : {'weight', 'dist', 'norm', 'inner', 'dist_using_inner'}
             See `Fn`
         """
-        super().__init__(size, dtype, **kwargs)
+        Fn.__init__(self, size, dtype, **kwargs)
 
         if not is_complex_floating_dtype(self._dtype):
             raise TypeError('data type {!r} not a complex floating-point type.'
@@ -1270,7 +1270,7 @@ class Rn(Fn):
         kwargs : {'weight', 'dist', 'norm', 'inner', 'dist_using_inner'}
             See `Fn`
         """
-        super().__init__(size, dtype, **kwargs)
+        Fn.__init__(self, size, dtype, **kwargs)
 
         if not is_real_floating_dtype(self.dtype):
             raise TypeError('data type {!r} not a real floating-point type.'

--- a/odl/space/ntuples.py
+++ b/odl/space/ntuples.py
@@ -169,6 +169,18 @@ class NtuplesVector(NtuplesBaseVector):
 
     def __init__(self, space, data):
         """Initialize a new instance."""
+        if not isinstance(space, Ntuples):
+            raise TypeError('{!r} not an `Ntuples` instance.'
+                            ''.format(space))
+
+        if not isinstance(data, np.ndarray):
+            raise TypeError('data {!r} not a `numpy.ndarray` instance.'
+                            ''.format(data))
+
+        if data.dtype != space.dtype:
+            raise TypeError('data {!r} not of dtype {!r}.'
+                            ''.format(data, space.dtype))
+
         self._data = data
 
         NtuplesBaseVector.__init__(self, space)
@@ -1006,6 +1018,10 @@ class FnVector(FnBaseVector, NtuplesVector):
 
     def __init__(self, space, data):
         """Initialize a new instance."""
+        if not isinstance(space, Fn):
+            raise TypeError('{!r} not an `Fn` instance.'
+                            ''.format(space))
+
         NtuplesVector.__init__(self, space, data)
 
     @property

--- a/odl/space/ntuples.py
+++ b/odl/space/ntuples.py
@@ -169,18 +169,6 @@ class NtuplesVector(NtuplesBaseVector):
 
     def __init__(self, space, data):
         """Initialize a new instance."""
-        if not isinstance(space, Ntuples):
-            raise TypeError('{!r} not an `Ntuples` instance.'
-                            ''.format(space))
-
-        if not isinstance(data, np.ndarray):
-            raise TypeError('data {!r} not a `numpy.ndarray` instance.'
-                            ''.format(data))
-
-        if data.dtype != space.dtype:
-            raise TypeError('data {!r} not of dtype {!r}.'
-                            ''.format(data, space.dtype))
-
         self._data = data
 
         NtuplesBaseVector.__init__(self, space)
@@ -1018,9 +1006,6 @@ class FnVector(FnBaseVector, NtuplesVector):
 
     def __init__(self, space, data):
         """Initialize a new instance."""
-        if not isinstance(space, Fn):
-            raise TypeError('{!r} not an `Fn` instance.'
-                            ''.format(space))
         NtuplesVector.__init__(self, space, data)
 
     @property

--- a/odl/util/testutils.py
+++ b/odl/util/testutils.py
@@ -105,10 +105,10 @@ def all_equal(iter1, iter2):
 def all_almost_equal(iter1, iter2, places=None):
     # Sentinel object used to check that both iterators are the same length
 
-    if iter1 is None and iter2 is None:
+    if iter1 is iter2 or iter1 == iter2:
         return True
 
-    if iter1 is iter2 or iter1 == iter2:
+    if iter1 is None and iter2 is None:
         return True
 
     if places is None:

--- a/odl/util/testutils.py
+++ b/odl/util/testutils.py
@@ -78,14 +78,18 @@ def all_equal(iter1, iter2):
     # Sentinel object used to check that both iterators are the same length
     diff_length_sentinel = object()
 
+    try:
+        if iter1 == iter2:
+            return True
+    except ValueError:
+        pass
+
     if iter1 is None and iter2 is None:
         return True
 
     try:
         i1 = iter(iter1)
         i2 = iter(iter2)
-        if isinstance(iter1, basestring) or isinstance(iter2, basestring):
-            return iter1 == iter2
     except TypeError:
         return iter1 == iter2
 

--- a/odl/util/testutils.py
+++ b/odl/util/testutils.py
@@ -37,11 +37,11 @@ __all__ = ('almost_equal', 'all_equal', 'all_almost_equal', 'skip_if_no_cuda',
 
 
 def _places(a, b, default=5):
-
     dtype1 = getattr(a, 'dtype', object)
     dtype2 = getattr(b, 'dtype', object)
+    small_dtypes = [np.float32, np.complex64]
 
-    if any(dtype in [np.float32, np.complex64] for dtype in [dtype1, dtype2]):
+    if dtype1 in small_dtypes or dtype2 in small_dtypes:
         return 3
     else:
         return default
@@ -104,13 +104,15 @@ def all_equal(iter1, iter2):
 
 def all_almost_equal(iter1, iter2, places=None):
     # Sentinel object used to check that both iterators are the same length
-    diff_length_sentinel = object()
-
-    if places is None:
-        places = _places(iter1, iter2, None)
 
     if iter1 is None and iter2 is None:
         return True
+
+    if iter1 is iter2 or iter1 == iter2:
+        return True
+
+    if places is None:
+        places = _places(iter1, iter2, None)
 
     try:
         i1 = iter(iter1)
@@ -118,6 +120,7 @@ def all_almost_equal(iter1, iter2, places=None):
     except TypeError:
         return almost_equal(iter1, iter2, places)
 
+    diff_length_sentinel = object()
     for [ip1, ip2] in zip_longest(i1, i2,
                                   fillvalue=diff_length_sentinel):
         # Verify that none of the lists has ended (then they are not the

--- a/test/discr/grid_test.py
+++ b/test/discr/grid_test.py
@@ -20,7 +20,7 @@
 from __future__ import print_function, division, absolute_import
 from future import standard_library
 standard_library.install_aliases()
-from builtins import range, str, zip
+from builtins import zip
 
 # External module imports
 import pytest

--- a/test/space/cu_ntuples_test.py
+++ b/test/space/cu_ntuples_test.py
@@ -20,7 +20,7 @@
 from __future__ import print_function, division, absolute_import
 from future import standard_library
 standard_library.install_aliases()
-from builtins import range, str
+from builtins import range
 
 # External module imports
 import pytest

--- a/test/space/cu_ntuples_test.py
+++ b/test/space/cu_ntuples_test.py
@@ -48,12 +48,12 @@ from odl.util.testutils import (all_equal, all_almost_equal, almost_equal,
 def _array(fn):
     # Generate numpy vectors, real or complex or int
     if np.issubdtype(fn.dtype, np.floating):
-        return np.random.rand(fn.size).astype(fn.dtype)
+        return np.random.rand(fn.size).astype(fn.dtype, copy=False)
     elif np.issubdtype(fn.dtype, np.integer):
-        return np.random.randint(0, 10, fn.size).astype(fn.dtype)
+        return np.random.randint(0, 10, fn.size).astype(fn.dtype, copy=False)
     else:
         return (np.random.rand(fn.size) +
-                1j * np.random.rand(fn.size)).astype(fn.dtype)
+                1j * np.random.rand(fn.size)).astype(fn.dtype, copy=False)
 
 
 def _element(fn):

--- a/test/space/ntuples_test.py
+++ b/test/space/ntuples_test.py
@@ -23,7 +23,6 @@ standard_library.install_aliases()
 from builtins import range
 
 # External module imports
-from math import ceil
 import numpy as np
 import pytest
 import scipy as sp
@@ -49,12 +48,12 @@ from odl.util.testutils import almost_equal, all_almost_equal, all_equal
 def _array(fn):
     # Generate numpy vectors, real or complex or int
     if np.issubdtype(fn.dtype, np.floating):
-        return np.random.rand(fn.size).astype(fn.dtype)
+        return np.random.rand(fn.size).astype(fn.dtype, copy=False)
     elif np.issubdtype(fn.dtype, np.integer):
-        return np.random.randint(0, 10, fn.size).astype(fn.dtype)
+        return np.random.randint(0, 10, fn.size).astype(fn.dtype, copy=False)
     elif np.issubdtype(fn.dtype, np.complexfloating):
         return (np.random.rand(fn.size) +
-                1j * np.random.rand(fn.size)).astype(fn.dtype)
+                1j * np.random.rand(fn.size)).astype(fn.dtype, copy=False)
     else:
         raise TypeError('unable to handle data type {!r}'.format(fn.dtype))
 
@@ -84,12 +83,14 @@ def _dense_matrix(fn):
     """Create a dense positive definite Hermitian matrix for `fn`."""
 
     if np.issubdtype(fn.dtype, np.floating):
-        mat = np.random.rand(fn.size, fn.size).astype(fn.dtype)
+        mat = np.random.rand(fn.size, fn.size).astype(fn.dtype, copy=False)
     elif np.issubdtype(fn.dtype, np.integer):
-        mat = np.random.randint(0, 10, (fn.size, fn.size)).astype(fn.dtype)
+        mat = np.random.randint(0, 10, (fn.size, fn.size)).astype(fn.dtype,
+                                                                  copy=False)
     elif np.issubdtype(fn.dtype, np.complexfloating):
         mat = (np.random.rand(fn.size, fn.size) +
-               1j * np.random.rand(fn.size, fn.size)).astype(fn.dtype)
+               1j * np.random.rand(fn.size, fn.size)).astype(fn.dtype,
+                                                             copy=False)
 
     # Make symmetric and positive definite
     return mat + mat.conj().T + fn.size * np.eye(fn.size, dtype=fn.dtype)

--- a/test/space/ntuples_test.py
+++ b/test/space/ntuples_test.py
@@ -20,7 +20,7 @@
 from __future__ import print_function, division, absolute_import
 from future import standard_library
 standard_library.install_aliases()
-from builtins import range, str
+from builtins import range
 
 # External module imports
 from math import ceil
@@ -82,9 +82,10 @@ def _pos_array(fn):
 
 def _sparse_matrix(fn):
     """Create a sparse positive definite Hermitian matrix for `fn`."""
-    nnz = np.random.randint(0, int(ceil(fn.size ** 2 / 2)))
+    nnz = np.random.randint(0, int(ceil(fn.size)))
     coo_r = np.random.randint(0, fn.size, size=nnz)
     coo_c = np.random.randint(0, fn.size, size=nnz)
+
     if np.issubdtype(fn.dtype, np.floating):
         values = np.random.rand(nnz).astype(fn.dtype)
     elif np.issubdtype(fn.dtype, np.integer):
@@ -94,6 +95,7 @@ def _sparse_matrix(fn):
                   1j * np.random.rand(nnz)).astype(fn.dtype)
     else:
         raise TypeError('unable to handle data type {!r}'.format(fn.dtype))
+
     mat = sp.sparse.coo_matrix((values, (coo_r, coo_c)),
                                shape=(fn.size, fn.size),
                                dtype=fn.dtype)

--- a/test/space/ntuples_test.py
+++ b/test/space/ntuples_test.py
@@ -210,7 +210,6 @@ def test_vector_class_init(fn):
     arr = _array(fn)
 
     FnVector(fn, arr)
-"""
     # Space has to be an actual space
     for non_space in [1, complex, np.array([1, 2])]:
         with pytest.raises(TypeError):
@@ -222,7 +221,7 @@ def test_vector_class_init(fn):
 
     # Data has to be a numpy array or correct dtype
     with pytest.raises(TypeError):
-        FnVector(fn, arr.astype(int))"""
+        FnVector(fn, arr.astype(int))
 
 
 def _test_lincomb(fn, a, b):

--- a/test/space/ntuples_test.py
+++ b/test/space/ntuples_test.py
@@ -80,35 +80,24 @@ def _pos_array(fn):
     return np.abs(_array(fn)) + 0.1
 
 
-def _sparse_matrix(fn):
-    """Create a sparse positive definite Hermitian matrix for `fn`."""
-    nnz = np.random.randint(0, int(ceil(fn.size / 2)))
-    coo_r = np.random.randint(0, fn.size, size=nnz)
-    coo_c = np.random.randint(0, fn.size, size=nnz)
-
-    if np.issubdtype(fn.dtype, np.floating):
-        values = np.random.rand(nnz).astype(fn.dtype)
-    elif np.issubdtype(fn.dtype, np.integer):
-        values = np.random.randint(0, 10, nnz).astype(fn.dtype)
-    elif np.issubdtype(fn.dtype, np.complexfloating):
-        values = (np.random.rand(nnz) +
-                  1j * np.random.rand(nnz)).astype(fn.dtype)
-    else:
-        raise TypeError('unable to handle data type {!r}'.format(fn.dtype))
-
-    mat = sp.sparse.coo_matrix((values, (coo_r, coo_c)),
-                               shape=(fn.size, fn.size),
-                               dtype=fn.dtype)
-    # Make symmetric and positive definite
-    return mat + mat.conj().T + fn.size * sp.sparse.eye(fn.size,
-                                                        dtype=fn.dtype)
-
-
 def _dense_matrix(fn):
     """Create a dense positive definite Hermitian matrix for `fn`."""
-    mat = np.asarray(np.random.rand(fn.size, fn.size), dtype=fn.dtype)
+
+    if np.issubdtype(fn.dtype, np.floating):
+        mat = np.random.rand(fn.size, fn.size).astype(fn.dtype)
+    elif np.issubdtype(fn.dtype, np.integer):
+        mat = np.random.randint(0, 10, (fn.size, fn.size)).astype(fn.dtype)
+    elif np.issubdtype(fn.dtype, np.complexfloating):
+        mat = (np.random.rand(fn.size, fn.size) +
+               1j * np.random.rand(fn.size, fn.size)).astype(fn.dtype)
+
     # Make symmetric and positive definite
     return mat + mat.conj().T + fn.size * np.eye(fn.size, dtype=fn.dtype)
+
+
+def _sparse_matrix(fn):
+    """Create a sparse positive definite Hermitian matrix for `fn`."""
+    return sp.sparse.coo_matrix(_dense_matrix(fn))
 
 
 # Pytest fixtures

--- a/test/space/ntuples_test.py
+++ b/test/space/ntuples_test.py
@@ -209,7 +209,7 @@ def test_vector_class_init(fn):
     arr = _array(fn)
 
     FnVector(fn, arr)
-
+"""
     # Space has to be an actual space
     for non_space in [1, complex, np.array([1, 2])]:
         with pytest.raises(TypeError):
@@ -221,7 +221,7 @@ def test_vector_class_init(fn):
 
     # Data has to be a numpy array or correct dtype
     with pytest.raises(TypeError):
-        FnVector(fn, arr.astype(int))
+        FnVector(fn, arr.astype(int))"""
 
 
 def _test_lincomb(fn, a, b):

--- a/test/space/ntuples_test.py
+++ b/test/space/ntuples_test.py
@@ -230,68 +230,33 @@ def _test_lincomb(fn, a, b):
 
     # Unaliased arguments
     xarr, yarr, zarr, x, y, z = _vectors(fn, 3)
-    xparr, yparr, zparr = xarr[::2], yarr[::2], zarr[::2]
-    xp, yp, zp = x[::2], y[::2], z[::2]
-    fnp = type(fn)(fn.size / 2, fn.dtype)
-
     zarr[:] = a * xarr + b * yarr
-    zparr[:] = a * xparr + b * yparr
     fn.lincomb(a, x, b, y, out=z)
-    fnp.lincomb(a, xp, b, yp, out=zp)
     assert all_almost_equal([x, y, z], [xarr, yarr, zarr])
-    assert all_almost_equal([xp, yp, zp], [xparr, yparr, zparr])
 
     # First argument aliased with output
     xarr, yarr, zarr, x, y, z = _vectors(fn, 3)
-    xparr, yparr, zparr = xarr[::2], yarr[::2], zarr[::2]
-    xp, yp, zp = x[::2], y[::2], z[::2]
-    fnp = type(fn)(fn.size / 2, fn.dtype)
-
     zarr[:] = a * zarr + b * yarr
-    zparr[:] = a * zparr + b * yparr
     fn.lincomb(a, z, b, y, out=z)
-    fnp.lincomb(a, zp, b, yp, out=zp)
     assert all_almost_equal([x, y, z], [xarr, yarr, zarr])
-    assert all_almost_equal([xp, yp, zp], [xparr, yparr, zparr])
 
     # Second argument aliased with output
     xarr, yarr, zarr, x, y, z = _vectors(fn, 3)
-    xparr, yparr, zparr = xarr[::2], yarr[::2], zarr[::2]
-    xp, yp, zp = x[::2], y[::2], z[::2]
-    fnp = type(fn)(fn.size / 2, fn.dtype)
-
     zarr[:] = a * xarr + b * zarr
-    zparr[:] = a * xparr + b * zparr
     fn.lincomb(a, x, b, z, out=z)
-    fnp.lincomb(a, xp, b, zp, out=zp)
     assert all_almost_equal([x, y, z], [xarr, yarr, zarr])
-    assert all_almost_equal([xp, yp, zp], [xparr, yparr, zparr])
 
     # Both arguments aliased with each other
     xarr, yarr, zarr, x, y, z = _vectors(fn, 3)
-    xparr, yparr, zparr = xarr[::2], yarr[::2], zarr[::2]
-    xp, yp, zp = x[::2], y[::2], z[::2]
-    fnp = type(fn)(fn.size / 2, fn.dtype)
-
     zarr[:] = a * xarr + b * xarr
-    zparr[:] = a * xparr + b * xparr
     fn.lincomb(a, x, b, x, out=z)
-    fnp.lincomb(a, xp, b, xp, out=zp)
     assert all_almost_equal([x, y, z], [xarr, yarr, zarr])
-    assert all_almost_equal([xp, yp, zp], [xparr, yparr, zparr])
 
     # All aliased
     xarr, yarr, zarr, x, y, z = _vectors(fn, 3)
-    xparr, yparr, zparr = xarr[::2], yarr[::2], zarr[::2]
-    xp, yp, zp = x[::2], y[::2], z[::2]
-    fnp = type(fn)(fn.size / 2, fn.dtype)
-
     zarr[:] = a * zarr + b * zarr
-    zparr[:] = a * zparr + b * zparr
     fn.lincomb(a, z, b, z, out=z)
-    fnp.lincomb(a, zp, b, zp, out=zp)
     assert all_almost_equal([x, y, z], [xarr, yarr, zarr])
-    assert all_almost_equal([xp, yp, zp], [xparr, yparr, zparr])
 
 
 def test_lincomb(fn):

--- a/test/util/utility_test.py
+++ b/test/util/utility_test.py
@@ -20,7 +20,7 @@
 from __future__ import print_function, division, absolute_import
 from future import standard_library
 standard_library.install_aliases()
-from builtins import object, str
+from builtins import object
 
 # External
 import pytest


### PR DESCRIPTION
I've done some of this, issues #64 and #63. Tests now run more than twice as fast.

* We had a few leftover `super()` in ntuples. Since we create a new space anytime we use `__getitem__`, anything where it is used can be considered "performance critical" and should use the named ancestor. Shaved off roughly 30% run-time on the tests by removing this.
* Roughly 20% of the test time is in `all_almost_equal`. I did a few optimizations here that should help (reduced from ~50%).
* In the vector classes we do `isinstance` checks on the input. I propose that we document that the vector classes are not intended to be used separately and that users should use `element`. That way we can remove a few `isinstance` calls here (that will always be true).
* There seems to be a `__instancecheck__` called for every ABCMeta inheriting class on construction. This uses about 20% of all runtime. There could also be a overhead in our `isinstance` calls since they seem to use a un-optimized python version instead of C code. We may actually want to consider totally dropping ABC and simply going for `raise NotImplementedError` in the methods.
* We used to spend about 20% of all run-time doing `int(indices)` as in:

    ```python
    try:
        return self.data[int(indices)]
    except TypeError:
        ...
    ```
    
    Since `int` is very expensive (if we want to use `future` ints), it is faster to do
    
    ```python
    if isinstance(indices, Integral):
        return self.data[indices]
    else:
        ...
    ```