### PR TITLE
ENH: made field a property of LinearSpace

### DIFF
--- a/examples/reals.py
+++ b/examples/reals.py
@@ -1,4 +1,4 @@
-# Copyright 2014, 2015 The ODL development group
+﻿# Copyright 2014, 2015 The ODL development group
 #
 # This file is part of ODL.
 #
@@ -23,6 +23,7 @@
 from __future__ import print_function, division, absolute_import
 from future import standard_library
 standard_library.install_aliases()
+from builtins import super
 
 import odl
 
@@ -31,7 +32,7 @@ class Reals(odl.LinearSpace):
     """The real numbers."""
 
     def __init__(self):
-        self._field = odl.RealNumbers()
+        super().__init__(odl.RealNumbers())
 
     def _inner(self, x1, x2):
         return x1.__val__ * x2.__val__
@@ -41,10 +42,6 @@ class Reals(odl.LinearSpace):
 
     def _multiply(self, x1, x2, out):
         out.__val__ = x1.__val__ * x2.__val__
-
-    @property
-    def field(self):
-        return self._field
 
     def __eq__(self, other):
         return isinstance(other, Reals)

--- a/odl/set/pspace.py
+++ b/odl/set/pspace.py
@@ -198,18 +198,12 @@ class ProductSpace(LinearSpace):
 
         self._spaces = tuple(spaces)
         self._size = len(spaces)
-        self._field = spaces[0].field
-        super().__init__()
+        super().__init__(spaces[0].field)
 
     @property
     def size(self):
         """The number of factors."""
         return self._size
-
-    @property
-    def field(self):
-        """The common underlying field of all factors."""
-        return self._field
 
     @property
     def spaces(self):

--- a/odl/set/sets.py
+++ b/odl/set/sets.py
@@ -248,7 +248,13 @@ class Field(Set):
 
     @property
     def field(self):
-        """The field of scalars for a field is itself."""
+        """The field of scalars for a field is itself.
+
+        Notes
+        -----
+        This is a hack for this to work with duck-typing
+        with `LinearSpace`'s.
+        """
         return self
 
 

--- a/odl/set/space.py
+++ b/odl/set/space.py
@@ -60,12 +60,26 @@ class LinearSpace(Set):
 
         This method should be called by all inheriting methods so that the
         field property of the space is set properly.
+
+        Parameters
+        ----------
+        field : `Field`
+            The underlying scalar field of the space
         """
         self._field = field
 
     @property
     def field(self):
-        """The field of this vector space."""
+        """The field of this vector space.
+
+        The field is the set of scalars of the space, that is numbers that
+        the vectors in the space can be multiplied with.
+
+        Returns
+        -------
+        field : `Field`
+            The underlying field.
+        """
         return self._field
 
     @abstractmethod

--- a/odl/set/space.py
+++ b/odl/set/space.py
@@ -45,7 +45,7 @@ import math as m
 from odl.set.sets import Set, UniversalSet
 
 
-__all__ = ('LinearSpace', 'LinearSpaceVector')
+__all__ = ('LinearSpace', 'LinearSpaceVector', 'UniversalSpace')
 
 
 class LinearSpace(Set):
@@ -54,6 +54,19 @@ class LinearSpace(Set):
     Its elements are represented as instances of the inner
     `LinearSpaceVector` class.
     """
+
+    def __init__(self, field):
+        """Initialize a LinearSpace.
+
+        This method should be called by all inheriting methods so that the
+        field property of the space is set properly.
+        """
+        self._field = field
+
+    @property
+    def field(self):
+        """The field of this vector space."""
+        return self._field
 
     @abstractmethod
     def element(self, inp=None, **kwargs):
@@ -132,10 +145,6 @@ class LinearSpace(Set):
             The one vector of this space
         """
         raise NotImplementedError('This space has no one')
-
-    @property
-    def field(self):
-        """The field of this vector space."""
 
     # Default methods
     def zero(self):
@@ -697,6 +706,10 @@ class LinearSpaceVector(object):
 class UniversalSpace(LinearSpace):
     """A dummy linear space class mostly raising `NotImplementedError`."""
 
+    def __init__(self):
+        """Initialize a universal space"""
+        LinearSpace.__init__(self, field=UniversalSet())
+
     def element(self, inp=None):
         """Dummy element creation method.
 
@@ -744,11 +757,6 @@ class UniversalSpace(LinearSpace):
         raises `NotImplementedError`.
         """
         raise NotImplementedError
-
-    @property
-    def field(self):
-        """Dummy field `UniversalSet`."""
-        return UniversalSet()
 
     def __eq__(self, other):
         """Return ``self == other``.

--- a/odl/space/base_ntuples.py
+++ b/odl/space/base_ntuples.py
@@ -361,9 +361,10 @@ class FnBase(NtuplesBase, LinearSpace):
             raise TypeError('{!r} is not a scalar data type.'.format(dtype))
 
         if is_real_dtype(self.dtype):
-            self._field = RealNumbers()
+            field = RealNumbers()
         else:
-            self._field = ComplexNumbers()
+            field = ComplexNumbers()
+        LinearSpace.__init__(self, field)
 
     @abstractmethod
     def zero(self):
@@ -380,11 +381,6 @@ class FnBase(NtuplesBase, LinearSpace):
     @abstractmethod
     def _divide(self, x1, x2, out):
         """The entry-wise division of two vectors, assigned to ``out``."""
-
-    @property
-    def field(self):
-        """The field of this space."""
-        return self._field
 
     @property
     def element_type(self):

--- a/odl/space/fspace.py
+++ b/odl/space/fspace.py
@@ -343,13 +343,8 @@ class FunctionSpace(FunctionSet, LinearSpace):
             raise TypeError('field {!r} not a RealNumbers or '
                             'ComplexNumbers instance.'.format(field))
 
-        super().__init__(dom, field)
-        self._field = field
-
-    @property
-    def field(self):
-        """Return the field of this space."""
-        return self._field
+        FunctionSet.__init__(self, dom, field)
+        LinearSpace.__init__(self, field)
 
     def element(self, fcall=None, fapply=None):
         """Create a `FunctionSpace` element.


### PR DESCRIPTION
Removed the condition that `LinearSpace`'s inplement `field` property, instead call `LinearSpace.__init__` for it to be initialized.