### PR TITLE
BUG: Fix broken vectorized raw FunctionSetVector, see #195

### DIFF
--- a/odl/discr/discr_mappings.py
+++ b/odl/discr/discr_mappings.py
@@ -259,12 +259,19 @@ class GridCollocation(FunctionSetMapping):
         >>> coll_op(func_elem)
         Rn(6).element([-2.0, -1.0, -3.0, -2.0, -4.0, -3.0])
         """
-        mesh = self.grid.meshgrid()
-        if out is None:
-            out = func(mesh).ravel(order=self.order)
-        else:
-            func(mesh, out=out.asarray().reshape(self.grid.shape,
-                                                 order=self.order))
+        try:
+            mesh = self.grid.meshgrid()
+            if out is None:
+                out = func(mesh).ravel(order=self.order)
+            else:
+                func(mesh, out=out.asarray().reshape(self.grid.shape,
+                                                     order=self.order))
+        except (ValueError, TypeError):
+            points = self.grid.points()
+            if out is None:
+                out = func(points)
+            else:
+                func(points, out=out.asarray())
         return out
 
     def __repr__(self):

--- a/odl/space/fspace.py
+++ b/odl/space/fspace.py
@@ -306,18 +306,19 @@ class FunctionSetVector(Operator):
                                  'domain {}, missing `contains_all()` '
                                  'method.'.format(self.domain))
 
+        ndim = getattr(self.domain, 'ndim', None)
         # Check for input type and determine output shape
-        if is_valid_input_array(x, self.domain.ndim):
+        if is_valid_input_array(x, ndim):
             out_shape = out_shape_from_array(x)
             scalar_out = False
             # For 1d, squeeze the array
-            if self.domain.ndim == 1 and x.ndim == 2:
+            if ndim == 1 and x.ndim == 2:
                 x = x.squeeze()
-        elif is_valid_input_meshgrid(x, self.domain.ndim):
+        elif is_valid_input_meshgrid(x, ndim):
             out_shape = out_shape_from_meshgrid(x)
             scalar_out = False
             # For 1d, fish out the vector from the tuple
-            if self.domain.ndim == 1:
+            if ndim == 1:
                 x = x[0]
         elif x in self.domain:
             x = np.atleast_2d(x).T  # make a (d, 1) array

--- a/odl/util/vectorization.py
+++ b/odl/util/vectorization.py
@@ -36,11 +36,11 @@ __all__ = ('is_valid_input_array', 'is_valid_input_meshgrid',
            'vectorize')
 
 
-def is_valid_input_array(x, ndim):
+def is_valid_input_array(x, ndim=None):
     """Test if ``x`` is a correctly shaped point array in R^d."""
     if not isinstance(x, np.ndarray):
         return False
-    if ndim == 1:
+    if ndim is None or ndim == 1:
         return x.ndim == 1 or x.ndim == 2 and x.shape[0] == 1
     else:
         return x.ndim == 2 and x.shape[0] == ndim
@@ -48,13 +48,19 @@ def is_valid_input_array(x, ndim):
 
 def is_valid_input_meshgrid(x, ndim):
     """Test if ``x`` is a meshgrid sequence for points in R^d."""
+    # This case is triggered in FunctionSetVector.__call__ if the
+    # domain does not have an 'ndim' attribute. We return False and
+    # continue.
+    if ndim is None:
+        return False
     try:
-        iter(x)
+        len(x)
     except TypeError:
         return False
 
     if isinstance(x, np.ndarray):
         return False
+
     if ndim > 1:
         try:
             np.broadcast(*x)

--- a/test/space/fspace_test.py
+++ b/test/space/fspace_test.py
@@ -55,6 +55,12 @@ def test_fspace_init():
     FunctionSpace(ndbox, field=odl.ComplexNumbers())
 
 
+def test_fset_init():
+    str3 = odl.Strings(3)
+    ints = odl.Integers()
+    FunctionSet(str3, ints)
+
+
 def test_fspace_simple_attributes():
     intv = odl.Interval(0, 1)
     fspace = FunctionSpace(intv)
@@ -128,6 +134,23 @@ def test_fspace_vector_init():
     fspace.element(cfunc_2d_vec_oop, vectorized=True)
     fspace.element(cfunc_2d_vec_ip, vectorized=True)
     fspace.element(cfunc_2d_vec_dual, vectorized=True)
+
+
+def test_fset_vector_eval():
+    str3 = odl.Strings(3)
+    ints = odl.Integers()
+    fset = FunctionSet(str3, ints)
+    strings = np.array(['aa', 'b', 'cab', 'aba'])
+    out_vec = np.empty((4,), dtype=int)
+
+    # Vectorized for arrays only
+    f_vec = fset.element(lambda s: np.array([str(si).count('a') for si in s]))
+    true_vec = [2, 0, 1, 2]
+
+    assert f_vec('abc') == 1
+    assert all_equal(f_vec(strings), true_vec)
+    f_vec(strings, out=out_vec)
+    assert all_equal(out_vec, true_vec)
 
 
 def _standard_setup_2d():


### PR DESCRIPTION
This fixes the issue with the vectorization of `FunctionSetVector`'s which are not `FunctionSpaceVector`'s. I followed the suggested fix in #195. Additionally I had to handle the case `ndim=None` also in the `is_valid_input_meshgrid` function so that it doesn't crash. Now it just returns `False`.

Just saw that the test has a duplication. Removing that.