### PR TITLE
Issue 188 numba

### DIFF
--- a/examples/vectorization.py
+++ b/examples/vectorization.py
@@ -63,14 +63,14 @@ def numba_example():
         else:
             return x[0] + x[1]
 
-    @vectorize(vectorizer=numba.vectorize, nin=2,
-               vec_args=[['float64(float64, float64)']])
+    # Numba expects functions f(x1, x2, x3, ...), while we have the
+    # convention f(x) with x = (x1, x2, x3, ...). Therefore we need
+    # to wrap the Numba-vectorized function.
+    vectorized = numba.vectorize(lambda x, y: x - y if x > y else x + y)
+
     def myfunc_vec(x):
         """Return x - y if x > y, otherwise return x + y."""
-        if x[0] > x[1]:
-            return x[0] - x[1]
-        else:
-            return x[0] + x[1]
+        return vectorized(*x)
 
     def myfunc_native_vec(x):
         """Return x - y if x > y, otherwise return x + y."""

--- a/examples/vectorization.py
+++ b/examples/vectorization.py
@@ -1,0 +1,85 @@
+# Copyright 2014, 2015 The ODL development group
+#
+# This file is part of ODL.
+#
+# ODL is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# ODL is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with ODL.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Example showing how to use vectorization of FunctionSpaceVector's."""
+
+# Imports for common Python 2/3 codebase
+from __future__ import print_function, division, absolute_import
+from future import standard_library
+standard_library.install_aliases()
+import numpy as np
+import odl
+import timeit
+
+
+def performace_example():
+    # Create a function space
+    X = odl.FunctionSpace(odl.Interval(0, 1))
+
+    # Functions default to vectorized
+    f_vec = X.element(lambda x: x**2)
+
+    # If 'vectorized=False' is used, odl automatically vectorizes
+    f_novec = X.element(lambda x: x**2, vectorized=False)
+
+    # Example of runtime, expect vectorized to be much faster
+    points = np.linspace(0, 1, 10000)
+
+    print('Vectorized runtime:     {:5f}'
+          ''.format(timeit.timeit(lambda: f_vec(points), number=100)))
+    print('Non-vectorized runtime: {:5f}'
+          ''.format(timeit.timeit(lambda: f_novec(points), number=100)))
+
+
+def numba_example():
+    # Some functions are not easily vectorized,
+    # here we can use numba to improve performance.
+
+    try:
+        import numba
+    except ImportError:
+        print('Numba not installed, skipping.')
+        return
+
+    def myfunc(x):
+        "Return a-b if a>b, otherwise return a+b"
+        if x[0] > x[1]:
+            return x[0] - x[1]
+        else:
+            return x[0] + x[1]
+
+    my_vectorized_func = numba.vectorize(myfunc)
+
+    # Create functions
+    X = odl.FunctionSpace(odl.Rectangle([0, 0], [1, 1]))
+    f_default = X.element(myfunc, vectorized=False)
+    f_numba = X.element(my_vectorized_func)
+
+    # Create points
+    points = odl.uniform_sampling(X.domain, [100, 100]).points().T
+
+    print('Vectorized runtime:     {:5f}'
+          ''.format(timeit.timeit(lambda: f_default(points), number=100)))
+    print('Non-vectorized runtime: {:5f}'
+          ''.format(timeit.timeit(lambda: f_numba(points), number=100)))
+
+if __name__ == '__main__':
+    print('Running performance example')
+    performace_example()
+
+    print('Running numba example')
+    numba_example()

--- a/examples/vectorization.py
+++ b/examples/vectorization.py
@@ -23,21 +23,24 @@ from future import standard_library
 standard_library.install_aliases()
 import numpy as np
 import odl
-from odl.util.vectorization import vectorize
 import timeit
 
 
 def performace_example():
-    # Create a function space
-    X = odl.FunctionSpace(odl.Interval(0, 1))
+    # Create a space of functions on the interval [0, 1].
+    fspace = odl.FunctionSpace(odl.Interval(0, 1))
 
-    # Functions default to vectorized
-    f_vec = X.element(lambda x: x ** 2)
+    # Simple function, already supports vectorization.
+    f_vec = fspace.element(lambda x: x ** 2)
 
-    # If 'vectorized=False' is used, odl automatically vectorizes
-    f_novec = X.element(lambda x: x ** 2, vectorized=False)
+    # If 'vectorized=False' is used, odl automatically vectorizes with
+    # the help of numpy.vectorize. This will be very slow, though, since
+    # the implementation is basically a Python loop.
+    f_novec = fspace.element(lambda x: x ** 2, vectorized=False)
 
-    # Example of runtime, expect vectorized to be much faster
+    # We test both versions with 10000 evaluation points. The natively
+    # vectorized version should be much faster than the one using
+    # numpy.vectorize.
     points = np.linspace(0, 1, 10000)
 
     print('Vectorized runtime:     {:5f}'
@@ -47,8 +50,9 @@ def performace_example():
 
 
 def numba_example():
-    # Some functions are not easily vectorized,
-    # here we can use numba to improve performance.
+    # Some functions are not easily vectorized, here we can use Numba to
+    # improve performance.
+    # See http://numba.pydata.org/
 
     try:
         import numba
@@ -70,39 +74,59 @@ def numba_example():
 
     def myfunc_vec(x):
         """Return x - y if x > y, otherwise return x + y."""
-        return vectorized(*x)
+        return vectorized(x[0], x[1])
 
     def myfunc_native_vec(x):
         """Return x - y if x > y, otherwise return x + y."""
+        # This implementation uses Numpy's fast built-in vectorization
+        # directly. The function np.where checks the condition in the
+        # first argument and takes the values from the second argument
+        # for all entries where the condition is `True`, otherwise
+        # the values from the third argument are taken. The arrays are
+        # automatically broadcast, i.e. the broadcast shape of the
+        # condition expression determines the output shape.
         return np.where(x[0] > x[1], x[0] - x[1], x[0] + x[1])
 
-    # Create functions
+    # Create (continuous) functions in the space of function defined
+    # on the rectangle [0, 1] x [0, 1].
     fspace = odl.FunctionSpace(odl.Rectangle([0, 0], [1, 1]))
     f_default = fspace.element(myfunc, vectorized=False)
     f_numba = fspace.element(myfunc_vec)
     f_native = fspace.element(myfunc_native_vec, vectorized=True)
 
-    # Create points
-    points = odl.uniform_sampling(fspace.domain, [2000, 2000]).points().T
-    mesh = odl.uniform_sampling(fspace.domain, [2000, 2000]).meshgrid()
+    # Create a unform grid in [0, 1] x [0, 1] (fspace.domain) with 2000
+    # samples per dimension.
+    grid = odl.uniform_sampling(fspace.domain, [2000, 2000])
+    # The points() method really creates all grid points (2000^2) and
+    # stores them one-by-one (row-wise) in a large array with shape
+    # (2000*2000, 2). Since the function expects points[i] to be the
+    # array of i-th components of all points, we need to transpose.
+    points = grid.points().T
+    # The meshgrid() method only returns a sparse representation of the
+    # grid, a tuple whose i-th entry is the vector of all possible i-th
+    # components in the grid (2000). Extra dimensions are added to the
+    # vector in order to support automatic broadcasting. This is both
+    # faster and more memory-friendly than creating the full point array.
+    # See the numpy.meshgrid function for more information.
+    mesh = grid.meshgrid()  # Creates a sparse meshgrid (2000 * 2)
 
-    print('Non-Vectorized runtime (points):     {:5f}'
+    print('Non-Vectorized runtime (points):      {:5f}'
           ''.format(timeit.timeit(lambda: f_default(points), number=1)))
-    print('Non-Vectorized runtime (meshgrid):     {:5f}'
+    print('Non-Vectorized runtime (meshgrid):    {:5f}'
           ''.format(timeit.timeit(lambda: f_default(mesh), number=1)))
-    print('Numba vectorized runtime (points): {:5f}'
+    print('Numba vectorized runtime (points):    {:5f}'
           ''.format(timeit.timeit(lambda: f_numba(points), number=1)))
-    print('Numba vectorized runtime (meshgrid): {:5f}'
+    print('Numba vectorized runtime (meshgrid):  {:5f}'
           ''.format(timeit.timeit(lambda: f_numba(mesh), number=1)))
-    print('Native vectorized runtime (points): {:5f}'
+    print('Native vectorized runtime (points):   {:5f}'
           ''.format(timeit.timeit(lambda: f_native(points), number=1)))
     print('Native vectorized runtime (meshgrid): {:5f}'
           ''.format(timeit.timeit(lambda: f_native(mesh), number=1)))
 
 
 if __name__ == '__main__':
-    print('Running performance example')
+    print('Running vectorization performance example.')
     performace_example()
 
-    print('Running numba example')
+    print('Running Numba example.')
     numba_example()

--- a/odl/space/fspace.py
+++ b/odl/space/fspace.py
@@ -126,7 +126,7 @@ class FunctionSet(Set):
             raise TypeError('function {!r} is not callable.'.format(fcall))
 
         if not vectorized:
-            fcall = vectorize(dtype=None)(fcall)
+            fcall = vectorize(fcall)
 
         return self.element_type(self, fcall)
 
@@ -199,7 +199,9 @@ class FunctionSetVector(Operator):
         if isinstance(fcall, FunctionSetVector):
             call_has_out, call_out_optional, _ = _dispatch_call_args(
                 bound_call=fcall._call)
-        elif isinstance(fcall, np.ufunc):
+
+        # Numpy Ufuncs and similar objects (e.g. Numba DUfuncs)
+        elif hasattr(fcall, 'nin') and hasattr(fcall, 'nout'):
             if fcall.nin != 1:
                 raise ValueError('ufunc {} has {} input parameter(s), '
                                  'expected 1.'
@@ -500,7 +502,7 @@ class FunctionSpace(FunctionSet, LinearSpace):
                 else:
                     dtype = 'complex128'
 
-                fcall = vectorize(dtype=dtype)(fcall)
+                fcall = vectorize(otypes=[dtype])(fcall)
 
             return self.element_type(self, fcall)
 

--- a/odl/util/vectorization.py
+++ b/odl/util/vectorization.py
@@ -21,12 +21,11 @@
 # Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
 from future import standard_library
-from future.utils import raise_from
 standard_library.install_aliases()
+from builtins import super
 
 # External module imports
 from functools import wraps
-from itertools import product
 import numpy as np
 
 
@@ -133,169 +132,218 @@ def out_shape_from_array(arr):
         return (arr.shape[1],)
 
 
-def vectorize(dtype=None):
-    """Vectorization decorator for our input parameter pattern.
+class OptionalArgDecorator(object):
 
-    The wrapped function must be callable with one positional
-    parameter. Keyword arguments are passed through, hence positional
-    arguments with defaults can either be left out or passed by keyword,
-    but not by position.
+    """Abstract class to create decorators with optional arguments.
 
-    The decorated function has the call signature
+    This class implements the functionality of a decorator that can
+    be used with and without arguments, i.e. the following patterns
+    both work::
 
-    ``func(x, out=None, **kwargs)``,
+        @decorator
+        def myfunc(x, *args, **kwargs):
+            pass
 
-    where the optional ``out`` argument is an array of adequate size
-    to which the result is written.
+        @decorator(param, **dec_kwargs)
+        def myfunc(x, *args, **kwargs):
+            pass
 
-    **Important**: It is not possible to give array-like input to
-    a manually vectorized function since there is no reliable way
-    to distinguish between arrays or meshgrids with equally long
-    vectors in that case.
+    The arguments to the decorator are passed on to the underlying
+    wrapper.
 
-    Parameters
-    ----------
-    dtype : `type` or `str`, optional
-        Data type of the output array. Needs to be understood by the
-        `numpy.dtype` function. If not provided, a "lazy" vectorization
-        is performed, meaning that the results are collected in a
-        list instead of an array.
+    To use this class, subclass it and implement the static ``_wrapper``
+    method.
+    """
 
-    Notes
-    -----
-    The decorated function returns the array given as ``out`` argument
-    if it is not `None`.
+    def __new__(cls, *args, **kwargs):
+        """Create a new decorator instance.
+
+        There are two cases to distinguish:
+
+        1. Without arguments::
+
+               @decorator
+               def myfunc(x):
+                   pass
+
+           which is equivalent to
+           ::
+
+               def myfunc(x):
+                   pass
+
+               myfunc = decorator(myfunc)
+
+
+           Hence, in this case, the ``__new__`` method of the decorator
+           immediately returns the wrapped function.
+
+        2. With arguments::
+
+               @decorator(*dec_args, **dec_kwargs)
+               def myfunc(x):
+                   pass
+
+           which is equivalent to
+           ::
+
+               def myfunc(x):
+                   pass
+
+               dec_instance = decorator(*dec_args, **dec_kwargs)
+               myfunc = dec_instance(myfunc)
+
+           Hence, in this case, the first call creates an actual class
+           instance of ``decorator``, and in the second statement, the
+           ``dec_instance.__call__`` method returns the wrapper using
+           the stored ``dec_args`` and ``dec_kwargs``.
+        """
+        # Decorating without arguments: return wrapper w/o args directly
+        instance = super().__new__(cls)
+
+        if (not kwargs and
+                len(args) == 1 and
+                callable(args[0])):
+            func = args[0]
+
+            return instance._wrapper(func)
+
+        # With arguments, return class instance
+        else:
+            instance.wrapper_args = args
+            instance.wrapper_kwargs = kwargs
+            return instance
+
+    def __call__(self, func):
+        """Return ``self(func)``.
+
+        This method is invoked when the decorator was created with
+        arguments.
+
+        Parameters
+        ----------
+        func : callable
+            Original function to be wrapped
+
+        Returns
+        -------
+        wrapped : callable
+            The wrapped function
+        """
+        return self._wrapper(func, *self.wrapper_args, **self.wrapper_kwargs)
+
+    @staticmethod
+    def _wrapper(func, *wrapper_args, **wrapper_kwargs):
+        """Return the wrapped function."""
+        raise NotImplementedError
+
+
+class vectorize(OptionalArgDecorator):
+
+    """Decorator class for function vectorization.
+
+    This vectorizer expects a function with exactly one positional
+    argument (input) and optional keyword arguments. The decorated
+    function has an optional ``out`` parameter for in-place evaluation.
 
     Examples
     --------
-    Vectorize a step function in the first variable:
+    Use the decorator witout arguments:
 
-    >>> @vectorize(dtype=float)
-    ... def step(x):
-    ...     return 0 if x[0] <= 0 else 1
+    >>> @vectorize
+    ... def f(x):
+    ...     return x[0] + x[1] if x[0] < x[1] else x[0] - x[1]
+    >>>
+    >>> f([0, 1])  # np.vectorize'd functions always return an array
+    array(1)
+    >>> f([[0, -2], [1, 4]])  # corresponds to points [0, 1], [-2, 4]
+    array([1, 2])
 
-    This corresponds to (but is much slower than)
+    The function may have ``kwargs``:
 
-    >>> import numpy as np
-    >>> def step_vec(x):
-    ...     x0, x1 = x
-    ...     # np.broadcast is your friend to determine the output shape
-    ...     out = np.zeros(np.broadcast(x0, x1).shape, dtype=x0.dtype)
-    ...     idcs = np.where(x0 > 0)
-    ...     # Need to throw away the indices from the empty dimensions
-    ...     idcs = idcs[0] if len(idcs) > 1 else idcs
-    ...     out[idcs] = 1
-    ...     return out
+    >>> @vectorize
+    ... def f(x, param=1.0):
+    ...     return x[0] + x[1] if x[0] < param else x[0] - x[1]
+    >>>
+    >>> f([[0, -2], [1, 4]])
+    array([1, 2])
+    >>> f([[0, -2], [1, 4]], param=-1.0)
+    array([-1,  2])
 
-    Both versions work for arrays and meshgrids:
+    You can pass arguments to the vectorizer, too:
 
-    >>> x = np.linspace(-5, 13, 10, dtype=float).reshape((2, 5))
-    >>> x  # array representing 5 points in 2d
-    array([[ -5.,  -3.,  -1.,   1.,   3.],
-           [  5.,   7.,   9.,  11.,  13.]])
-    >>> np.array_equal(step(x), step_vec(x))
-    True
-
-    >>> x = y = np.linspace(-1, 2, 5)
-    >>> mg_sparse = np.meshgrid(x, y, indexing='ij', sparse=True)
-    >>> np.array_equal(step(mg_sparse), step_vec(mg_sparse))
-    True
-    >>> mg_dense = np.meshgrid(x, y, indexing='ij', sparse=False)
-    >>> np.array_equal(step(mg_dense), step_vec(mg_dense))
-    True
-
-    With output parameter:
-
-    >>> @vectorize(dtype=float)
-    ... def step(x):
-    ...     return 0 if x[0] <= 0 else 1
-    >>> x = np.linspace(-5, 13, 10, dtype=float).reshape((2, 5))
-    >>> out = np.empty(5, dtype=float)
-    >>> step(x, out)  # returns out
-    array([ 0.,  0.,  0.,  1.,  1.])
+    >>> @vectorize(otypes=['float32'])
+    ... def f(x):
+    ...     return x[0] + x[1] if x[0] < x[1] else x[0] - x[1]
+    >>> f([[0, -2], [1, 4]])
+    array([ 1.,  2.], dtype=float32)
     """
-    def vect_decorator(func):
 
-        def _vect_wrapper_array(x, out, **kwargs):
-            # Assume that x is an ndarray
-            if out is None:
-                out_shape = out_shape_from_array(x)
-                if dtype is None:
-                    out = [None] * out_shape[0]  # lazy vectorization
-                else:
-                    out = np.empty(out_shape, dtype=dtype)
+    @staticmethod
+    def _wrapper(func, *vect_args, **vect_kwargs):
+        """Return the vectorized wrapper function."""
+        return wraps(func)(_NumpyVectorizeWrapper(func, *vect_args,
+                                                  **vect_kwargs))
 
-            for i, xi in enumerate(x.T):
-                out[i] = func(xi, **kwargs)
-            return np.asarray(out)
 
-        def _vect_wrapper_meshgrid(x, out, ndim, **kwargs):
-            if out is None:
-                out_shape = out_shape_from_meshgrid(x)
+class _NumpyVectorizeWrapper(object):
 
-                if dtype is None:
+    """Class for vectorization wrapping using `numpy.vectorize`.
 
-                    # Small helper to initialize a nested list
-                    def _nested(shape):
-                        if len(shape) == 0:
-                            return None
-                        else:
-                            return [_nested(shape[1:])
-                                    for _ in range(shape[0])]
-                    out = _nested(out_shape)
+    The purpose of this class is to store the vectorized version of
+    a function when it is called for the first time.
+    """
 
-                else:
-                    out = np.empty(out_shape, dtype=dtype)
+    def __init__(self, func, *vect_args, **vect_kwargs):
+        """Initialize a new instance.
 
-            order = meshgrid_input_order(x)
-            vecs = vecs_from_meshgrid(x, order=order)
-            if ndim == 1:
-                for i, xi in enumerate(vecs[0]):
-                    out[i] = func(xi, **kwargs)
-            elif dtype is None:
-                for i, xi in enumerate(product(*vecs)):
-                    # Worst multi-index implementation ever, but still good
-                    # enough for slow code
-                    index = np.unravel_index(i, out_shape)
-                    sub = out
-                    for j in index[:-1]:
-                        sub = sub[j]
-                    sub[index[-1]] = func(xi, **kwargs)
-            else:
-                for i, xi in enumerate(product(*vecs)):
-                    out.flat[i] = func(xi, **kwargs)
-            return np.asarray(out)
+        Parameters
+        ----------
+        func : callable
+            Python function or method to be wrapped
+        vect_args :
+            positional arguments for `numpy.vectorize`
+        vect_kwargs :
+            keyword arguments for `numpy.vectorize`
+        """
+        self.func = func
+        self.vfunc = None
+        self.vect_args = vect_args
+        self.vect_kwargs = vect_kwargs
 
-        @wraps(func)
-        def vect_wrapper(x, out=None, **kwargs):
-            # Find out dimension first
-            if isinstance(x, np.ndarray):  # array
-                if x.ndim == 1:
-                    ndim = 1
-                elif x.ndim == 2:
-                    ndim = len(x)
-                else:
-                    raise ValueError('only 1- or 2-dimensional arrays '
-                                     'supported.')
-            else:  # meshgrid or single value
-                try:
-                    ndim = len(x)
-                except TypeError:
-                    ndim = 1
+    def __call__(self, x, out=None, **kwargs):
+        """Vectorized function call.
 
-            if is_valid_input_meshgrid(x, ndim):
-                return _vect_wrapper_meshgrid(x, out, ndim, **kwargs)
-            elif is_valid_input_array(x, ndim):
-                return _vect_wrapper_array(x, out, **kwargs)
-            else:
-                try:
-                    return func(x)
-                except Exception as err:
-                    raise_from(
-                        TypeError('invalid vectorized input type.'), err)
+        Parameters
+        ----------
+        x : array-like or sequence of array-like
+            Input argument(s) to the wrapped function
+        out : `numpy.ndarray`, optional
+            Appropriately sized array to write to
 
-        return vect_wrapper
-    return vect_decorator
+        Returns
+        -------
+        out : `numpy.ndarray`
+            Result of the vectorized function evaluation. If ``out``
+            was given, the returned object is a reference to it.
+        """
+        if np.isscalar(x):
+            x = np.array([x])
+        elif isinstance(x, np.ndarray) and x.ndim == 1:
+            x = x[None, :]
+
+        if self.vfunc is None:
+            # Not yet vectorized
+            def _func(*x, **kw):
+                return self.func(np.array(x), **kw)
+
+            self.vfunc = np.vectorize(_func, *self.vect_args,
+                                      **self.vect_kwargs)
+
+        if out is None:
+            return self.vfunc(*x, **kwargs)
+        else:
+            out[:] = self.vfunc(*x, **kwargs)
 
 
 if __name__ == '__main__':

--- a/test/util/vectorization_test.py
+++ b/test/util/vectorization_test.py
@@ -255,7 +255,7 @@ def test_out_shape_from_meshgrid():
     assert out_shape_from_meshgrid(mg) == (2, 3, 4)
 
 
-def test_vectorize_1d_dtype():
+def test_vectorize_1d_otype():
 
     import sys
 
@@ -265,7 +265,7 @@ def test_vectorize_1d_dtype():
     val_1 = -1
     val_2 = 2
 
-    @vectorize(dtype='int')
+    @vectorize(otypes=['int'])
     def simple_func(x):
         return 0 if x < 0 else 1
 
@@ -313,7 +313,7 @@ def test_vectorize_1d_lazy():
     val_1 = -1
     val_2 = 2
 
-    @vectorize()
+    @vectorize
     def simple_func(x):
         return 0 if x < 0 else 1
 
@@ -347,7 +347,7 @@ def test_vectorize_2d_dtype():
     val_1 = (-1, 1)
     val_2 = (2, 1)
 
-    @vectorize(dtype='int')
+    @vectorize(otypes=['int'])
     def simple_func(x):
         return 0 if x[0] < 0 and x[1] > 0 else 1
 
@@ -370,7 +370,6 @@ def test_vectorize_2d_dtype():
     assert isinstance(out, np.ndarray)
     assert out.dtype == np.dtype('int')
     assert out.shape == (5, 5)
-    print(out)
     assert all_equal(out, true_result_mg)
 
     assert simple_func(val_1) == 0
@@ -396,7 +395,7 @@ def test_vectorize_2d_lazy():
     val_1 = (-1, 1)
     val_2 = (2, 1)
 
-    @vectorize()
+    @vectorize
     def simple_func(x):
         return 0 if x[0] < 0 and x[1] > 0 else 1
 


### PR DESCRIPTION
Initial addition, currently fails in the numba example with:

```python
Running numba example
Traceback (most recent call last):
  ...
  File "D:/GitHub/ODL/examples/vectorization.py", line 70, in numba_example
    f_numba = X.element(my_vectorized_func)
  File "d:\github\odl\odl\space\fspace.py", line 509, in element
    return self.element_type(self, fcall)
  File "d:\github\odl\odl\space\fspace.py", line 780, in __init__
    FunctionSetVector.__init__(self, fspace, fcall)
  File "d:\github\odl\odl\space\fspace.py", line 221, in __init__
    bound_call=fcall.__call__)
  File "d:\github\odl\odl\operator\operator.py", line 231, in _dispatch_call_args
    raise TypeError('{} is not a bound method.'.format(call))
TypeError: <method-wrapper '__call__' of DUFunc object at 0x0000000019C27308> is not a bound method.
```

This is a "deficiency" in our vectorization implementation and should perhaps be fixed as discussed in #188. Perhaps @kohr-h could look at it?