### PR TITLE
Add gradient descent and projection onto convex sets to landweber

### DIFF
--- a/odl/operator/default_ops.py
+++ b/odl/operator/default_ops.py
@@ -32,7 +32,7 @@ from odl.set.sets import Field
 
 __all__ = ('ScalingOperator', 'ZeroOperator', 'IdentityOperator',
            'LinCombOperator', 'MultiplyOperator',
-           'InnerProductOperator', 'ConstantOperator')
+           'InnerProductOperator', 'ConstantOperator', 'ResidualOperator')
 
 
 class ScalingOperator(Operator):

--- a/odl/solvers/iterative/iterative.py
+++ b/odl/solvers/iterative/iterative.py
@@ -22,11 +22,8 @@ from __future__ import print_function, division, absolute_import
 from future import standard_library
 standard_library.install_aliases()
 
-# External
-
 # Internal
-from odl.operator.default_ops import IdentityOperator
-from odl.operator.operator import OperatorComp, OperatorSum
+from odl.operator import IdentityOperator, OperatorComp, OperatorSum
 
 __all__ = ('gradient_descent', 'landweber', 'conjugate_gradient',
            'conjugate_gradient_normal', 'gauss_newton')
@@ -43,12 +40,13 @@ def gradient_descent(gradient_op, x, niter=1, omega=1, projection=None,
 
     This method calculates an approximate solution of the optimization problem
 
-        :math:`\min_{x\\in \mathcal{X}} \mathcal{A}(x)`
+        :math:`\min_{x\\in \mathcal{X}} f(x)`
 
     for a (Frechet-) differentiable operator
-    :math:`\mathcal{A}: \mathcal{X} \\to \mathcal{Y}` between Hilbert
-    spaces :math:`\mathcal{X}` and :math:`\mathcal{Y}`. The method
-    starts from an initial guess :math:`x_0` and uses the
+    :math:`\mathcal{A}: \mathcal{X} \\to R` where :math:`\mathcal{X}` is a
+    hilbert space.
+
+    The method starts from an initial guess :math:`x_0` and uses the
     iteration
 
     :math:`x_{k+1} = x_k - \omega \nabla \mathcal{A}(x)`,
@@ -69,14 +67,14 @@ def gradient_descent(gradient_op, x, niter=1, omega=1, projection=None,
     Parameters
     ----------
     gradient_op : `Operator`
-        Operator in the inverse problem.
+        Gradient of the functional that should be optimized.
     x : element of the domain of ``op``
         Vector to which the result is written. Its initial value is
         used as starting point of the iteration, and its values are
         updated in each iteration step.
     niter : `int`, optional
         Maximum number of iterations
-    omega : positive `float`
+    omega : positive `float`, optional
         Relaxation parameter in the iteration
     projection : `callable`, optional
         Function that can be used to modify the iterates in each iteration,
@@ -88,6 +86,11 @@ def gradient_descent(gradient_op, x, niter=1, omega=1, projection=None,
     Returns
     -------
     `None`
+
+    See Also
+    --------
+    landweber : Optimized solver for the case f(x) = ||Ax - b||_2^2
+    conjugate_gradient : Optimized solver for the case f(x) = x^T Ax - 2 x^T b
     """
     # Reusable temporary
     gradient = gradient_op.domain.element()
@@ -158,7 +161,7 @@ def landweber(op, x, rhs, niter=1, omega=1, projection=None, partial=None):
         Right-hand side of the equation defining the inverse problem
     niter : `int`, optional
         Maximum number of iterations
-    omega : positive `float`
+    omega : positive `float`, optional
         Relaxation parameter in the iteration
     projection : `callable`, optional
         Function that can be used to modify the iterates in each iteration,
@@ -226,6 +229,10 @@ def conjugate_gradient(op, x, rhs, niter=1, partial=None):
     Returns
     -------
     `None`
+
+    See Also
+    --------
+    conjugate_gradient_normal : Solver for nonsymmetric matrices
     """
     # TODO: add a book reference
     # TODO: update doc
@@ -309,6 +316,10 @@ Conjugate_gradient_on_the_normal_equations>`_.
     Returns
     -------
     `None`
+
+    See Also
+    --------
+    conjugate_gradient : Optimized solver for symmetric matrices
     """
     # TODO: add a book reference
     # TODO: update doc

--- a/odl/solvers/iterative/iterative.py
+++ b/odl/solvers/iterative/iterative.py
@@ -62,8 +62,8 @@ def landweber(op, x, rhs, niter=1, omega=1, projection=None, partial=None):
     convergence, where :math:`\\lVert\mathcal{A}\\rVert` stands for the
     operator norm of :math:`\mathcal{A}`.
 
-    Users may also optionally provide a projection operator to project each
-    partial result on some subset.
+    Users may also optionally provide a projection to project each
+    iterate onto some subset. For example enforcing positivity.
 
     This implementation uses a minimum amount of memory copies by
     applying re-usable temporaries and in-place evaluation.
@@ -92,7 +92,7 @@ def landweber(op, x, rhs, niter=1, omega=1, projection=None, partial=None):
     projection : `callable`, optional
         Function that can be used to modify the iterates in each iteration,
         for example enforcing positivity. The function should take one
-        argument and modify it inplace.
+        argument and modify it in place.
     partial : `Partial`, optional
         Object executing code per iteration, e.g. plotting each iterate
 

--- a/odl/solvers/iterative/iterative.py
+++ b/odl/solvers/iterative/iterative.py
@@ -25,85 +25,11 @@ standard_library.install_aliases()
 # Internal
 from odl.operator import IdentityOperator, OperatorComp, OperatorSum
 
-__all__ = ('gradient_descent', 'landweber', 'conjugate_gradient',
-           'conjugate_gradient_normal', 'gauss_newton')
+__all__ = ('landweber', 'conjugate_gradient', 'conjugate_gradient_normal',
+           'gauss_newton')
 
 
 # TODO: update all docs
-
-
-def gradient_descent(gradient_op, x, niter=1, omega=1, projection=None,
-                     partial=None):
-    """Optimized implementation of gradient descent method.
-
-    Also known as steepest descent method.
-
-    This method calculates an approximate solution of the optimization problem
-
-        :math:`\min_{x\\in \mathcal{X}} f(x)`
-
-    for a (Frechet-) differentiable operator
-    :math:`\mathcal{A}: \mathcal{X} \\to R` where :math:`\mathcal{X}` is a
-    hilbert space.
-
-    The method starts from an initial guess :math:`x_0` and uses the
-    iteration
-
-    :math:`x_{k+1} = x_k - \omega \nabla \mathcal{A}(x)`,
-
-    where :math:`\nabla \mathcal{A}(x)` is the gradient of :math:`\mathcal{A}`
-    at :math:`x` and :math:`\omega` is a relaxation parameter.
-
-    Users may also optionally provide a projection operator to project each
-    partial result on some subset.
-
-    This implementation uses a minimum amount of memory copies by
-    applying re-usable temporaries and in-place evaluation.
-
-    The method is also described in a
-    `Wikipedia article
-    <https://en.wikipedia.org/wiki/Gradient_descent>`_.
-
-    Parameters
-    ----------
-    gradient_op : `Operator`
-        Gradient of the functional that should be optimized.
-    x : element of the domain of ``op``
-        Vector to which the result is written. Its initial value is
-        used as starting point of the iteration, and its values are
-        updated in each iteration step.
-    niter : `int`, optional
-        Maximum number of iterations
-    omega : positive `float`, optional
-        Relaxation parameter in the iteration
-    projection : `callable`, optional
-        Function that can be used to modify the iterates in each iteration,
-        for example enforcing positivity. The function should take one
-        argument and modify it inplace.
-    partial : `Partial`, optional
-        Object executing code per iteration, e.g. plotting each iterate
-
-    Returns
-    -------
-    `None`
-
-    See Also
-    --------
-    landweber : Optimized solver for the case f(x) = ||Ax - b||_2^2
-    conjugate_gradient : Optimized solver for the case f(x) = x^T Ax - 2 x^T b
-    """
-    # Reusable temporary
-    gradient = gradient_op.domain.element()
-
-    for _ in range(niter):
-        gradient_op(x, out=gradient)
-        x.lincomb(1, x, -omega, gradient)
-
-        if projection is not None:
-            projection(x)
-
-        if partial is not None:
-            partial(x)
 
 
 def landweber(op, x, rhs, niter=1, omega=1, projection=None, partial=None):

--- a/odl/solvers/scalar/__init__.py
+++ b/odl/solvers/scalar/__init__.py
@@ -21,6 +21,7 @@ from __future__ import absolute_import
 
 __all__ = ()
 
+
 from . import gradient
 from .gradient import *
 __all__ += gradient.__all__

--- a/odl/solvers/scalar/gradient.py
+++ b/odl/solvers/scalar/gradient.py
@@ -61,7 +61,7 @@ def steepest_descent(grad, x, niter=1, line_search=1, projection=None,
     niter : `int`, optional
         Number of iterations
     line_search : float or `LineSearch`, optional
-        Strategy to choose the step length, if a float is given. Uses it as a
+        Strategy to choose the step length. If a float is given, uses it as a
         fixed step length.
     projection : `callable`, optional
         Function that can be used to modify the iterates in each iteration,

--- a/pytest.ini
+++ b/pytest.ini
@@ -2,7 +2,7 @@
 markers = not benchmark and not largescale
 testpaths = test odl
 doctest_optionflags = NORMALIZE_WHITESPACE IGNORE_EXCEPTION_DETAIL ELLIPSIS ALLOW_UNICODE
-addopts = --doctest-modules --ignore=test/benchmark --ignore=test/largescale
+addopts = --doctest-modules
 
 # PEP8
 pep8ignore = 

--- a/test/solvers/iterative/iterative.py
+++ b/test/solvers/iterative/iterative.py
@@ -1,0 +1,84 @@
+# Copyright 2014, 2015 The ODL development group
+#
+# This file is part of ODL.
+#
+# ODL is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# ODL is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with ODL.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Test iterative solvers."""
+
+# Imports for common Python 2/3 codebase
+from __future__ import print_function, division, absolute_import
+from future import standard_library
+standard_library.install_aliases()
+
+import odl
+from odl.util.testutils import all_almost_equal
+import pytest
+import numpy as np
+
+
+# Find the valid projectors
+solvers = ['gradient_descent',
+           'landweber',
+           'conjugate_gradient',
+           'conjugate_gradient_normal']
+
+
+@pytest.fixture(scope="module",
+                params=solvers)
+def iterative_solver(request):
+    solver_name = request.param
+
+    if solver_name == 'gradient_descent':
+        def solver(A, x, rhs):
+            norm2 = A.adjoint(A(x)).norm() / x.norm()
+
+            # Define gradient as A* (Ax - b)
+            gradient_op = A.adjoint * odl.ResidualOperator(A, rhs)
+            odl.solvers.gradient_descent(gradient_op, x, niter=10,
+                                         omega=0.5/norm2)
+    elif solver_name == 'landweber':
+        def solver(A, x, rhs):
+            norm2 = A.adjoint(A(x)).norm() / x.norm()
+            odl.solvers.landweber(A, x, rhs, niter=10, omega=0.5/norm2)
+    elif solver_name == 'conjugate_gradient':
+        def solver(A, x, rhs):
+            odl.solvers.conjugate_gradient(A, x, rhs, niter=10)
+    elif solver_name == 'conjugate_gradient_normal':
+        def solver(A, x, rhs):
+            odl.solvers.conjugate_gradient_normal(A, x, rhs, niter=10)
+    else:
+        raise ValueError('solver not valid')
+
+    return solver
+
+
+def test_solver(iterative_solver):
+    """Test discrete X-ray transform using ASTRA for reconstruction."""
+
+    places = 2
+
+    space = odl.Rn(5)
+    rhs_arr = np.ones(5)
+    op_arr = np.eye(5) * 5 + np.ones([5, 5])
+
+    op = odl.MatVecOperator(op_arr, space, space)
+    x = op.domain.one()
+    rhs = op.range.element(rhs_arr)
+    iterative_solver(op, x, rhs)
+
+    assert all_almost_equal(op(x), rhs, places)
+
+if __name__ == '__main__':
+    pytest.main(str(__file__.replace('\\', '/') + ' -v'))


### PR DESCRIPTION
* Add projection option to landweber, with this users can for example project onto the set of positive functions in each iteration

* Add steepest descent solver for the most simple cases.

* Add simple tests for solvers, closes #244. This one is more simple than the previous as well.