### PR TITLE
STY: Fix many pylint warnings, add good names and remove local disables

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -47,9 +47,10 @@ disable=redefined-builtin,
   no-member,
   missing-super-argument,
   abstract-method,
-  protected-access
+  protected-access,
+  not-callable
 
-# redefined-builtin: 'object', 'range', 'str', 'super' are redefined, 
+# redefined-builtin: 'object', 'range', 'str', 'super' are redefined,
 #                    that's okay
 # no-name-in-module, no-member: triggered by scipy and numpy, let's ignore them
 # missing-super-argument: importing new super, pylint doesn't get it
@@ -57,6 +58,8 @@ disable=redefined-builtin,
 #                  abstract methods. This warning does not really prevent bugs, so we're disabling it.
 # protected-access: We use private attributes of "internalized" objects. Since this check is not really
 #                   a bug catcher, we're disabling it.
+# not-callable: pylint tries to determine if a class attribute (e.g. element_type) is
+#               callable or not - and fails to do so
 
 [REPORTS]
 
@@ -131,10 +134,10 @@ indent-after-paren=4
 bad-functions=map,filter,apply,input
 
 # Good variable names which should always be accepted, separated by a comma
-good-names=i,j,k,ex,Run,_,a,b,x,y,z,xp,yp,zp,s,q,p,I,T,dx,dy,x1,x2,xi,yi,n,m,ax
+good-names=a,b,c,d,f,g,h,i,j,k,m,n,p,q,r,s,t,u,v,w,x,y,z,xp,yp,zp,dx,dy,dz,x0,x1,x2,y0,y1,y2,z0,z1,z2,xi,yi,zi,ax,rn,cn,op,ex,_,I,T,nx,ny,nz,fx
 
 # Bad variable names which should always be refused, separated by a comma
-bad-names=foo,bar,baz,toto,tutu,tata
+bad-names=foo,baz,toto,tutu,tata,l
 
 # Colon-delimited sets of names that determine each other's naming style when
 # the name regexes allow several styles.

--- a/examples/convolution_test.py
+++ b/examples/convolution_test.py
@@ -59,8 +59,8 @@ class Convolution(odl.Operator):
 cont_space = odl.FunctionSpace(odl.Interval(0, 10))
 
 # Complicated functions to check performance
-cont_kernel = cont_space.element(lambda x: np.exp(x/2) * np.cos(x*1.172))
-cont_phantom = cont_space.element(lambda x: x**2 * np.sin(x)**2*(x > 5))
+cont_kernel = cont_space.element(lambda x: np.exp(x / 2) * np.cos(x * 1.172))
+cont_phantom = cont_space.element(lambda x: x ** 2 * np.sin(x) ** 2 * (x > 5))
 
 # Discretization
 discr_space = odl.uniform_discr_fromspace(cont_space, 500, impl='numpy')
@@ -72,7 +72,7 @@ conv = Convolution(kernel)
 
 # Dampening parameter for landweber
 iterations = 100
-omega = 1/conv.opnorm()**2
+omega = 1 / conv.opnorm() ** 2
 
 # Display partial
 partial = solvers.util.ForEachPartial(lambda result: plt.plot(conv(result)))

--- a/examples/convolution_test_cuda.py
+++ b/examples/convolution_test_cuda.py
@@ -64,8 +64,8 @@ class CudaConvolution(odl.Operator):
 cont_space = odl.FunctionSpace(odl.Interval(0, 10))
 
 # Complicated functions to check performance
-cont_kernel = cont_space.element(lambda x: np.exp(x/2) * np.cos(x*1.172))
-cont_data = cont_space.element(lambda x: x**2 * np.sin(x)**2*(x > 5))
+cont_kernel = cont_space.element(lambda x: np.exp(x / 2) * np.cos(x * 1.172))
+cont_data = cont_space.element(lambda x: x ** 2 * np.sin(x) ** 2 * (x > 5))
 
 # Discretization
 discr_space = odl.uniform_discr_fromspace(cont_space, 5000, impl='cuda')
@@ -77,7 +77,7 @@ conv = CudaConvolution(kernel)
 
 # Dampening parameter for landweber
 iterations = 100
-omega = 1.0/conv.opnorm()**2
+omega = 1.0 / conv.opnorm() ** 2
 
 # Display partial
 partial = solvers.util.ForEachPartial(

--- a/examples/cudaspace_speedtest.py
+++ b/examples/cudaspace_speedtest.py
@@ -78,5 +78,5 @@ run_test(lambda z, x, y: x.space.lincomb(2, z, 2, y, z), "z = a*z + b*y")
 run_test(lambda z, x, y: x.space.lincomb(2, z, 2, z, z), "z = (a+b)*z")
 
 # Non lincomb tests
-run_test(lambda z, x, y: x+y, "z = x + y")
+run_test(lambda z, x, y: x + y, "z = x + y")
 run_test(lambda z, x, y: y.assign(x), "y.assign(x)")

--- a/examples/operator_test.py
+++ b/examples/operator_test.py
@@ -33,6 +33,7 @@ import odl
 
 
 class Convolution(odl.Operator):
+
     def __init__(self, space, kernel, adjkernel):
         self.kernel = kernel
         self.adjkernel = adjkernel
@@ -58,7 +59,7 @@ class Convolution(odl.Operator):
 def kernel(x):
     mean = [0.0, 0.25]
     std = [0.05, 0.05]
-    return np.exp(-(((x[0]-mean[0])/std[0])**2 + ((x[1]-mean[1])/std[1])**2))
+    return np.exp(-(((x[0] - mean[0]) / std[0])**2 + ((x[1] - mean[1]) / std[1])**2))
 
 
 def adjkernel(x):
@@ -71,8 +72,8 @@ kernel_space = odl.FunctionSpace(cont_space.domain - cont_space.domain)
 
 # Discretization parameters
 n = 20
-npoints = np.array([n+1, n+1])
-npoints_kernel = np.array([2*n+1, 2*n+1])
+npoints = np.array([n + 1, n + 1])
+npoints_kernel = np.array([2 * n + 1, 2 * n + 1])
 
 # Discretized spaces
 disc_space = odl.uniform_discr_fromspace(cont_space, npoints)

--- a/examples/reals.py
+++ b/examples/reals.py
@@ -36,7 +36,7 @@ class Reals(odl.LinearSpace):
         return x1.__val__ * x2.__val__
 
     def _lincomb(self, a, x1, b, x2, out):
-        out.__val__ = a*x1.__val__ + b*x2.__val__
+        out.__val__ = a * x1.__val__ + b * x2.__val__
 
     def _multiply(self, x1, x2, out):
         out.__val__ = x1.__val__ * x2.__val__
@@ -70,7 +70,7 @@ if __name__ == '__main__':
 
     print(x)
     print(y)
-    print(x+y)
-    print(x*y)
-    print(x-y)
+    print(x + y)
+    print(x * y)
+    print(x - y)
     print(3.14 * x)

--- a/examples/solver_examples.py
+++ b/examples/solver_examples.py
@@ -27,7 +27,7 @@ from builtins import range
 def landweber_base(operator, x, rhs, iterations=1, omega=1):
     """Straightforward implementation of Landweber's iteration."""
     for _ in range(iterations):
-        x = x - omega * operator.adjoint(operator(x)-rhs)
+        x = x - omega * operator.adjoint(operator(x) - rhs)
 
     return x
 
@@ -42,8 +42,8 @@ def conjugate_gradient_base(op, x, rhs, iterations=1):
         q = op(p)
         norms2 = s.norm()**2
         a = norms2 / q.norm()**2
-        x = x + a*p
-        d = d - a*q
+        x = x + a * p
+        d = d - a * q
         s = op.adjoint(d)
-        b = s.norm()**2/norms2
-        p = s + b*p
+        b = s.norm()**2 / norms2
+        p = s + b * p

--- a/examples/tomo/stir_project.py
+++ b/examples/tomo/stir_project.py
@@ -53,7 +53,7 @@ proj = odl.tomo.stir_bindings.ForwardProjectorByBinWrapper(recon_sp,
                                                            proj_data)
 
 # Create shepp-logan phantom
-vol = odl.util.shepp_logan(proj.domain)
+vol = odl.util.shepp_logan(proj.domain, modified=True)
 
 # Project and show
 result = proj(vol)

--- a/examples/tomo/stir_reconstruct.py
+++ b/examples/tomo/stir_reconstruct.py
@@ -35,7 +35,7 @@ proj = odl.tomo.stir_bindings.stir_projector_from_file(volume_file,
                                                        projection_file)
 
 # Create shepp-logan phantom
-vol = odl.util.shepp_logan(proj.domain)
+vol = odl.util.shepp_logan(proj.domain, modified=True)
 
 # Project data
 projections = proj(vol)

--- a/examples/tomography.py
+++ b/examples/tomography.py
@@ -63,7 +63,7 @@ ran = odl.uniform_discr([0, 0], [1, np.pi], [142, 100])
 
 proj_op = ForwardProjector(dom, ran)
 
-phantom = odl.util.shepp_logan(dom)
+phantom = odl.util.shepp_logan(dom, modified=True)
 data = proj_op(phantom)
 
 x = dom.zero()

--- a/examples/visualization/show_2d.py
+++ b/examples/visualization/show_2d.py
@@ -26,7 +26,7 @@ issues with these examples.
 import odl
 
 spc = odl.uniform_discr([0, 0], [1, 1], [100, 100])
-vec = odl.util.shepp_logan(spc)
+vec = odl.util.shepp_logan(spc, modified=True)
 
 # Can also force "instant" plotting
 vec.show(show=True)

--- a/examples/visualization/show_productspace.py
+++ b/examples/visualization/show_productspace.py
@@ -15,7 +15,7 @@
 # You should have received a copy of the GNU General Public License
 # along with ODL.  If not, see <http://www.gnu.org/licenses/>.
 
-""" Example on using show with ProductSpace's """
+"""Example on using show with ProductSpace's."""
 
 # Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
@@ -42,5 +42,5 @@ vec.show(indices=np.s_[::3], show=True,
          title='Show every third element')
 
 # Slices propagate (as in numpy)
-vec.show(indices=np.s_[2, :, n//2], show=True,
+vec.show(indices=np.s_[2, :, n // 2], show=True,
          title='Show second element, then slice by [:, n//2]')

--- a/examples/visualization/show_productspace.py
+++ b/examples/visualization/show_productspace.py
@@ -29,7 +29,8 @@ m = 7
 spc = odl.uniform_discr([0, 0], [1, 1], [n, n])
 pspace = odl.ProductSpace(spc, m)
 
-vec = pspace.element([odl.util.shepp_logan(spc) * i for i in range(1, m+1)])
+vec = pspace.element([odl.util.shepp_logan(spc, modified=True) * i
+                      for i in range(1, m + 1)])
 
 # By default 4 uniformly spaced elements are shown
 vec.show(title='Default')

--- a/examples/visualization/show_update_1d.py
+++ b/examples/visualization/show_update_1d.py
@@ -15,7 +15,7 @@
 # You should have received a copy of the GNU General Public License
 # along with ODL.  If not, see <http://www.gnu.org/licenses/>.
 
-""" Example on using show and updating the figure in real time in 1d. """
+"""Example on using show and updating the figure in real time in 1d."""
 
 # Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import

--- a/examples/visualization/show_update_2d.py
+++ b/examples/visualization/show_update_2d.py
@@ -27,7 +27,7 @@ import matplotlib.pyplot as plt
 n = 100
 m = 20
 spc = odl.uniform_discr([0, 0], [1, 1], [n, n])
-vec = odl.util.shepp_logan(spc)
+vec = odl.util.shepp_logan(spc, modified=True)
 
 # Create a figure by saving the result of show
 fig = None

--- a/examples/visualization/show_update_2d.py
+++ b/examples/visualization/show_update_2d.py
@@ -15,7 +15,7 @@
 # You should have received a copy of the GNU General Public License
 # along with ODL.  If not, see <http://www.gnu.org/licenses/>.
 
-""" Example on using show and updating the figure in real time in 2d. """
+"""Example on using show and updating the figure in real time in 2d."""
 
 # Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import

--- a/odl/diagnostics/operator.py
+++ b/odl/diagnostics/operator.py
@@ -35,6 +35,7 @@ __all__ = ('OperatorTest',)
 
 
 class OperatorTest(object):
+
     """Automated tests for `Operator` implementations.
 
     This class allows users to automatically test various
@@ -78,7 +79,7 @@ class OperatorTest(object):
         print('\n== Calculating operator norm ==\n')
 
         operator_norm = 0.0
-        for [n_x, x] in samples(self.operator.domain):
+        for _, x in samples(self.operator.domain):
             result = self.operator(x)
             x_norm = x.norm()
             estimate = 0 if x_norm == 0 else result.norm() / x_norm
@@ -93,30 +94,30 @@ class OperatorTest(object):
         """Verify (Ax, y) = (x, Ay)"""
         print('\nVerifying the identity (Ax, y) = (x, Ay)')
 
-        Axy_vals = []
-        xAty_vals = []
+        left_inner_vals = []
+        right_inner_vals = []
 
         with FailCounter('error = ||(Ax, y) - (x, Ay)|| / '
                          '||A|| ||x|| ||y||') as counter:
-            for [n_x, x], [n_y, y] in samples(self.operator.domain,
-                                              self.operator.range):
+            for [name_x, x], [name_y, y] in samples(self.operator.domain,
+                                                    self.operator.range):
                 x_norm = x.norm()
                 y_norm = y.norm()
 
-                Axy = self.operator(x).inner(y)
-                xAy = x.inner(self.operator(y))
+                l_inner = self.operator(x).inner(y)
+                r_inner = x.inner(self.operator(y))
 
                 denom = self.operator_norm * x_norm * y_norm
-                error = 0 if denom == 0 else abs(Axy - xAy) / denom
+                error = 0 if denom == 0 else abs(l_inner - r_inner) / denom
 
                 if error > 0.00001:
                     counter.fail('x={:25s} y={:25s} : error={:6.5f}'
-                                 ''.format(n_x, n_y, error))
+                                 ''.format(name_x, name_y, error))
 
-                Axy_vals.append(Axy)
-                xAty_vals.append(xAy)
+                left_inner_vals.append(l_inner)
+                right_inner_vals.append(r_inner)
 
-        scale = np.polyfit(Axy_vals, xAty_vals, 1)[0]
+        scale = np.polyfit(left_inner_vals, right_inner_vals, 1)[0]
         print('\nThe adjoint seems to be scaled according to:')
         print('(x, Ay) / (Ax, y) = {}. Should be 1.0'.format(scale))
 
@@ -124,30 +125,30 @@ class OperatorTest(object):
         """Verify (Ax, y) = (x, A^T y)"""
         print('\nVerifying the identity (Ax, y) = (x, A^T y)')
 
-        Axy_vals = []
-        xAty_vals = []
+        left_inner_vals = []
+        right_inner_vals = []
 
         with FailCounter('error = ||(Ax, y) - (x, A^T y)|| / '
                          '||A|| ||x|| ||y||') as counter:
-            for [n_x, x], [n_y, y] in samples(self.operator.domain,
-                                              self.operator.range):
+            for [name_x, x], [name_y, y] in samples(self.operator.domain,
+                                                    self.operator.range):
                 x_norm = x.norm()
                 y_norm = y.norm()
 
-                Axy = self.operator(x).inner(y)
-                xAty = x.inner(self.operator.adjoint(y))
+                l_inner = self.operator(x).inner(y)
+                r_inner = x.inner(self.operator.adjoint(y))
 
                 denom = self.operator_norm * x_norm * y_norm
-                error = 0 if denom == 0 else abs(Axy - xAty) / denom
+                error = 0 if denom == 0 else abs(l_inner - r_inner) / denom
 
                 if error > 0.00001:
                     counter.fail('x={:25s} y={:25s} : error={:6.5f}'
-                                 ''.format(n_x, n_y, error))
+                                 ''.format(name_x, name_y, error))
 
-                Axy_vals.append(Axy)
-                xAty_vals.append(xAty)
+                left_inner_vals.append(l_inner)
+                right_inner_vals.append(r_inner)
 
-        scale = np.polyfit(Axy_vals, xAty_vals, 1)[0]
+        scale = np.polyfit(left_inner_vals, right_inner_vals, 1)[0]
         print('\nThe adjoint seems to be scaled according to:')
         print('(x, A^T y) / (Ax, y) = {}. Should be 1.0'.format(scale))
 
@@ -167,18 +168,18 @@ class OperatorTest(object):
 
         with FailCounter('error = ||Ax - (A^T)^T x|| / '
                          '||A|| ||x||') as counter:
-            for [n_x, x] in vector_examples(self.operator.domain):
-                A_result = self.operator(x)
-                ATT_result = self.operator.adjoint.adjoint(x)
+            for [name_x, x] in vector_examples(self.operator.domain):
+                opx = self.operator(x)
+                op_adj_adj_x = self.operator.adjoint.adjoint(x)
 
                 denom = self.operator_norm * x.norm()
                 if denom == 0:
                     error = 0
                 else:
-                    error = (A_result - ATT_result).norm() / denom
+                    error = (opx - op_adj_adj_x).norm() / denom
                 if error > 0.00001:
                     counter.fail('x={:25s} : error={:6.5f}'
-                                 ''.format(n_x, error))
+                                 ''.format(name_x, error))
 
     def adjoint(self):
         """Verify that `Operator.adjoint` works appropriately.
@@ -219,8 +220,8 @@ class OperatorTest(object):
 
         with FailCounter("error = ||A(x+c*dx)-A(x)-c*A'(x)(dx)|| / "
                          "|c| ||dx|| ||A||") as counter:
-            for [n_x, x], [n_dx, dx] in samples(self.operator.domain,
-                                                self.operator.domain):
+            for [name_x, x], [name_dx, dx] in samples(self.operator.domain,
+                                                      self.operator.domain):
                 deriv = self.operator.derivative(x)
                 opx = self.operator(x)
 
@@ -232,7 +233,7 @@ class OperatorTest(object):
 
                 if error > 0.00001:
                     counter.fail('x={:15s} dx={:15s} c={}: error={:6.5f}'
-                                 ''.format(n_x, n_dx, step, error))
+                                 ''.format(name_x, name_dx, step, error))
 
     def derivative(self, step=0.0001):
         """Verify that `Operator.derivative` works appropriately.
@@ -273,8 +274,8 @@ class OperatorTest(object):
         # Test scaling
         with FailCounter('error = ||A(c*x)-c*A(x)|| / '
                          '|c| ||A|| ||x||') as counter:
-            for [n_x, x], scale in samples(self.operator.domain,
-                                           self.operator.domain.field):
+            for [name_x, x], scale in samples(self.operator.domain,
+                                              self.operator.domain.field):
                 opx = self.operator(x)
                 scaled_opx = self.operator(scale * x)
 
@@ -284,7 +285,7 @@ class OperatorTest(object):
 
                 if error > 0.00001:
                     counter.fail('x={:25s} scale={:7.2f} error={:6.5f}'
-                                 ''.format(n_x, scale, error))
+                                 ''.format(name_x, scale, error))
 
     def _addition_invariance(self):
         print("\nCalculating invariance under addition")
@@ -292,8 +293,8 @@ class OperatorTest(object):
         # Test addition
         with FailCounter('error = ||A(x+y) - A(x) - A(y)|| / '
                          '||A||(||x|| + ||y||)') as counter:
-            for [n_x, x], [n_y, y] in samples(self.operator.domain,
-                                              self.operator.domain):
+            for [name_x, x], [name_y, y] in samples(self.operator.domain,
+                                                    self.operator.domain):
                 opx = self.operator(x)
                 opy = self.operator(y)
                 opxy = self.operator(x + y)
@@ -304,7 +305,7 @@ class OperatorTest(object):
 
                 if error > 0.00001:
                     counter.fail('x={:25s} y={:25s} error={:6.5f}'
-                                 ''.format(n_x, n_y, error))
+                                 ''.format(name_x, name_y, error))
 
     def linear(self):
         """Verify that the operator is actually linear."""

--- a/odl/diagnostics/space.py
+++ b/odl/diagnostics/space.py
@@ -34,9 +34,11 @@ from odl.util.testutils import FailCounter
 __all__ = ('SpaceTest',)
 
 
-def _apprimately_equal(x, y, eps):
-    # Tests if vectors x and y are approximately equal
-    # eps is an given error
+def _approx_equal(x, y, eps):
+    """Test if vectors ``x`` and ``y`` are approximately equal.
+
+    ``eps`` is a given absolute tolerance.
+    """
     if x.space != y.space:
         return False
 
@@ -44,7 +46,7 @@ def _apprimately_equal(x, y, eps):
         return True
 
     try:
-        return x.dist(y) < eps
+        return x.dist(y) <= eps
     except NotImplementedError:
         try:
             return x == y
@@ -62,7 +64,7 @@ class SpaceTest(object):
     """
 
     def __init__(self, space, eps=0.00001):
-        """ Initialize an instance
+        """Initialize a new instance.
 
         Parameters
         ----------
@@ -79,12 +81,12 @@ class SpaceTest(object):
         print('\n== Verifying element method ==\n')
 
         try:
-            el = self.space.element()
+            elem = self.space.element()
         except NotImplementedError:
             print('*** element failed ***')
             return
 
-        if el not in self.space:
+        if elem not in self.space:
             print('*** space.element() not in space ***')
         else:
             print('space.element() OK')
@@ -110,10 +112,10 @@ class SpaceTest(object):
             print('*** field.element(0) failed ***')
             return
 
-        if not zero == 0:
+        if zero != 0:
             print('*** field.element(0) != 0 ***')
 
-        if not zero == 0.0:
+        if zero != 0.0:
             print('*** field.element(0) != 0.0 ***')
 
         # one
@@ -123,10 +125,10 @@ class SpaceTest(object):
             print('*** field.element(1) failed ***')
             return
 
-        if not one == 1:
+        if one != 1:
             print('*** field.element(1) != 1 ***')
 
-        if not one == 1.0:
+        if one != 1.0:
             print('*** field.element(1) != 1.0 ***')
 
         # minus one
@@ -136,13 +138,14 @@ class SpaceTest(object):
             print('*** field.element(-1) failed ***')
             return
 
-        if not minus_one == -1:
+        if minus_one != -1:
             print('*** field.element(-1) != -1 ***')
 
-        if not minus_one == -1.0:
+        if minus_one != -1.0:
             print('*** field.element(-1) != -1.0 ***')
 
     def _associativity_of_addition(self):
+        """Check addition associativity."""
         print('\nAssociativity of addition, '
               'x + (y + z) = (x + y) + z')
 
@@ -150,23 +153,25 @@ class SpaceTest(object):
             for [n_x, x], [n_y, y], [n_z, z] in samples(self.space,
                                                         self.space,
                                                         self.space):
-                ok = _apprimately_equal(x + (y + z), (x + y) + z, self.eps)
-                if not ok:
+                correct = _approx_equal(x + (y + z), (x + y) + z, self.eps)
+                if not correct:
                     counter.fail('failed with x={:25s} y={:25s} z={:25s}'
                                  ''.format(n_x, n_y, n_z))
 
     def _commutativity_of_addition(self):
+        """Check addition commutativity."""
         print('\nCommutativity of addition, x + y = y + x')
 
         with FailCounter() as counter:
             for [n_x, x], [n_y, y] in samples(self.space,
                                               self.space):
-                ok = _apprimately_equal(x + y, y + x, self.eps)
-                if not ok:
+                correct = _approx_equal(x + y, y + x, self.eps)
+                if not correct:
                     counter.fail('failed with x={:25s} y={:25s}'
                                  ''.format(n_x, n_y))
 
     def _identity_of_addition(self):
+        """Check additional neutral element ('zero')."""
         print('\nIdentity element of addition, x + 0 = x')
 
         try:
@@ -176,21 +181,23 @@ class SpaceTest(object):
 
         with FailCounter() as counter:
             for [n_x, x] in samples(self.space):
-                ok = _apprimately_equal(x + zero, x, self.eps)
-                if not ok:
+                correct = _approx_equal(x + zero, x, self.eps)
+                if not correct:
                     counter.fail('failed with x={:25s}'.format(n_x))
 
     def _inverse_element_of_addition(self):
+        """Check additional inverse."""
         print('\nInverse element of addition, x + (-x) = 0')
         zero = self.space.zero()
 
         with FailCounter() as counter:
             for [n_x, x] in samples(self.space):
-                ok = _apprimately_equal(x + (-x), zero, self.eps)
-                if not ok:
+                correct = _approx_equal(x + (-x), zero, self.eps)
+                if not correct:
                     counter.fail('failed with x={:25s}'.format(n_x))
 
     def _commutativity_of_scalar_mult(self):
+        """Check scalar multiplication commutativity."""
         print('\nCommutativity of scalar multiplication, '
               'a * (b * x) = (a * b) * x')
 
@@ -198,21 +205,23 @@ class SpaceTest(object):
             for [n_x, x], a, b in samples(self.space,
                                           self.space.field,
                                           self.space.field):
-                ok = _apprimately_equal(a * (b * x), (a * b) * x, self.eps)
-                if not ok:
+                correct = _approx_equal(a * (b * x), (a * b) * x, self.eps)
+                if not correct:
                     counter.fail('failed with x={:25s}, a={}, b={}'
                                  ''.format(n_x, a, b))
 
     def _identity_of_mult(self):
+        """Check multiplicative neutral element ('one')."""
         print('\nIdentity element of multiplication, 1 * x = x')
 
         with FailCounter() as counter:
             for [n_x, x] in samples(self.space):
-                ok = _apprimately_equal(1 * x, x, self.eps)
-                if not ok:
+                correct = _approx_equal(1 * x, x, self.eps)
+                if not correct:
                     counter.fail('failed with x={:25s}'.format(n_x))
 
     def _distributivity_of_mult_vector(self):
+        """Check vector multiplication distributivity."""
         print('\nDistributivity of multiplication wrt vector add, '
               'a * (x + y) = a * x + a * y')
 
@@ -220,12 +229,13 @@ class SpaceTest(object):
             for [n_x, x], [n_y, y], a in samples(self.space,
                                                  self.space,
                                                  self.space.field):
-                ok = _apprimately_equal(a * (x + y), a * x + a * y, self.eps)
-                if not ok:
+                correct = _approx_equal(a * (x + y), a * x + a * y, self.eps)
+                if not correct:
                     counter.fail('failed with x={:25s}, y={:25s}, a={}'
                                  ''.format(n_x, n_y, a))
 
     def _distributivity_of_mult_scalar(self):
+        """Check scalar multiplication distributivity."""
         print('\nDistributivity of multiplication wrt scalar add, '
               '(a + b) * x = a * x + b * x')
 
@@ -233,63 +243,67 @@ class SpaceTest(object):
             for [n_x, x], a, b in samples(self.space,
                                           self.space.field,
                                           self.space.field):
-                ok = _apprimately_equal((a + b) * x, a * x + b * x, self.eps)
-                if not ok:
+                correct = _approx_equal((a + b) * x, a * x + b * x, self.eps)
+                if not correct:
                     counter.fail('failed with x={:25s}, a={}, b={}'
                                  ''.format(n_x, a, b))
 
     def _subtraction(self):
+        """Check subtraction as addition of additive inverse."""
         print('\nSubtraction, x - y = x + (-1 * y)')
 
         with FailCounter() as counter:
             for [n_x, x], [n_y, y] in samples(self.space,
                                               self.space):
-                ok = (_apprimately_equal(x - y, x + (-1 * y), self.eps) and
-                      _apprimately_equal(x - y, x + (-y), self.eps))
-                if not ok:
+                correct = (_approx_equal(x - y, x + (-1 * y), self.eps) and
+                           _approx_equal(x - y, x + (-y), self.eps))
+                if not correct:
                     counter.fail('failed with x={:25s}, y={:25s}'
                                  ''.format(n_x, n_y))
 
     def _division(self):
+        """Check scalar division as multiplication with mult. inverse."""
         print('\nDivision, x / a = x * (1/a)')
 
         with FailCounter() as counter:
             for [n_x, x], a in samples(self.space,
                                        self.space.field):
                 if a != 0:
-                    ok = _apprimately_equal(x / a, x * (1.0 / a), self.eps)
-                    if not ok:
+                    correct = _approx_equal(x / a, x * (1.0 / a), self.eps)
+                    if not correct:
                         counter.fail('failed with x={:25s}, a={}'
                                      ''.format(n_x, a))
 
     def _lincomb_aliased(self):
+        """Check several scenarios of aliased linear combination."""
         print('\nAliased input in lincomb')
 
         with FailCounter() as counter:
             for [n_x, x_in], [n_y, y] in samples(self.space, self.space):
                 x = x_in.copy()
                 x.lincomb(1, x, 1, y)
-                ok = _apprimately_equal(x, x_in + y, self.eps)
-                if not ok:
+                correct = _approx_equal(x, x_in + y, self.eps)
+                if not correct:
                     counter.fail('failed with x.lincomb(1, x, 1, y),'
                                  'x={:25s} y={:25s} '
                                  ''.format(n_x, n_y))
 
                 x = x_in.copy()
                 x.lincomb(1, x, 1, x)
-                ok = _apprimately_equal(x, x_in + x_in, self.eps)
-                if not ok:
+                correct = _approx_equal(x, x_in + x_in, self.eps)
+                if not correct:
                     counter.fail('failed with x.lincomb(1, x, 1, x),'
                                  'x={:25s} '
                                  ''.format(n_x))
 
     def _lincomb(self):
+        """Check linear combination."""
         print('\nTesting lincomb')
 
         self._lincomb_aliased()
 
     def linearity(self):
-        """Verifies the linear space properties by examples
+        """Verify the linear space properties by examples.
 
         These properties include things such as associativity
 
@@ -320,6 +334,7 @@ class SpaceTest(object):
         self._lincomb()
 
     def _inner_linear_scalar(self):
+        """Check homogeneity of the inner product in the first argument."""
         print('\nLinearity scalar, (a*x, y) = a*(x, y)')
 
         with FailCounter('error = |(a*x, y) - a*(x, y)|') as counter:
@@ -332,6 +347,7 @@ class SpaceTest(object):
                                  ''.format(n_x, n_y, a, error))
 
     def _inner_conjugate_symmetry(self):
+        """Check conjugate symmetry of the inner product."""
         print('\nConjugate symmetry, (x, y) = (y, x).conj()')
 
         with FailCounter('error = |(x, y) - (y, x).conj()|') as counter:
@@ -343,6 +359,7 @@ class SpaceTest(object):
                                  ''.format(n_x, n_y, error))
 
     def _inner_linear_sum(self):
+        """Check additivity of the inner product in the first argument."""
         print('\nLinearity sum, (x+y, z) = (x, z) + (y, z)')
 
         with FailCounter('error = |(x+y, z) - ((x, z)+(y, z))|') as counter:
@@ -355,6 +372,7 @@ class SpaceTest(object):
                                  ''.format(n_x, n_y, n_z, error))
 
     def _inner_positive(self):
+        """Check positive definiteness of the inner product."""
         print('\nPositivity, (x, x) >= 0')
 
         with FailCounter() as counter:
@@ -409,6 +427,7 @@ class SpaceTest(object):
         self._inner_positive()
 
     def _norm_positive(self):
+        """Check nonnegativity of the norm."""
         print('\nPositivity, ||x|| >= 0')
 
         with FailCounter() as counter:
@@ -424,6 +443,7 @@ class SpaceTest(object):
                                  ''.format(n_x, norm))
 
     def _norm_subadditive(self):
+        """Check subadditivity of the norm."""
         print('\nSub-additivity, ||x+y|| <= ||x|| + ||y||')
 
         with FailCounter('error = ||x+y|| - ||x|| + ||y||') as counter:
@@ -440,6 +460,7 @@ class SpaceTest(object):
                                  ''.format(n_x, n_y, error))
 
     def _norm_homogeneity(self):
+        """Check positive homogeneity of the norm."""
         print('\nHomogeneity, ||a*x|| = |a| ||x||')
 
         with FailCounter('error = abs(||a*x|| - |a| ||x||)') as counter:
@@ -451,6 +472,7 @@ class SpaceTest(object):
                                  ''.format(name, scalar, error))
 
     def _norm_inner_compatible(self):
+        """Check compatibility of norm and inner product."""
         print('\nInner compatibility, ||x||^2 = (x, x)')
 
         try:
@@ -505,6 +527,7 @@ class SpaceTest(object):
         self._norm_inner_compatible()
 
     def _dist_positivity(self):
+        """Check nonnegativity of the distance."""
         print('\nPositivity, d(x, y) >= 0')
 
         with FailCounter() as counter:
@@ -520,6 +543,7 @@ class SpaceTest(object):
                                  ''.format(n_x, n_y, dist))
 
     def _dist_symmetric(self):
+        """Check symmetry of the distance."""
         print('\nSymmetry, d(x, y) = d(y, x)')
 
         with FailCounter('error = |d(x, y) - d(y, x)|') as counter:
@@ -534,6 +558,7 @@ class SpaceTest(object):
                                  ''.format(n_x, n_y, error))
 
     def _dist_subadditive(self):
+        """Check subadditivity of the distance."""
         print('\nSub-additivity, d(x, y) = d(y, x)')
 
         with FailCounter('error = d(x,z) - (d(x, y) + d(y, z))') as counter:
@@ -550,6 +575,7 @@ class SpaceTest(object):
                                  ''.format(n_x, n_y, n_z, error))
 
     def _dist_norm_compatible(self):
+        """Check compatibility of distance and norm."""
         print('\nNorm compatibility, d(x, y) = ||x-y||')
 
         try:
@@ -605,6 +631,7 @@ class SpaceTest(object):
         self._dist_norm_compatible()
 
     def _multiply_zero(self):
+        """Check vector multiplication with zero is zero."""
         print('\nMultiplication by zero, x * 0 = 0')
 
         zero = self.space.zero()
@@ -618,30 +645,33 @@ class SpaceTest(object):
                                  ''.format(n_x, error))
 
     def _multiply_commutative(self):
+        """Check commutativity of vector multiplication."""
         print('\nMultiplication commutative, x * y = y * x')
 
         with FailCounter() as counter:
-            for [n_x, x], [n_y, y], [n_z, z] in samples(self.space,
-                                                        self.space,
-                                                        self.space):
-                ok = _apprimately_equal(x * y, y * x, self.eps)
-                if not ok:
+            for [n_x, x], [n_y, y], _ in samples(self.space,
+                                                 self.space,
+                                                 self.space):
+                correct = _approx_equal(x * y, y * x, self.eps)
+                if not correct:
                     counter.fail('failed with x={:25s} y={:25s}'
                                  ''.format(n_x, n_y))
 
     def _multiply_associative(self):
+        """Check associativity of vector multiplication."""
         print('\nMultiplication associative, x * (y * z) = (x * y) * z')
 
         with FailCounter() as counter:
             for [n_x, x], [n_y, y], [n_z, z] in samples(self.space,
                                                         self.space,
                                                         self.space):
-                ok = _apprimately_equal(x * (y * z), (x * y) * z, self.eps)
-                if not ok:
+                correct = _approx_equal(x * (y * z), (x * y) * z, self.eps)
+                if not correct:
                     counter.fail('failed with x={:25s} y={:25s} z={:25s}'
                                  ''.format(n_x, n_y, n_z))
 
     def _multiply_distributive_scalar(self):
+        """Check distributivity of scalar multiplication."""
         print('\nMultiplication distributive wrt scal, a * (x + y) = '
               'a * x + a * y')
 
@@ -649,12 +679,13 @@ class SpaceTest(object):
             for [n_x, x], [n_y, y], a in samples(self.space,
                                                  self.space,
                                                  self.space.field):
-                ok = _apprimately_equal(a * (x + y), a * x + a * y, self.eps)
-                if not ok:
+                correct = _approx_equal(a * (x + y), a * x + a * y, self.eps)
+                if not correct:
                     counter.fail('failed with x={:25s} y={:25s} a={}'
                                  ''.format(n_x, n_y, a))
 
     def _multiply_distributive_vec(self):
+        """Check distributivity of vector multiplication."""
         print('\nMultiplication distributive wrt vec, x * (y + z) = '
               'x * y + x * z')
 
@@ -662,8 +693,8 @@ class SpaceTest(object):
             for [n_x, x], [n_y, y], [n_z, z] in samples(self.space,
                                                         self.space,
                                                         self.space):
-                ok = _apprimately_equal(x * (y + z), x * y + x * z, self.eps)
-                if not ok:
+                correct = _approx_equal(x * (y + z), x * y + x * z, self.eps)
+                if not correct:
                     counter.fail('failed with x={:25s} y={:25s} z={:25s}'
                                  ''.format(n_x, n_y, n_z))
 
@@ -762,8 +793,8 @@ class SpaceTest(object):
             for [n_x, x], [n_y, y] in samples(self.space,
                                               self.space):
                 x.assign(y)
-                ok = _apprimately_equal(x, y, self.eps)
-                if not ok:
+                correct = _approx_equal(x, y, self.eps)
+                if not correct:
                     counter.fail('failed with x={:25s} y={:25s}'
                                  ''.format(n_x, n_y))
 
@@ -776,15 +807,15 @@ class SpaceTest(object):
             for [n_x, x] in samples(self.space):
                 # equal after copy
                 y = x.copy()
-                ok = _apprimately_equal(x, y, self.eps)
-                if not ok:
+                correct = _approx_equal(x, y, self.eps)
+                if not correct:
                     counter.fail('failed with x={:s5s}'
                                  ''.format(n_x))
 
                 # modify y, x stays the same
                 y *= 2.0
-                ok = n_x == 'Zero' or not _apprimately_equal(x, y, self.eps)
-                if not ok:
+                correct = n_x == 'Zero' or not _approx_equal(x, y, self.eps)
+                if not correct:
                     counter.fail('modified y, x changed with x={:25s}'
                                  ''.format(n_x))
 
@@ -797,8 +828,8 @@ class SpaceTest(object):
         with FailCounter() as counter:
             for [n_x, x] in samples(self.space):
                 x.set_zero()
-                ok = _apprimately_equal(x, zero, self.eps)
-                if not ok:
+                correct = _approx_equal(x, zero, self.eps)
+                if not correct:
                     counter.fail('failed with x={:25s}'
                                  ''.format(n_x))
 
@@ -841,7 +872,7 @@ class SpaceTest(object):
 
         with FailCounter() as counter:
             for [n_x, x] in samples(self.space):
-                if not x.space == self.space:
+                if x.space != self.space:
                     counter.fail('failed with x={:25s}'.format(n_x))
 
     def vector(self):
@@ -873,10 +904,13 @@ class SpaceTest(object):
         self.vector()
 
     def __str__(self):
+        """Return ``str(self)``."""
         return 'SpaceTest({})'.format(self.space)
 
     def __repr__(self):
+        """Return ``repr(self)``."""
         return 'SpaceTest({!r})'.format(self.space)
+
 
 if __name__ == '__main__':
     from odl.space.ntuples import Rn

--- a/odl/discr/discretization.py
+++ b/odl/discr/discretization.py
@@ -278,7 +278,7 @@ class RawDiscretizationVector(NtuplesBaseVector):
             `True` if all entries of ``other`` are equal to this
             vector's entries, `False` otherwise.
         """
-        return (isinstance(other, RawDiscretizationVector) and
+        return (other in self.space and
                 self.ntuple == other.ntuple)
 
     def __getitem__(self, indices):

--- a/odl/discr/grid.py
+++ b/odl/discr/grid.py
@@ -330,7 +330,6 @@ class TensorGrid(Set):
         if self.as_midp != getattr(other, 'as_midp', self.as_midp):
             return False
 
-        # pylint: disable=arguments-differ
         return (isinstance(other, TensorGrid) and
                 self.ndim == other.ndim and
                 self.shape == other.shape and
@@ -412,7 +411,6 @@ class TensorGrid(Set):
         # Array version of the fuzzy subgrid test, about 3 times faster
         # than the loop version.
         for vec_o, vec_s in zip(other.coord_vectors, self.coord_vectors):
-            # pylint: disable=unbalanced-tuple-unpacking
             vec_o_mg, vec_s_mg = sparse_meshgrid(vec_o, vec_s)
             if not np.all(np.any(np.abs(vec_s_mg - vec_o_mg) <= tol, axis=0)):
                 return False

--- a/odl/operator/default_ops.py
+++ b/odl/operator/default_ops.py
@@ -117,10 +117,11 @@ class ScalingOperator(Operator):
 
     @property
     def adjoint(self):
-        """ The adjoint is given by taking the conjugate of the scalar
-        """
-        # TODO: optimize to self if `scal` is real
-        return ScalingOperator(self._space, self._scal.conjugate())
+        """Adjoint, given as scaling with the conjugate of the scalar."""
+        if complex(self._scal).imag == 0.0:
+            return self
+        else:
+            return ScalingOperator(self._space, self._scal.conjugate())
 
     def __repr__(self):
         """op.__repr__() <==> repr(op)."""
@@ -326,7 +327,7 @@ class MultiplyOperator(Operator):
 
     @property
     def adjoint(self):
-        """ The adjoint operator.
+        """The adjoint operator.
 
         Returns
         -------
@@ -414,7 +415,7 @@ class InnerProductOperator(Operator):
 
     @property
     def adjoint(self):
-        """ The adjoint operator.
+        """The adjoint operator.
 
         Returns
         -------
@@ -531,38 +532,33 @@ class ConstantOperator(Operator):
 
 class ResidualOperator(Operator):
 
-    """ Operator that returns the residual of some operator application
-    with a vector
+    """Operator that calculates the residual ``op(x) - vec``.
 
-    ``ResidualOperator(op, vector)(x) <==> op(x) - vector``
+    ``ResidualOperator(op, vector)(x) <==> op(x) - vec``
     """
 
-    def __init__(self, op, vector):
-        """ Initialize an instance.
+    def __init__(self, op, vec):
+        """Initialize a new instance.
 
         Parameters
         ----------
-        vector : `LinearSpaceVector`
-            The vector constant to be returned
-
-        dom : `LinearSpace`, default : vector.space
-            The domain of the operator.
+        op : `Operator`
+            Operator to be used in the residual expression. Its
+            `Operator.range` must be a `LinearSpace`.
+        vec : `Operator.range` element-like
+            Vector to be subtracted from the operator result
         """
         if not isinstance(op, Operator):
             raise TypeError('op {!r} not a Operator instance.'
                             ''.format(op))
 
-        if not isinstance(vector, LinearSpaceVector):
-            raise TypeError('space {!r} not a LinearSpaceVector instance.'
-                            ''.format(vector))
-
-        if vector not in op.range:
-            raise TypeError('space {!r} not in op.range {!r}.'
-                            ''.format(vector, op.range))
+        if not isinstance(op.range, LinearSpace):
+            raise TypeError('operator range {!r} not a LinearSpace instance.'
+                            ''.format(op.range))
 
         self.op = op
-        self.vector = vector
-        super().__init__(op.domain, vector.space)
+        self.vector = op.range.element(vec)
+        super().__init__(op.domain, op.range)
 
     def _call(self, x, out=None):
         """Evaluate the residual at ``x``.

--- a/odl/operator/operator.py
+++ b/odl/operator/operator.py
@@ -98,7 +98,6 @@ def _signature_from_spec(func):
     sig : `str`
         Signature of the function
     """
-    # pylint: disable=deprecated-method,redefined-variable-type,no-member
     py3 = (sys.version_info.major > 2)
     if py3:
         spec = inspect.getfullargspec(func)
@@ -232,7 +231,6 @@ def _dispatch_call_args(cls=None, bound_call=None, unbound_call=None,
     else:
         call = unbound_call
 
-    # pylint: disable=deprecated-method,redefined-variable-type
     if py3:
         # support kw-only args and annotations
         spec = inspect.getfullargspec(call)
@@ -431,7 +429,6 @@ class Operator(object):
         """Create a new instance."""
         instance = super().__new__(cls)
 
-        # pylint: disable=redefined-variable-type
         call_has_out, call_out_optional, _ = _dispatch_call_args(cls)
         instance._call_has_out = call_has_out
         instance._call_out_optional = call_out_optional
@@ -918,7 +915,6 @@ class Operator(object):
         >>> squared(x)
         Rn(3).element([27.0, 54.0, 81.0])
         """
-        # pylint: disable=redefined-variable-type
         if isinstance(n, Integral) and n > 0:
             op = self
             while n > 1:
@@ -1084,10 +1080,13 @@ class OperatorSum(Operator):
     def derivative(self, x):
         """Return the operator derivative at ``x``.
 
-        # TODO: finish doc
-
         The derivative of a sum of two operators is equal to the sum of
         the derivatives.
+
+        Parameters
+        ----------
+        x : `Operator.domain` element-like
+            Evaluation point of the derivative
         """
         return OperatorSum(self._op1.derivative(x), self._op2.derivative(x))
 
@@ -1184,17 +1183,23 @@ class OperatorComp(Operator):
         """
         return OperatorComp(self._right.inverse, self._left.inverse, self._tmp)
 
-    def derivative(self, point):
+    def derivative(self, x):
         """Return the operator derivative.
 
         The derivative of the operator composition follows the chain
         rule:
 
-        ``OperatorComp(left, right).derivative(point) ==
-        OperatorComp(left.derivative(right(point)), right.derivative(point))``
+        ``OperatorComp(left, right).derivative(x) ==
+        OperatorComp(left.derivative(right(x)), right.derivative(x))``
+
+        Parameters
+        ----------
+        x : `Operator.domain` element-like
+            Evaluation point of the derivative. Needs to be usable as
+            input for the ``right`` operator.
         """
-        left_deriv = self._left.derivative(self._right(point))
-        right_deriv = self._right.derivative(point)
+        left_deriv = self._left.derivative(self._right(x))
+        right_deriv = self._right.derivative(x)
 
         return OperatorComp(left_deriv, right_deriv)
 
@@ -1347,6 +1352,11 @@ class OperatorLeftScalarMult(Operator):
         ``OperatorLeftScalarMult(op, scalar).derivative(x) <==>``
         ``OperatorLeftScalarMult(op.derivative(x), scalar)``
 
+        Parameters
+        ----------
+        x : `Operator.domain` element-like
+            Evaluation point of the derivative
+
         See also
         --------
         OperatorLeftScalarMult : the result
@@ -1461,6 +1471,11 @@ class OperatorRightScalarMult(Operator):
 
         ``OperatorRightScalarMult(op, scalar).derivative(x) <==>``
         ``OperatorLeftScalarMult(op.derivative(scalar * x), scalar)``
+
+        Parameters
+        ----------
+        x : `Operator.domain` element-like
+            Evaluation point of the derivative
         """
         return OperatorLeftScalarMult(self._op.derivative(self._scalar * x),
                                       self._scalar)
@@ -1502,11 +1517,12 @@ class FunctionalLeftVectorMult(Operator):
     """Expression type for the functional left vector multiplication.
 
     A functional is a `Operator` whose `Operator.range` is
-    a `Field`.
+    a `Field`. It is multiplied from left with a vector, resulting in
+    an operator mapping from the `Operator.domain` to the vector's
+    `LinearSpaceVector.space`.
 
     ``FunctionalLeftVectorMult(op, vector)(x) <==> vector * op(x)``
     """
-    # TODO: improve doc, not comprehensible
 
     def __init__(self, op, vector):
         """Initialize a new instance.
@@ -1516,7 +1532,7 @@ class FunctionalLeftVectorMult(Operator):
         op : `Operator`
             The range of ``op`` must be a `Field`.
         vector : `LinearSpaceVector`
-            The vector to multiply by. its space's
+            The vector to multiply by. Its space's
             `LinearSpace.field` must be the same as
             ``op.range``
         """
@@ -1871,6 +1887,5 @@ def simple_operator(call=None, inv=None, deriv=None, dom=None, ran=None,
 
 
 if __name__ == '__main__':
-    # pylint: disable=wrong-import-order,wrong-import-position
     from doctest import testmod, NORMALIZE_WHITESPACE
     testmod(optionflags=NORMALIZE_WHITESPACE)

--- a/odl/operator/pspace_ops.py
+++ b/odl/operator/pspace_ops.py
@@ -381,7 +381,7 @@ class ComponentProjection(Operator):
 
     @property
     def index(self):
-        """ Index of the subspace. """
+        """Index of the subspace."""
         return self._index
 
     def _call(self, x, out=None):
@@ -492,7 +492,7 @@ class ComponentProjectionAdjoint(Operator):
 
     @property
     def index(self):
-        """ Index of the subspace. """
+        """Index of the subspace."""
         return self._index
 
     def _call(self, x, out=None):

--- a/odl/set/domain.py
+++ b/odl/set/domain.py
@@ -17,7 +17,7 @@
 
 # Imports for common Python 2/3 codebase
 
-""" Typical domains for inverse problems. """
+"""Typical domains for inverse problems. """
 
 from __future__ import print_function, division, absolute_import
 
@@ -177,7 +177,6 @@ class IntervalProd(Set):
         >>> rbox1.approx_equals(rbox2, tol=1e-15)
         True
         """
-        # pylint: disable=arguments-differ
         if other is self:
             return True
         elif not isinstance(other, IntervalProd):

--- a/odl/set/pspace.py
+++ b/odl/set/pspace.py
@@ -48,9 +48,9 @@ def _strip_space(x):
 
 def _indent(x):
     """Indent a string by 4 characters."""
-    lines = x.split('\n')
-    for i in range(len(lines)):
-        lines[i] = '    ' + lines[i]
+    lines = x.splitlines()
+    for i, line in enumerate(lines):
+        lines[i] = '    ' + line
     return '\n'.join(lines)
 
 
@@ -166,7 +166,7 @@ class ProductSpace(LinearSpace):
                 self._weights = np.atleast_1d(weights)
                 if not np.all(self._weights > 0):
                     raise ValueError('weights must all be positive')
-                if not len(self._weights) == len(spaces):
+                if len(self._weights) != len(spaces):
                     raise ValueError('spaces and weights have different '
                                      'lengths ({} != {}).'
                                      ''.format(len(spaces), len(weights)))
@@ -332,11 +332,13 @@ class ProductSpace(LinearSpace):
         return self.element([space.one() for space in self.spaces])
 
     def _lincomb(self, a, x, b, y, out):
+        """Linear combination ``out = a*x + b*y``."""
         for space, xp, yp, outp in zip(self.spaces, x.parts, y.parts,
                                        out.parts):
             space._lincomb(a, xp, b, yp, outp)
 
     def _dist(self, x1, x2):
+        """Distance between two vectors."""
         dists = np.fromiter(
             (spc._dist(x1p, x2p)
              for spc, x1p, x2p in zip(self.spaces, x1.parts, x2.parts)),
@@ -344,6 +346,7 @@ class ProductSpace(LinearSpace):
         return self._prod_norm(dists)
 
     def _norm(self, x):
+        """Norm of a vector."""
         norms = np.fromiter(
             (spc._norm(xp)
              for spc, xp in zip(self.spaces, x.parts)),
@@ -351,6 +354,7 @@ class ProductSpace(LinearSpace):
         return self._prod_norm(norms)
 
     def _inner(self, x1, x2):
+        """Inner product of two vectors."""
         inners = np.fromiter(
             (spc._inner(x1p, x2p)
              for spc, x1p, x2p in zip(self.spaces, x1.parts, x2.parts)),
@@ -358,11 +362,13 @@ class ProductSpace(LinearSpace):
         return self._prod_inner_sum(inners)
 
     def _multiply(self, x1, x2, out):
+        """Product ``out = x1 * x2``."""
         for spc, xp, yp, outp in zip(self.spaces, x1.parts, x2.parts,
                                      out.parts):
             spc._multiply(xp, yp, outp)
 
     def _divide(self, x1, x2, out):
+        """Quotient ``out = x1 / x2``."""
         for spc, xp, yp, outp in zip(self.spaces, x1.parts, x2.parts,
                                      out.parts):
             spc._divide(xp, yp, outp)
@@ -439,7 +445,8 @@ class ProductSpace(LinearSpace):
 
 
 class ProductSpaceVector(LinearSpaceVector):
-    """ Elements in a `ProductSpace` """
+
+    """Elements of a `ProductSpace`."""
 
     def __init__(self, space, parts):
         """"Initialize a new instance."""
@@ -613,8 +620,7 @@ class ProductSpaceVector(LinearSpaceVector):
         return '{!r}.element({})'.format(self.space, inner_str)
 
     def show(self, *args, **kwargs):
-        """ Display the parts of this vector.
-        """
+        """Display the parts of this vector."""
         title = kwargs.pop('title', 'ProductSpaceVector')
         indices = kwargs.pop('indices', None)
 

--- a/odl/set/sets.py
+++ b/odl/set/sets.py
@@ -19,9 +19,7 @@
 
 # Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
-
 from builtins import int, object, str, zip
-from odl.util.utility import with_metaclass
 from future import standard_library
 from past.builtins import basestring
 standard_library.install_aliases()
@@ -32,7 +30,8 @@ from numbers import Integral, Real, Complex
 import numpy as np
 
 # ODL
-from odl.util.utility import is_int_dtype, is_real_dtype, is_scalar_dtype
+from odl.util.utility import (is_int_dtype, is_real_dtype, is_scalar_dtype,
+                              with_metaclass)
 
 
 __all__ = ('Set', 'EmptySet', 'UniversalSet', 'Field', 'Integers',
@@ -108,7 +107,7 @@ class Set(with_metaclass(ABCMeta, object)):
         """
         return self == other
 
-    def contains_all(self, other, **kwargs):
+    def contains_all(self, other):
         """Test if all points in ``other`` are contained in this set.
 
         This is a default implementation and should be overridden by
@@ -210,10 +209,10 @@ class Strings(Set):
             The fixed length of the strings in this set. Must be
             positive.
         """
-        le = int(length)
-        if le <= 0:
+        length_ = int(length)
+        if length_ <= 0:
             raise ValueError('`length` {} is not positive.'.format(length))
-        self._length = le
+        self._length = length_
 
     @property
     def length(self):
@@ -232,9 +231,9 @@ class Strings(Set):
         dtype = getattr(array, 'dtype', None)
         if dtype is None:
             dtype = np.result_type(*array)
-        dtype_byte = np.dtype('S{}'.format(self.length))
+        dtype_str = np.dtype('S{}'.format(self.length))
         dtype_uni = np.dtype('<U{}'.format(self.length))
-        return dtype in (dtype_byte, dtype_uni)
+        return dtype in (dtype_str, dtype_uni)
 
     def __eq__(self, other):
         """Return ``self == other``."""

--- a/odl/set/space.py
+++ b/odl/set/space.py
@@ -624,7 +624,7 @@ class LinearSpaceVector(object):
             return self.__ipow__(n // 2)
         else:
             tmp = self.copy()
-            for i in range(n - 1):
+            for _ in range(n - 1):
                 self.space.multiply(tmp, self, out=tmp)
             return tmp
 

--- a/odl/solvers/findroot/newton.py
+++ b/odl/solvers/findroot/newton.py
@@ -96,16 +96,16 @@ Goldfarb%E2%80%93Shanno_algorithm>`_
         # grad_diff = grad(x) - grad(x_old)
         grad_diff.space.lincomb(-1, grad_diff, 1, grad_x, out=grad_diff)
 
-        ys = grad_diff.inner(x_update)
+        y_inner_s = grad_diff.inner(x_update)
         # TODO: use a small (adjustable) tolerance instead of 0.0
-        if ys == 0.0:
+        if y_inner_s == 0.0:
             return
 
         # Update Hessian
-        hess = ((ident - x_update * grad_diff.T / ys) *
+        hess = ((ident - x_update * grad_diff.T / y_inner_s) *
                 hess *
-                (ident - grad_diff * x_update.T / ys) +
-                x_update * x_update.T / ys)
+                (ident - grad_diff * x_update.T / y_inner_s) +
+                x_update * x_update.T / y_inner_s)
 
         if partial is not None:
             partial.send(x)

--- a/odl/solvers/scalar/steplen.py
+++ b/odl/solvers/scalar/steplen.py
@@ -130,7 +130,7 @@ class BacktrackingLineSearch(LineSearch):
         """
         self.function = function
         self.tau = tau
-        self.c = c
+        self.discount = c
         self.total_num_iter = 0
         # Use a default value that allows the shortest step to be < 0.0001
         # times the original step length
@@ -160,7 +160,7 @@ class BacktrackingLineSearch(LineSearch):
         fx = self.function(x)
         num_iter = 0
         while ((self.function(x + alpha * direction) >=
-                fx + alpha * dir_derivative * self.c) and
+                fx + alpha * dir_derivative * self.discount) and
                num_iter <= self.max_num_iter):
             num_iter += 1
             alpha *= self.tau

--- a/odl/solvers/util/partial.py
+++ b/odl/solvers/util/partial.py
@@ -15,6 +15,8 @@
 # You should have received a copy of the GNU General Public License
 # along with ODL.  If not, see <http://www.gnu.org/licenses/>.
 
+"""Partial objects for per-iterate actions in iterative methods."""
+
 # Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
 from future import standard_library

--- a/odl/space/cu_ntuples.py
+++ b/odl/space/cu_ntuples.py
@@ -27,11 +27,10 @@ from builtins import int, super
 import numpy as np
 
 # ODL imports
-from odl.set.space import LinearSpace, LinearSpaceVector
-from odl.space.base_ntuples import (NtuplesBase, NtuplesBaseVector,
-                                    FnBase, FnBaseVector,
-                                    FnWeightingBase)
-from odl.util.utility import is_real_dtype, is_real_floating_dtype, dtype_repr
+from odl.set.space import LinearSpaceVector
+from odl.space.base_ntuples import (
+    NtuplesBase, NtuplesBaseVector, FnBase, FnBaseVector, FnWeightingBase)
+from odl.util.utility import dtype_repr
 from odl.util.ufuncs import CudaNtuplesUFuncs
 
 try:
@@ -49,6 +48,7 @@ __all__ = ('CudaNtuples', 'CudaNtuplesVector',
 
 
 def _get_int_type():
+    """Return the correct int vector type on the current platform."""
     if np.dtype(np.int).itemsize == 4:
         return 'CudaVectorInt32'
     elif np.dtype(np.int).itemsize == 8:
@@ -58,6 +58,7 @@ def _get_int_type():
 
 
 def _add_if_exists(dtype, name):
+    """Add ``dtype`` to ``CUDA_DTYPES`` if it's available."""
     if hasattr(cuda, name):
         _TYPE_MAP_NPY2CUDA[np.dtype(dtype)] = getattr(cuda, name)
         CUDA_DTYPES.append(np.dtype(dtype))
@@ -431,7 +432,7 @@ class CudaNtuplesVector(NtuplesBaseVector, LinearSpaceVector):
                 # Convert value to the correct type if needed
                 value_array = np.asarray(values, dtype=self.space.dtype)
 
-                if (value_array.ndim == 0):
+                if value_array.ndim == 0:
                     self.data.fill(values)
                 else:
                     # Size checking is performed in c++
@@ -489,6 +490,7 @@ class CudaNtuplesVector(NtuplesBaseVector, LinearSpaceVector):
 
 
 def _repr_space_funcs(space):
+    """Return the string in the parentheses of repr for space funcs."""
     inner_str = ''
 
     weight = 1.0
@@ -953,6 +955,7 @@ def CudaRn(size, dtype=np.float32, **kwargs):
 
 
 def _weighting(weight, exponent):
+    """Return a weighting whose type is inferred from the arguments."""
     if np.isscalar(weight):
         weighting = CudaFnConstWeighting(
             weight, exponent)
@@ -1056,36 +1059,43 @@ def cu_weighted_dist(weight, exponent=2.0):
 
 
 def _dist_default(x1, x2):
+    """Default Euclidean distance implementation."""
     return x1.data.dist(x2.data)
 
 
 def _pdist_default(x1, x2, p):
+    """Default p-distance implementation."""
     if p == float('inf'):
         raise NotImplementedError('inf-norm not implemented.')
     return x1.data.dist_power(x2.data, p)
 
 
 def _pdist_diagweight(x1, x2, p, w):
+    """Diagonally weighted p-distance implementation."""
     return x1.data.dist_weight(x2.data, p, w.data)
 
 
 def _norm_default(x):
+    """Default Euclidean norm implementation."""
     return x.data.norm()
 
 
 def _pnorm_default(x, p):
+    """Default p-norm implementation."""
     if p == float('inf'):
         raise NotImplementedError('inf-norm not implemented.')
     return x.data.norm_power(p)
 
 
 def _pnorm_diagweight(x, p, w):
+    """Diagonally weighted p-norm implementation."""
     if p == float('inf'):
         raise NotImplementedError('inf-norm not implemented.')
     return x.data.norm_weight(p, w.data)
 
 
 def _inner_default(x1, x2):
+    """Default Euclidean inner product implementation."""
     return x1.data.inner(x2.data)
 
 

--- a/odl/space/fspace.py
+++ b/odl/space/fspace.py
@@ -58,10 +58,8 @@ def _default_out_of_place(func, dtype, x, **kwargs):
         raise TypeError('cannot use in-place method to implement '
                         'out-of-place non-vectorized evaluation.')
 
-    # TODO: implement this. Needs a helper to infer data type without
-    # creating an array.
     if dtype is None:
-        raise NotImplementedError('lazy out-of-place default not implemented.')
+        dtype = np.result_type(*x)
 
     out = np.empty(out_shape, dtype=dtype)
     func(x, out=out, **kwargs)
@@ -638,9 +636,13 @@ class FunctionSpace(FunctionSet, LinearSpace):
         return out
 
     def _multiply(self, x1, x2, out):
-        """Raw pointwise multiplication of two functions."""
-        # pylint: disable=no-self-use
+        """Raw pointwise multiplication of two functions.
 
+        Notes
+        -----
+        The multiplication is implemented with a simple Python
+        function, so the non-vectorized versions are slow.
+        """
         # Store to allow aliasing
         x1_call_oop = x1._call_out_of_place
         x1_call_ip = x1._call_in_place
@@ -666,8 +668,6 @@ class FunctionSpace(FunctionSet, LinearSpace):
 
     def _divide(self, x1, x2, out):
         """Raw pointwise division of two functions."""
-        # pylint: disable=no-self-use
-
         # Store to allow aliasing
         x1_call_oop = x1._call_out_of_place
         x1_call_ip = x1._call_in_place
@@ -693,7 +693,6 @@ class FunctionSpace(FunctionSet, LinearSpace):
 
     def _scalar_power(self, x, p, out):
         """Raw p-th power of a function, p integer or general scalar."""
-        # pylint: disable=no-self-use
         x_call_oop = x._call_out_of_place
         x_call_ip = x._call_in_place
 

--- a/odl/space/ntuples.py
+++ b/odl/space/ntuples.py
@@ -26,9 +26,9 @@ This is a default implementation of :math:`A^n` for an arbitrary set
 from __future__ import print_function, division, absolute_import
 
 from future import standard_library
+from future.utils import native
 standard_library.install_aliases()
 from builtins import super
-from future.utils import native
 
 # External module imports
 import ctypes
@@ -41,8 +41,8 @@ from scipy.sparse.base import isspmatrix
 
 # ODL imports
 from odl.operator.operator import Operator
-from odl.space.base_ntuples import (NtuplesBase, NtuplesBaseVector,
-                                    FnBase, FnBaseVector, FnWeightingBase)
+from odl.space.base_ntuples import (
+    NtuplesBase, NtuplesBaseVector, FnBase, FnBaseVector, FnWeightingBase)
 from odl.util.utility import (
     dtype_repr, is_real_dtype, is_real_floating_dtype,
     is_complex_floating_dtype)
@@ -451,9 +451,6 @@ def _blas_is_applicable(*args):
     x1,...,xN : `NtuplesBaseVector`
         The vectors to be tested for BLAS conformity
     """
-    if len(args) == 0:
-        return False
-
     return (all(x.dtype == args[0].dtype and
                 x.dtype in _BLAS_DTYPES and
                 x.data.flags.contiguous
@@ -488,7 +485,6 @@ def _lincomb(a, x1, b, x2, out, dtype):
         return x2
 
     if _blas_is_applicable(x1, x2, out):
-        # pylint: disable=unbalanced-tuple-unpacking
         axpy, scal, copy = linalg.blas.get_blas_funcs(
             ['axpy', 'scal', 'copy'], arrays=(x1.data, x2.data, out.data))
     else:
@@ -539,6 +535,7 @@ def _lincomb(a, x1, b, x2, out, dtype):
 
 
 def _repr_space_funcs(space):
+    """Return the string in the parentheses of repr for space funcs."""
     inner_str = ''
 
     weight = 1.0
@@ -691,6 +688,7 @@ class Fn(FnBase, Ntuples):
 
             Default: `False`.
         """
+        Ntuples.__init__(self, size, dtype)
         FnBase.__init__(self, size, dtype)
 
         dist = kwargs.pop('dist', None)
@@ -1026,7 +1024,7 @@ class Fn(FnBase, Ntuples):
 
     @property
     def element_type(self):
-        """ `FnVector` """
+        """Return `FnVector`."""
         return FnVector
 
 
@@ -1040,6 +1038,7 @@ class FnVector(FnBaseVector, NtuplesVector):
             raise TypeError('{!r} not an `Fn` instance.'
                             ''.format(space))
 
+        FnBaseVector.__init__(self, space)
         NtuplesVector.__init__(self, space, data)
 
     @property
@@ -1368,6 +1367,7 @@ class MatVecOperator(Operator):
 
 
 def _weighting(weight, exponent, dist_using_inner=False):
+    """Return a weighting whose type is inferred from the arguments."""
     if np.isscalar(weight):
         weighting = FnConstWeighting(
             weight, exponent=exponent, dist_using_inner=dist_using_inner)
@@ -1483,6 +1483,7 @@ def weighted_dist(weight, exponent=2.0, use_inner=False):
 
 
 def _norm_default(x):
+    """Default Euclidean norm implementation."""
     if _blas_is_applicable(x):
         nrm2 = linalg.blas.get_blas_funcs('nrm2', dtype=x.dtype)
         norm = partial(nrm2, n=native(x.size))
@@ -1492,12 +1493,12 @@ def _norm_default(x):
 
 
 def _pnorm_default(x, p):
-    # TODO: Other approaches based on BLAS dot or nrm2 do not give a speed
-    # advantage. Maybe there is a faster method?
+    """Default p-norm implementation."""
     return np.linalg.norm(x.data, ord=p)
 
 
 def _pnorm_diagweight(x, p, w):
+    """Diagonally weighted p-norm implementation."""
     # This is faster than first applying the weights and then summing with
     # BLAS dot or nrm2
     xp = np.abs(x.data)
@@ -1511,6 +1512,7 @@ def _pnorm_diagweight(x, p, w):
 
 
 def _inner_default(x1, x2):
+    """Default Euclidean inner product implementation."""
     if _blas_is_applicable(x1, x2):
         dotc = linalg.blas.get_blas_funcs('dotc', dtype=x1.dtype)
         dot = partial(dotc, n=native(x1.size))
@@ -2104,7 +2106,6 @@ class FnConstWeighting(FnWeightingBase):
         if other is self:
             return True
 
-        # TODO: make symmetric?
         return (isinstance(other, FnConstWeighting) and
                 self.const == other.const and
                 super().__eq__(other))
@@ -2235,8 +2236,7 @@ class FnNoWeighting(FnConstWeighting):
     _instance = None
 
     def __new__(cls, *args, **kwargs):
-        """ Implement singleton pattern if exp==2.0
-        """
+        """Implement singleton pattern if ``exp==2.0``."""
         if len(args) == 0:
             exponent = kwargs.pop('exponent', 2.0)
             dist_using_inner = kwargs.pop('dist_using_inner', False)
@@ -2357,7 +2357,6 @@ class FnCustomInnerProduct(FnWeightingBase):
             `True` if other is an `FnCustomInnerProduct`
             instance with the same inner product, `False` otherwise.
         """
-        # TODO: make symmetric
         return (isinstance(other, FnCustomInnerProduct) and
                 self.inner == other.inner and
                 super().__eq__(other))
@@ -2423,7 +2422,6 @@ class FnCustomNorm(FnWeightingBase):
             `True` if other is an `FnCustomNorm`
             instance with the same norm, `False` otherwise.
         """
-        # TODO: make symmetric
         return (isinstance(other, FnCustomNorm) and
                 self.norm == other.norm and
                 super().__eq__(other))

--- a/odl/trafos/wavelet.py
+++ b/odl/trafos/wavelet.py
@@ -25,16 +25,15 @@ from builtins import range, str, super
 
 # External
 import numpy as np
-
-# Internal
-from odl.discr.lp_discr import DiscreteLp
-from odl.operator.operator import Operator
-
 try:
     import pywt
     PYWAVELETS_AVAILABLE = True
 except ImportError:
     PYWAVELETS_AVAILABLE = False
+
+# Internal
+from odl.discr.lp_discr import DiscreteLp
+from odl.operator.operator import Operator
 
 __all__ = ('DiscreteWaveletTransform', 'DiscreteWaveletTransformInverse',
            'PYWAVELETS_AVAILABLE')
@@ -179,7 +178,7 @@ def pywt_coeff_to_array(coeff, size_list):
         ``[aaaN, (aadN, adaN, addN, daaN, dadN, ddaN, dddN), ...
         (aad1, ada1, add1, daa1, dad1, dda1, ddd1)]``
 
-        The appreviations refer to
+        The abbreviations refer to
 
         ``aaa`` = approx. on 1st dim, approx. on 2nd dim, approx. on 3rd dim,
 
@@ -235,9 +234,9 @@ def pywt_coeff_to_array(coeff, size_list):
             start, stop = stop, stop + fsize
             flat_coeff[start:stop] = detail_coeffs.ravel()
         else:
-            for dc in detail_coeffs:
+            for dcoeff in detail_coeffs:
                 start, stop = stop, stop + fsize
-                flat_coeff[start:stop] = dc.ravel()
+                flat_coeff[start:stop] = dcoeff.ravel()
 
     return flat_coeff
 
@@ -305,7 +304,7 @@ def array_to_pywt_coeff(coeff, size_list):
         ``[aaaN, (aadN, adaN, addN, daaN, dadN, ddaN, dddN), ...
         (aad1, ada1, add1, daa1, dad1, dda1, ddd1)]``
 
-        The appreviations refer to,
+        The abbreviations refer to
 
         ``aaa`` = approx. on 1st dim, approx. on 2nd dim, approx. on 3rd dim,
 
@@ -382,7 +381,7 @@ signal-extension-modes.html>`_ of PyWavelets.
          ```[aaaN, (aadN, adaN, addN, daaN, dadN, ddaN, dddN), ...
          (aad1, ada1, add1, daa1, dad1, dda1, ddd1)]``` .
 
-         The appreviations refer to,
+         The abbreviations refer to
 
          ``aaa`` = approx. on 1st dim, approx. on 2nd dim, approx. on 3rd dim,
 
@@ -417,7 +416,7 @@ signal-extension-modes.html>`_ of PyWavelets.
     coeff_list = []
     coeff_list.append(details)
 
-    for kk in range(1, nscales):
+    for _ in range(1, nscales):
         wcoeffs = pywt.dwtn(aaa, wbasis, mode)
         aaa = wcoeffs['aaa']
         aad = wcoeffs['aad']
@@ -453,7 +452,7 @@ def wavelet_reconstruction3d(coeff_list, wbasis, mode, nscales):
         ```[caaaN, (aadN, adaN, addN, daaN, dadN, ddaN, dddN), ...
         (aad1, ada1, add1, daa1, dad1, dda1, ddd1)]```.
 
-        The appreviations refer to
+        The abbreviations refer to
 
         ``aaa`` = approx. on 1st dim, approx. on 2nd dim, approx. on 3rd dim,
 
@@ -494,13 +493,12 @@ signal-extension-modes.html>`_
         A wavalet reconstruction.
     """
     aaa = coeff_list[0]
-    k = 1
-    (aad, ada, add, daa, dad, dda, ddd) = coeff_list[k]
+    (aad, ada, add, daa, dad, dda, ddd) = coeff_list[1]
     coeff_dict = {'aaa': aaa, 'aad': aad, 'ada': ada, 'add': add,
                   'daa': daa, 'dad': dad, 'dda': dda, 'ddd': ddd}
-    for k in range(2, nscales + 1):
+    for tpl in coeff_list[2:]:
         aaa = pywt.idwtn(coeff_dict, wbasis, mode)
-        (aad, ada, add, daa, dad, dda, ddd) = coeff_list[k]
+        (aad, ada, add, daa, dad, dda, ddd) = tpl
         coeff_dict = {'aaa': aaa, 'aad': aad, 'ada': ada, 'add': add,
                       'daa': daa, 'dad': dad, 'dda': dda, 'ddd': ddd}
 
@@ -625,7 +623,7 @@ dwt-discrete-wavelet-transform.html#maximum-decomposition-level\
             raise NotImplementedError('ndim {} not 1, 2 or 3'
                                       ''.format(len(dom.ndim)))
 
-        # TODO: Maybe allow other ranges like Besov spaces (yet to be crated)
+        # TODO: Maybe allow other ranges like Besov spaces (yet to be created)
         ran = dom.dspace_type(ran_size, dtype=dom.dtype)
         super().__init__(dom, ran, linear=True)
 

--- a/odl/util/graphics.py
+++ b/odl/util/graphics.py
@@ -20,16 +20,15 @@
 
 # Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
-
 from future import standard_library
 standard_library.install_aliases()
 
-# ODL
-from odl.util.utility import is_real_dtype
-
-# External module imports
+# External
 from numbers import Integral
 import numpy as np
+
+# ODL
+from odl.util.utility import is_real_dtype
 
 
 __all__ = ('show_discrete_function',)
@@ -198,9 +197,9 @@ def show_discrete_function(dfunc, method='', title=None, indices=None,
             sub_kwargs.update({'projection': '3d'})
         elif method in ('wireframe', 'plot_wireframe'):
             method = 'plot_wireframe'
-            xm, ym = grid.meshgrid()
-            args_re = [xm, ym, np.rot90(values.real)]
-            args_im = ([xm, ym, np.rot90(values.imag)] if dfunc_is_complex
+            x, y = grid.meshgrid()
+            args_re = [x, y, np.rot90(values.real)]
+            args_im = ([x, y, np.rot90(values.imag)] if dfunc_is_complex
                        else [])
             sub_kwargs.update({'projection': '3d'})
         else:

--- a/odl/util/phantom.py
+++ b/odl/util/phantom.py
@@ -390,7 +390,7 @@ def derenzo_sources(space):
         raise ValueError("Dimension not 2, no phantom available")
 
 
-def shepp_logan(space, modified=True):
+def shepp_logan(space, modified=False):
     """Create a Shepp-Logan phantom.
 
     The standard Shepp-Logan phantom in 2 or 3 dimensions.

--- a/odl/util/phantom.py
+++ b/odl/util/phantom.py
@@ -30,7 +30,10 @@ __all__ = ('derenzo_sources', 'shepp_logan')
 
 
 def _shepp_logan_ellipse_2d():
-    # Modified Shepp Logan
+    """Return ellipse parameters for a 2d Shepp-Logan phantom.
+
+    This is the standard phantom in 2d medical imaging.
+    """
     return [[2.00, .6900, .9200, 0, 0, 0],
             [-.98, .6624, .8740, 0, -.0184, 0],
             [-.02, .1100, .3100, .22, 0, -18],
@@ -44,7 +47,11 @@ def _shepp_logan_ellipse_2d():
 
 
 def _modified_shepp_logan_ellipse_2d():
-    # Modified Shepp Logan
+    """Return ellipse parameters for a 2d modified Shepp-Logan phantom.
+
+    This is the modified version of the standard 2d medical imaging
+    phantom with higher contrast.
+    """
     return [[1.00, .6900, .9200, 0, 0, 0],
             [-.80, .6624, .8740, 0, -.0184, 0],
             [-.20, .1100, .3100, .22, 0, -18],
@@ -58,9 +65,10 @@ def _modified_shepp_logan_ellipse_2d():
 
 
 def _derenzo_sources_2d():
-    """ A popular phantom in spect/pet.
+    """Return ellipse parameters for a 2d Derenzo sources phantom.
 
-    This phantom defines the source terms.
+    This is a popular phantom in SPECT and PET. It defines the source
+    locations and intensities.
     """
     return [[1.0, 0.047788, 0.047788, -0.77758, -0.11811, 0.0],
             [1.0, 0.063525, 0.063525, -0.71353, 0.12182, 0.0],
@@ -144,6 +152,10 @@ def _derenzo_sources_2d():
 
 
 def _shepp_logan_ellipse_3d():
+    """Return ellipse parameters for a 3d Shepp-Logan phantom.
+
+    This is the standard phantom in 3d medical imaging.
+    """
     return [[2.00, .6900, .9200, .810, 0.0000, 0.0000, 0.00, 0.0, 0, 0],
             [-.98, .6624, .8740, .780, 0.0000, -.0184, 0.00, 0.0, 0, 0],
             [-.02, .1100, .3100, .220, 0.2200, 0.0000, 0.00, -18, 0, 10],
@@ -157,6 +169,11 @@ def _shepp_logan_ellipse_3d():
 
 
 def _modified_shepp_logan_ellipse_3d():
+    """Return ellipse parameters for a 3d modified Shepp-Logan phantom.
+
+    This is the modified version of the standard 3d medical imaging
+    phantom with higher contrast.
+    """
     return [[1.00, .6900, .9200, .810, 0.0000, 0.0000, 0.00, 0.0, 0, 0],
             [-.80, .6624, .8740, .780, 0.0000, -.0184, 0.00, 0.0, 0, 0],
             [-.20, .1100, .3100, .220, 0.2200, 0.0000, 0.00, -18, 0, 10],
@@ -202,9 +219,9 @@ def _phantom_2d(space, ellipses):
     points = points * 2 - 1
 
     for ellip in ellipses:
-        I = ellip[0]
-        a2 = ellip[1] ** 2
-        b2 = ellip[2] ** 2
+        intensity = ellip[0]
+        a_squared = ellip[1] ** 2
+        b_squared = ellip[2] ** 2
         x0 = ellip[3]
         y0 = ellip[4]
         phi = ellip[5] * np.pi / 180.0
@@ -216,19 +233,20 @@ def _phantom_2d(space, ellipses):
         sin_p = np.sin(phi)
 
         # Find the pixels within the ellipse
-        scales = [1 / a2, 1 / b2]
+        scales = [1 / a_squared, 1 / b_squared]
         mat = [[cos_p, sin_p],
                [-sin_p, cos_p]]
         radius = np.dot(scales, np.dot(mat, offset_points.T) ** 2)
         inside = radius <= 1
 
         # Add the ellipse intensity to those pixels
-        p[inside] += I
+        p[inside] += intensity
 
     return space.element(p)
 
 
 def _getshapes(center, max_radius, shape):
+    """Calculate indices and slices for the bounding box of a ball."""
     index_mean = shape * center
     index_radius = max_radius / 2.0 * np.array(shape)
 
@@ -267,8 +285,8 @@ def _phantom_3d(space, ellipses):
     # data volumes.
     #
     # The main optimization is that it only considers a subset of all the
-    # points when updating for each ellipse, it does this by first finding
-    # a subset of points that could possibly be inside the ellipse, this
+    # points when updating for each ellipse. It does this by first finding
+    # a subset of points that could possibly be inside the ellipse. This
     # approximation is accurate for "spherical" ellipsoids, but not so
     # accurate for elongated ones.
 
@@ -288,10 +306,10 @@ def _phantom_3d(space, ellipses):
         grid += [(grid_in[i] - meani) / diffi]
 
     for ellip in ellipses:
-        I = ellip[0]
-        a2 = ellip[1] ** 2
-        b2 = ellip[2] ** 2
-        c2 = ellip[3] ** 2
+        intensity = ellip[0]
+        a_squared = ellip[1] ** 2
+        b_squared = ellip[2] ** 2
+        c_squared = ellip[3] ** 2
         x0 = ellip[4]
         y0 = ellip[5]
         z0 = ellip[6]
@@ -299,7 +317,7 @@ def _phantom_3d(space, ellipses):
         theta = ellip[8] * np.pi / 180
         psi = ellip[9] * np.pi / 180
 
-        scales = [1 / a2, 1 / b2, 1 / c2]
+        scales = [1 / a_squared, 1 / b_squared, 1 / c_squared]
 
         # Create the offset x,y and z values for the grid
         if any([phi, theta, psi]):
@@ -325,7 +343,8 @@ def _phantom_3d(space, ellipses):
             # Since the points are rotated, we cannot do anything directional
             # without more logic
             center = (np.array([x0, y0, z0]) + 1.0) / 2.0
-            max_radius = np.sqrt(np.abs(mat).dot([a2, b2, c2]))
+            max_radius = np.sqrt(
+                np.abs(mat).dot([a_squared, b_squared, c_squared]))
             idx, shapes = _getshapes(center, max_radius, space.shape)
 
             subgrid = [g[idi] for g, idi in zip(grid, shapes)]
@@ -339,7 +358,7 @@ def _phantom_3d(space, ellipses):
         else:
             # Calculate the points that could possibly be inside the volume
             center = (np.array([x0, y0, z0]) + 1.0) / 2.0
-            max_radius = np.sqrt([a2, b2, c2])
+            max_radius = np.sqrt([a_squared, b_squared, c_squared])
             idx, shapes = _getshapes(center, max_radius, space.shape)
 
             subgrid = [g[idi] for g, idi in zip(grid, shapes)]
@@ -355,15 +374,15 @@ def _phantom_3d(space, ellipses):
         inside = radius <= 1
 
         # Add the ellipse intensity to those pixels
-        p[idx][inside] += I
+        p[idx][inside] += intensity
 
     return space.element(p)
 
 
 def derenzo_sources(space):
-    """ Creates the PET/SPECT derenzo phantom.
+    """Create the PET/SPECT Derenzo sources phantom.
 
-    The derenzo phantom contains a series of circles of decreasing size.
+    The Derenzo phantom contains a series of circles of decreasing size.
     """
     if space.ndim == 2:
         return _phantom_2d(space, _derenzo_sources_2d())
@@ -372,9 +391,9 @@ def derenzo_sources(space):
 
 
 def shepp_logan(space, modified=True):
-    """ Create a Shepp-Logan phantom.
+    """Create a Shepp-Logan phantom.
 
-    The shepp-logan phantom
+    The standard Shepp-Logan phantom in 2 or 3 dimensions.
 
     References
     ----------
@@ -400,14 +419,14 @@ if __name__ == '__main__':
     n = 300
 
     # 2D
-    disc = odl.uniform_discr([-1, -1], [1, 1], [n, n])
+    discr = odl.uniform_discr([-1, -1], [1, 1], [n, n])
 
-    shepp_logan(disc, modified=True).show()
-    shepp_logan(disc, modified=False).show()
-    derenzo_sources(disc).show()
+    shepp_logan(discr, modified=True).show()
+    shepp_logan(discr, modified=False).show()
+    derenzo_sources(discr).show()
 
     # Shepp-logan 3d
-    disc = odl.uniform_discr([-1, -1, -1], [1, 1, 1], [n, n, n])
+    discr = odl.uniform_discr([-1, -1, -1], [1, 1, 1], [n, n, n])
     with odl.util.Timer():
-        shepp_logan_3d = shepp_logan(disc)
+        shepp_logan_3d = shepp_logan(discr)
     shepp_logan_3d.show()

--- a/odl/util/testutils.py
+++ b/odl/util/testutils.py
@@ -24,7 +24,6 @@ standard_library.install_aliases()
 from builtins import int, object
 
 # External
-# pylint: disable=no-name-in-module
 from itertools import zip_longest
 import numpy as np
 from numpy import ravel_multi_index, prod
@@ -37,6 +36,7 @@ __all__ = ('almost_equal', 'all_equal', 'all_almost_equal', 'skip_if_no_cuda',
 
 
 def _places(a, b, default=5):
+    """Return 3 if one dtype is 'float32' or 'complex64', else 5."""
     dtype1 = getattr(a, 'dtype', object)
     dtype2 = getattr(b, 'dtype', object)
     small_dtypes = [np.float32, np.complex64]
@@ -48,6 +48,7 @@ def _places(a, b, default=5):
 
 
 def almost_equal(a, b, places=None):
+    """`True` if scalars a and b are almost equal."""
     if a is None and b is None:
         return True
 
@@ -75,6 +76,7 @@ def almost_equal(a, b, places=None):
 
 
 def all_equal(iter1, iter2):
+    """`True` if all elements in ``a`` and ``b`` are equal."""
     # Direct comparison for scalars, tuples or lists
     try:
         if iter1 == iter2:
@@ -88,23 +90,19 @@ def all_equal(iter1, iter2):
 
     # If one nested iterator is exhausted, go to direct comparison
     try:
-        i1 = iter(iter1)
-        i2 = iter(iter2)
+        it1 = iter(iter1)
+        it2 = iter(iter2)
     except TypeError:
         try:
-            if iter1 == iter2:
-                return True
-            else:
-                return False
+            return iter1 == iter2
         except ValueError:  # Raised by NumPy when comparing arrays
             return False
 
-    # Sentinel object used to check that both iterators are the same length
     diff_length_sentinel = object()
 
     # Compare element by element and return False if the sequences have
     # different lengths
-    for [ip1, ip2] in zip_longest(i1, i2,
+    for [ip1, ip2] in zip_longest(it1, it2,
                                   fillvalue=diff_length_sentinel):
         # Verify that none of the lists has ended (then they are not the
         # same size)
@@ -118,8 +116,7 @@ def all_equal(iter1, iter2):
 
 
 def all_almost_equal(iter1, iter2, places=None):
-    # Sentinel object used to check that both iterators are the same length
-
+    """`True` if all elements in ``a`` and ``b`` are almost equal."""
     try:
         if iter1 is iter2 or iter1 == iter2:
             return True
@@ -133,13 +130,13 @@ def all_almost_equal(iter1, iter2, places=None):
         places = _places(iter1, iter2, None)
 
     try:
-        i1 = iter(iter1)
-        i2 = iter(iter2)
+        it1 = iter(iter1)
+        it2 = iter(iter2)
     except TypeError:
         return almost_equal(iter1, iter2, places)
 
     diff_length_sentinel = object()
-    for [ip1, ip2] in zip_longest(i1, i2,
+    for [ip1, ip2] in zip_longest(it1, it2,
                                   fillvalue=diff_length_sentinel):
         # Verify that none of the lists has ended (then they are not the
         # same size)
@@ -153,10 +150,12 @@ def all_almost_equal(iter1, iter2, places=None):
 
 
 def is_subdict(subdict, dictionary):
+    """`True` if all items of ``subdict`` are in ``dictionary``."""
     return all(item in dictionary.items() for item in subdict.items())
 
 
 def _pass(function):
+    """Trivial decorator used if pytest marks are not available."""
     return function
 
 try:
@@ -194,6 +193,7 @@ class FailCounter(object):
         return self
 
     def fail(self, string=None):
+        """Add failure with reason as string."""
         self.num_failed += 1
 
         # Todo: possibly limit number of printed strings
@@ -256,10 +256,10 @@ def timeit(arg):
                 return arg(*args, **kwargs)
         return timed_function
     else:
-        def _timeit_helper(fn):
+        def _timeit_helper(func):
             def timed_function(*args, **kwargs):
                 with Timer(arg):
-                    return fn(*args, **kwargs)
+                    return func(*args, **kwargs)
             return timed_function
         return _timeit_helper
 
@@ -291,6 +291,7 @@ class ProgressBar(object):
     """
 
     def __init__(self, text='progress', *njobs):
+        """Initialize a new instance."""
         self.text = str(text)
         if len(njobs) == 0:
             raise ValueError('Need to provide at least one job len')
@@ -301,12 +302,14 @@ class ProgressBar(object):
         self.start()
 
     def start(self):
+        """Print the initial bar."""
         sys.stdout.write('\r{0}: [{1:30s}] Starting'.format(self.text,
                                                             ' ' * 30))
 
         sys.stdout.flush()
 
     def update(self, *indices):
+        """Update the bar according to ``indices``."""
         if indices:
             if len(indices) != len(self.njobs):
                 raise ValueError('number of indices not correct')
@@ -336,7 +339,10 @@ class ProgressBar(object):
 
 class ProgressRange(object):
 
+    """Simple range sequence with progress bar output."""
+
     def __init__(self, text, n):
+        """Initialize a new instance."""
         self.current = 0
         self.n = n
         self.bar = ProgressBar(text, n)

--- a/odl/util/ufuncs.py
+++ b/odl/util/ufuncs.py
@@ -15,13 +15,14 @@
 # You should have received a copy of the GNU General Public License
 # along with ODL.  If not, see <http://www.gnu.org/licenses/>.
 
-""" UFuncs for ODL vectors.
+"""UFuncs for ODL vectors.
 
 These functions are internal and should only be used as methods on
 `NtuplesBaseVector` type spaces.
 
 See `numpy.ufuncs
-<http://docs.scipy.org/doc/numpy-1.10.0/reference/ufuncs.html#universal-functions-ufunc>`_
+<http://docs.scipy.org/doc/numpy-1.10.0/reference/ufuncs.html#\
+universal-functions-ufunc>`_
 for more information.
 
 Notes
@@ -55,9 +56,8 @@ RAW_UFUNCS = ['absolute', 'add', 'arccos', 'arccosh', 'arcsin', 'arcsinh',
               'multiply', 'negative', 'nextafter', 'not_equal', 'power',
               'rad2deg', 'reciprocal', 'remainder', 'right_shift', 'rint',
               'sign', 'signbit', 'sin', 'sinh', 'sqrt', 'square', 'subtract',
-              'tan', 'tanh', 'true_divide', 'trunc'
-              # ,'isreal', 'iscomplex', 'ldexp', 'frexp'
-              ]
+              'tan', 'tanh', 'true_divide', 'trunc']
+# ,'isreal', 'iscomplex', 'ldexp', 'frexp'
 
 # Add some standardized information
 UFUNCS = []
@@ -155,10 +155,12 @@ def wrap_reduction_base(name, doc):
 
 
 class NtuplesBaseUFuncs(object):
+
     """UFuncs for `NtuplesBaseVector` objects.
 
     Internal object, should not be created except in `NtuplesBaseVector`.
     """
+
     def __init__(self, vector):
         """Create ufunc wrapper for vector."""
         self.vector = vector
@@ -228,6 +230,7 @@ def wrap_ufunc_ntuples(name, n_in, n_out, doc):
 
 
 class NtuplesUFuncs(NtuplesBaseUFuncs):
+
     """UFuncs for `NtuplesVector` objects.
 
     Internal object, should not be created except in `NtuplesVector`.
@@ -263,6 +266,12 @@ def _make_unary_fun(name):
 
 
 class CudaNtuplesUFuncs(NtuplesBaseUFuncs):
+
+    """UFuncs for `CudaNtuplesVector` objects.
+
+    Internal object, should not be created except in `CudaNtuplesVector`.
+    """
+
     # Ufuncs
     sin = _make_unary_fun('sin')
     cos = _make_unary_fun('cos')
@@ -352,6 +361,7 @@ def wrap_reduction_discretelp(name, doc):
 
 
 class DiscreteLpUFuncs(NtuplesBaseUFuncs):
+
     """UFuncs for `DiscreteLpVector` objects.
 
     Internal object, should not be created except in `DiscreteLpVector`.
@@ -434,6 +444,7 @@ def wrap_ufunc_productspace(name, n_in, n_out, doc):
 
 
 def wrap_reduction_productspace(name, doc):
+    """Add reduction methods to `ProductSpaceVector`."""
     def wrapper(self):
         results = [getattr(x.ufunc, name)() for x in self.vector]
         return getattr(np, name)(results)
@@ -444,6 +455,7 @@ def wrap_reduction_productspace(name, doc):
 
 
 class ProductSpaceUFuncs(object):
+
     """UFuncs for `ProductSpaceVector` objects.
 
     Internal object, should not be created except in `ProductSpaceVector`.

--- a/test/operator/difference_test_cuda.py
+++ b/test/operator/difference_test_cuda.py
@@ -74,8 +74,8 @@ class ForwardDiff2D(odl.Operator):
 
 
 class ForwardDiff2DAdjoint(odl.Operator):
-    """ Calculates the circular convolution of two CUDA vectors
-    """
+
+    """Calculate the circular convolution of two CUDA vectors."""
 
     def __init__(self, space):
         super().__init__(odl.ProductSpace(space, space), space, linear=True)

--- a/test/space/fspace_test.py
+++ b/test/space/fspace_test.py
@@ -28,22 +28,9 @@ import numpy as np
 
 # ODL imports
 import odl
-from odl import FunctionSpace
+from odl import FunctionSet, FunctionSpace
+from odl.discr.grid import sparse_meshgrid
 from odl.util.testutils import all_almost_equal, all_equal, almost_equal
-
-
-# Pytest fixture
-
-
-# Simply modify exp_params to modify the fixture
-exp_params = [2.0, 1.0, float('inf'), 0.5, 1.5]
-exp_ids = [' p = {} '.format(p) for p in exp_params]
-exp_fixture = pytest.fixture(scope="module", ids=exp_ids, params=exp_params)
-
-
-@exp_fixture
-def exponent(request):
-    return request.param
 
 
 def test_fspace_init():
@@ -112,8 +99,7 @@ def _meshgrid(domain, shape):
         vec = np.random.uniform(low=beg[i], high=end[i], size=shape[i])
         vec.sort()
         coord_vecs.append(vec)
-    return np.meshgrid(*coord_vecs, indexing='ij', sparse=True,
-                       copy=True)
+    return sparse_meshgrid(*coord_vecs)
 
 
 def test_fspace_vector_init():

--- a/test/util/vectorization_test.py
+++ b/test/util/vectorization_test.py
@@ -44,11 +44,11 @@ def test_is_valid_input_array():
 
     for shp in valid_shapes:
         arr = np.zeros(shp)
-        assert is_valid_input_array(arr, d=1)
+        assert is_valid_input_array(arr, ndim=1)
 
     for shp in invalid_shapes:
         arr = np.zeros(shp)
-        assert not is_valid_input_array(arr, d=1)
+        assert not is_valid_input_array(arr, ndim=1)
 
     # 3d
     valid_shapes = [(3, 1), (3, 2), (3, 20)]
@@ -56,16 +56,16 @@ def test_is_valid_input_array():
 
     for shp in valid_shapes:
         arr = np.zeros(shp)
-        assert is_valid_input_array(arr, d=3)
+        assert is_valid_input_array(arr, ndim=3)
 
     for shp in invalid_shapes:
         arr = np.zeros(shp)
-        assert not is_valid_input_array(arr, d=3)
+        assert not is_valid_input_array(arr, ndim=3)
 
     # Other input
     invalid_input = [1, [[1, 2], [3, 4]], (5,)]
     for inp in invalid_input:
-        assert not is_valid_input_array(inp, d=2)
+        assert not is_valid_input_array(inp, ndim=2)
 
 
 def test_is_valid_input_meshgrid():
@@ -74,36 +74,36 @@ def test_is_valid_input_meshgrid():
     x = np.zeros(2)
 
     valid_mg = sparse_meshgrid(x)
-    assert is_valid_input_meshgrid(valid_mg, d=1)
+    assert is_valid_input_meshgrid(valid_mg, ndim=1)
 
     invalid_mg = sparse_meshgrid(x, x)
-    assert not is_valid_input_meshgrid(invalid_mg, d=1)
+    assert not is_valid_input_meshgrid(invalid_mg, ndim=1)
 
     x = np.zeros((2, 2))
     invalid_mg = sparse_meshgrid(x)
-    assert not is_valid_input_meshgrid(invalid_mg, d=1)
+    assert not is_valid_input_meshgrid(invalid_mg, ndim=1)
 
     # 3d
     x, y, z = np.zeros(2), np.zeros(3), np.zeros(4)
 
     valid_mg = sparse_meshgrid(x, y, z)
-    assert is_valid_input_meshgrid(valid_mg, d=3)
+    assert is_valid_input_meshgrid(valid_mg, ndim=3)
 
     valid_mg = sparse_meshgrid(x, y, z, order='F')
-    assert is_valid_input_meshgrid(valid_mg, d=3)
+    assert is_valid_input_meshgrid(valid_mg, ndim=3)
 
     invalid_mg = sparse_meshgrid(x, x, y, z)
-    assert not is_valid_input_meshgrid(invalid_mg, d=3)
+    assert not is_valid_input_meshgrid(invalid_mg, ndim=3)
 
     x = np.zeros((3, 3))
     invalid_mg = sparse_meshgrid(x)
-    assert not is_valid_input_meshgrid(invalid_mg, d=3)
+    assert not is_valid_input_meshgrid(invalid_mg, ndim=3)
 
     # Other input
     invalid_input = [1, [1, 2], ([1, 2], [3, 4]), (5,), np.zeros((2, 2))]
     for inp in invalid_input:
-        assert not is_valid_input_meshgrid(inp, d=1)
-        assert not is_valid_input_meshgrid(inp, d=2)
+        assert not is_valid_input_meshgrid(inp, ndim=1)
+        assert not is_valid_input_meshgrid(inp, ndim=2)
 
 
 def test_meshgrid_input_order():


### PR DESCRIPTION
Reducing the errors and warnings as far as possible. Remaining stuff mainly consists in
- TODOs
- too many arguments / branches / local variables / return statements
- Imports at the wrong place
- Warnings in `__init__.py` files

Total number of warnings is now ~500, which is still a lot, but acceptable given the list above, which contributes over 90 %, I'd say.

Closes #194 
