### PR TITLE
Issue 231 uniform discr dtype

### DIFF
--- a/odl/discr/lp_discr.py
+++ b/odl/discr/lp_discr.py
@@ -224,7 +224,7 @@ class DiscreteLp(Discretization):
             arg_fstr = '{}, {}, {}'
             if self.exponent != 2.0:
                 arg_fstr += ', exponent={exponent}'
-            if not self.dtype == default_dtype:
+            if self.dtype != default_dtype:
                 arg_fstr += ', dtype={dtype}'
             if self.interp != 'nearest':
                 arg_fstr += ', interp={interp!r}'
@@ -576,8 +576,7 @@ def uniform_discr_fromspace(fspace, nsamples, exponent=2.0, interp='nearest',
 
 
 def uniform_discr(min_corner, max_corner, nsamples,
-                  exponent=2.0, field=None,
-                  interp='nearest', impl='numpy', **kwargs):
+                  exponent=2.0, interp='nearest', impl='numpy', **kwargs):
     """Discretize an Lp function space by uniform sampling.
 
     Parameters

--- a/odl/discr/lp_discr.py
+++ b/odl/discr/lp_discr.py
@@ -33,12 +33,10 @@ from odl.discr.discretization import (
 from odl.discr.discr_mappings import (
     GridCollocation, NearestInterpolation, LinearInterpolation)
 from odl.discr.grid import uniform_sampling, RegularGrid
-from odl.set.sets import Field, RealNumbers
-from odl.set.domain import IntervalProd
-from odl.space.ntuples import Fn
-from odl.space.fspace import FunctionSpace
-from odl.space.cu_ntuples import CudaFn, CUDA_AVAILABLE
+from odl.set import RealNumbers, ComplexNumbers, IntervalProd
+from odl.space import Fn, FunctionSpace, CudaFn, CUDA_AVAILABLE
 from odl.util.ufuncs import DiscreteLpUFuncs
+from odl.util.utility import is_real_dtype, dtype_repr
 
 __all__ = ('DiscreteLp', 'DiscreteLpVector',
            'uniform_discr', 'uniform_discr_fromspace')
@@ -217,15 +215,17 @@ class DiscreteLp(Discretization):
                              as_midp=True) == self.grid):
             if isinstance(self.dspace, Fn):
                 impl = 'numpy'
+                default_dtype = np.float64
             elif isinstance(self.dspace, CudaFn):
                 impl = 'cuda'
+                default_dtype = np.float32
             else:  # This should never happen
                 raise RuntimeError('unable to determine data space impl.')
             arg_fstr = '{}, {}, {}'
             if self.exponent != 2.0:
                 arg_fstr += ', exponent={exponent}'
-            if not isinstance(self.field, RealNumbers):
-                arg_fstr += ', field={field!r}'
+            if not self.dtype == default_dtype:
+                arg_fstr += ', dtype={dtype}'
             if self.interp != 'nearest':
                 arg_fstr += ', interp={interp!r}'
             if impl != 'numpy':
@@ -245,7 +245,7 @@ class DiscreteLp(Discretization):
             arg_str = arg_fstr.format(
                 min_str, max_str, shape_str,
                 exponent=self.exponent,
-                field=self.field,
+                dtype=dtype_repr(self.dtype),
                 interp=self.interp,
                 impl=impl,
                 order=self.order)
@@ -576,7 +576,7 @@ def uniform_discr_fromspace(fspace, nsamples, exponent=2.0, interp='nearest',
 
 
 def uniform_discr(min_corner, max_corner, nsamples,
-                  exponent=2.0, field=RealNumbers(),
+                  exponent=2.0, field=None,
                   interp='nearest', impl='numpy', **kwargs):
     """Discretize an Lp function space by uniform sampling.
 
@@ -592,8 +592,6 @@ def uniform_discr(min_corner, max_corner, nsamples,
     exponent : positive `float`, optional
         The parameter :math:`p` in :math:`L^p`. If the exponent is not
         equal to the default 2.0, the space has no inner product.
-    field : `Field`, optional
-        The field of the `FunctionSpace`, default `RealNumbers`.
     interp : `str`, optional
             Interpolation type to be used for discretization.
 
@@ -629,18 +627,22 @@ def uniform_discr(min_corner, max_corner, nsamples,
     >>> uniform_discr([0, 0], [1, 1], [10, 10])
     uniform_discr([0.0, 0.0], [1.0, 1.0], [10, 10])
 
-    >>> from odl import ComplexNumbers
-    >>> uniform_discr([0, 0], [1, 1], [10, 10], field=ComplexNumbers())
-    uniform_discr([0.0, 0.0], [1.0, 1.0], [10, 10], field=ComplexNumbers())
+    Can create complex space by giving a dtype
+
+    >>> uniform_discr([0, 0], [1, 1], [10, 10], dtype='complex')
+    uniform_discr([0.0, 0.0], [1.0, 1.0], [10, 10], dtype='complex')
 
     See also
     --------
     uniform_discr_fromspace : uniform discretization from an existing
         function space
     """
-    if not isinstance(field, Field):
-        raise TypeError('field {} not a Field instance'
-                        ''.format(field))
+    # Select field by dtype
+    dtype = kwargs.get('dtype', None)
+    if dtype is None or is_real_dtype(dtype):
+        field = RealNumbers()
+    else:
+        field = ComplexNumbers()
 
     fspace = FunctionSpace(IntervalProd(min_corner, max_corner), field)
 

--- a/odl/util/utility.py
+++ b/odl/util/utility.py
@@ -87,6 +87,8 @@ def dtype_repr(dtype):
         return "'int'"
     elif dtype == np.dtype(float):
         return "'float'"
+    elif dtype == np.dtype(complex):
+        return "'complex'"
     else:
         return "'{}'".format(dtype)
 

--- a/test/discr/lp_discr_test.py
+++ b/test/discr/lp_discr_test.py
@@ -118,7 +118,7 @@ def test_factory(exponent):
     assert discr.dspace.exponent == exponent
 
     # Complex
-    discr = odl.uniform_discr(0, 1, 10, field=odl.ComplexNumbers(),
+    discr = odl.uniform_discr(0, 1, 10, dtype='complex',
                               impl='numpy', exponent=exponent)
 
     assert isinstance(discr.dspace, odl.Fn)
@@ -135,8 +135,7 @@ def test_factory_cuda(exponent):
 
     # Cuda currently does not support complex numbers, check error
     with pytest.raises(NotImplementedError):
-        odl.uniform_discr(0, 1, 10, impl='cuda',
-                          field=odl.ComplexNumbers())
+        odl.uniform_discr(0, 1, 10, impl='cuda', dtype='complex')
 
 
 def test_factory_dtypes():
@@ -145,40 +144,21 @@ def test_factory_dtypes():
                        np.uint8, np.uint16, np.uint32, np.uint64]
     complex_float_dtypes = [np.complex64, np.complex128]
 
-    # Real
-    invalid_dtypes = complex_float_dtypes
-
     for dtype in real_float_dtypes:
-        discr = odl.uniform_discr(0, 1, 10, impl='numpy', dtype=dtype,
-                                  field=odl.RealNumbers())
+        discr = odl.uniform_discr(0, 1, 10, impl='numpy', dtype=dtype)
         assert isinstance(discr.dspace, odl.Fn)
         assert discr.is_rn
 
     for dtype in nonfloat_dtypes:
-        discr = odl.uniform_discr(0, 1, 10, impl='numpy', dtype=dtype,
-                                  field=odl.RealNumbers())
+        discr = odl.uniform_discr(0, 1, 10, impl='numpy', dtype=dtype)
         assert isinstance(discr.dspace, odl.Fn)
         assert discr.dspace.element().space.dtype == dtype
 
-    for dtype in invalid_dtypes:
-        with pytest.raises(TypeError):
-            odl.uniform_discr(0, 1, 10, impl='numpy', dtype=dtype,
-                              field=odl.RealNumbers())
-
-    # Complex
-    invalid_dtypes = real_float_dtypes + nonfloat_dtypes
-
     for dtype in complex_float_dtypes:
-        discr = odl.uniform_discr(0, 1, 10, impl='numpy', dtype=dtype,
-                                  field=odl.ComplexNumbers())
+        discr = odl.uniform_discr(0, 1, 10, impl='numpy', dtype=dtype)
         assert isinstance(discr.dspace, odl.Fn)
         assert discr.is_cn
         assert discr.dspace.element().space.dtype == dtype
-
-    for dtype in invalid_dtypes:
-        with pytest.raises(TypeError):
-            odl.uniform_discr(0, 1, 10, impl='numpy', dtype=dtype,
-                              field=odl.ComplexNumbers())
 
 
 @skip_if_no_cuda
@@ -187,9 +167,6 @@ def test_factory_dtypes_cuda():
     nonfloat_dtypes = [np.int8, np.int16, np.int32, np.int64,
                        np.uint8, np.uint16, np.uint32, np.uint64]
     complex_float_dtypes = [np.complex64, np.complex128]
-
-    # Real
-    invalid_dtypes = complex_float_dtypes
 
     for dtype in real_float_dtypes:
         if dtype not in odl.CUDA_DTYPES:
@@ -211,22 +188,9 @@ def test_factory_dtypes_cuda():
             assert not discr.is_rn
             assert discr.dspace.element().space.dtype == dtype
 
-    for dtype in invalid_dtypes:
-        with pytest.raises(TypeError):
-            odl.uniform_discr(0, 1, 10, impl='cuda', dtype=dtype)
-
-    # Complex (not implemented)
-    invalid_dtypes = real_float_dtypes + nonfloat_dtypes
-
     for dtype in complex_float_dtypes:
         with pytest.raises(NotImplementedError):
-            odl.uniform_discr(0, 1, 10, impl='cuda', dtype=dtype,
-                              field=odl.ComplexNumbers())
-
-    for dtype in invalid_dtypes:
-        with pytest.raises(TypeError):
-            odl.uniform_discr(0, 1, 10, impl='cuda', dtype=dtype,
-                              field=odl.ComplexNumbers())
+            odl.uniform_discr(0, 1, 10, impl='cuda', dtype=dtype)
 
 
 def test_factory_nd(exponent):
@@ -338,7 +302,7 @@ def test_getslice():
     assert isinstance(vec[:], odl.FnVector)
     assert all_equal(vec[:], [1, 2, 3])
 
-    discr = odl.uniform_discr(0, 1, 3, field=odl.ComplexNumbers())
+    discr = odl.uniform_discr(0, 1, 3, dtype='complex')
     vec = discr.element([1 + 2j, 2 - 2j, 3])
 
     assert isinstance(vec[:], odl.FnVector)


### PR DESCRIPTION
Should close issue #231. Changes:

* Remove field parameter from `uniform_discr`, now deduced from `dtype`. The previous behaviour violated "there should be one obvious way to do it". 
* Field is (uniquely) determined by dtype
* Change repr to match these changes
* Add doctest