### PR TITLE
Issue 247  astra geometry slow

### DIFF
--- a/odl/set/domain.py
+++ b/odl/set/domain.py
@@ -30,8 +30,8 @@ standard_library.install_aliases()
 import numpy as np
 
 # ODL imports
-from odl.set.sets import Set, RealNumbers
-from odl.util.utility import array1d_repr
+from odl.set.sets import Set
+from odl.util.utility import array1d_repr, is_real_dtype
 from odl.util.vectorization import (
     is_valid_input_array, is_valid_input_meshgrid, meshgrid_input_order,
     vecs_from_meshgrid)
@@ -154,9 +154,37 @@ class IntervalProd(Set):
         """The maximum value in this interval product"""
         return self.end
 
-    def element(self):
-        """An arbitrary element, the midpoint."""
-        return self.midpoint
+    def element(self, inp=None):
+        """Create element in this set.
+
+        Parameters
+        ----------
+        inp : `float` or array-like, optional
+            Point to be cast to an element in self
+
+        Returns
+        -------
+        element
+            Returns ``inp`` if given, else ``self.midpoint``
+
+        Raises
+        ------
+        TypeError
+            If ``inp`` is not a valid element.
+
+        Examples
+        --------
+        >>> interv = IntervalProd(0, 1)
+        >>> interv.element(0.5)
+        0.5
+        """
+        if inp is None:
+            return self.midpoint
+        elif inp in self:
+            return inp
+        else:
+            raise TypeError('inp {!r} not a valid element in {!r}.'
+                            ''.format(inp, self))
 
     # Overrides of the abstract base class methods
     def approx_equals(self, other, tol):
@@ -218,23 +246,44 @@ class IntervalProd(Set):
         True
         """
         point = np.atleast_1d(point)
-        if point.dtype == object:
+        if point.shape != (self.ndim,):
             return False
-        if np.any(np.isnan(point)):
+        if not is_real_dtype(point.dtype):
             return False
-        if point.ndim > 1:
-            return False
-        if len(point) != self.ndim:
-            return False
-        if point[0] not in RealNumbers():
-            return False
-        if self.dist(point, ord=np.inf) > tol:
-            return False
-        return True
+        return self.dist(point, ord=np.inf) <= tol
 
     def __contains__(self, other):
-        """Return ``other in self``."""
-        return self.approx_contains(other, tol=0)
+        """Return ``other in self``.
+
+        Parameters
+        ----------
+        other
+            Arbitrary object to be tested.
+
+        Returns
+        -------
+        containts : `bool`
+            True if other is inside self.
+
+        Examples
+        --------
+        >>> interv = IntervalProd(0, 1)
+        >>> 0.5 in interv
+        True
+        >>> 2 in interv
+        False
+        >>> 'string' in interv
+        False
+        """
+        try:
+            # Ducktyped check
+            point = np.array(other, dtype=np.float, copy=False, ndmin=1)
+        except (ValueError, TypeError):
+            return False
+
+        if point.shape != (self.ndim,):
+            return False
+        return (self.begin <= point).all() and (point <= self.end).all()
 
     def contains_set(self, other, tol=0.0):
         """Test if another set is contained.
@@ -370,6 +419,13 @@ class IntervalProd(Set):
               The order of the norm (see `numpy.linalg.norm`).
               Default: 2.0
 
+        Returns
+        -------
+        dist : `float`
+            Distance to the interior of the IntervalProd.
+            Points strictly inside have distance ``0.0``, points with ``NaN``
+            have distance ``infinity``.
+
         Examples
         --------
 
@@ -385,6 +441,9 @@ class IntervalProd(Set):
             raise ValueError('length {} of point {} does not match '
                              'the dimension {} of the set {}.'
                              ''.format(len(point), point, self.ndim, self))
+
+        if np.any(np.isnan(point)):
+            return np.inf
 
         i_larger = np.where(point > self.end)
         i_smaller = np.where(point < self.begin)

--- a/odl/set/domain.py
+++ b/odl/set/domain.py
@@ -276,7 +276,7 @@ class IntervalProd(Set):
         False
         """
         try:
-            # Ducktyped check
+            # Duck-typed check of type
             point = np.array(other, dtype=np.float, copy=False, ndmin=1)
         except (ValueError, TypeError):
             return False

--- a/odl/tomo/backends/astra_setup.py
+++ b/odl/tomo/backends/astra_setup.py
@@ -346,6 +346,11 @@ def astra_projection_geometry(geometry):
     if not isinstance(geometry, Geometry):
         raise TypeError('geometry {!r} is not a `Geometry` instance.'
                         ''.format(geometry))
+
+    if 'astra' in geometry.implementations:
+        # Shortcut, reuse already computed value.
+        return geometry.implementations['astra']
+
     if not geometry.has_det_sampling:
         raise ValueError('geometry has no detector sampling grid.')
     if not geometry.has_motion_sampling:
@@ -395,6 +400,10 @@ def astra_projection_geometry(geometry):
     else:
         raise NotImplementedError('unkown ASTRA geometry type {}.'.format(
             geometry))
+
+    if 'astra' not in geometry.implementations:
+        # Shortcut, reuse already computed value.
+        geometry.implementations['astra'] = proj_geom
 
     return proj_geom
 

--- a/odl/tomo/backends/astra_setup.py
+++ b/odl/tomo/backends/astra_setup.py
@@ -347,9 +347,9 @@ def astra_projection_geometry(geometry):
         raise TypeError('geometry {!r} is not a `Geometry` instance.'
                         ''.format(geometry))
 
-    if 'astra' in geometry.implementations:
+    if 'astra' in geometry.implementation_cache:
         # Shortcut, reuse already computed value.
-        return geometry.implementations['astra']
+        return geometry.implementation_cache['astra']
 
     if not geometry.has_det_sampling:
         raise ValueError('geometry has no detector sampling grid.')
@@ -401,9 +401,9 @@ def astra_projection_geometry(geometry):
         raise NotImplementedError('unkown ASTRA geometry type {}.'.format(
             geometry))
 
-    if 'astra' not in geometry.implementations:
-        # Shortcut, reuse already computed value.
-        geometry.implementations['astra'] = proj_geom
+    if 'astra' not in geometry.implementation_cache:
+        # Save computed value for later
+        geometry.implementation_cache['astra'] = proj_geom
 
     return proj_geom
 

--- a/odl/tomo/geometry/geometry.py
+++ b/odl/tomo/geometry/geometry.py
@@ -61,6 +61,7 @@ class Geometry(with_metaclass(ABCMeta, object)):
            The number of dimensions of the geometry
         """
         self._ndim = ndim
+        self._implementations = {}
 
     @abstractproperty
     def motion_params(self):
@@ -152,6 +153,18 @@ class Geometry(with_metaclass(ABCMeta, object)):
     def ndim(self):
         """The number of dimensions of the geometry."""
         return self._ndim
+
+    @property
+    def implementations(self):
+        """Dict where computed implementations of this geometry can be saved.
+
+        Intended for reuse of computations.
+
+        Returns
+        -------
+        implementations : `dict`
+        """
+        return self._implementations
 
     @property
     def motion_grid(self):

--- a/odl/tomo/geometry/geometry.py
+++ b/odl/tomo/geometry/geometry.py
@@ -61,7 +61,7 @@ class Geometry(with_metaclass(ABCMeta, object)):
            The number of dimensions of the geometry
         """
         self._ndim = ndim
-        self._implementations = {}
+        self._implementation_cache = {}
 
     @abstractproperty
     def motion_params(self):
@@ -155,16 +155,17 @@ class Geometry(with_metaclass(ABCMeta, object)):
         return self._ndim
 
     @property
-    def implementations(self):
+    def implementation_cache(self):
         """Dict where computed implementations of this geometry can be saved.
 
-        Intended for reuse of computations.
+        Intended for reuse of computations. Implementations that use this
+        storage should take care to use a sufficiently unique name.
 
         Returns
         -------
         implementations : `dict`
         """
-        return self._implementations
+        return self._implementation_cache
 
     @property
     def motion_grid(self):

--- a/test/set/domain_test.py
+++ b/test/set/domain_test.py
@@ -219,10 +219,14 @@ def test_contains():
     assert 2 in set_
     assert 1.5 in set_
     assert 3 not in set_
+    assert 'string' not in set_
+    assert [1, 2] not in set_
+    assert np.nan not in set_
 
     positive_reals = IntervalProd(0, np.inf)
     assert 1 in positive_reals
     assert np.inf in positive_reals
+    assert -np.inf not in positive_reals
     assert -1 not in positive_reals
 
 
@@ -260,6 +264,7 @@ def test_dist():
                                           abs(exterior - set_.end))
 
     assert set_.dist(np.NaN) == np.inf
+
 
 # Set arithmetic
 def test_pos():

--- a/test/set/domain_test.py
+++ b/test/set/domain_test.py
@@ -249,6 +249,18 @@ def test_contains_set():
             set_.contains_set(non_set)
 
 
+def test_dist():
+    set_ = IntervalProd(1, 2)
+
+    for interior in [1.0, 1.1, 2.0]:
+        assert set_.dist(interior) == 0.0
+
+    for exterior in [0.0, 2.0, np.inf]:
+        assert set_.dist(exterior) == min(abs(set_.begin - exterior),
+                                          abs(exterior - set_.end))
+
+    assert set_.dist(np.NaN) == np.inf
+
 # Set arithmetic
 def test_pos():
     interv = Interval(1, 2)


### PR DESCRIPTION
Minor changes according to #247 

* Add a cache to geometries where implementations can be stored. Running a 50^3 -> 50^3 problem went from 0.08s per iteration to 0.027s.
* Improve performance of `IntervalProd.__contains__`, reduce runtime by ~70%.