### PR TITLE
Issue 202  partitions

### DIFF
--- a/doc/source/guide/glossary.rst
+++ b/doc/source/guide/glossary.rst
@@ -21,9 +21,17 @@ Glossary
     domain
         Set of elements to which an operator can be applied.
 
+    element
+        Saying that ``x`` is an element of a given `Set` ``my_set`` means that ``x in my_set``
+        evaluates to `True`. The term is typically used as "element of <set>" or "<set>" element.
+        When referring to a `LinearSpace` like, e.g., `DiscreteLp`, an element is of the
+        corresponding type `LinearSpaceVector`, i.e. `DiscreteLpVector` in the above example.
+        Elements of a set can be created by the `Set.element` method.
+
     element-like
-        Any data structure which can be converted into a ``<set>Vector`` by
-        the ``<set>.element`` method.
+        Any data structure which can be converted into an :term:`element` of a `Set` by
+        the `Set.element` method. For example, an ``Rn(3) element-like`` is any :term:`array-like`
+        object with 3 real entries.
     
         Example: ```DiscreteLp` element-like`` means that
         `DiscreteLp.element` can create a `DiscreteLpVector` from the input.

--- a/doc/source/guide/in_depth/index.rst
+++ b/doc/source/guide/in_depth/index.rst
@@ -10,3 +10,4 @@ This is a more in depth guide to the different parts of odl.
     operator_guide
     linearspace_guide
     discretization_guide
+    vectorization_guide

--- a/doc/source/guide/in_depth/vectorization_guide.rst
+++ b/doc/source/guide/in_depth/vectorization_guide.rst
@@ -1,0 +1,115 @@
+.. _vectorization_in_depth:
+
+####################
+Vectorized functions
+####################
+
+
+This section is intended as a small guideline on how to write functions which work with the
+vectorization machinery by Numpy which is used internally in ODL. 
+
+
+What is vectorization?
+======================
+
+In general, :term:`vectorization` means that a function can be evaluated on a whole array of values
+at once instead of looping over individual entries. This is very important for performance in an
+interpreted language like python, since loops are usually very slow compared to compiled languages.
+
+Technically, vectorization in Numpy works through the `Universal functions (ufunc)`_ interface. It
+is fast because all loops over data are implemented in C, and the resulting implementations are
+exposed to Python for each function individually.
+
+
+How to use Numpy's ufuncs?
+==========================
+
+The easiest way to write fast custom mathematical functions in Python is to use the
+`available ufuncs`_ and compose them to a new function::
+
+    def gaussian(x):
+        # Negation, powers and scaling are vectorized, of course.
+        return np.exp(-x ** 2 / 2)
+
+    def step(x):
+        # np.where checks the condition in the first argument and
+        # returns the second for `True`, otherwise the third. The
+        # last two arguments can be arrays, too.
+        # Note that also the comparison operation is vectorized.
+        return np.where(x[0] <= 0, 0, 1)
+
+This should cover a very large range of useful functions already (basic arithmetic is vectorized,
+too!). An even larger list of `special functions`_ are available in the Scipy package.
+
+
+Usage in ODL
+============
+
+Python functions are in most cases used as input to a discretization process. For example, we may
+want to discretize a two-dimensional Gaussian function
+::
+    def gaussian2(x):
+        return np.exp(-(x[0] ** 2 + x[1] ** 2) / 2)
+    
+on the rectangle [-5, 5] x [-5, 5] with 100 pixels in each
+dimension. The code for this is simply
+::
+    # Note that the minimum and maxiumum coordinates are given as
+    # vectors, not one interval at a time.
+    discr = odl.uniform_discr([-5, -5], [5, 5], (100, 100))
+
+    # This creates an element in the discretized space ``discr``
+    gaussian_discr = discr.element(gaussian2)
+
+What happens behind the scenes is that ``discr`` creates a :term:`discretization` object which
+has a built-in method ``element`` to turn continuous functions into discrete arrays by evaluating
+them at a set of grid points. In the example above, this grid is a uniform sampling of the rectangle
+by 100 points per dimension.
+
+To make this process fast, ``element`` assumes that the function is written in a way that not only
+supports vectorization, but also guarantees that the output has the correct shape. The function
+receives a :term:`meshgrid` tuple as input, in the above case consisting of two vectors::
+
+    >>> mesh = discr.meshgrid()
+    >>> mesh[0].shape
+    (100, 1)
+    >>> mesh[1].shape
+    (1, 100)
+
+When inserted into the function, the final shape of the output is determined by Numpy's
+`broadcasting rules`_. For the Gaussian function, Numpy will conclude that the output shape must
+be ``(100, 100)`` since the arrays in ``mesh`` are added after squaring. This size is the same
+as expected by the discretization.
+
+If, however, the function does not use all components of its input, the shape will be different::
+
+    >>> def gaussian_const_x0_bad(x):
+    ...     return np.exp(-x[1] ** 2 / 2)  # no x[0] -> no broadcasting
+
+    >>> gaussian_const_x0_bad(mesh).shape
+    (1, 100)
+
+This array is too small for the discretization, and an exception will be raised, stating that this
+function cannot be discretized.
+
+The solution to this issue is rather simple: just make sure that all components are used such that
+the broadcasting rules are triggered::
+
+    >>> def gaussian_const_x0_good(x):
+    ...     return np.exp(-x[1] ** 2 / 2) + 0 * x[0]  # broadcasting
+
+    >>> gaussian_const_x0_good(mesh).shape
+    (100, 100)
+
+
+
+Further reading
+===============
+
+`Scipy Lecture notes on Numpy <http://www.scipy-lectures.org/intro/numpy/index.html>`_
+
+
+.. _Universal functions (ufunc): http://docs.scipy.org/doc/numpy/reference/ufuncs.html
+.. _available ufuncs: http://docs.scipy.org/doc/numpy/reference/ufuncs.html#available-ufuncs
+.. _special functions: http://docs.scipy.org/doc/scipy/reference/special.html
+.. _broadcasting rules: http://docs.scipy.org/doc/numpy/user/basics.broadcasting.html

--- a/examples/convolution_test_cuda.py
+++ b/examples/convolution_test_cuda.py
@@ -29,9 +29,7 @@ import matplotlib.pyplot as plt
 
 # ODL
 import odl
-from odl.space import cu_ntuples
 import odl.solvers as solvers
-from odl.util.testutils import Timer
 from odlpp import odlpp_cuda
 
 
@@ -44,7 +42,8 @@ class CudaConvolution(odl.Operator):
         self.kernel = kernel
         self.adjkernel = (adjointkernel if adjointkernel is not None
                           else self.space.element(kernel[::-1].copy()))
-        self.norm = float(cu_ntuples.sum(cu_ntuples.abs(self.kernel.ntuple)))
+        kernel_abs = self.kernel.ufunc.absolute()
+        self.norm = float(kernel_abs.ufunc.sum())
         super().__init__(self.space, self.space, linear=True)
 
     def _call(self, rhs, out):

--- a/examples/convolution_test_cuda.py
+++ b/examples/convolution_test_cuda.py
@@ -42,8 +42,7 @@ class CudaConvolution(odl.Operator):
         self.kernel = kernel
         self.adjkernel = (adjointkernel if adjointkernel is not None
                           else self.space.element(kernel[::-1].copy()))
-        kernel_abs = self.kernel.ufunc.absolute()
-        self.norm = float(kernel_abs.ufunc.sum())
+        self.norm = float(np.sum(np.abs(self.kernel)))
         super().__init__(self.space, self.space, linear=True)
 
     def _call(self, rhs, out):

--- a/examples/operator_test.py
+++ b/examples/operator_test.py
@@ -43,11 +43,9 @@ class Convolution(odl.Operator):
 
         super().__init__(space, space, linear=True)
 
-    def _call(self, rhs, out):
-        scipy.ndimage.convolve(rhs,
-                               self.kernel,
-                               output=out.asarray(),
-                               mode='wrap')
+    def _call(self, x, out):
+        scipy.ndimage.convolve(
+            x, self.kernel, output=out.asarray(), mode='wrap')
 
         out *= self.scale
 
@@ -59,7 +57,8 @@ class Convolution(odl.Operator):
 def kernel(x):
     mean = [0.0, 0.25]
     std = [0.05, 0.05]
-    return np.exp(-(((x[0] - mean[0]) / std[0])**2 + ((x[1] - mean[1]) / std[1])**2))
+    return np.exp(-(((x[0] - mean[0]) / std[0]) ** 2 +
+                    ((x[1] - mean[1]) / std[1]) ** 2))
 
 
 def adjkernel(x):

--- a/examples/simple_operator.py
+++ b/examples/simple_operator.py
@@ -28,17 +28,17 @@ import odl
 
 
 class AddOp(odl.Operator):
-    def __init__(self, n, x):
-        super().__init__(odl.Rn(n), odl.Rn(n))
-        self.x = x
+    def __init__(self, size, add_this):
+        super().__init__(odl.Rn(size), odl.Rn(size))
+        self.value = add_this
 
-    def _call(self, rhs, out):
-        out[:] = rhs.data + self.x
+    def _call(self, x, out):
+        out[:] = x.data + self.value
 
-n = 3
-rn = odl.Rn(n)
+size = 3
+rn = odl.Rn(size)
 x = rn.element([1, 2, 3])
 
-op = AddOp(n, 10)
+op = AddOp(size, add_this=10)
 
 print(op(x))

--- a/examples/tomo/stir_project.py
+++ b/examples/tomo/stir_project.py
@@ -38,19 +38,12 @@ proj_data = stir.ProjDataInMemory(proj_data_in.get_exam_info(),
                                   proj_data_in.get_proj_data_info())
 
 # Create ODL spaces
-recon_sp = odl.uniform_discr(odl.FunctionSpace(odl.Cuboid([0, 0, 0],
-                                                          [1, 1, 1])),
-                             [15, 64, 64])
-
-data_sp = odl.uniform_discr(odl.FunctionSpace(odl.Cuboid([0, 0, 0],
-                                                         [1, 1, 1])),
-                            [37, 28, 56])
+recon_sp = odl.uniform_discr([0, 0, 0], [1, 1, 1], (15, 64, 64))
+data_sp = odl.uniform_discr([0, 0, 0], [1, 1, 1], (37, 28, 56))
 
 # Make STIR projector
-proj = odl.tomo.stir_bindings.ForwardProjectorByBinWrapper(recon_sp,
-                                                           data_sp,
-                                                           volume,
-                                                           proj_data)
+proj = odl.tomo.stir_bindings.ForwardProjectorByBinWrapper(
+    recon_sp, data_sp, volume, proj_data)
 
 # Create shepp-logan phantom
 vol = odl.util.shepp_logan(proj.domain, modified=True)

--- a/examples/tomography.py
+++ b/examples/tomography.py
@@ -36,7 +36,7 @@ import odl
 
 class ForwardProjector(odl.Operator):
     def __init__(self, dom, ran):
-        self.theta = ran.grid.meshgrid()[1][0] * 180 / np.pi
+        self.theta = ran.grid.meshgrid[1][0] * 180 / np.pi
         super().__init__(dom, ran, True)
 
     def _call(self, x):
@@ -49,7 +49,7 @@ class ForwardProjector(odl.Operator):
 
 class BackProjector(odl.Operator):
     def __init__(self, dom, ran):
-        self.theta = dom.grid.meshgrid()[1][0] * 180 / np.pi
+        self.theta = dom.grid.meshgrid[1][0] * 180 / np.pi
         self.npoint = ran.grid.shape[0]
         super().__init__(dom, ran, True)
 

--- a/examples/vectorization.py
+++ b/examples/vectorization.py
@@ -102,13 +102,13 @@ def numba_example():
     # (2000*2000, 2). Since the function expects points[i] to be the
     # array of i-th components of all points, we need to transpose.
     points = grid.points().T
-    # The meshgrid() method only returns a sparse representation of the
+    # The meshgrid property only returns a sparse representation of the
     # grid, a tuple whose i-th entry is the vector of all possible i-th
     # components in the grid (2000). Extra dimensions are added to the
     # vector in order to support automatic broadcasting. This is both
     # faster and more memory-friendly than creating the full point array.
     # See the numpy.meshgrid function for more information.
-    mesh = grid.meshgrid()  # Creates a sparse meshgrid (2000 * 2)
+    mesh = grid.meshgrid  # Returns a sparse meshgrid (2000 * 2)
 
     print('Non-Vectorized runtime (points):      {:5f}'
           ''.format(timeit.timeit(lambda: f_default(points), number=1)))

--- a/examples/visualization/show_1d.py
+++ b/examples/visualization/show_1d.py
@@ -28,10 +28,12 @@ import odl
 import numpy as np
 
 spc = odl.uniform_discr(0, 5, 100)
-vec = spc.element(np.sin(spc.points()))
+vec = spc.element(np.sin)
 
-vec.show()
-(vec * 2).show()
+# Get figure object
+fig = vec.show(title='Sine functions')
+# Plot into the same figure
+fig = (vec / 2).show(fig=fig)
 
 # Plotting is deferred until show() is called
 plt.show()

--- a/examples/visualization/show_ntuple.py
+++ b/examples/visualization/show_ntuple.py
@@ -15,7 +15,7 @@
 # You should have received a copy of the GNU General Public License
 # along with ODL.  If not, see <http://www.gnu.org/licenses/>.
 
-"""Examples on using the vector.show() syntax for ntuples"""
+"""Example on the usage of the vector.show() syntax for n-tuples"""
 
 import odl
 

--- a/examples/visualization/show_productspace.py
+++ b/examples/visualization/show_productspace.py
@@ -29,19 +29,26 @@ m = 7
 spc = odl.uniform_discr([0, 0], [1, 1], [n, n])
 pspace = odl.ProductSpace(spc, m)
 
+# Making a product space element where each component consists of a
+# Shepp-Logan phantom multiplied by the constant (i+1), where i is the
+# index of the product space component.
 vec = pspace.element([odl.util.shepp_logan(spc, modified=True) * i
                       for i in range(1, m + 1)])
 
-# By default 4 uniformly spaced elements are shown
+# By default 4 uniformly spaced elements are shown. Since there are 7 in
+# total, the shown components are 0, 2, 4 and 6
 vec.show(title='Default')
 
-# User can also define a slice or by indexing
+# One can also use indexing by a list of indices or a slice.
 vec.show(indices=[0, 1], show=True,
          title='Show first 2 elements')
 
 vec.show(indices=np.s_[::3], show=True,
          title='Show every third element')
 
-# Slices propagate (as in numpy)
+# Slices propagate (as in numpy): the first index in the slice applies to
+# the product space components, the other dimensions are applied to each
+# component. Here we take the second vector component and slice in the
+# middle along the second axis.
 vec.show(indices=np.s_[2, :, n // 2], show=True,
          title='Show second element, then slice by [:, n//2]')

--- a/examples/visualization/show_update_1d.py
+++ b/examples/visualization/show_update_1d.py
@@ -30,7 +30,7 @@ m = 20
 spc = odl.uniform_discr(0, 5, n)
 vec = spc.element(np.sin(spc.points()))
 
-# Pre-create a plot and set some property
+# Pre-create a plot and set some property, here the plot limits in the y axis.
 fig = plt.figure()
 plt.ylim(-m, m)
 

--- a/odl/diagnostics/examples.py
+++ b/odl/diagnostics/examples.py
@@ -102,7 +102,7 @@ def vector_examples(space):
         # Indicator function in first dimension
         def _step_fun(x):
             z = np.zeros(space.shape, dtype=space.dtype)
-            z[:space.grid.shape[0] // 2, ...] = 1
+            z[:space.shape[0] // 2, ...] = 1
             return z
 
         yield ('Step', element(_step_fun))
@@ -119,7 +119,7 @@ def vector_examples(space):
         yield ('Cube', element(_cube_fun))
 
         # Indicator function on hypersphere
-        if space.grid.ndim > 1:  # Only if ndim > 1, don't duplicate cube
+        if space.ndim > 1:  # Only if ndim > 1, don't duplicate cube
             def _sphere_fun(x):
                 r = np.zeros(space.shape)
 
@@ -141,7 +141,7 @@ def vector_examples(space):
         yield ('Gaussian', element(_gaussian_fun))
 
         # Gradient in each dimensions
-        for dim in range(space.grid.ndim):
+        for dim in range(space.ndim):
             def _gradient_fun(x):
                 s = np.zeros(space.shape)
                 s += (x[dim] - mins[dim]) / (maxs[dim] - mins[dim])
@@ -152,7 +152,7 @@ def vector_examples(space):
                    element(_gradient_fun))
 
         # Gradient in all dimensions
-        if space.grid.ndim > 1:  # Only if ndim > 1, don't duplicate grad 0
+        if space.ndim > 1:  # Only if ndim > 1, don't duplicate grad 0
             def _all_gradient_fun(x):
                 s = np.zeros(space.shape)
 

--- a/odl/discr/__init__.py
+++ b/odl/discr/__init__.py
@@ -35,6 +35,10 @@ from . import grid
 from .grid import *
 __all__ += grid.__all__
 
+from . import partition
+from .partition import *
+__all__ += partition.__all__
+
 from . import discr_mappings
 from .discr_mappings import *
 __all__ += discr_mappings.__all__

--- a/odl/discr/discr_mappings.py
+++ b/odl/discr/discr_mappings.py
@@ -709,7 +709,7 @@ scipy.interpolate.RegularGridInterpolator.html>`_ class.
 
         coord_vecs : `sequence` of `numpy.ndarray`
             Coordinate vectors defining the interpolation grid
-        values : array-like
+        values : `array-like`
             Grid values to use for interpolation
         input_type : {'array', 'meshgrid'}
             Type of expected input values in ``__call__``
@@ -819,7 +819,7 @@ scipy.interpolate.RegularGridInterpolator.html>`_ class.
 
         coord_vecs : `sequence` of `numpy.ndarray`
             Coordinate vectors defining the interpolation grid
-        values : array-like
+        values : `array-like`
             Grid values to use for interpolation
         input_type : {'array', 'meshgrid'}
             Type of expected input values in ``__call__``
@@ -948,7 +948,7 @@ class _PerAxisInterpolator(_Interpolator):
 
         coord_vecs : `sequence` of `numpy.ndarray`
             Coordinate vectors defining the interpolation grid
-        values : array-like
+        values : `array-like`
             Grid values to use for interpolation
         input_type : {'array', 'meshgrid'}
             Type of expected input values in ``__call__``
@@ -1017,7 +1017,7 @@ class _LinearInterpolator(_PerAxisInterpolator):
 
         coord_vecs : `sequence` of `numpy.ndarray`
             Coordinate vectors defining the interpolation grid
-        values : array-like
+        values : `array-like`
             Grid values to use for interpolation
         input_type : {'array', 'meshgrid'}
             Type of expected input values in ``__call__``

--- a/odl/discr/discr_mappings.py
+++ b/odl/discr/discr_mappings.py
@@ -634,7 +634,6 @@ class PerAxisInterpolation(FunctionSetMapping):
         return '{}({})'.format(self.__class__.__name__, inner_str)
 
 
-# TODO: use partition information to steer behavior at the boundary
 class _Interpolator(object):
 
     """Abstract interpolator class.
@@ -935,6 +934,7 @@ class _PerAxisInterpolator(_Interpolator):
         for lo_hi, edge in zip(product(*([['l', 'h']] * len(indices))),
                                product(*edge_indices)):
             weight = 1.0
+            # TODO: determine best summation order from array strides
             for lh, w_lo, w_hi in zip(lo_hi, low_weights, high_weights):
 
                 # We don't multiply in place to exploit the cheap operations

--- a/odl/discr/discr_mappings.py
+++ b/odl/discr/discr_mappings.py
@@ -234,9 +234,10 @@ class PointCollocation(FunctionSetMapping):
 
         Partition the rectangle by a tensor grid:
 
-        >>> from odl import TensorGrid, RectPartition, Rn
+        >>> from odl import TensorGrid, Rectangle, RectPartition, Rn
+        >>> rect = Rectangle([1, 3], [2, 5])
         >>> grid = TensorGrid([1, 2], [3, 4, 5])
-        >>> partition = RectPartition(grid, begin=[1, 3], end=[2, 5])
+        >>> partition = RectPartition(rect, grid)
         >>> rn = Rn(grid.size)
 
         Finally create the operator and test it on a function:
@@ -384,8 +385,9 @@ class NearestInterpolation(FunctionSetMapping):
         Partitioning the domain uniformly with no nodes on the boundary
         (will shift the grid points):
 
-        >>> from odl import uniform_partition, Ntuples
-        >>> part = uniform_partition(rect, [4, 2], nodes_on_bdry=False)
+        >>> from odl import uniform_partition_fromintv, Ntuples
+        >>> part = uniform_partition_fromintv(rect, [4, 2],
+        ...                                   nodes_on_bdry=False)
         >>> part.grid.coord_vectors
         (array([ 0.125,  0.375,  0.625,  0.875]), array([ 0.25,  0.75]))
 

--- a/odl/discr/discr_mappings.py
+++ b/odl/discr/discr_mappings.py
@@ -182,7 +182,7 @@ class PointCollocation(FunctionSetMapping):
         fset : `FunctionSet`
             The non-discretized (abstract) set of functions to be
             discretized. The function domain must provide a
-            `IntervalProd.contains_set` method.
+            `Set.contains_set` method.
         partition : `RectPartition`
             Partition of (a subset of) ``ip_fset.domain`` based on a
             `TensorGrid`
@@ -270,7 +270,7 @@ vectorization_guide.html>`_ for a detailed introduction.
         Rn(6).element([-2.0, -1.0, -3.0, -2.0, -4.0, -3.0])
         """
         try:
-            mesh = self.grid.meshgrid()
+            mesh = self.grid.meshgrid
             if out is None:
                 out = func(mesh).ravel(order=self.order)
             else:
@@ -291,7 +291,7 @@ vectorization_guide.html>`_ for a detailed introduction.
         inner_str = '\n  {!r},\n  {!r},\n  {!r}'.format(
             self.domain, self.grid, self.range)
         if self.order != 'C':
-            inner_str += ",\n order='{}'".format(self.order)
+            inner_str += ",\n  order='{}'".format(self.order)
         return '{}({})'.format(self.__class__.__name__, inner_str)
 
 
@@ -325,10 +325,10 @@ class NearestInterpolation(FunctionSetMapping):
         fset : `FunctionSet`
             The undiscretized (abstract) set of functions to be
             discretized. The function domain must provide a
-            ``contains_set`` method such as `IntervalProd` does.
+            `Set.contains_set` method.
         partition : `RectPartition`
             Partition of (a subset of) ``ip_fset.domain`` based on a
-            `TensorGrid`
+            spatial grid
         dspace : `NtuplesBase`
             Data space providing containers for the values of a
             discretized object. Its `NtuplesBase.size` must be equal
@@ -472,7 +472,7 @@ class LinearInterpolation(FunctionSetMapping):
             The undiscretized (abstract) space of functions to be
             discretized. Its field must be the same as that of data
             space. The function domain must provide a
-            ``contains_set`` method such as `IntervalProd` does.
+            `Set.contains_set` method.
         partition : `RectPartition`
             Partition of (a subset of) ``fspace.domain`` based on a
             `TensorGrid`
@@ -552,7 +552,7 @@ class PerAxisInterpolation(FunctionSetMapping):
             The undiscretized (abstract) space of functions to be
             discretized. Its field must be the same as that of data
             space. The function domain must provide a
-            ``contains_set`` method such as `IntervalProd` does.
+            `Set.contains_set` method.
         partition : `RectPartition`
             Partition of (a subset of) ``fspace.domain`` based on a
             `TensorGrid`

--- a/odl/discr/discr_mappings.py
+++ b/odl/discr/discr_mappings.py
@@ -241,7 +241,7 @@ class PointCollocation(FunctionSetMapping):
         try:
             mesh = self.grid.meshgrid()
             if out is None:
-                out = func(mesh).ravel(order=self.order)
+                out = func(mesh).ravel()
             else:
                 func(mesh, out=out.asarray().reshape(self.grid.shape,
                                                      order=self.order))

--- a/odl/discr/discr_ops.py
+++ b/odl/discr/discr_ops.py
@@ -412,7 +412,7 @@ class Gradient(Operator):
 
         x_data = x.asarray()
         ndim = self.domain.ndim
-        dx = self.domain.cell_size
+        dx = self.domain.cell_sides
 
         for axis in range(ndim):
             out_arr = out[axis].asarray()
@@ -520,7 +520,7 @@ class Divergence(Operator):
             out = self.range.element()
 
         ndim = self.range.ndim
-        dx = self.range.cell_size
+        dx = self.range.cell_sides
 
         arr = out.asarray()
         tmp = np.empty(out.shape, out.dtype, order=out.space.order)
@@ -620,7 +620,7 @@ class Laplacian(Operator):
         tmp = np.empty(out.shape, out.dtype, order=out.space.order)
 
         ndim = self.domain.ndim
-        dx = self.domain.cell_size
+        dx = self.domain.cell_sides
 
         for axis in range(ndim):
             # TODO: this can be optimized

--- a/odl/discr/discr_ops.py
+++ b/odl/discr/discr_ops.py
@@ -364,7 +364,7 @@ class Gradient(Operator):
         self.method = method
 
         super().__init__(domain=space,
-                         range=ProductSpace(space, space.grid.ndim),
+                         range=ProductSpace(space, space.ndim),
                          linear=True)
 
     def _call(self, x, out=None):
@@ -411,8 +411,8 @@ class Gradient(Operator):
             out = self.range.element()
 
         x_data = x.asarray()
-        ndim = self.domain.grid.ndim
-        dx = self.domain.grid.stride
+        ndim = self.domain.ndim
+        dx = self.domain.stride
 
         for axis in range(ndim):
             out_arr = out[axis].asarray()
@@ -475,7 +475,7 @@ class Divergence(Operator):
         self.space = space
         self.method = method
 
-        super().__init__(domain=ProductSpace(space, space.grid.ndim),
+        super().__init__(domain=ProductSpace(space, space.ndim),
                          range=space, linear=True)
 
     def _call(self, x, out=None):
@@ -519,8 +519,8 @@ class Divergence(Operator):
         if out is None:
             out = self.range.element()
 
-        ndim = self.range.grid.ndim
-        dx = self.range.grid.stride
+        ndim = self.range.ndim
+        dx = self.range.stride
 
         arr = out.asarray()
         tmp = np.empty(out.shape, out.dtype, order=out.space.order)
@@ -620,7 +620,7 @@ class Laplacian(Operator):
         tmp = np.empty(out.shape, out.dtype, order=out.space.order)
 
         ndim = self.domain.ndim
-        dx = self.domain.grid.stride
+        dx = self.domain.stride
 
         for axis in range(ndim):
             # TODO: this can be optimized

--- a/odl/discr/discr_ops.py
+++ b/odl/discr/discr_ops.py
@@ -412,7 +412,7 @@ class Gradient(Operator):
 
         x_data = x.asarray()
         ndim = self.domain.ndim
-        dx = self.domain.stride
+        dx = self.domain.grid.stride
 
         for axis in range(ndim):
             out_arr = out[axis].asarray()
@@ -520,7 +520,7 @@ class Divergence(Operator):
             out = self.range.element()
 
         ndim = self.range.ndim
-        dx = self.range.stride
+        dx = self.range.grid.stride
 
         arr = out.asarray()
         tmp = np.empty(out.shape, out.dtype, order=out.space.order)
@@ -620,7 +620,7 @@ class Laplacian(Operator):
         tmp = np.empty(out.shape, out.dtype, order=out.space.order)
 
         ndim = self.domain.ndim
-        dx = self.domain.stride
+        dx = self.domain.grid.stride
 
         for axis in range(ndim):
             # TODO: this can be optimized

--- a/odl/discr/discr_ops.py
+++ b/odl/discr/discr_ops.py
@@ -389,7 +389,7 @@ class Gradient(Operator):
         >>> from odl import uniform_discr
         >>> data = np.array([[ 0., 1., 2., 3., 4.],
         ...                  [ 0., 2., 4., 6., 8.]])
-        >>> discr = uniform_discr([0,0], [2,5], data.shape)
+        >>> discr = uniform_discr([0, 0], [2, 5], data.shape)
         >>> f = discr.element(data)
         >>> grad = Gradient(discr)
         >>> grad_f = grad(f)
@@ -412,7 +412,7 @@ class Gradient(Operator):
 
         x_data = x.asarray()
         ndim = self.domain.ndim
-        dx = self.domain.grid.stride
+        dx = self.domain.cell_size
 
         for axis in range(ndim):
             out_arr = out[axis].asarray()
@@ -520,7 +520,7 @@ class Divergence(Operator):
             out = self.range.element()
 
         ndim = self.range.ndim
-        dx = self.range.grid.stride
+        dx = self.range.cell_size
 
         arr = out.asarray()
         tmp = np.empty(out.shape, out.dtype, order=out.space.order)
@@ -602,7 +602,7 @@ class Laplacian(Operator):
         >>> data = np.array([[ 0., 0., 0.],
         ...                  [ 0., 1., 0.],
         ...                  [ 0., 0., 0.]])
-        >>> discr = uniform_discr([0,0], [3,3], data.shape)
+        >>> discr = uniform_discr([0, 0], [3, 3], data.shape)
         >>> f = discr.element(data)
         >>> lap = Laplacian(discr)
         >>> print(lap(f))
@@ -620,7 +620,7 @@ class Laplacian(Operator):
         tmp = np.empty(out.shape, out.dtype, order=out.space.order)
 
         ndim = self.domain.ndim
-        dx = self.domain.grid.stride
+        dx = self.domain.cell_size
 
         for axis in range(ndim):
             # TODO: this can be optimized

--- a/odl/discr/discr_ops.py
+++ b/odl/discr/discr_ops.py
@@ -289,14 +289,14 @@ class PartialDerivative(Operator):
 
         Parameters
         ----------
-        x : ``domain`` element
+        x : ``domain`` `element`
             Input vector to which the operator is applied to
         out : ``range`` element, optional
             Output vector to which the result is written
 
         Returns
         -------
-        out : ``range`` element, optional
+        out : ``range`` `element`
             Result of the evaluation. If ``out`` was provided, the
             returned object is a reference to it.
 
@@ -372,15 +372,15 @@ class Gradient(Operator):
 
         Parameters
         ----------
-        x : ``domain`` element
+        x : ``domain`` `element`
             Input vector to which the `Gradient` operator is
             applied
-        out : ``range`` element, optional
+        out : ``range`` `element`, optional
             Output vector to which the result is written
 
         Returns
         -------
-        out : ``range`` element, optional
+        out : ``range`` `element`
             Result of the evaluation. If ``out`` was
             provided, the returned object is a reference to it.
 
@@ -483,15 +483,15 @@ class Divergence(Operator):
 
         Parameters
         ----------
-        x : ``domain`` element
+        x : ``domain`` `element`
             `ProductSpaceVector` to which the divergence operator
             is applied
-        out : ``range`` element, optional
+        out : ``range`` `element`, optional
             Output vector to which the result is written
 
         Returns
         -------
-        out : ``range`` element, optional
+        out : ``range`` `element`
             Result of the evaluationIf ``out`` was
             provided, the returned object is a reference to it.
 
@@ -584,15 +584,15 @@ class Laplacian(Operator):
 
         Parameters
         ----------
-        x : ``domain`` element
+        x : ``domain`` `element`
             Input vector to which the `Laplacian` operator is
             applied
-        out : ``range`` element, optional
+        out : ``range`` `element`, optional
             Output vector to which the result is written
 
         Returns
         -------
-        out : ``range`` element, optional
+        out : ``range`` `element`
             Result of the evaluation. If ``out`` was
             provided, the returned object is a reference to it.
 

--- a/odl/discr/discr_ops.py
+++ b/odl/discr/discr_ops.py
@@ -51,7 +51,7 @@ def finite_diff(f, out=None, axis=0, dx=1.0, edge_order=2,
 
     Parameters
     ----------
-    f : array-like
+    f : `array-like`
          An N-dimensional array
     out : `numpy.ndarray`, optional
          An N-dimensional array to which the output is written.

--- a/odl/discr/discretization.py
+++ b/odl/discr/discretization.py
@@ -363,7 +363,7 @@ class Discretization(RawDiscretization, FnBase):
             to a `RawDiscretization.uspace` element. Must satisfy
             ``ext.domain == dspace``, ``ext.range == uspace``.
         """
-        super().__init__(uspace, dspace, restr, ext)
+        RawDiscretization.__init__(self, uspace, dspace, restr, ext)
         FnBase.__init__(self, dspace.size, dspace.dtype)
 
         if not isinstance(uspace, LinearSpace):

--- a/odl/discr/discretization.py
+++ b/odl/discr/discretization.py
@@ -183,7 +183,6 @@ class RawDiscretization(NtuplesBase):
         if inp is None:
             return self.element_type(self, self.dspace.element())
         try:
-            # pylint: disable=not-callable
             return self.element_type(self, self.restriction(inp))
         except TypeError:
             # Sequence-type input
@@ -282,7 +281,7 @@ class RawDiscretizationVector(NtuplesBaseVector):
                 self.ntuple == other.ntuple)
 
     def __getitem__(self, indices):
-        """Access values of this vector.
+        """Return ``self[indices]``.
 
         Parameters
         ----------
@@ -297,13 +296,13 @@ class RawDiscretizationVector(NtuplesBaseVector):
         return self.ntuple.__getitem__(indices)
 
     def __setitem__(self, indices, values):
-        """Set values of this vector.
+        """Implement ``self[indices] = values``.
 
         Parameters
         ----------
         indices : `int` or `slice`
             The position(s) that should be set
-        values : {scalar, array-like, `NtuplesBaseVector`}
+        values : scalar, `array-like` or `NtuplesBaseVector`
             The value(s) that are to be assigned.
 
             If ``index`` is an `int`, ``value`` must be single value.
@@ -341,7 +340,7 @@ class Discretization(RawDiscretization, FnBase):
     `Operator`'s.
     """
 
-    def __init__(self, uspace, dspace, restr=None, ext=None, **kwargs):
+    def __init__(self, uspace, dspace, restr=None, ext=None):
         """Abstract initialization method.
 
         Intended to be called by subclasses for proper type checking
@@ -364,7 +363,7 @@ class Discretization(RawDiscretization, FnBase):
             to a `RawDiscretization.uspace` element. Must satisfy
             ``ext.domain == dspace``, ``ext.range == uspace``.
         """
-        super().__init__(uspace, dspace, restr, ext, **kwargs)
+        super().__init__(uspace, dspace, restr, ext)
         FnBase.__init__(self, dspace.size, dspace.dtype)
 
         if not isinstance(uspace, LinearSpace):

--- a/odl/discr/grid.py
+++ b/odl/discr/grid.py
@@ -423,12 +423,12 @@ class TensorGrid(Set):
 
         Parameters
         ----------
-        other :  `TensorGrid`, `float` or array-like
-            The grid to be inserted. A `float` or array ``a`` is treated as
-            ``TensorGrid(a)``.
         index : `numbers.Integral`
             The index of the dimension before which ``other`` is to
             be inserted. Must fulfill ``0 <= index <= ndim``.
+        other :  `TensorGrid`, `float` or array-like
+            The grid to be inserted. A `float` or array ``a`` is treated as
+            ``TensorGrid(a)``.
 
         Returns
         -------
@@ -446,17 +446,19 @@ class TensorGrid(Set):
         --------
         append
         """
-        if index not in Integers():
-            raise TypeError('{!r} is not an integer.'.format(index))
-        if not 0 <= index <= self.ndim:
-            raise IndexError('index {} out of valid range 0 -> {}.'
-                             ''.format(index, self.ndim))
+        idx = int(index)
+        # Support backward indexing
+        if idx < 0:
+            idx = self.ndim + idx
+        if not 0 <= idx <= self.ndim:
+            raise IndexError('index out of valid range 0 -> {}.'
+                             ''.format(self.ndim))
 
         if not isinstance(other, TensorGrid):
             other = TensorGrid(other)
 
-        new_vecs = (self.coord_vectors[:index] + other.coord_vectors +
-                    self.coord_vectors[index:])
+        new_vecs = (self.coord_vectors[:idx] + other.coord_vectors +
+                    self.coord_vectors[idx:])
         return TensorGrid(*new_vecs, order=self.order)
 
     def append(self, other):
@@ -806,7 +808,7 @@ class RegularGrid(TensorGrid):
     This is a sparse representation of an n-dimensional grid defined
     as the tensor product of n coordinate vectors with equidistant
     nodes. The grid points are calculated according to the rule
-
+    ::
         x_j = min_pt + j * (max_pt - min_pt) / (shape - 1)
 
     with elementwise addition and multiplication.
@@ -983,7 +985,7 @@ class RegularGrid(TensorGrid):
             self_tg = TensorGrid(*self.coord_vectors, order=self.order)
             return self_tg.is_subgrid(other)
 
-    def insert(self, other, index):
+    def insert(self, index, other):
         """Insert another regular grid before the given index.
 
         The given grid (``m`` dimensions) is inserted into the current
@@ -993,12 +995,12 @@ class RegularGrid(TensorGrid):
 
         Parameters
         ----------
-        other : `TensorGrid`
-            The grid to be inserted. If a `RegularGrid` is given,
-            the output will be a `RegularGrid`.
         index : `numbers.Integral`
             The index of the dimension before which ``other`` is to
             be inserted. Must fulfill ``0 <= index <= ndim``.
+        other : `TensorGrid`
+            The grid to be inserted. If a `RegularGrid` is given,
+            the output will be a `RegularGrid`.
 
         Returns
         -------
@@ -1010,14 +1012,18 @@ class RegularGrid(TensorGrid):
         --------
         >>> rg1 = RegularGrid([-1.5, -1], [-0.5, 3], (2, 3))
         >>> rg2 = RegularGrid(-3, 7, 6)
-        >>> rg1.insert(rg2, 1)
-        RegularGrid([-1.5, -3.0, -1.0], [-0.5, 7.0, 3.0], [2, 6, 3])
+        >>> rg1.insert(1, rg2)
+        RegularGrid([-1.5 -3.  -1. ], [-0.5  7.   3. ], (2, 6, 3))
         """
         if isinstance(other, RegularGrid):
             idx = int(index)
+
+            # Support backward indexing
+            if idx < 0:
+                idx = self.ndim + idx
             if not 0 <= idx <= self.ndim:
-                raise IndexError('index {} out of valid range 0 -> {}.'
-                                 ''.format(index, self.ndim))
+                raise IndexError('index out of valid range 0 -> {}.'
+                                 ''.format(self.ndim))
 
             new_shape = self.shape[:idx] + other.shape + self.shape[idx:]
             new_minpt = (self.min_pt[:idx].tolist() + other.min_pt.tolist() +

--- a/odl/discr/grid.py
+++ b/odl/discr/grid.py
@@ -273,7 +273,7 @@ class TensorGrid(Set):
         return self.max_pt
 
     def extent(self):
-        """Return a vector containing the total grid extent.
+        """Return the edge lengths of this grid's minimal bounding box.
 
         Examples
         --------
@@ -284,7 +284,7 @@ class TensorGrid(Set):
         return self.max_pt - self.min_pt
 
     def convex_hull(self):
-        """The smallest `IntervalProd` containing this grid.
+        """Return the smallest `IntervalProd` containing this grid.
 
         The convex hull of a set is the union of all line segments
         between points in the set. For a tensor grid, it is the
@@ -450,7 +450,7 @@ class TensorGrid(Set):
         ----------
         index : `int`
             The index of the dimension before which ``other`` is to
-            be inserted. Must fulfill ``0 <= index <= ndim``.
+            be inserted. Negative indices are added to `ndim`.
         other :  `TensorGrid`, `float` or `array-like`
             The grid to be inserted
 
@@ -505,7 +505,7 @@ class TensorGrid(Set):
         return self.insert(self.ndim, other)
 
     def squeeze(self):
-        """Return the grid with removed degenerate dimensions.
+        """Return the grid with removed degenerate (length 1) dimensions.
 
         Returns
         -------
@@ -538,7 +538,7 @@ class TensorGrid(Set):
         Examples
         --------
         >>> g = TensorGrid([0, 1], [-1, 0, 2])
-        >>> g.points()  # default 'C' ordering
+        >>> g.points()
         array([[ 0., -1.],
                [ 0.,  0.],
                [ 0.,  2.],
@@ -611,7 +611,7 @@ class TensorGrid(Set):
         Examples
         --------
         >>> g = TensorGrid([0, 1], [-1, 0, 2])
-        >>> g.corners()  # default 'C' ordering
+        >>> g.corners()
         array([[ 0., -1.],
                [ 0.,  2.],
                [ 1., -1.],
@@ -624,6 +624,7 @@ class TensorGrid(Set):
         """
         return self.corner_grid().points(order=order)
 
+    @property
     def meshgrid(self):
         """A grid suitable for function evaluation.
 
@@ -641,7 +642,7 @@ class TensorGrid(Set):
         Examples
         --------
         >>> g = TensorGrid([0, 1], [-1, 0, 2])
-        >>> x, y = g.meshgrid()
+        >>> x, y = g.meshgrid
         >>> x
         array([[ 0.],
                [ 1.]])

--- a/odl/discr/grid.py
+++ b/odl/discr/grid.py
@@ -394,7 +394,7 @@ class TensorGrid(Set):
         return True
 
     def insert(self, index, other):
-        """Insert another grid before the given index.
+        """Return a copy with ``other`` inserted before ``index``.
 
         The given grid (``m`` dimensions) is inserted into the current
         one (``n`` dimensions) before the given index, resulting in a new
@@ -403,7 +403,7 @@ class TensorGrid(Set):
 
         Parameters
         ----------
-        index : `numbers.Integral`
+        index : `int`
             The index of the dimension before which ``other`` is to
             be inserted. Must fulfill ``0 <= index <= ndim``.
         other :  `TensorGrid`, `float` or array-like
@@ -899,11 +899,11 @@ class RegularGrid(TensorGrid):
 
         Parameters
         ----------
-        index : `numbers.Integral`
-            The index of the dimension before which ``other`` is to
+        index : `int`
+            Index of the dimension before which ``other`` is to
             be inserted. Must fulfill ``0 <= index <= ndim``.
         other : `TensorGrid`
-            The grid to be inserted. If a `RegularGrid` is given,
+            Grid to be inserted. If a `RegularGrid` is given,
             the output will be a `RegularGrid`.
 
         Returns

--- a/odl/discr/grid.py
+++ b/odl/discr/grid.py
@@ -63,21 +63,13 @@ def sparse_meshgrid(*x, **kwargs):
     numpy.meshgrid : dense or sparse meshgrids
     """
     n = len(x)
-    order = kwargs.pop('order', 'C')
     mesh = []
     for ax, xi in enumerate(x):
         xi = np.asarray(xi)
         slc = [None] * n
-        slc[ax] = np.s_[:]
+        slc[ax] = slice(None)
 
-        if order == 'C':
-            mesh.append(np.ascontiguousarray(xi[slc]))
-        else:
-            mesh.append(np.asfortranarray(xi[slc]))
-    if order == 'C':
-        return tuple(mesh)
-    else:
-        return tuple(reversed(mesh))
+    return tuple(mesh)
 
 
 class TensorGrid(Set):
@@ -590,7 +582,7 @@ class TensorGrid(Set):
         Returns
         -------
         meshgrid : `tuple` of `numpy.ndarray`
-            Function evaluation grid with :attr:`ndim` axes
+            Function evaluation grid with ``ndim`` axes
 
         See also
         --------
@@ -613,19 +605,8 @@ class TensorGrid(Set):
         >>> x**2 - y**2
         array([[-1.,  0., -4.],
                [ 0.,  1., -3.]])
-
-        Fortran ordering of the grid is respected:
-
-        >>> g = TensorGrid([0, 1], [-1, 0, 2], order='F')
-        >>> x, y = g.meshgrid()
-        >>> x.flags.f_contiguous, y.flags.f_contiguous
-        (True, True)
-
-        See Also
-        --------
-        coord_vectors : Same result but with 1d arrays
         """
-        return sparse_meshgrid(*self.coord_vectors, order=self.order)
+        return sparse_meshgrid(*self.coord_vectors)
 
     def __getitem__(self, slc):
         """self[slc] implementation.

--- a/odl/discr/grid.py
+++ b/odl/discr/grid.py
@@ -109,7 +109,7 @@ class TensorGrid(Set):
         >>> g
         TensorGrid([1.0, 2.0, 5.0], [-2.0, 1.5, 2.0])
         >>> print(g)
-        grid [1.0, 2.0, 5.0] x [-2.0, 1.5, 2.0]
+        [1.0, 2.0, 5.0] x [-2.0, 1.5, 2.0]
         >>> g.ndim  # number of axes
         2
         >>> g.shape  # points per axis
@@ -322,7 +322,7 @@ class TensorGrid(Set):
         Examples
         --------
         >>> g = TensorGrid([0, 1], [-1, 0, 2])
-        >>> g.approx_contains([0, 0], tol=0.0)
+        >>> g.approx_contains([0, 0], atol=0.0)
         True
         >>> [0, 0] in g  # equivalent
         True
@@ -538,6 +538,7 @@ class TensorGrid(Set):
         --------
         >>> g = TensorGrid([0, 1], [-1, 0, 2])  # default 'C' ordering
         >>> g.corner_grid()
+        TensorGrid([0.0, 1.0], [-1.0, 2.0])
         """
         minmax_vecs = []
         for axis in range(self.ndim):
@@ -737,7 +738,7 @@ class RegularGrid(TensorGrid):
         --------
         >>> rg = RegularGrid([-1.5, -1], [-0.5, 3], (2, 3))
         >>> rg
-        RegularGrid([-1.5, -1.0], [-0.5, 3.0], [2, 3])
+        RegularGrid([-1.5, -1.0], [-0.5, 3.0], (2, 3))
         >>> rg.coord_vectors
         (array([-1.5, -0.5]), array([-1.,  1.,  3.]))
         >>> rg.ndim, rg.size
@@ -901,7 +902,7 @@ class RegularGrid(TensorGrid):
         >>> rg1 = RegularGrid([-1.5, -1], [-0.5, 3], (2, 3))
         >>> rg2 = RegularGrid(-3, 7, 6)
         >>> rg1.insert(1, rg2)
-        RegularGrid([-1.5 -3.  -1. ], [-0.5  7.   3. ], (2, 6, 3))
+        RegularGrid([-1.5, -3.0, -1.0], [-0.5, 7.0, 3.0], (2, 6, 3))
         """
         if isinstance(other, RegularGrid):
             idx = int(index)
@@ -940,7 +941,7 @@ class RegularGrid(TensorGrid):
         --------
         >>> g = RegularGrid([0, 0, 0], [1, 0, 1], (5, 1, 5))
         >>> g.squeeze()
-        RegularGrid([0.0, 0.0], [1.0, 1.0], [5, 5])
+        RegularGrid([0.0, 0.0], [1.0, 1.0], (5, 5))
         """
         sq_minpt = [self.min_pt[axis] for axis in self._inondeg]
         sq_maxpt = [self.max_pt[axis] for axis in self._inondeg]
@@ -961,12 +962,12 @@ class RegularGrid(TensorGrid):
         >>> g[0, 0, 0]
         array([-1.5, -3. , -1. ])
         >>> g[:, 0, 0]
-        RegularGrid([-1.5, -3.0, -1.0], [-0.5, -3.0, -1.0], [2, 1, 1])
+        RegularGrid([-1.5, -3.0, -1.0], [-0.5, -3.0, -1.0], (2, 1, 1))
 
         Ellipsis can be used, too:
 
         >>> g[..., ::3]
-        RegularGrid([-1.5, -3.0, -1.0], [-0.5, 7.0, 2.0], [2, 3, 2])
+        RegularGrid([-1.5, -3.0, -1.0], [-0.5, 7.0, 2.0], (2, 3, 2))
         """
         from math import ceil
 
@@ -1042,7 +1043,8 @@ class RegularGrid(TensorGrid):
 
     def __repr__(self):
         """Return ``repr(self)``."""
-        inner_str = '{}, {}, {}'.format(self.min_pt, self.max_pt, self.shape)
+        inner_str = '{}, {}, {}'.format(list(self.min_pt), list(self.max_pt),
+                                        tuple(self.shape))
         if self.order == 'F':
             inner_str += ", order='F'"
 
@@ -1051,6 +1053,11 @@ class RegularGrid(TensorGrid):
 
 def uniform_sampling(intv_prod, num_nodes, order='C'):
     """Sample an interval product uniformly.
+
+    The resulting grid will include ``begin`` and ``end`` of
+    ``intv_prod`` as grid points. If you want a subdivision into
+    equally sized cells with grid points in the middle, use
+    `uniform_partition` instead.
 
     Parameters
     ----------
@@ -1069,13 +1076,18 @@ def uniform_sampling(intv_prod, num_nodes, order='C'):
     sampling : `RegularGrid`
         Uniform sampling grid for the interval product
 
+    See also
+    --------
+    uniform_partition :
+        divide interval products into equally sized subsets
+
     Examples
     --------
     >>> from odl import IntervalProd
     >>> rbox = IntervalProd([-1.5, 2], [-0.5, 3])
-    >>> grid = uniform_sampling(rbox, [2, 4])
+    >>> grid = uniform_sampling(rbox, [3, 3])
     >>> grid.coord_vectors
-    (array([-1.5, -0.5]), array([ 2.  ,  2.25,  2.5,  2.75,  3.  ]))
+    (array([-1.5, -1. , -0.5]), array([ 2. ,  2.5,  3. ]))
     """
     num_nodes = np.atleast_1d(num_nodes).astype('int64')
 

--- a/odl/discr/grid.py
+++ b/odl/discr/grid.py
@@ -48,10 +48,6 @@ def sparse_meshgrid(*x, **kwargs):
     ----------
     x1,...,xN : array-like
         Input arrays to turn into sparse meshgrid vectors
-    order : {'C', 'F'}, optional
-        Ordering of the output meshgrid. The vectors in the produced
-        meshgrid tuple are guaranteed to be contiguous in this
-        ordering,
 
     Returns
     -------
@@ -61,6 +57,13 @@ def sparse_meshgrid(*x, **kwargs):
     See also
     --------
     numpy.meshgrid : dense or sparse meshgrids
+
+    Examples
+    --------
+    >>> x, y = [0, 1], [2, 3, 4]
+    >>> mesh = sparse_meshgrid(x, y)
+    >>> sum(xi for xi in mesh).ravel()  # first axis slowest
+    array([2, 3, 4, 3, 4, 5])
     """
     n = len(x)
     mesh = []

--- a/odl/discr/grid.py
+++ b/odl/discr/grid.py
@@ -34,7 +34,7 @@ import numpy as np
 
 # ODL imports
 from odl.set.domain import IntervalProd
-from odl.set.sets import Set, Integers
+from odl.set.sets import Set
 from odl.util.utility import array1d_repr, array1d_str
 
 
@@ -248,29 +248,9 @@ class TensorGrid(Set):
         """Return ``self.min_pt``."""
         return self.min_pt
 
-        # TODO: move code to Partition
-#        if not self.as_midp:
-#            return self.min_pt
-#        elif self._exact_min is not None:
-#            return self._exact_min
-#        else:
-#            minpt_cell_size = np.array([cs[0] for cs in self.cell_sizes()])
-#            return self.min_pt - minpt_cell_size / 2
-
     def max(self):
         """Return ``self.max_pt``."""
         return self.max_pt
-
-        # TODO: move code to Partition
-#        if not self.as_midp:
-#            return self.max_pt
-#        elif self._exact_max is not None:
-#            return self._exact_max
-#        else:
-#            maxpt_cell_size = np.array([cs[-1] for cs in self.cell_sizes()])
-#            return self.max_pt + maxpt_cell_size / 2
-
-    # Methods
 
     def extent(self):
         """Return a vector containing the total grid extent."""
@@ -604,43 +584,6 @@ class TensorGrid(Set):
         """
         return self.corner_grid().points(order=order)
 
-    # TODO: move code to Partition
-#    def cell_sizes(self):
-#        """The grid cell sizes as coordinate vectors.
-#
-#        Returns
-#        -------
-#        csizes : `tuple` of `numpy.ndarray`
-#            The cell sizes per axis. The length of the vectors will be
-#            one less than `coord_vectors` if `as_midp` is `False`,
-#            otherwise they will have the same length.
-#            For axes with 1 grid point, cell size is set to 0.
-#
-#        Examples
-#        --------
-#        >>> g = TensorGrid([0, 1], [-1, 0, 2])
-#        >>> g.cell_sizes()
-#        (array([ 1.]), array([ 1.,  2.]))
-#        >>> g = TensorGrid([0, 1], [-1, 0, 2], as_midp=True)
-#        >>> g.cell_sizes()
-#        (array([ 1.,  1.]), array([ 1. ,  1.5,  2. ]))
-#        """
-#        csizes = []
-#        for vec in self.coord_vectors:
-#            if len(vec) == 1:
-#                csizes.append(np.array([0.0]))
-#            else:
-#                if self.as_midp:
-#                    csize = np.empty_like(vec)
-#                    csize[1:-1] = (vec[2:] - vec[:-2]) / 2.0
-#                    csize[0] = vec[1] - vec[0]
-#                    csize[-1] = vec[-1] - vec[-2]
-#                else:
-#                    csize = vec[1:] - vec[:-1]
-#                csizes.append(csize)
-#
-#        return tuple(csizes)
-
     def meshgrid(self):
         """A grid suitable for function evaluation.
 
@@ -683,32 +626,6 @@ class TensorGrid(Set):
         coord_vectors : Same result but with 1d arrays
         """
         return sparse_meshgrid(*self.coord_vectors, order=self.order)
-
-        # TODO: move code to Partition
-#    def convex_hull(self):
-#        """The "inner" of the grid, an `IntervalProd`.
-#
-#        The convex hull of a set is the union of all line segments
-#        between points in the set. For a tensor grid, it is the
-#        interval product given by the extremal coordinates.
-#
-#        Returns
-#        -------
-#        chull : `IntervalProd`
-#            Interval product defined by the minimum and maximum of
-#            the grid (depends on `as_midp`)
-#
-#        Examples
-#        --------
-#        >>> g = TensorGrid([-1, 0, 3], [2, 4], [5], [2, 4, 7])
-#        >>> g.convex_hull()
-#        IntervalProd([-1.0, 2.0, 5.0, 2.0], [3.0, 4.0, 5.0, 7.0])
-#        >>> g = TensorGrid([-1, 0, 3], [2, 4], [5], [2, 4, 7],
-#        ...                as_midp=True)
-#        >>> g.convex_hull()
-#        IntervalProd([-1.5, 1.0, 5.0, 1.0], [4.5, 5.0, 5.0, 8.5])
-#        """
-#        return IntervalProd(self.min(), self.max())
 
     def __getitem__(self, slc):
         """self[slc] implementation.
@@ -911,19 +828,6 @@ class RegularGrid(TensorGrid):
         array([ 1.,  2.])
         """
         return self._stride
-
-    # TODO: move code to Partition
-#    @property
-#    def cell_volume(self):
-#        """Cell volume of an underlying regular grid.
-#
-#        Examples
-#        --------
-#        >>> rg = RegularGrid([0, 0], [1, 1], (2, 2))
-#        >>> rg.cell_volume
-#        1.0
-#        """
-#        return float(np.prod(self.stride))
 
     def is_subgrid(self, other, atol=0.0):
         """Test if this grid is contained in another grid.
@@ -1210,13 +1114,6 @@ def uniform_sampling(intv_prod, num_nodes, order='C'):
         raise ValueError('degenerate axes {} cannot be sampled with more '
                          'than one node.'.format(tuple(intv_prod._ideg)))
 
-    # TODO: move code to Partition
-#    if as_midp:
-#        grid_min = intv_prod.begin + intv_prod.extent / (2 * num_nodes)
-#        grid_max = intv_prod.end - intv_prod.extent / (2 * num_nodes)
-#        return RegularGrid(grid_min, grid_max, num_nodes, as_midp=as_midp,
-#                           _exact_min=intv_prod.begin,
-#                           _exact_max=intv_prod.end)
     return RegularGrid(intv_prod.begin, intv_prod.end, num_nodes, order=order)
 
 

--- a/odl/discr/lp_discr.py
+++ b/odl/discr/lp_discr.py
@@ -367,11 +367,11 @@ class DiscreteLpVector(DiscretizationVector):
             if indices == slice(None):
                 values = np.atleast_1d(values)
                 if (values.ndim > 1 and
-                        values.shape != self.space.grid.shape):
+                        values.shape != self.space.shape):
                     raise ValueError('shape {} of value array {} not equal'
                                      ' to sampling grid shape {}.'
                                      ''.format(values.shape, values,
-                                               self.space.grid.shape))
+                                               self.space.shape))
                 values = values.ravel(order=self.space.order)
 
             super().__setitem__(indices, values)
@@ -482,7 +482,7 @@ class DiscreteLpVector(DiscretizationVector):
         # Default to showing x-y slice "in the middle"
         if indices is None and self.ndim >= 3:
             indices = [np.s_[:]] * 2
-            indices += [n // 2 for n in self.space.grid.shape[2:]]
+            indices += [n // 2 for n in self.space.shape[2:]]
 
         if isinstance(indices, (Integral, slice)):
             indices = [indices]
@@ -617,10 +617,10 @@ def uniform_discr_fromspace(fspace, nsamples, exponent=2.0, interp='nearest',
         raise NotImplementedError
 
     if dtype is not None:
-        dspace = ds_type(partition.grid.size, dtype=dtype, weight=weight,
+        dspace = ds_type(partition.size, dtype=dtype, weight=weight,
                          exponent=exponent)
     else:
-        dspace = ds_type(partition.grid.size, weight=weight, exponent=exponent)
+        dspace = ds_type(partition.size, weight=weight, exponent=exponent)
 
     return DiscreteLp(fspace, partition, dspace, exponent, interp)
 

--- a/odl/discr/lp_discr.py
+++ b/odl/discr/lp_discr.py
@@ -33,7 +33,7 @@ from odl.discr.discretization import (
     Discretization, DiscretizationVector, dspace_type)
 from odl.discr.discr_mappings import (
     PointCollocation, NearestInterpolation, LinearInterpolation)
-from odl.discr.partition import RectPartition, uniform_partition
+from odl.discr.partition import RectPartition, uniform_partition_from_intv_prod
 from odl.set.sets import RealNumbers, ComplexNumbers
 from odl.set.domain import IntervalProd
 from odl.space.ntuples import Fn
@@ -302,8 +302,8 @@ class DiscreteLp(Discretization):
     def __repr__(self):
         """Return ``repr(self).``"""
         # Check if the factory repr can be used
-        if (uniform_partition(self.uspace.domain, self.shape, False) ==
-                self.partition):
+        if (uniform_partition_from_intv_prod(
+                self.uspace.domain, self.shape) == self.partition):
             if isinstance(self.dspace, Fn):
                 impl = 'numpy'
                 default_dtype = np.float64
@@ -690,7 +690,8 @@ def uniform_discr_fromspace(fspace, nsamples, exponent=2.0, interp='nearest',
 
     order = kwargs.pop('order', 'C')
     nodes_on_bdry = kwargs.pop('nodes_on_bdry', False)
-    partition = uniform_partition(fspace.domain, nsamples, nodes_on_bdry)
+    partition = uniform_partition_from_intv_prod(fspace.domain, nsamples,
+                                                 nodes_on_bdry)
 
     weighting = kwargs.pop('weighting', 'simple')
     weighting_ = weighting.lower()

--- a/odl/discr/lp_discr.py
+++ b/odl/discr/lp_discr.py
@@ -249,12 +249,7 @@ class DiscreteLp(Discretization):
             # TODO: implement without copying x
             func_list = _scaling_func_list(bdry_fracs)
 
-            x_arr = x.asarray()
-            if not x_arr.flags.owndata:
-                x_arr = x_arr.copy()
-
-            apply_on_boundary(x_arr, func=func_list, only_once=False,
-                              out=x_arr)
+            x_arr = apply_on_boundary(x, func=func_list, only_once=False)
             return super()._inner(self.element(x_arr), y)
 
     def _norm(self, x):
@@ -265,14 +260,9 @@ class DiscreteLp(Discretization):
             return super()._norm(x)
         else:
             # TODO: implement without copying x
-            func_list = _scaling_func_list(bdry_fracs,
-                                           exponent=self.exponent)
-            x_arr = x.asarray()
-            if not x_arr.flags.owndata:
-                x_arr = x_arr.copy()
+            func_list = _scaling_func_list(bdry_fracs, exponent=self.exponent)
 
-            apply_on_boundary(x_arr, func=func_list, only_once=False,
-                              out=x_arr)
+            x_arr = apply_on_boundary(x, func=func_list, only_once=False)
             return super()._norm(self.element(x_arr))
 
     def _dist(self, x, y):
@@ -283,20 +273,12 @@ class DiscreteLp(Discretization):
             return super()._dist(x, y)
         else:
             # TODO: implement without copying x
-            func_list = _scaling_func_list(bdry_fracs,
-                                           exponent=self.exponent)
+            func_list = _scaling_func_list(bdry_fracs, exponent=self.exponent)
 
-            x_arr, y_arr = x.asarray(), y.asarray()
-            if not x_arr.flags.owndata:
-                x_arr = x_arr.copy()
-            if not y_arr.flags.owndata:
-                y_arr = y_arr.copy()
+            arrs = [apply_on_boundary(vec, func=func_list, only_once=False)
+                    for vec in (x, y)]
 
-            for arr in (x_arr, y_arr):
-                apply_on_boundary(arr, func=func_list, only_once=False,
-                                  out=x_arr)
-
-            return super()._dist(self.element(x_arr), self.element(y_arr))
+            return super()._dist(self.element(arrs[0]), self.element(arrs[1]))
 
     def __repr__(self):
         """Return ``repr(self).``"""

--- a/odl/discr/lp_discr.py
+++ b/odl/discr/lp_discr.py
@@ -33,7 +33,7 @@ from odl.discr.discretization import (
     Discretization, DiscretizationVector, dspace_type)
 from odl.discr.discr_mappings import (
     PointCollocation, NearestInterpolation, LinearInterpolation)
-from odl.discr.partition import RectPartition, uniform_partition_from_intv_prod
+from odl.discr.partition import RectPartition, uniform_partition_fromintv
 from odl.set.sets import RealNumbers, ComplexNumbers
 from odl.set.domain import IntervalProd
 from odl.space.ntuples import Fn
@@ -92,7 +92,7 @@ class DiscreteLp(Discretization):
         if not isinstance(partition, RectPartition):
             raise TypeError('Partition {!r} is not a RectPartition '
                             'instance.'.format(partition))
-        if not fspace.domain.contains_set(partition.bbox):
+        if not fspace.domain.contains_set(partition.set):
             raise ValueError('Partition {} is not a subset of the function '
                              'domain {}'.format(partition, fspace.domain))
 
@@ -158,9 +158,9 @@ class DiscreteLp(Discretization):
         return self.partition.size
 
     @property
-    def cell_size(self):
-        """Cell size of an underlying regular partition."""
-        return self.partition.cell_size
+    def cell_sides(self):
+        """Side lengths of a cell in an underlying *uniform* partition."""
+        return self.partition.cell_sides
 
     @property
     def cell_volume(self):
@@ -169,11 +169,11 @@ class DiscreteLp(Discretization):
 
     def meshgrid(self):
         """All sampling points in the partition as a sparse meshgrid."""
-        return self.partition.sampling_meshgrid()
+        return self.partition.meshgrid()
 
     def points(self):
         """All sampling points in the partition."""
-        return self.partition.sampling_points()
+        return self.partition.points()
 
     @property
     def exponent(self):
@@ -302,7 +302,7 @@ class DiscreteLp(Discretization):
     def __repr__(self):
         """Return ``repr(self).``"""
         # Check if the factory repr can be used
-        if (uniform_partition_from_intv_prod(
+        if (uniform_partition_fromintv(
                 self.uspace.domain, self.shape) == self.partition):
             if isinstance(self.dspace, Fn):
                 impl = 'numpy'
@@ -421,9 +421,9 @@ class DiscreteLpVector(DiscretizationVector):
         return self.space.shape
 
     @property
-    def cell_size(self):
-        """Cell size of an underlying regular grid."""
-        return self.space.cell_size
+    def cell_sides(self):
+        """Side lengths of a cell in an underlying *uniform* partition."""
+        return self.space.cell_sides
 
     @property
     def cell_volume(self):
@@ -690,8 +690,8 @@ def uniform_discr_fromspace(fspace, nsamples, exponent=2.0, interp='nearest',
 
     order = kwargs.pop('order', 'C')
     nodes_on_bdry = kwargs.pop('nodes_on_bdry', False)
-    partition = uniform_partition_from_intv_prod(fspace.domain, nsamples,
-                                                 nodes_on_bdry)
+    partition = uniform_partition_fromintv(fspace.domain, nsamples,
+                                           nodes_on_bdry)
 
     weighting = kwargs.pop('weighting', 'simple')
     weighting_ = weighting.lower()

--- a/odl/discr/lp_discr.py
+++ b/odl/discr/lp_discr.py
@@ -253,7 +253,8 @@ class DiscreteLp(Discretization):
             if not x_arr.flags.owndata:
                 x_arr = x_arr.copy()
 
-            apply_on_boundary(x_arr, func=func_list, only_once=False)
+            apply_on_boundary(x_arr, func=func_list, only_once=False,
+                              out=x_arr)
             return super()._inner(self.element(x_arr), y)
 
     def _norm(self, x):
@@ -270,7 +271,8 @@ class DiscreteLp(Discretization):
             if not x_arr.flags.owndata:
                 x_arr = x_arr.copy()
 
-            apply_on_boundary(x_arr, func=func_list, only_once=False)
+            apply_on_boundary(x_arr, func=func_list, only_once=False,
+                              out=x_arr)
             return super()._norm(self.element(x_arr))
 
     def _dist(self, x, y):
@@ -291,7 +293,8 @@ class DiscreteLp(Discretization):
                 y_arr = y_arr.copy()
 
             for arr in (x_arr, y_arr):
-                apply_on_boundary(arr, func=func_list, only_once=False)
+                apply_on_boundary(arr, func=func_list, only_once=False,
+                                  out=x_arr)
 
             return super()._dist(self.element(x_arr), self.element(y_arr))
 

--- a/odl/discr/lp_discr.py
+++ b/odl/discr/lp_discr.py
@@ -168,9 +168,10 @@ class DiscreteLp(Discretization):
         """Cell volume of an underlying regular partition."""
         return self.partition.cell_volume
 
+    @property
     def meshgrid(self):
         """All sampling points in the partition as a sparse meshgrid."""
-        return self.partition.meshgrid()
+        return self.partition.meshgrid
 
     def points(self):
         """All sampling points in the partition."""

--- a/odl/discr/partition.py
+++ b/odl/discr/partition.py
@@ -1,0 +1,203 @@
+﻿# Copyright 2014-2016 The ODL development group
+#
+# This file is part of ODL.
+#
+# ODL is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# ODL is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with ODL.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Partitons of interval products based on tensor grid.
+
+A partition of a set is a finite collection of nonempty, pairwise
+disjoint subsets whose union is the original set. The partitions
+considered here are based on hypercubes, i.e. the tensor products
+of partitions of intervals.
+"""
+
+# Imports for common Python 2/3 codebase
+from __future__ import print_function, division, absolute_import
+
+from future import standard_library
+standard_library.install_aliases()
+from builtins import super, str, zip
+
+# External module imports
+import numpy as np
+
+# ODL imports
+from odl.discr.grid import TensorGrid
+from odl.set.domain import IntervalProd
+from odl.util.utility import array1d_repr
+
+
+__all__ = ('GridBasedPartition',)
+
+_POINT_POSITIONS = ('center', 'left')
+
+
+class GridBasedPartition(object):
+
+    """Abstract partition class based on `TensorGrid`s.
+
+    In 1d, a partition of an interval is implicitly defined by a
+    collection of points x[0], ..., x[N-1] (a grid) and the information
+    where in the subintervals the grid points lie. If, e.g. the
+    points are to lie in the center of the subintervals, these
+    subintervals are given as ``[(x[i-1]-x[i])/2, (x[i]+x[i+1])/2]``.
+    """
+
+    def __init__(self, grid, begin=None, end=None, point_pos='center'):
+        """Initialize a new instance.
+
+        Parameters
+        ----------
+        grid : `TensorGrid`
+            Spatial points supporting the partition
+        begin, end : array-like
+            Spatial points defining the begin and end of an interval
+            product to be partitioned. ``begin`` must be component-wise
+            at most ``grid.min_pt``, and ``end`` at least
+            ``grid.max_pt``. If not provided, they are inferred
+            from the grid.
+        point_pos : {'center', 'left'} or sequence of `str`
+            Where the grid points lie in the subintervals. A sequence
+            is interpreted per dimension, its length must be equal
+            to ``grid.ndim``. If a single string is given, that option
+            is applied in all dimensions.
+
+        Notes
+        -----
+        The ``begin`` and ``end`` points are determined from the grid
+        as follows:
+
+        - In dimensions with ``point_pos='left'``, it is ``begin = x[0]``
+          and ``end = x[N-1]``, where ``x`` is the length ``N`` vector of
+          grid coodinates in that dimension.
+
+        - In dimensions with ``point_pos='center'``, the left endpoint
+          is given as ``begin = x[0] - (x[1]-x[0])/2``, the right
+          endpoint is ``end = x[N-1] + (x[N-1]-x[N-2])/2``.
+        """
+        if not isinstance(grid, TensorGrid):
+            raise TypeError('{!r} is not a TensorGrid instance.'
+                            ''.format(grid))
+
+        # Make a grid.ndim - length list from the point_pos, raise if
+        # bad length sequence.
+        try:
+            # String check by concatenation with ''
+            pos_lst = [str(point_pos + '').lower()] * grid.ndim
+        except TypeError:
+            # Sequence given
+            pos_lst = [str(pos).lower() for pos in point_pos]
+            if len(pos_lst) != grid.ndim:
+                raise ValueError('expected {} entries in point_pos, got {}.'
+                                 ''.format(grid.ndim, len(pos_lst)))
+
+        for pos, orig_pos in zip(pos_lst, point_pos):
+            if pos not in _POINT_POSITIONS:
+                raise ValueError('point position {} not understood.'
+                                 ''.format(orig_pos))
+
+        # Begin and end: check correct shapes and values if given,
+        # calculate otherwise.
+        if begin is not None:
+            begin = np.asarray(begin, dtype='float64')
+            if begin.shape != (grid.ndim,):
+                raise ValueError('begin has shape {}, expected {}.'
+                                 ''.format(begin.shape, (grid.ndim,)))
+            if np.any(begin > grid.min_pt):
+                raise ValueError('begin {} has entries larger than the '
+                                 'minimum grid point {}.'
+                                 ''.format(begin, grid.min_pt))
+            self._custom_begin = True
+
+        else:
+            begin = np.empty(grid.ndim, dtype='float64')
+            for i, (pos, coo_vec) in enumerate(zip(pos_lst,
+                                                   grid.coord_vectors)):
+                if len(coo_vec) == 1:
+                    raise ValueError(
+                        'cannot infer begin and end in degenerate dimension '
+                        '{}.'.format(i))
+                if pos == 'left':
+                    begin[i] = coo_vec[0]
+                else:  # pos == 'center'
+                    begin[i] = coo_vec[0] - (coo_vec[1] - coo_vec[0]) / 2
+            self._custom_begin = False
+
+        if end is not None:
+            end = np.asarray(end, dtype='float64')
+            if end.shape != (grid.ndim,):
+                raise ValueError('end has shape {}, expected {}.'
+                                 ''.format(end.shape, (grid.ndim,)))
+            if np.any(end < grid.max_pt):
+                raise ValueError('end {} has entries smaller than the '
+                                 'maximum grid point {}.'
+                                 ''.format(end, grid.max_pt))
+            self._custom_end = True
+        else:
+            end = np.empty(grid.ndim, dtype='float64')
+            for i, (pos, coo_vec) in enumerate(zip(pos_lst,
+                                                   grid.coord_vectors)):
+                if pos == 'left':
+                    end[i] = coo_vec[-1]
+                else:  # pos == 'center'
+                    end[i] = coo_vec[-1] + (coo_vec[-1] - coo_vec[-2]) / 2
+            self._custom_end = False
+
+        super().__init__()
+        self._interv_prod = IntervalProd(begin, end)
+        self._grid = grid
+        self._point_pos = pos_lst
+
+    @property
+    def grid(self):
+        """The `TensorGrid` defining this partition."""
+        return self._grid
+
+    @property
+    def interv_prod(self):
+        """The `IntervalProd` partitioned by this partition."""
+        return self._interv_prod
+
+    @property
+    def point_pos(self):
+        """Position of the grid points in the subsets (per axis)."""
+        return self._point_pos
+
+    # TODO: pretty-print
+    def __repr__(self):
+        """Return ``repr(self)``."""
+        inner_str = '\n {!r}'.format(self.grid)
+        sep = ',\n '
+        if self._custom_begin:
+            inner_str += sep + 'begin={}'.format(
+                array1d_repr(self.interv_prod.begin))
+            sep = ', '
+        if self._custom_end:
+            inner_str += sep + 'end={}'.format(
+                array1d_repr(self.interv_prod.end))
+            sep = ', '
+        single_pos = all(pos == self.point_pos[0]
+                         for pos in self.point_pos[1:])
+        if single_pos and self.point_pos[0] != 'center':
+            inner_str += sep + "point_pos='{}'".format(self.point_pos[0])
+        elif not single_pos:
+            inner_str += sep + 'point_pos={}'.format(self.point_pos)
+
+        return '{}({})'.format(self.__class__.__name__, inner_str)
+
+
+if __name__ == '__main__':
+    from doctest import testmod, NORMALIZE_WHITESPACE
+    testmod(optionflags=NORMALIZE_WHITESPACE)

--- a/odl/discr/partition.py
+++ b/odl/discr/partition.py
@@ -39,7 +39,7 @@ from odl.set.domain import IntervalProd
 from odl.util.utility import array1d_repr
 
 
-__all__ = ('RectPartition',)
+__all__ = ('RectPartition', 'uniform_partition')
 
 _POINT_POSITIONS = ('center', 'left')
 

--- a/odl/discr/partition.py
+++ b/odl/discr/partition.py
@@ -36,7 +36,6 @@ import numpy as np
 # ODL imports
 from odl.discr.grid import TensorGrid, RegularGrid
 from odl.set.domain import IntervalProd
-from odl.util.utility import array1d_repr
 
 
 __all__ = ('RectPartition', 'uniform_partition_fromintv',
@@ -401,10 +400,10 @@ def uniform_partition_fromintv(intv_prod, num_nodes, nodes_on_bdry=False):
     ----------
     intv_prod : `IntervalProd`
         Interval product to be partitioned
-    num_nodes : `int` or sequence of `int`
+    num_nodes : `int` or `sequence` of `int`
         Number of nodes per axis. For 1d intervals, a single integer
         can be specified.
-    nodes_on_bdry : `bool` or sequence, optional
+    nodes_on_bdry : `bool` or `sequence`, optional
         If a sequence is provided, it determines per axis whether to
         place the last grid point on the boundary (True) or shift it
         by half a cell size into the interior (False). In each axis,
@@ -526,13 +525,13 @@ def uniform_partition(begin, end, num_nodes, nodes_on_bdry=False):
 
     Parameters
     ----------
-    begin, end : array-like
+    begin, end : `array-like`
         Vectors defining the begin end end points of an `IntervalProd`
         (a rectangular box)
-    num_nodes : `int` or sequence of `int`
+    num_nodes : `int` or `sequence` of `int`
         Number of nodes per axis. For 1d intervals, a single integer
         can be specified.
-    nodes_on_bdry : `bool` or sequence, optional
+    nodes_on_bdry : `bool` or `sequence`, optional
         If a sequence is provided, it determines per axis whether to
         place the last grid point on the boundary (True) or shift it
         by half a cell size into the interior (False). In each axis,
@@ -600,20 +599,22 @@ def uniform_partition_fromgrid(grid, begin=None, end=None):
     ----------
     grid : `TensorGrid`
         Grid on which the partition is based
-    begin, end : array-like or `dict`
+    begin, end : `array-like` or `dictionary`
         Spatial points defining the begin and end of an interval
         product to be partitioned. The points can be specified in
         two ways:
 
         array-like: These values are used directly as begin and/or end.
 
-        dict: Index-value pairs specifying an axis and a spatial
+        dictionary: Index-value pairs specifying an axis and a spatial
         coordinate to be used in that axis. In axes which are not a key
         in the dictionary, the coordinate for the vector is calculated
         as::
             begin = x[0] - (x[1] - x[0]) / 2
+
         or::
             end = x[-1] + (x[-1] - x[-2]) / 2
+
         respectively. See ``Examples`` below.
 
         In general, ``begin`` may not be larger than ``grid.min_pt``,

--- a/odl/discr/partition.py
+++ b/odl/discr/partition.py
@@ -28,137 +28,171 @@ from __future__ import print_function, division, absolute_import
 
 from future import standard_library
 standard_library.install_aliases()
-from builtins import super, str, zip
+from builtins import super
 
 # External module imports
 import numpy as np
 
 # ODL imports
-from odl.discr.grid import TensorGrid
+from odl.discr.grid import TensorGrid, RegularGrid
 from odl.set.domain import IntervalProd
 from odl.util.utility import array1d_repr
 
 
-__all__ = ('GridBasedPartition',)
+__all__ = ('RectPartition',)
 
 _POINT_POSITIONS = ('center', 'left')
 
 
-class GridBasedPartition(object):
+class RectPartition(object):
 
-    """Abstract partition class based on `TensorGrid`s.
+    """Rectangular partition by hypercubes based on `TensorGrid`s.
 
     In 1d, a partition of an interval is implicitly defined by a
-    collection of points x[0], ..., x[N-1] (a grid) and the information
-    where in the subintervals the grid points lie. If, e.g. the
-    points are to lie in the center of the subintervals, these
-    subintervals are given as ``[(x[i-1]-x[i])/2, (x[i]+x[i+1])/2]``.
+    collection of points x[0], ..., x[N-1] (a grid) which are chosen to
+    lie in the center of the subintervals. The i-th subinterval is thus
+    given by
+    ::
+        I[i] = [(x[i-1]+x[i])/2, (x[i]+x[i+1])/2]
     """
 
-    def __init__(self, grid, begin=None, end=None, point_pos='center'):
+    def __init__(self, grid, begin=None, end=None, **kwargs):
         """Initialize a new instance.
 
         Parameters
         ----------
         grid : `TensorGrid`
             Spatial points supporting the partition
-        begin, end : array-like
+        begin, end : array-like, shape ``(grid.ndim,)``
             Spatial points defining the begin and end of an interval
             product to be partitioned. ``begin`` must be component-wise
             at most ``grid.min_pt``, and ``end`` at least
-            ``grid.max_pt``. If not provided, they are inferred
-            from the grid.
-        point_pos : {'center', 'left'} or sequence of `str`
-            Where the grid points lie in the subintervals. A sequence
-            is interpreted per dimension, its length must be equal
-            to ``grid.ndim``. If a single string is given, that option
-            is applied in all dimensions.
+            ``grid.max_pt``. If not provided, they are inferred from
+            the grid.
+        begin_axes, end_axes : sequence of `int`, optional
+            Dimensions in which to apply ``begin`` and ``end``. If
+            given, only these dimensions in ``begin`` or ``end``, resp.,
+            are considered - other entries are ignored.
 
         Notes
         -----
-        The ``begin`` and ``end`` points are determined from the grid
-        as follows:
+        The endpoints ``begin`` and ``end`` are determined from the grid
+        as follows::
 
-        - In dimensions with ``point_pos='left'``, it is ``begin = x[0]``
-          and ``end = x[N-1]``, where ``x`` is the length ``N`` vector of
-          grid coodinates in that dimension.
-
-        - In dimensions with ``point_pos='center'``, the left endpoint
-          is given as ``begin = x[0] - (x[1]-x[0])/2``, the right
-          endpoint is ``end = x[N-1] + (x[N-1]-x[N-2])/2``.
+            begin = x[0] - (x[1] - x[0]) / 2
+            end = x[N-1] + (x[N-1] - x[N-2]) / 2
         """
+        # TODO: add switch for boundary mode
         if not isinstance(grid, TensorGrid):
             raise TypeError('{!r} is not a TensorGrid instance.'
                             ''.format(grid))
 
-        # Make a grid.ndim - length list from the point_pos, raise if
-        # bad length sequence.
-        try:
-            # String check by concatenation with ''
-            pos_lst = [str(point_pos + '').lower()] * grid.ndim
-        except TypeError:
-            # Sequence given
-            pos_lst = [str(pos).lower() for pos in point_pos]
-            if len(pos_lst) != grid.ndim:
-                raise ValueError('expected {} entries in point_pos, got {}.'
-                                 ''.format(grid.ndim, len(pos_lst)))
-
-        for pos, orig_pos in zip(pos_lst, point_pos):
-            if pos not in _POINT_POSITIONS:
-                raise ValueError('point position {} not understood.'
-                                 ''.format(orig_pos))
-
         # Begin and end: check correct shapes and values if given,
         # calculate otherwise.
-        if begin is not None:
-            begin = np.asarray(begin, dtype='float64')
-            if begin.shape != (grid.ndim,):
-                raise ValueError('begin has shape {}, expected {}.'
-                                 ''.format(begin.shape, (grid.ndim,)))
-            if np.any(begin > grid.min_pt):
-                raise ValueError('begin {} has entries larger than the '
-                                 'minimum grid point {}.'
-                                 ''.format(begin, grid.min_pt))
-            self._custom_begin = True
+        begin_axes = kwargs.pop('begin_axes', None)
+        end_axes = kwargs.pop('end_axes', None)
 
-        else:
-            begin = np.empty(grid.ndim, dtype='float64')
-            for i, (pos, coo_vec) in enumerate(zip(pos_lst,
-                                                   grid.coord_vectors)):
-                if len(coo_vec) == 1:
-                    raise ValueError(
-                        'cannot infer begin and end in degenerate dimension '
-                        '{}.'.format(i))
-                if pos == 'left':
-                    begin[i] = coo_vec[0]
-                else:  # pos == 'center'
-                    begin[i] = coo_vec[0] - (coo_vec[1] - coo_vec[0]) / 2
-            self._custom_begin = False
-
-        if end is not None:
-            end = np.asarray(end, dtype='float64')
-            if end.shape != (grid.ndim,):
-                raise ValueError('end has shape {}, expected {}.'
-                                 ''.format(end.shape, (grid.ndim,)))
-            if np.any(end < grid.max_pt):
-                raise ValueError('end {} has entries smaller than the '
-                                 'maximum grid point {}.'
-                                 ''.format(end, grid.max_pt))
-            self._custom_end = True
-        else:
-            end = np.empty(grid.ndim, dtype='float64')
-            for i, (pos, coo_vec) in enumerate(zip(pos_lst,
-                                                   grid.coord_vectors)):
-                if pos == 'left':
-                    end[i] = coo_vec[-1]
-                else:  # pos == 'center'
-                    end[i] = coo_vec[-1] + (coo_vec[-1] - coo_vec[-2]) / 2
-            self._custom_end = False
+        begin = self._calc_begin_end(grid, begin_axes, begin, 'begin')
+        end = self._calc_begin_end(grid, end_axes, end, 'end')
 
         super().__init__()
-        self._interv_prod = IntervalProd(begin, end)
+        self._bounding_box = IntervalProd(begin, end)
         self._grid = grid
-        self._point_pos = pos_lst
+
+    def _calc_begin_end(self, grid, vec_axes, vector, which):
+        """Return the interval product begin/end from ``grid``.
+
+        Parameters
+        ----------
+        grid : `TensorGrid`
+            Grid from which to infer
+        vec_axes : sequence of `int`
+            Dimensions in which to take the values from ``vector``
+        vector : array-like, shape ``(grid.ndim,)``
+            Array from which to take the values corresponding to the
+            dimensions in ``vec_axes``
+        which : {'begin', 'end'}
+            Which one of the endpoints to calculate
+
+        Returns
+        -------
+        newvec : `numpy.ndarray`
+            The new begin or end vector, depending on ``which``
+        """
+        # Check axes sanity
+        if vector is None:
+            vector = np.zeros(grid.ndim)
+            if vec_axes is None:
+                vec_axes = []
+            else:
+                raise ValueError('{which}_axes cannot be given without '
+                                 '{which} parameter.'.format(which=which))
+        elif vec_axes is None:
+            vec_axes = list(range(grid.ndim))
+
+        # Normalize negative values and check for errors
+        vec_axes = [i if i >= 0 else grid.ndim + i
+                    for i in vec_axes]
+        if any(i < 0 or i >= grid.ndim for i in vec_axes):
+            raise IndexError('{}_axes {} contains out-ouf-bounds indices.'
+                             ''.format(which, vec_axes))
+
+        if len(set(vec_axes)) != len(vec_axes):
+            raise ValueError('{}_axes {} contains duplicate indices.'
+                             ''.format(which, vec_axes))
+
+        # Set private attribute to be used in __repr__
+        # TODO: find good way to handle this without running into slight
+        # rounding errors. Best would be to determine in __repr__ if
+        # begin/end are as calculated, but it may be better to store if
+        # begin/end was given and just always add it to the __repr__ output
+        # in that case, regardless of other factors
+        if which == 'begin':
+            if vec_axes:
+                self._custom_begin = True
+            else:
+                self._custom_begin = False
+        else:
+            if vec_axes:
+                self._custom_end = True
+            else:
+                self._custom_end = False
+
+        # The other axes
+        calc_axes = [i for i in range(grid.ndim) if i not in vec_axes]
+
+        # Check vector sanity (shape and bounds in relevant axes)
+        vector = np.asarray(vector, dtype='float64')
+        if vector.shape != (grid.ndim,):
+            raise ValueError('{} has shape {}, expected {}.'
+                             ''.format(which, vector.shape, (grid.ndim,)))
+        if (which == 'begin' and
+                np.any(vector[vec_axes] > grid.min_pt[vec_axes])):
+            raise ValueError('begin {} has entries larger than the '
+                             'minimum grid point {} in one of the axes {}.'
+                             ''.format(vector, grid.min_pt, vec_axes))
+        elif (which == 'end' and
+              np.any(vector[vec_axes] < grid.max_pt[vec_axes])):
+            raise ValueError('end {} has entries smaller than the '
+                             'maximum grid point {} in one of the axes {}.'
+                             ''.format(vector, grid.max_pt, vec_axes))
+
+        # Create the new vector
+        new_vec = np.empty(grid.ndim, dtype='float64')
+        new_vec[vec_axes] = vector[vec_axes]
+        for ax in calc_axes:
+            cvec = grid.coord_vectors[ax]
+            if len(cvec) == 1:
+                raise ValueError(
+                    'Degenerate dimension {} requires explicit begin and '
+                    'end.'.format(ax))
+
+            if which == 'begin':
+                new_vec[ax] = cvec[0] - (cvec[1] - cvec[0]) / 2
+            else:
+                new_vec[ax] = cvec[-1] + (cvec[-1] - cvec[-2]) / 2
+
+        return new_vec
 
     @property
     def grid(self):
@@ -166,14 +200,96 @@ class GridBasedPartition(object):
         return self._grid
 
     @property
-    def interv_prod(self):
+    def bounding_box(self):
         """The `IntervalProd` partitioned by this partition."""
-        return self._interv_prod
+        return self._bounding_box
+
+    # TODO: doctests
+    def min(self):
+        """Return the 'minimum corner' of ``self.interv_prod``."""
+        return self.bounding_box.min()
+
+    def max(self):
+        """Return the 'minimum corner' of ``self.interv_prod``."""
+        return self.bounding_box.max()
 
     @property
-    def point_pos(self):
-        """Position of the grid points in the subsets (per axis)."""
-        return self._point_pos
+    def order(self):
+        """Return axis ordering, equal to that of the grid."""
+        return self.grid.order
+
+    def extent(self):
+        """Return a vector containing the total extent."""
+        return self.max() - self.min()
+
+    def sampling_points(self):
+        """Return the grid sampling points."""
+        return self.grid.points()
+
+    def subintv_bdry_vecs():
+        """Return the subinterval boundaries as coordineate vectors."""
+        pass
+
+    def cell_sizes(self):
+        """Return the cell sizes as coordinate vectors.
+
+        Returns
+        -------
+        csizes : `tuple` of `numpy.ndarray`
+            The cell sizes per axis. The length of the vectors is the
+            same as the corresponding ``grid.coord_vectors``.
+            For axes with 1 grid point, cell size is set to 0.
+
+        Examples
+        --------
+        >>> g = TensorGrid([0, 1], [-1, 0, 2])
+        >>> g.cell_sizes()
+        (array([ 1.]), array([ 1.,  2.]))
+        >>> g = TensorGrid([0, 1], [-1, 0, 2], as_midp=True)
+        >>> g.cell_sizes()
+        (array([ 1.,  1.]), array([ 1. ,  1.5,  2. ]))
+        """
+        # TODO: adapt doctest and add unit test
+        csizes = []
+        for vec in self.grid.coord_vectors:
+            if len(vec) == 1:
+                csizes.append(np.array([0.0]))
+            else:
+                csize = np.empty_like(vec)
+                csize[1:-1] = (vec[2:] - vec[:-2]) / 2.0
+                csize[0] = vec[1] - vec[0]
+                csize[-1] = vec[-1] - vec[-2]
+                csizes.append(csize)
+
+        return tuple(csizes)
+
+    @property
+    def cell_volume(self):
+        """Cell volume of an underlying regular grid.
+
+        Examples
+        --------
+        >>> rg = RegularGrid([0, 0], [1, 1], (2, 2))
+        >>> rg.cell_volume
+        1.0
+        """
+        # TODO: adapt doctest
+        if not isinstance(self.grid, RegularGrid):
+            raise TypeError('cell_volume not defined for non-regular grids.')
+        return float(np.prod(self.grid.stride))
+
+    def approx_equals(self, other, atol):
+        pass
+
+    def __eq__(self, other):
+        pass
+
+    def insert(self, index, other):
+        # other may be another partition or a grid
+        pass
+
+    # TODO: determine whether __contains__ and __getitem__ make sense,
+    # and in which sense if yes
 
     # TODO: pretty-print
     def __repr__(self):
@@ -187,16 +303,19 @@ class GridBasedPartition(object):
         if self._custom_end:
             inner_str += sep + 'end={}'.format(
                 array1d_repr(self.interv_prod.end))
-            sep = ', '
-        single_pos = all(pos == self.point_pos[0]
-                         for pos in self.point_pos[1:])
-        if single_pos and self.point_pos[0] != 'center':
-            inner_str += sep + "point_pos='{}'".format(self.point_pos[0])
-        elif not single_pos:
-            inner_str += sep + 'point_pos={}'.format(self.point_pos)
 
         return '{}({})'.format(self.__class__.__name__, inner_str)
 
+
+def uniform_partition(intv_prod, num_nodes, order='C', node_at_bdry=True):
+    """Return a partition of ``intv_prod`` by a regular grid."""
+    pass
+#    if as_midp:
+#        grid_min = intv_prod.begin + intv_prod.extent / (2 * num_nodes)
+#        grid_max = intv_prod.end - intv_prod.extent / (2 * num_nodes)
+#        return RegularGrid(grid_min, grid_max, num_nodes, as_midp=as_midp,
+#                           _exact_min=intv_prod.begin,
+#                           _exact_max=intv_prod.end)
 
 if __name__ == '__main__':
     from doctest import testmod, NORMALIZE_WHITESPACE

--- a/odl/discr/partition.py
+++ b/odl/discr/partition.py
@@ -39,8 +39,8 @@ from odl.set.domain import IntervalProd
 from odl.util.utility import array1d_repr
 
 
-__all__ = ('RectPartition', 'uniform_partition_from_intv_prod',
-           'uniform_partition_from_grid', 'uniform_partition')
+__all__ = ('RectPartition', 'uniform_partition_fromintv',
+           'uniform_partition_fromgrid', 'uniform_partition')
 
 _POINT_POSITIONS = ('center', 'left')
 
@@ -87,14 +87,79 @@ class RectPartition(object):
                              ''.format(grid, intv_prod))
 
         super().__init__()
-        self._bbox = intv_prod
+        self._set = intv_prod
         self._grid = grid
+
+        # Initialize the cell boundaries, the defining property of partitions
+        bdry_vecs = []
+        for ax, vec in enumerate(self.grid.coord_vectors):
+            bdry = np.empty(len(vec) + 1)
+            bdry[1:-1] = (vec[1:] + vec[:-1]) / 2.0
+            bdry[0] = self.min()[ax]
+            bdry[-1] = self.max()[ax]
+            bdry_vecs.append(bdry)
+
+        self._cell_boundary_vecs = tuple(bdry_vecs)
+
+    @property
+    def cell_boundary_vecs(self):
+        """Return the cell boundaries as coordinate vectors.
+
+        Examples
+        --------
+        >>> rect = IntervalProd([0, -1], [1, 2])
+        >>> grid = TensorGrid([0, 1], [-1, 0, 2])
+        >>> part = RectPartition(rect, grid)
+        >>> part.cell_boundary_vecs
+        (array([ 0. ,  0.5,  1. ]), array([-1. , -0.5,  1. ,  2. ]))
+        """
+        return self._cell_boundary_vecs
+
+    @property
+    def set(self):
+        """The partitioned set, an `IntervalProd`."""
+        return self._set
+
+    # IntervalProd related pass-through methods and derived properties
+    # min, max and extent are for duck-typing purposes
+    @property
+    def begin(self):
+        """Minimum coordinates of the partitioned set."""
+        return self.set.begin
+
+    @property
+    def end(self):
+        """Maximum coordinates of the partitioned set."""
+        return self.set.end
+
+    def min(self):
+        """Return the minimum point of the partitioned set.
+
+        See also
+        --------
+        Intervalprod.min
+        """
+        return self.set.min()
+
+    def max(self):
+        """Return the maximum point of the partitioned set.
+
+        See also
+        --------
+        Intervalprod.max
+        """
+        return self.set.max()
+
+    def extent(self):
+        """Return a vector containing the total extent (max - min)."""
+        return self.set.extent()
 
     @property
     def grid(self):
         """The `TensorGrid` defining this partition."""
         return self._grid
 
+    # TensorGrid related pass-through methods and derived properties
     @property
     def is_regular(self):
         """Return `True` if ``self.grid`` is a `RegularGrid`."""
@@ -115,83 +180,16 @@ class RectPartition(object):
         """Total number of cells, equal to ``self.grid.size``."""
         return self.grid.size
 
+    def points(self):
+        """Return the sampling grid points."""
+        return self.grid.points()
+
+    def meshgrid(self):
+        """Return the sparse meshgrid of sampling points."""
+        return self.grid.meshgrid()
+
+    # Further derived methods / properties
     @property
-    def bbox(self):
-        """The bounding box, i.e. the `IntervalProd` being partitioned.
-
-        Examples
-        --------
-        By default, the bounding box is inferred from the grid and
-        extends beyond the grid boundaries:
-
-        >>> grid = TensorGrid([0, 1], [-1, 0, 2])
-        >>> part = RectPartition(grid)  # Implicit begin and end
-        >>> part.bbox
-        Rectangle([-0.5, -1.5], [1.5, 3.0])
-
-        This behavior can be changed by explicitly giving begin and
-        end:
-
-        >>> part = RectPartition(grid, begin=[0, -1], end=[1, 2])
-        >>> part.bbox
-        Rectangle([0.0, -1.0], [1.0, 2.0])
-        """
-        return self._bbox
-
-    @property
-    def begin(self):
-        """Vector with minimum bounding box coordinates."""
-        return self.bbox.begin
-
-    @property
-    def end(self):
-        """Vector with maximum bounding box coordinates."""
-        return self.bbox.end
-
-    def min(self):
-        """Return the 'minimum corner' of ``self.interv_prod``.
-
-        Examples
-        --------
-        >>> grid = TensorGrid([0, 1], [-1, 0, 2])
-        >>> part = RectPartition(grid)  # Implicit begin and end
-        >>> part.min()
-        array([-0.5, -1.5])
-
-        >>> part = RectPartition(grid, begin=[0, -1], end=[1, 2])
-        >>> part.min()
-        array([ 0., -1.])
-
-        See also
-        --------
-        bbox
-        """
-        return self.bbox.min()
-
-    def max(self):
-        """Return the 'minimum corner' of ``self.interv_prod``.
-
-        Examples
-        --------
-        >>> grid = TensorGrid([0, 1], [-1, 0, 2])
-        >>> part = RectPartition(grid)  # Implicit begin and end
-        >>> part.max()
-        array([ 1.5,  3. ])
-
-        >>> part = RectPartition(grid, begin=[0, -1], end=[1, 2])
-        >>> part.max()
-        array([ 1.,  2.])
-
-        See also
-        --------
-        bbox
-        """
-        return self.bbox.max()
-
-    def extent(self):
-        """Return a vector containing the total extent (max - min)."""
-        return self.max() - self.min()
-
     def nodes_on_boundary(self):
         """Return a list indicating if nodes lie on the boundary.
 
@@ -200,57 +198,27 @@ class RectPartition(object):
         on_bdry : `tuple` of 2-tuple of `bool`
             Each 2-tuple contains the information whether the leftmost
             (first entry) and rightmost (second entry) grid nodes lie
-            on the boundary of the bounding box in the corresponding
+            on the boundary of the partitioned set in the corresponding
             dimension.
 
         Examples
         --------
+        >>> rect = IntervalProd([0, -2], [2, 2])
         >>> grid = TensorGrid([0, 1], [-1, 0, 2])
-        >>> part = RectPartition(grid, begin=[0, -2], end=[2, 2])
-        >>> part.nodes_on_boundary()
+        >>> part = RectPartition(rect, grid)
+        >>> part.nodes_on_boundary
         ((True, False), (False, True))
         """
         bdry_list = []
         for ax, (minpt, maxpt, bmin, bmax) in enumerate(zip(
                 self.grid.min_pt, self.grid.max_pt,
-                self.bbox.begin, self.bbox.end)):
+                self.set.begin, self.set.end)):
             bdry_list.append((minpt == bmin, maxpt == bmax))
 
         return tuple(bdry_list)
 
-    def sampling_points(self):
-        """Return the sampling grid points."""
-        return self.grid.points()
-
-    def sampling_meshgrid(self):
-        """Return the sparse meshgrid of sampling points."""
-        return self.grid.meshgrid()
-
-    def cell_boundaries(self):
-        """Return the cell boundaries as coordinate vectors.
-
-        Examples
-        --------
-        >>> grid = TensorGrid([0, 1], [-1, 0, 2])
-        >>> part = RectPartition(grid)  # Implicit begin and end
-        >>> part.cell_boundaries()
-        (array([-0.5,  0.5,  1.5]), array([-1.5, -0.5,  1. ,  3. ]))
-
-        >>> part = RectPartition(grid, begin=[0, -1], end=[1, 2])
-        >>> part.cell_boundaries()
-        (array([ 0. ,  0.5,  1. ]), array([-1. , -0.5,  1. ,  2. ]))
-        """
-        bdry_vecs = []
-        for ax, vec in enumerate(self.grid.coord_vectors):
-            bdry = np.empty(len(vec) + 1)
-            bdry[1:-1] = (vec[1:] + vec[:-1]) / 2.0
-            bdry[0] = self.min()[ax]
-            bdry[-1] = self.max()[ax]
-            bdry_vecs.append(bdry)
-
-        return tuple(bdry_vecs)
-
-    def cell_sizes(self):
+    @property
+    def cell_sizes_vecs(self):
         """Return the cell sizes as coordinate vectors.
 
         Returns
@@ -262,13 +230,18 @@ class RectPartition(object):
 
         Examples
         --------
-        >>> grid = TensorGrid([0, 1], [-1, 0, 2])
-        >>> part = RectPartition(grid)  # Implicit begin and end
-        >>> part.cell_sizes()
-        (array([ 1.,  1.]), array([ 1. ,  1.5,  2. ]))
+        We create a partition of the rectangle [0, 1] x [-1, 2] into
+        2 x 3 cells with the grid points [0, 1] x [-1, 0, 2]. This
+        implies that the cell boundaries are given as
+        [0, 0.5, 1] x [-1, -0.5, 1, 2], hence the cell size vectors
+        are [0.5, 0.5] x [0.5, 1.5, 1]:
 
-        >>> part = RectPartition(grid, begin=[0, -1], end=[1, 2])
-        >>> part.cell_sizes()
+        >>> rect = IntervalProd([0, -1], [1, 2])
+        >>> grid = TensorGrid([0, 1], [-1, 0, 2])
+        >>> part = RectPartition(rect, grid)
+        >>> part.cell_boundary_vecs
+        (array([ 0. ,  0.5,  1. ]), array([-1. , -0.5,  1. ,  2. ]))
+        >>> part.cell_sizes_vecs
         (array([ 0.5,  0.5]), array([ 0.5,  1.5,  1. ]))
         """
         csizes = []
@@ -285,25 +258,30 @@ class RectPartition(object):
         return tuple(csizes)
 
     @property
-    def cell_size(self):
-        """Size of the 'inner' cells, regardless of begin and end.
+    def cell_sides(self):
+        """Side lengths of all 'inner' cells of a regular partition.
 
         Only defined if ``self.grid`` is a `RegularGrid`.
 
         Examples
         --------
-        >>> grid = RegularGrid([0, 0], [1, 1], (3, 5))
-        >>> part = RectPartition(grid)
-        >>> part.cell_size
-        array([ 0.5 ,  0.25])
-        """
+        We create a partition of the rectangle [0, 1] x [-1, 2] into
+        3 x 3 cells, where the grid points lie on the boundary. This
+        means that the grid points are [0, 0.5, 1] x [-1, 0.5, 2],
+        i.e. the inner cell has side lengths 0.5 x 1.5:
 
+        >>> rect = IntervalProd([0, -1], [1, 2])
+        >>> grid = RegularGrid([0, -1], [1, 2], (3, 3))
+        >>> part = RectPartition(rect, grid)
+        >>> part.cell_sides
+        array([ 0.5,  1.5])
+        """
         if not self.is_regular:
             raise NotImplementedError(
-                'cell size not defined for irregular partitions. Use '
-                'cell_sizes() instead.')
+                'cell sides not defined for irregular partitions. Use '
+                'cell_sizes_vecs() instead.')
 
-        on_boundary = self.nodes_on_boundary()
+        on_boundary = self.nodes_on_boundary
         num_cells = []
         for n, on_bdry in zip(self.shape, on_boundary):
             num_on_bdry = sum(on for on in on_bdry)
@@ -319,12 +297,20 @@ class RectPartition(object):
 
         Examples
         --------
-        >>> grid = RegularGrid([0, 0], [1, 1], (3, 5))
-        >>> part = RectPartition(grid)
+        We create a partition of the rectangle [0, 1] x [-1, 2] into
+        3 x 3 cells, where the grid points lie on the boundary. This
+        means that the grid points are [0, 0.5, 1] x [-1, 0.5, 2],
+        i.e. the inner cell has side lengths 0.5 x 1.5:
+
+        >>> rect = IntervalProd([0, -1], [1, 2])
+        >>> grid = RegularGrid([0, -1], [1, 2], (3, 3))
+        >>> part = RectPartition(rect, grid)
+        >>> part.cell_sides
+        array([ 0.5,  1.5])
         >>> part.cell_volume
-        0.125
+        0.75
         """
-        return float(np.prod(self.cell_size))
+        return float(np.prod(self.cell_sides))
 
     def approx_equals(self, other, atol):
         """Return `True` in case of approximate equality.
@@ -333,7 +319,7 @@ class RectPartition(object):
         -------
         approx_eq : `bool`
             `True` if ``other`` is a `RectPartition` instance with
-            ``self.bbox == other.bbox`` up to ``atol`` and
+            ``self.set == other.set`` up to ``atol`` and
             ``self.grid == other.other`` up to ``atol``.
         """
         if other is self:
@@ -341,12 +327,13 @@ class RectPartition(object):
         elif not isinstance(other, RectPartition):
             return False
         else:
-            return (self.bbox.approx_equals(other.bbox, atol=atol) and
+            return (self.set.approx_equals(other.set, atol=atol) and
                     self.grid.approx_equals(other.grid, atol=atol))
 
     def __eq__(self, other):
         """Return ``self == other``."""
-        return self.bbox == other.bbox and self.grid == other.grid
+        # Optimized version for exact equality
+        return self.set == other.set and self.grid == other.grid
 
     def insert(self, index, other):
         """Return a copy with ``other`` inserted before ``index``.
@@ -368,136 +355,17 @@ class RectPartition(object):
         --------
         """
         newgrid = self.grid.insert(index, other.grid)
-        newbbox = self.bbox.insert(index, other.bbox)
-        new_b = newbbox.begin
-        new_e = newbbox.end
-        return RectPartition(newgrid, begin=new_b, end=new_e)
+        newset = self.set.insert(index, other.set)
+        return RectPartition(newset, newgrid)
 
     # TODO: pretty-print
     def __repr__(self):
         """Return ``repr(self)``."""
-        inner_str = '\n {!r},\n {!r}'.format(self.bbox, self.grid)
+        inner_str = '\n {!r},\n {!r}'.format(self.set, self.grid)
         return '{}({})'.format(self.__class__.__name__, inner_str)
 
 
-def uniform_partition_from_grid(grid, begin=None, end=None):
-    """Return a partition of an interval product based on a given grid.
-
-    This method is complementary to
-    `uniform_partition_from_intv_prod` in that it infers the
-    set to be partitioned from a given grid and optional parameters
-    for the begin and the end of the set.
-
-    Parameters
-    ----------
-    grid : `TensorGrid`
-        Grid on which the partition is based
-    begin, end : array-like or `dict`
-        Spatial points defining the begin and end of an interval
-        product to be partitioned. The points can be specified in
-        two ways:
-
-        array-like: These values are used directly as begin and/or end.
-
-        dict: Index-value pairs specifying an axis and a spatial
-        coordinate to be used in that axis. In axes which are not a key
-        in the dictionary, the coordinate for the vector is calculated
-        as::
-            begin = x[0] - (x[1] - x[0]) / 2
-        or::
-            end = x[-1] + (x[-1] - x[-2]) / 2
-        respectively. See ``Examples`` below.
-
-        In general, ``begin`` may not be larger than ``grid.min_pt``,
-        and ``end`` not smaller than ``grid.max_pt`` in any component.
-        `None` is equivalent to an empty dictionary, i.e. the values
-        are calculated in each dimension.
-
-    See also
-    --------
-    uniform_partition_from_intv_prod
-
-    Examples
-    --------
-    Have begin and end of the bounding box automatically calculated:
-
-    >>> grid = RegularGrid(0, 1, 3)
-    >>> grid.coord_vectors
-    (array([ 0. ,  0.5,  1. ]),)
-    >>> part = uniform_partition_from_grid(grid)
-    >>> part.cell_boundaries()
-    (array([-0.25,  0.25,  0.75,  1.25]),)
-
-    Begin and end can be given explicitly as array-like:
-
-    >>> part = uniform_partition_from_grid(grid, begin=0, end=1)
-    >>> part.cell_boundaries()
-    (array([ 0.  ,  0.25,  0.75,  1.  ]),)
-
-    Using dictionaries, selective axes can be explicitly set. The
-    keys refer to axes, the values to the coordinates to use:
-
-    >>> grid = RegularGrid([0, 0], [1, 1], (3, 3))
-    >>> part = uniform_partition_from_grid(grid, begin={0: -1},
-    ...                                    end={-1: 3})
-    >>> part.cell_boundaries()[0]
-    array([-1.  ,  0.25,  0.75,  1.25])
-    >>> part.cell_boundaries()[1]
-    array([-0.25,  0.25,  0.75,  3.  ])
-    """
-    # Make dictionaries from begin and end and fill with None where no value
-    # is given.
-    if begin is None:
-        begin = {i: None for i in range(grid.ndim)}
-    elif not hasattr(begin, 'items'):  # array-like
-        begin = np.atleast_1d(begin)
-        begin = {i: float(v) for i, v in enumerate(begin)}
-    else:
-        if len(set(begin.items())) != len(begin.items()):
-            raise ValueError('dictionary {} for begin point has duplicate '
-                             'keys.'.format(begin))
-        begin.update({i: None for i in range(grid.ndim) if i not in begin})
-
-    if end is None:
-        end = {i: None for i in range(grid.ndim)}
-    elif not hasattr(end, 'items'):
-        end = np.atleast_1d(end)
-        end = {i: float(v) for i, v in enumerate(end)}
-    else:
-        if len(set(end.items())) != len(end.items()):
-            raise ValueError('dictionary {} for end point has duplicate keys.'
-                             ''.format(end))
-        end.update({i: None for i in range(grid.ndim) if i not in end})
-
-    # Set the values in the vectors by computing (None) or directly from the
-    # given vectors (otherwise).
-    begin_vec = np.empty(grid.ndim)
-    for ax, beg_val in begin.items():
-        if beg_val is None:
-            cvec = grid.coord_vectors[ax]
-            if len(cvec) == 1:
-                raise ValueError('cannot calculate begin in axis {} with '
-                                 'only 1 grid point.'.format(ax))
-            begin_vec[ax] = cvec[0] - (cvec[1] - cvec[0]) / 2
-        else:
-            begin_vec[ax] = beg_val
-
-    end_vec = np.empty(grid.ndim)
-    for ax, end_val in end.items():
-        if end_val is None:
-            cvec = grid.coord_vectors[ax]
-            if len(cvec) == 1:
-                raise ValueError('cannot calculate end in axis {} with '
-                                 'only 1 grid point.'.format(ax))
-            end_vec[ax] = cvec[-1] + (cvec[-1] - cvec[-2]) / 2
-        else:
-            end_vec[ax] = end_val
-
-    return RectPartition(IntervalProd(begin_vec, end_vec), grid)
-
-
-def uniform_partition_from_intv_prod(intv_prod, num_nodes,
-                                     nodes_on_bdry=False):
+def uniform_partition_fromintv(intv_prod, num_nodes, nodes_on_bdry=False):
     """Return a partition of an interval product into equally sized cells.
 
     Parameters
@@ -521,24 +389,23 @@ def uniform_partition_from_intv_prod(intv_prod, num_nodes,
 
     See also
     --------
-    uniform_partition_from_grid
+    uniform_partition_fromgrid
 
     Examples
     --------
     By default, no grid points are placed on the boundary:
 
-    >>> bbox = IntervalProd(0, 1)
-    >>> part = uniform_partition_from_intv_prod(bbox, 4)
-    >>> part.cell_boundaries()
+    >>> interval = IntervalProd(0, 1)
+    >>> part = uniform_partition_fromintv(interval, 4)
+    >>> part.cell_boundary_vecs
     (array([ 0.  ,  0.25,  0.5 ,  0.75,  1.  ]),)
     >>> part.grid.coord_vectors
     (array([ 0.125,  0.375,  0.625,  0.875]),)
 
     This can be changed with the nodes_on_bdry parameter:
 
-    >>> part = uniform_partition_from_intv_prod(bbox, 3,
-    ...                                         nodes_on_bdry=True)
-    >>> part.cell_boundaries()
+    >>> part = uniform_partition_fromintv(interval, 3, nodes_on_bdry=True)
+    >>> part.cell_boundary_vecs
     (array([ 0.  ,  0.25,  0.75,  1.  ]),)
     >>> part.grid.coord_vectors
     (array([ 0. ,  0.5,  1. ]),)
@@ -546,15 +413,15 @@ def uniform_partition_from_intv_prod(intv_prod, num_nodes,
     We can specify this per axis, too. In this case we choose both
     in the first axis and only the rightmost in the second:
 
-    >>> bbox = IntervalProd([0, 0], [1, 1])
-    >>> part = uniform_partition_from_intv_prod(
-    ...     bbox, (3, 3), nodes_on_bdry=(True, (False, True)))
+    >>> rect = IntervalProd([0, 0], [1, 1])
+    >>> part = uniform_partition_fromintv(
+    ...     rect, (3, 3), nodes_on_bdry=(True, (False, True)))
     ...
-    >>> part.cell_boundaries()[0]  # first axis, as above
+    >>> part.cell_boundary_vecs[0]  # first axis, as above
     array([ 0.  ,  0.25,  0.75,  1.  ])
     >>> part.grid.coord_vectors[0]
     array([ 0. ,  0.5,  1. ])
-    >>> part.cell_boundaries()[1]  # second, asymmetric axis
+    >>> part.cell_boundary_vecs[1]  # second, asymmetric axis
     array([ 0. ,  0.4,  0.8,  1. ])
     >>> part.grid.coord_vectors[1]
     array([ 0.2,  0.6,  1. ])
@@ -633,8 +500,8 @@ def uniform_partition(begin, end, num_nodes, nodes_on_bdry=False):
 
     See also
     --------
-    uniform_partition_from_intv_prod : partition an existing set
-    uniform_partition_from_grid : use an existing grid as basis
+    uniform_partition_fromintv : partition an existing set
+    uniform_partition_fromgrid : use an existing grid as basis
 
     Examples
     --------
@@ -643,7 +510,7 @@ def uniform_partition(begin, end, num_nodes, nodes_on_bdry=False):
     By default, no grid points are placed on the boundary:
 
     >>> part = uniform_partition(0, 1, 4)
-    >>> part.cell_boundaries()
+    >>> part.cell_boundary_vecs
     (array([ 0.  ,  0.25,  0.5 ,  0.75,  1.  ]),)
     >>> part.grid.coord_vectors
     (array([ 0.125,  0.375,  0.625,  0.875]),)
@@ -651,7 +518,7 @@ def uniform_partition(begin, end, num_nodes, nodes_on_bdry=False):
     This can be changed with the nodes_on_bdry parameter:
 
     >>> part = uniform_partition(0, 1, 3, nodes_on_bdry=True)
-    >>> part.cell_boundaries()
+    >>> part.cell_boundary_vecs
     (array([ 0.  ,  0.25,  0.75,  1.  ]),)
     >>> part.grid.coord_vectors
     (array([ 0. ,  0.5,  1. ]),)
@@ -662,17 +529,126 @@ def uniform_partition(begin, end, num_nodes, nodes_on_bdry=False):
     >>> part = uniform_partition([0, 0], [1, 1], (3, 3),
     ...                          nodes_on_bdry=(True, (False, True)))
     ...
-    >>> part.cell_boundaries()[0]  # first axis, as above
+    >>> part.cell_boundary_vecs[0]  # first axis, as above
     array([ 0.  ,  0.25,  0.75,  1.  ])
     >>> part.grid.coord_vectors[0]
     array([ 0. ,  0.5,  1. ])
-    >>> part.cell_boundaries()[1]  # second, asymmetric axis
+    >>> part.cell_boundary_vecs[1]  # second, asymmetric axis
     array([ 0. ,  0.4,  0.8,  1. ])
     >>> part.grid.coord_vectors[1]
     array([ 0.2,  0.6,  1. ])
     """
-    return uniform_partition_from_intv_prod(
+    return uniform_partition_fromintv(
         IntervalProd(begin, end), num_nodes, nodes_on_bdry)
+
+
+def uniform_partition_fromgrid(grid, begin=None, end=None):
+    """Return a partition of an interval product based on a given grid.
+
+    This method is complementary to
+    `uniform_partition_fromintv` in that it infers the
+    set to be partitioned from a given grid and optional parameters
+    for the begin and the end of the set.
+
+    Parameters
+    ----------
+    grid : `TensorGrid`
+        Grid on which the partition is based
+    begin, end : array-like or `dict`
+        Spatial points defining the begin and end of an interval
+        product to be partitioned. The points can be specified in
+        two ways:
+
+        array-like: These values are used directly as begin and/or end.
+
+        dict: Index-value pairs specifying an axis and a spatial
+        coordinate to be used in that axis. In axes which are not a key
+        in the dictionary, the coordinate for the vector is calculated
+        as::
+            begin = x[0] - (x[1] - x[0]) / 2
+        or::
+            end = x[-1] + (x[-1] - x[-2]) / 2
+        respectively. See ``Examples`` below.
+
+        In general, ``begin`` may not be larger than ``grid.min_pt``,
+        and ``end`` not smaller than ``grid.max_pt`` in any component.
+        `None` is equivalent to an empty dictionary, i.e. the values
+        are calculated in each dimension.
+
+    See also
+    --------
+    uniform_partition_fromintv
+
+    Examples
+    --------
+    Have begin and end of the bounding box automatically calculated:
+
+    >>> grid = RegularGrid(0, 1, 3)
+    >>> grid.coord_vectors
+    (array([ 0. ,  0.5,  1. ]),)
+    >>> part = uniform_partition_fromgrid(grid)
+    >>> part.cell_boundary_vecs
+    (array([-0.25,  0.25,  0.75,  1.25]),)
+
+    Begin and end can be given explicitly as array-like:
+
+    >>> part = uniform_partition_fromgrid(grid, begin=0, end=1)
+    >>> part.cell_boundary_vecs
+    (array([ 0.  ,  0.25,  0.75,  1.  ]),)
+
+    Using dictionaries, selective axes can be explicitly set. The
+    keys refer to axes, the values to the coordinates to use:
+
+    >>> grid = RegularGrid([0, 0], [1, 1], (3, 3))
+    >>> part = uniform_partition_fromgrid(grid, begin={0: -1}, end={-1: 3})
+    >>> part.cell_boundary_vecs[0]
+    array([-1.  ,  0.25,  0.75,  1.25])
+    >>> part.cell_boundary_vecs[1]
+    array([-0.25,  0.25,  0.75,  3.  ])
+    """
+    # Make dictionaries from begin and end and fill with None where no value
+    # is given.
+    if begin is None:
+        begin = {i: None for i in range(grid.ndim)}
+    elif not hasattr(begin, 'items'):  # array-like
+        begin = np.atleast_1d(begin)
+        begin = {i: float(v) for i, v in enumerate(begin)}
+    else:
+        begin.update({i: None for i in range(grid.ndim) if i not in begin})
+
+    if end is None:
+        end = {i: None for i in range(grid.ndim)}
+    elif not hasattr(end, 'items'):
+        end = np.atleast_1d(end)
+        end = {i: float(v) for i, v in enumerate(end)}
+    else:
+        end.update({i: None for i in range(grid.ndim) if i not in end})
+
+    # Set the values in the vectors by computing (None) or directly from the
+    # given vectors (otherwise).
+    begin_vec = np.empty(grid.ndim)
+    for ax, beg_val in begin.items():
+        if beg_val is None:
+            cvec = grid.coord_vectors[ax]
+            if len(cvec) == 1:
+                raise ValueError('cannot calculate begin in axis {} with '
+                                 'only 1 grid point.'.format(ax))
+            begin_vec[ax] = cvec[0] - (cvec[1] - cvec[0]) / 2
+        else:
+            begin_vec[ax] = beg_val
+
+    end_vec = np.empty(grid.ndim)
+    for ax, end_val in end.items():
+        if end_val is None:
+            cvec = grid.coord_vectors[ax]
+            if len(cvec) == 1:
+                raise ValueError('cannot calculate end in axis {} with '
+                                 'only 1 grid point.'.format(ax))
+            end_vec[ax] = cvec[-1] + (cvec[-1] - cvec[-2]) / 2
+        else:
+            end_vec[ax] = end_val
+
+    return RectPartition(IntervalProd(begin_vec, end_vec), grid)
 
 
 if __name__ == '__main__':

--- a/odl/discr/partition.py
+++ b/odl/discr/partition.py
@@ -291,8 +291,12 @@ class RectPartition(object):
         return self.max() - self.min()
 
     def sampling_points(self):
-        """Return the grid sampling points."""
+        """Return the sampling grid points."""
         return self.grid.points()
+
+    def sampling_meshgrid(self):
+        """Return the sparse meshgrid of sampling points."""
+        return self.grid.meshgrid()
 
     def cell_boundaries(self):
         """Return the cell boundaries as coordinate vectors.
@@ -353,6 +357,27 @@ class RectPartition(object):
         return tuple(csizes)
 
     @property
+    def cell_size(self):
+        """Size of the 'inner' cells, regardless of begin and end.
+
+        Only defined if ``self.grid`` is a `RegularGrid`.
+
+        Examples
+        --------
+        >>> grid = RegularGrid([0, 0], [1, 1], (3, 5))
+        >>> part = RectPartition(grid)
+        >>> part.cell_size
+        array([ 0.5 ,  0.25])
+        """
+
+        if not isinstance(self.grid, RegularGrid):
+            raise NotImplementedError(
+                'cell size not defined for non-uniform grids. Use '
+                '`grid.cell_sizes()` instead.')
+
+        return self.extent() / self.shape
+
+    @property
     def cell_volume(self):
         """Volume of the 'inner' cells, regardless of begin and end.
 
@@ -360,14 +385,12 @@ class RectPartition(object):
 
         Examples
         --------
-        >>> grid = RegularGrid([0, 0], [1, 1], (3, 3))
+        >>> grid = RegularGrid([0, 0], [1, 1], (3, 5))
         >>> part = RectPartition(grid)
         >>> part.cell_volume
-        0.25
+        0.125
         """
-        if not isinstance(self.grid, RegularGrid):
-            raise TypeError('cell_volume not defined for non-regular grids.')
-        return float(np.prod(self.extent() / self.shape))
+        return float(np.prod(self.cell_size))
 
     def approx_equals(self, other, atol):
         """Return `True` in case of approximate equality.

--- a/odl/discr/partition.py
+++ b/odl/discr/partition.py
@@ -183,9 +183,10 @@ class RectPartition(object):
         """Return the sampling grid points."""
         return self.grid.points()
 
+    @property
     def meshgrid(self):
         """Return the sparse meshgrid of sampling points."""
-        return self.grid.meshgrid()
+        return self.grid.meshgrid
 
     # Further derived methods / properties
     @property

--- a/odl/discr/partition.py
+++ b/odl/discr/partition.py
@@ -384,7 +384,10 @@ class RectPartition(object):
         newset = self.set.insert(index, other.set)
         return RectPartition(newset, newgrid)
 
-    # TODO: pretty-print
+    def __str__(self):
+        """Return ``str(self)``."""
+        return 'partition of {} using {}'.format(self.set, self.grid)
+
     def __repr__(self):
         """Return ``repr(self)``."""
         inner_str = '\n {!r},\n {!r}'.format(self.set, self.grid)

--- a/odl/operator/default_ops.py
+++ b/odl/operator/default_ops.py
@@ -46,8 +46,8 @@ class ScalingOperator(Operator):
         ----------
         space : `LinearSpace`
             The space of elements which the operator is acting on
-        scalar : field element
-            An element in the field of the space that the vectors are
+        scalar : `LinearSpace.field` `element`
+            An element of the field of the space which vectors are
             scaled with
         """
         if not isinstance(space, LinearSpace):
@@ -63,14 +63,14 @@ class ScalingOperator(Operator):
 
         Parameters
         ----------
-        x : ``domain`` element
+        x : ``domain`` `element`
             input vector to be scaled
-        out : ``range`` element, optional
+        out : ``range`` `element`, optional
             Output vector to which the result is written
 
         Returns
         -------
-        out : ``range`` element
+        out : ``range`` `element`
             Result of the scaling. If ``out`` was provided, the
             returned object is a reference to it.
 
@@ -207,15 +207,15 @@ class LinCombOperator(Operator):
 
         Parameters
         ----------
-        x : ``domain`` element
-            An element in the operator domain (2-tuple of space
+        x : ``domain`` `element`
+            An element of the operator domain (2-tuple of space
             elements) whose linear combination is calculated
-        out : ```range`` element
+        out : ```range`` `element`
             Vector to which the result is written
 
         Returns
         -------
-        out : ``range`` element
+        out : ``range`` `element`
             Result of the linear combination. If ``out`` was provided,
             the returned object is a reference to it.
 
@@ -286,15 +286,15 @@ class MultiplyOperator(Operator):
 
         Parameters
         ----------
-        x : ``domain`` element
+        x : ``domain`` `element`
             An element in the operator domain (2-tuple of space
             elements) whose elementwise product is calculated
-        out : ``range`` element, optional
+        out : ``range`` `element`, optional
             Vector to which the result is written
 
         Returns
         -------
-        out : ``range`` element
+        out : ``range`` `element`
             Result of the multiplication. If ``out`` was provided, the
             returned object is a reference to it.
 
@@ -394,12 +394,12 @@ class InnerProductOperator(Operator):
 
         Parameters
         ----------
-        x : ``vector.space`` element
+        x : ``vector.space`` `element`
             An element in the space of the vector
 
         Returns
         -------
-        out : ``field`` element
+        out : ``field`` `element`
             Result of the inner product calculation
 
         Examples
@@ -496,8 +496,8 @@ class ConstantOperator(Operator):
 
         Parameters
         ----------
-        x : ``domain`` element
-            Any element in the domain
+        x : ``domain`` `element`
+            An element of the domain
         out : ``range`` element
             Vector that gets assigned to the constant vector
 
@@ -565,14 +565,14 @@ class ResidualOperator(Operator):
 
         Parameters
         ----------
-        x : ``domain`` element
-            Any element in the domain
-        out : ``range`` element
+        x : ``domain`` `element`
+            Any element of the domain
+        out : ``range`` `element`
             Vector that gets assigned to the constant vector
 
         Returns
         -------
-        out : ``range`` element
+        out : ``range`` `element`
             Result of the evaluation. If ``out`` was provided, the
             returned object is a reference to it.
 
@@ -604,7 +604,7 @@ class ResidualOperator(Operator):
 
         Parameters
         ----------
-        x : ``domain`` element
+        x : ``domain`` `element`
             Any element in the domain where the derivative should be taken
         """
         return self.op.derivative(point)

--- a/odl/operator/default_ops.py
+++ b/odl/operator/default_ops.py
@@ -545,7 +545,7 @@ class ResidualOperator(Operator):
         op : `Operator`
             Operator to be used in the residual expression. Its
             `Operator.range` must be a `LinearSpace`.
-        vec : `Operator.range` element-like
+        vec : `Operator.range` `element-like`
             Vector to be subtracted from the operator result
         """
         if not isinstance(op, Operator):

--- a/odl/operator/operator.py
+++ b/odl/operator/operator.py
@@ -50,13 +50,13 @@ def _default_call_out_of_place(op, x, **kwargs):
 
     Parameters
     ----------
-    x : ``domain`` element
+    x : ``domain`` `element`
         An object in the operator domain. The operator is applied
         to it.
 
     Returns
     -------
-    out : ``range`` element
+    out : ``range`` `element`
         An object in the operator range. The result of an operator
         evaluation.
     """
@@ -70,11 +70,11 @@ def _default_call_in_place(op, x, out, **kwargs):
 
     Parameters
     ----------
-    x : ``domain`` element
+    x : ``domain`` `element`
         An object in the operator domain. The operator is applied
         to it.
 
-    out : ``range`` element
+    out : ``range`` `element`
         An object in the operator range. The result of an operator
         evaluation.
 
@@ -359,11 +359,11 @@ class Operator(object):
 
     **Parameters:**
 
-    x : `Operator.domain` element
+    x : `Operator.domain` `element`
         An object in the operator domain to which the operator is
         applied
 
-    out : `Operator.range` element
+    out : `Operator.range` `element`
         An object in the operator range to which the result of the
         operator evaluation is written.
 
@@ -382,7 +382,7 @@ class Operator(object):
 
     **Parameters:**
 
-    x : `Operator.domain` element
+    x : `Operator.domain` `element`
         An object in the operator domain to which the operator is
         applied
 
@@ -399,11 +399,11 @@ class Operator(object):
 
     **Parameters:**
 
-    x : `Operator.domain` element
+    x : `Operator.domain` `element`
         An object in the operator domain to which the operator is
         applied
 
-    out : `Operator.range` element, optional
+    out : `Operator.range` `element`, optional
         An object in the operator range to which the result of the
         operator evaluation is written
 
@@ -547,7 +547,7 @@ class Operator(object):
         ----------
         x : `Operator.domain` `element-like`
             Element to which the operator is applied
-        out : `Operator.range` element, optional
+        out : `Operator.range` `element`, optional
             Element to which the result is written
 
         Returns
@@ -570,12 +570,12 @@ class Operator(object):
 
     @property
     def domain(self):
-        """The domain of this operator."""
+        """Set of objects on which this operator can be evaluated."""
         return self._domain
 
     @property
     def range(self):
-        """The range of this operator."""
+        """Set in which the result of an evaluation of this operator lies."""
         return self._range
 
     @property
@@ -637,11 +637,12 @@ class Operator(object):
 
         Parameters
         ----------
-        x : `Operator.domain` element
-            An object in the operator domain to which the operator is
-            applied. The object is treated as immutable, hence it is
-            not modified during evaluation.
-        out : `Operator.range` element, optional
+        x : `Operator.domain` `element-like`
+            An object which can be converted into an element of this
+            operator's domain with the ``self.domain.element`` method.
+            The operator is applied to this object, which is treated
+            as immutable, hence it is not modified during evaluation.
+        out : `Operator.range` `element`, optional
             An object in the operator range to which the result of the
             operator evaluation is written. The result is independent
             of the initial state of this object.
@@ -650,7 +651,7 @@ class Operator(object):
 
         Returns
         -------
-        out : `Operator.range` element
+        out : `Operator.range` `element`
             Result of the operator evaluation. If ``out`` was provided,
             the returned object is a reference to it.
 
@@ -937,9 +938,8 @@ class Operator(object):
         Parameters
         ----------
         other : scalar
-            If `Operator.range` is a `LinearSpace`,
-            ``scalar`` must be an element of this operator's
-            ``field``.
+            If `Operator.range` is a `LinearSpace`, ``scalar`` must be
+            an element of the ``field`` of this operator's range.
 
         Returns
         -------
@@ -1022,10 +1022,10 @@ class OperatorSum(Operator):
             The second summand. Must have the same
             `Operator.domain` and `Operator.range` as
             ``op1``.
-        tmp_ran : `Operator.range` element, optional
+        tmp_ran : `Operator.range` `element`, optional
             Used to avoid the creation of a temporary when applying the
             operator.
-        tmp_dom : `Operator.domain` element, optional
+        tmp_dom : `Operator.domain` `element`, optional
             Used to avoid the creation of a temporary when applying the
             operator adjoint.
         """
@@ -1143,7 +1143,7 @@ class OperatorComp(Operator):
         right : `Operator`
             The right ("inner") operator. Its range must coincide with the
             domain of ``left``.
-        tmp : element of the range of ``right``, optional
+        tmp : `element` of the range of ``right``, optional
             Used to avoid the creation of a temporary when applying the
             operator.
         """
@@ -1306,7 +1306,7 @@ class OperatorLeftScalarMult(Operator):
         op : `Operator`
             The range of ``op`` must be a `LinearSpace`
             or `Field`.
-        scalar : ``op.range.field`` element
+        scalar : ``op.range.field`` `element`
             A real or complex number, depending on the field of
             the range.
         """
@@ -1415,10 +1415,10 @@ class OperatorRightScalarMult(Operator):
         op : `Operator`
             The domain of ``op`` must be a `LinearSpace` or
             `Field`.
-        scalar : ``op.range.field`` element
+        scalar : ``op.range.field`` `element`
             A real or complex number, depending on the field of
             the operator domain.
-        tmp : domain element, optional
+        tmp : domain `element`, optional
             Used to avoid the creation of a temporary when applying the
             operator.
         """

--- a/odl/operator/operator.py
+++ b/odl/operator/operator.py
@@ -388,7 +388,7 @@ class Operator(object):
 
     **Returns:**
 
-    out : `Operator.range` element-like
+    out : `Operator.range` `element-like`
         An object in the operator range holding the result of the
         operator evaluation
 
@@ -545,14 +545,14 @@ class Operator(object):
 
         Parameters
         ----------
-        x : `Operator.domain` element-like
+        x : `Operator.domain` `element-like`
             Element to which the operator is applied
         out : `Operator.range` element, optional
             Element to which the result is written
 
         Returns
         -------
-        out : `Operator.range` element-like
+        out : `Operator.range` `element-like`
             Result of the evaluation. If ``out`` was provided, the
             returned object is a reference to it.
 
@@ -630,7 +630,7 @@ class Operator(object):
                                     ''.format(self))
 
     def __call__(self, x, out=None, **kwargs):
-        """Return ``self(x)``.
+        """Return ``self(x[, out, **kwargs])``.
 
         Implementation of the call pattern ``op(x)`` with the private
         ``_call()`` method and added error checking.
@@ -645,7 +645,8 @@ class Operator(object):
             An object in the operator range to which the result of the
             operator evaluation is written. The result is independent
             of the initial state of this object.
-        **kwargs : Further arguments to the function, optional
+        kwargs : Further arguments to the function, optional
+            Passed on to the underlying implementation in `_call`
 
         Returns
         -------
@@ -1086,7 +1087,7 @@ class OperatorSum(Operator):
 
         Parameters
         ----------
-        x : `Operator.domain` element-like
+        x : `Operator.domain` `element-like`
             Evaluation point of the derivative
         """
         return OperatorSum(self._op1.derivative(x), self._op2.derivative(x))
@@ -1195,7 +1196,7 @@ class OperatorComp(Operator):
 
         Parameters
         ----------
-        x : `Operator.domain` element-like
+        x : `Operator.domain` `element-like`
             Evaluation point of the derivative. Needs to be usable as
             input for the ``right`` operator.
         """
@@ -1355,7 +1356,7 @@ class OperatorLeftScalarMult(Operator):
 
         Parameters
         ----------
-        x : `Operator.domain` element-like
+        x : `Operator.domain` `element-like`
             Evaluation point of the derivative
 
         See also
@@ -1475,7 +1476,7 @@ class OperatorRightScalarMult(Operator):
 
         Parameters
         ----------
-        x : `Operator.domain` element-like
+        x : `Operator.domain` `element-like`
             Evaluation point of the derivative
         """
         return OperatorLeftScalarMult(self._op.derivative(self._scalar * x),

--- a/odl/operator/oputils.py
+++ b/odl/operator/oputils.py
@@ -132,7 +132,7 @@ def power_method_opnorm(op, niter, xstart=None):
         operator must be linear).
     niter : positive `int`
         Number of iterations to perform
-    xstart : `Operator.domain` element, optional
+    xstart : `Operator.domain` `element`, optional
         Starting point of the iteration. By default, the ``one``
         element of the `Operator.domain` is used.
 

--- a/odl/operator/pspace_ops.py
+++ b/odl/operator/pspace_ops.py
@@ -101,7 +101,7 @@ class ProductSpaceOperator(Operator):
 
         Parameters
         ----------
-        operators : array-like
+        operators : `array-like`
             An array of `Operator`'s
         dom : `ProductSpace`
             Domain of the operator. If not provided, it is tried to be

--- a/odl/operator/pspace_ops.py
+++ b/odl/operator/pspace_ops.py
@@ -208,14 +208,14 @@ class ProductSpaceOperator(Operator):
 
         Parameters
         ----------
-        x : domain element
+        x : domain `element`
             input vector to be evaluated
-        out : range element, optional
+        out : range `element`, optional
             output vector to write result to
 
         Returns
         -------
-        out : range element
+        out : range `element`
             Result of the evaluation. If ``out`` was provided, the
             returned object is a reference to it.
 
@@ -389,14 +389,14 @@ class ComponentProjection(Operator):
 
         Parameters
         ----------
-        x : domain element
+        x : domain `element`
             input vector to be projected
-        out : range element, optional
+        out : range `element`, optional
             output vector to write result to
 
         Returns
         -------
-        out : range element
+        out : range `element`
             Projection of x onto subspace. If ``out`` was provided, the
             returned object is a reference to it.
 
@@ -500,14 +500,14 @@ class ComponentProjectionAdjoint(Operator):
 
         Parameters
         ----------
-        x : domain element
+        x : domain `element`
             Input vector to be extended
-        out : range element, optional
+        out : range `element`, optional
             output vector to write result to
 
         Returns
         -------
-        out : range element
+        out : range `element`
             Extension of x to superspace. If ``out`` was provided, the
             returned object is a reference to it.
 

--- a/odl/set/domain.py
+++ b/odl/set/domain.py
@@ -515,8 +515,8 @@ class IntervalProd(Set):
         >>> rbox2 = IntervalProd([0, 0], [1, 0])
         >>> rbox.insert(1, rbox2)
         IntervalProd([-1.0, 0.0, 0.0, 2.0], [-0.5, 1.0, 0.0, 3.0])
-        >>> rbox.insert(2, [-1.0, 0.0])
-        IntervalProd([-1.0, 2.0, -1.0, 0.0], [-0.5, 3.0, -1.0, 0.0])
+        >>> rbox.insert(2, rbox2)
+        IntervalProd([-1.0, 2.0, 0.0, 0.0], [-0.5, 3.0, 1.0, 0.0])
         """
         if index < 0:
             index = int(index) + self.ndim

--- a/odl/set/domain.py
+++ b/odl/set/domain.py
@@ -115,11 +115,6 @@ class IntervalProd(Set):
         return len(self._inondeg)
 
     @property
-    def extent(self):
-        """The interval length per axis."""
-        return self.end - self.begin
-
-    @property
     def volume(self):
         """The 'dim'-dimensional volume of this interval product."""
         return self.measure(ndim=self.ndim)
@@ -153,11 +148,14 @@ class IntervalProd(Set):
         """The maximum value in this interval product"""
         return self.end
 
+    def extent(self):
+        """The interval length per axis."""
+        return self.max() - self.min()
+
     def element(self):
         """An arbitrary element, the midpoint."""
         return self.midpoint
 
-    # Overrides of the abstract base class methods
     def approx_equals(self, other, tol):
         """Test if ``other`` is equal to this set up to ``tol``.
 

--- a/odl/set/domain.py
+++ b/odl/set/domain.py
@@ -56,9 +56,9 @@ class IntervalProd(Set):
 
         Parameters
         ----------
-        begin : array-like or float
+        begin : `array-like` or `float`
             The lower ends of the intervals in the product
-        end : array-like or float
+        end : `array-like` or `float`
             The upper ends of the intervals in the product
 
         Examples
@@ -194,7 +194,7 @@ class IntervalProd(Set):
 
         Parameters
         ----------
-        point : array-like or `float`
+        point : `array-like` or `float`
             The point to be tested. Its length must be equal
             to the set's dimension. In the 1d case, 'point'
             can be given as a `float`.
@@ -270,7 +270,7 @@ class IntervalProd(Set):
 
         Parameters
         ----------
-        other : object
+        other :
             Can be a single point, a ``(d, N)`` array where ``d`` is the
             number of dimensions or a length-``d`` meshgrid sequence
 
@@ -359,7 +359,7 @@ class IntervalProd(Set):
 
         Parameters
         ----------
-        point : array-like or `float`
+        point : `array-like` or `float`
                 The point. Its length must be equal to the set's
                 dimension. Can be a `float` in the 1d case.
         ord : non-zero int or float('inf'), optional
@@ -404,7 +404,7 @@ class IntervalProd(Set):
         ----------
         indices : `int` or `tuple` of `int`
             The indices of the dimensions along which to collapse
-        values : `float` or array-like
+        values : `array-like` or `float`
             The values to which to collapse. Must have the same
             length as ``indices``. Values must lie within the interval
             boundaries.
@@ -423,13 +423,8 @@ class IntervalProd(Set):
         Cuboid([-1.0, 0.0, 2.0], [-0.5, 0.0, 3.0])
         >>> rbox.collapse([1, 2], [0, 2.5])
         Cuboid([-1.0, 0.0, 2.5], [-0.5, 0.0, 2.5])
-        >>> rbox.collapse([1, 2], [0, 3.5])
-        Traceback (most recent call last):
-            ...
-        ValueError: values [ 0.   3.5] not below the upper interval
-        boundaries [ 1.  3.].
         """
-        indices = np.atleast_1d(indices)
+        indices = np.atleast_1d(indices).astype('int64', casting='safe')
         values = np.atleast_1d(values)
         if len(indices) != len(values):
             raise ValueError('lengths of indices {} and values {} do not '
@@ -511,8 +506,8 @@ class IntervalProd(Set):
         >>> rbox2 = IntervalProd([0, 0], [1, 0])
         >>> rbox.insert(1, rbox2)
         IntervalProd([-1.0, 0.0, 0.0, 2.0], [-0.5, 1.0, 0.0, 3.0])
-        >>> rbox.insert(2, rbox2)
-        IntervalProd([-1.0, 2.0, 0.0, 0.0], [-0.5, 3.0, 1.0, 0.0])
+        >>> rbox.insert(-1, rbox2)
+        IntervalProd([-1.0, 0.0, 0.0, 2.0], [-0.5, 1.0, 0.0, 3.0])
         """
         if index < 0:
             index = int(index) + self.ndim
@@ -520,7 +515,8 @@ class IntervalProd(Set):
             index = int(index)
 
         if not 0 <= index <= self.ndim:
-            raise IndexError('Index ({}) out of range'.format(index))
+            raise IndexError('index {} outside the valid range 0 ... {}.'
+                             ''.format(index, self.ndim))
 
         new_beg = np.empty(self.ndim + other.ndim)
         new_end = np.empty(self.ndim + other.ndim)
@@ -744,9 +740,9 @@ def Interval(begin, end):
 
     Parameters
     ----------
-    begin : array-like or float
+    begin : `array-like`, shape ``(1,)``, or `float`
         The lower ends of the intervals in the product
-    end : array-like or float
+    end : `array-like`, shape ``(1,)``, or `float`
         The upper ends of the intervals in the product
 
     """
@@ -762,9 +758,9 @@ def Rectangle(begin, end):
 
     Parameters
     ----------
-    begin : array-like with two elements convertible to float
+    begin : `array-like`, shape ``(2,)``
         The lower ends of the intervals in the product
-    end : array-like with two elements convertible to float
+    end : `array-like`, shape ``(2,)``
         The upper ends of the intervals in the product
     """
     rectangle = IntervalProd(begin, end)
@@ -779,9 +775,9 @@ def Cuboid(begin, end):
 
     Parameters
     ----------
-    begin : array-like with three elements convertible to float
+    begin : `array-like`, shape ``(3,)``
         The lower ends of the intervals in the product
-    end : array-like with three elements convertible to float
+    end : `array-like`, shape ``(3,)``
         The upper ends of the intervals in the product
     """
     cuboid = IntervalProd(begin, end)

--- a/odl/set/domain.py
+++ b/odl/set/domain.py
@@ -33,8 +33,7 @@ import numpy as np
 from odl.set.sets import Set, RealNumbers
 from odl.util.utility import array1d_repr
 from odl.util.vectorization import (
-    is_valid_input_array, is_valid_input_meshgrid, meshgrid_input_order,
-    vecs_from_meshgrid)
+    is_valid_input_array, is_valid_input_meshgrid)
 
 
 __all__ = ('IntervalProd', 'Interval', 'Rectangle', 'Cuboid')
@@ -304,8 +303,7 @@ class IntervalProd(Set):
         if other in self:
             return True
         elif is_valid_input_meshgrid(other, self.ndim):
-            order = meshgrid_input_order(other)
-            vecs = vecs_from_meshgrid(other, order)
+            vecs = tuple(vec.squeeze() for vec in other)
             mins = np.fromiter((np.min(vec) for vec in vecs), dtype=float)
             maxs = np.fromiter((np.max(vec) for vec in vecs), dtype=float)
             return np.all(mins >= self.begin) and np.all(maxs <= self.end)
@@ -551,8 +549,8 @@ class IntervalProd(Set):
         Examples
         --------
         >>> rbox = IntervalProd([-1, 2], [-0.5, 3])
-        >>> rbox.append([-1.0, 0.0])
-        IntervalProd([-1.0, 2.0, -1.0, 0.0], [-0.5, 3.0, -1.0, 0.0])
+        >>> rbox.append(Interval(-1.0, 0.0))
+        Cuboid([-1.0, 2.0, -1.0], [-0.5, 3.0, 0.0])
 
         See Also
         --------
@@ -600,8 +598,6 @@ class IntervalProd(Set):
                [-0.5,  3. ,  0.5]])
         """
         from odl.discr.grid import TensorGrid
-        if order not in ('C', 'F'):
-            raise ValueError('order {} not understood.'.format(order))
 
         minmax_vecs = [0] * self.ndim
         for axis in self._ideg:

--- a/odl/set/domain.py
+++ b/odl/set/domain.py
@@ -488,29 +488,25 @@ class IntervalProd(Set):
         return IntervalProd(b_new, e_new)
 
     def insert(self, index, other):
-        """Insert another interval product before the given index.
+        """Return a copy with ``other`` inserted before ``index``.
 
         The given interval product (``ndim=m``) is inserted into the
         current one (``ndim=n``) before the given index, resulting in a
         new interval product with ``n+m`` dimensions.
 
-        No changes are made in-place.
-
         Parameters
         ----------
-        other : `IntervalProd`, `float` or array-like
-            The set to be inserted. A `float` or array a is
-            treated as an ``IntervalProd(a, a)``.
-        index : `int`, optional
-            The index of the dimension before which ``other`` is to
-            be inserted. Must fulfill ``0 <= index <= ndim``.
-
-            Default: `ndim`
+        index : `int`
+            Index of the dimension before which ``other`` is to
+            be inserted. Must fulfill ``-ndim <= index <= ndim``.
+            Negative indices are added to ``ndim``.
+        other : `IntervalProd`
+            Interval product to be inserted
 
         Returns
         -------
-        larger_set : `IntervalProd`
-            The enlarged set
+        newintvp : `IntervalProd`
+            Interval product with ``other`` inserted
 
         Examples
         --------
@@ -521,22 +517,14 @@ class IntervalProd(Set):
         IntervalProd([-1.0, 0.0, 0.0, 2.0], [-0.5, 1.0, 0.0, 3.0])
         >>> rbox.insert(2, [-1.0, 0.0])
         IntervalProd([-1.0, 2.0, -1.0, 0.0], [-0.5, 3.0, -1.0, 0.0])
-
-        Can also insert by array
-
-        >>> rbox.insert(0, 1).squeeze() == rbox
-        True
-
-        See Also
-        --------
-        append
         """
+        if index < 0:
+            index = int(index) + self.ndim
+        else:
+            index = int(index)
+
         if not 0 <= index <= self.ndim:
             raise IndexError('Index ({}) out of range'.format(index))
-
-        # TODO: do we want this?
-        if not isinstance(other, IntervalProd):
-            other = IntervalProd(other, other)
 
         new_beg = np.empty(self.ndim + other.ndim)
         new_end = np.empty(self.ndim + other.ndim)

--- a/odl/set/pspace.py
+++ b/odl/set/pspace.py
@@ -107,13 +107,14 @@ class ProductSpace(LinearSpace):
 
             Note that ``0 <= ord < 1`` are not allowed since these
             pseudo-norms are very unstable numerically.
-        weights : array-like, optional, only usable with 'ord'
+        weights : `array-like`, optional
             Array of weights, same size as number of space
             components. All weights must be positive. It is
             multiplied with the tuple of distances before
             applying the Rn norm or ``prod_norm``.
-
             Default: ``(1.0,...,1.0)``
+
+            This option can only be used together with ``ord``.
 
         prod_norm : `callable`, optional
             Function that should be applied to the array of
@@ -642,7 +643,7 @@ class ProductSpaceVector(LinearSpaceVector):
             pass the rest on to the underlying show methods.
 
         kwargs
-            Arguments for the underlying vectors.
+            Additional arguments passed on to the underlying vectors
 
         Returns
         -------

--- a/odl/set/pspace.py
+++ b/odl/set/pspace.py
@@ -212,14 +212,14 @@ class ProductSpace(LinearSpace):
         return self._spaces
 
     def element(self, inp=None):
-        """Create an element in the product space.
+        """Create an element of the product space.
 
         Parameters
         ----------
-        inp : `object`, optional
+        inp : optional
             If ``inp`` is `None`, a new element is created from
             scratch by allocation in the spaces. If ``inp`` is
-            already an element in this space, it is re-wrapped.
+            already an element of this space, it is re-wrapped.
             Otherwise, a new element is created from the
             components by calling the ``element()`` methods
             in the component spaces.
@@ -241,7 +241,7 @@ class ProductSpace(LinearSpace):
         >>> vec_3.space == vec_2x3[1].space
         True
 
-        Creates an element in the product space
+        Create an element of the product space
 
         >>> from odl import Rn
         >>> r2, r3 = Rn(2), Rn(3)

--- a/odl/set/space.py
+++ b/odl/set/space.py
@@ -87,15 +87,15 @@ class LinearSpace(Set):
     def element(self, inp=None, **kwargs):
         """Create a `LinearSpaceVector` from ``inp`` or from scratch.
 
-        If called without ``inp`` argument, an arbitrary element in the
+        If called without ``inp`` argument, an arbitrary element of the
         space is generated without guarantee of its state.
 
         Parameters
         ----------
-        inp : `object`, optional
-            The input data from which to create the element
-        **args : `dict`, optional
-            Optional further arguments.
+        inp : optional
+            Input data from which to create the element
+        kwargs :
+            Optional further arguments
 
         Returns
         -------

--- a/odl/solvers/findroot/newton.py
+++ b/odl/solvers/findroot/newton.py
@@ -63,7 +63,7 @@ Goldfarb%E2%80%93Shanno_algorithm>`_
     grad : `Operator`
         Gradient mapping of the objective function, i.e. the mapping
         :math:`x \mapsto \\nabla f(x) \\in \mathcal{X}`
-    x : element in the domain of ``grad``
+    x : `element` of the domain of ``grad``
         Starting point of the iteration
     line_search : `LineSearch`
         Strategy to choose the step length
@@ -137,7 +137,7 @@ def broydens_first_method(grad, x, line_search, niter=1, partial=None):
     grad : `Operator`
         Gradient mapping of the objective function, i.e. the mapping
         :math:`x \mapsto \\nabla f(x) \\in \mathcal{X}`
-    x : element in the domain of ``grad``
+    x : `element` of the domain of ``grad``
         Starting point of the iteration
     line_search : `LineSearch`
         Strategy to choose the step length
@@ -218,7 +218,7 @@ def broydens_second_method(grad, x, line_search, niter=1, partial=None):
     grad : `Operator`
         Gradient mapping of the objective function, i.e. the mapping
         :math:`x \mapsto \\nabla f(x) \\in \mathcal{X}`
-    x : element in the domain of ``grad``
+    x : `element` of the domain of ``grad``
         Starting point of the iteration
     line_search : `LineSearch`
         Strategy to choose the step length

--- a/odl/solvers/iterative/iterative.py
+++ b/odl/solvers/iterative/iterative.py
@@ -79,11 +79,11 @@ def landweber(op, x, rhs, niter=1, omega=1, projection=None, partial=None):
         property, which returns a new operator which in turn has an
         `Operator.adjoint` property, i.e. ``op.derivative(x).adjoint`` must be
         well-defined for ``x`` in the operator domain.
-    x : element of the domain of ``op``
+    x : `element` of the domain of ``op``
         Vector to which the result is written. Its initial value is
         used as starting point of the iteration, and its values are
         updated in each iteration step.
-    rhs : element of the range of ``op``
+    rhs : `element` of the range of ``op``
         Right-hand side of the equation defining the inverse problem
     niter : `int`, optional
         Maximum number of iterations
@@ -141,11 +141,11 @@ def conjugate_gradient(op, x, rhs, niter=1, partial=None):
         Operator in the inverse problem. It must be linear and
         self-adjoint. This implies in particular that its domain and
         range are equal.
-    x : element of the domain of ``op``
+    x : `element` of the domain of ``op``
         Vector to which the result is written. Its initial value is
         used as starting point of the iteration, and its values are
         updated in each iteration step.
-    rhs : element of the range of ``op``
+    rhs : `element` of the range of ``op``
         Right-hand side of the equation defining the inverse problem
     niter : int, optional
         Maximum number of iterations
@@ -228,11 +228,11 @@ Conjugate_gradient_on_the_normal_equations>`_.
         an implementation of `Operator.derivative`, which
         in turn must implement `Operator.adjoint`, i.e.
         the call ``op.derivative(x).adjoint`` must be valid.
-    x : element of the domain of ``op``
+    x : `element` of the domain of ``op``
         Vector to which the result is written. Its initial value is
         used as starting point of the iteration, and its values are
         updated in each iteration step.
-    rhs : element of the range of ``op``
+    rhs : `element` of the range of ``op``
         Right-hand side of the equation defining the inverse problem
     niter : int, optional
         Maximum number of iterations
@@ -333,11 +333,11 @@ def gauss_newton(op, x, rhs, niter=1, zero_seq=exp_zero_seq(2.0),
         an implementation of `Operator.derivative`, which
         in turn must implement `Operator.adjoint`, i.e.
         the call ``op.derivative(x).adjoint`` must be valid.
-    x : element of the domain of ``op``
+    x : `element` of the domain of ``op``
         Vector to which the result is written. Its initial value is
         used as starting point of the iteration, and its values are
         updated in each iteration step.
-    rhs : element of the range of ``op``
+    rhs : `element` of the range of ``op``
         Right-hand side of the equation defining the inverse problem
     niter : `int`, optional
         Maximum number of iterations

--- a/odl/solvers/scalar/gradient.py
+++ b/odl/solvers/scalar/gradient.py
@@ -56,7 +56,7 @@ def steepest_descent(grad, x, niter=1, line_search=1, projection=None,
     grad : `Operator`
         Gradient of the objective function,
         :math:`x \mapsto \\nabla f(x)`
-    x : element in the domain of ``deriv``
+    x : `element` of the domain of ``deriv``
         Starting point of the iteration
     niter : `int`, optional
         Number of iterations

--- a/odl/solvers/scalar/steplen.py
+++ b/odl/solvers/scalar/steplen.py
@@ -46,9 +46,9 @@ class StepLength(with_metaclass(ABCMeta, object)):
 
         Parameters
         ----------
-        x : `Operator.domain` element
+        x : `Operator.domain` `element`
             The current point
-        direction : `Operator.domain` element
+        direction : `Operator.domain` `element`
             Search direction in which the line search should be computed
         dir_derivative : `float`
             Directional derivative along the ``direction``
@@ -70,9 +70,9 @@ class LineSearch(with_metaclass(ABCMeta, object)):
 
         Parameters
         ----------
-        x : `Operator.domain` element
+        x : `Operator.domain` `element`
             The current point
-        direction : `Operator.domain` element
+        direction : `Operator.domain` `element`
             Search direction in which the line search should be computed
         dir_derivative : `float`
             Directional derivative along the ``direction``
@@ -144,9 +144,9 @@ class BacktrackingLineSearch(LineSearch):
 
         Parameters
         ----------
-        x : `Operator.domain` element
+        x : `Operator.domain` `element`
             The current point
-        direction : `Operator.domain` element
+        direction : `Operator.domain` `element`
             Search direction in which the line search should be computed
         dir_derivative : `float`
             Directional derivative along the ``direction``
@@ -187,9 +187,9 @@ class ConstantLineSearch(LineSearch):
 
         Parameters
         ----------
-        x : `Operator.domain` element
+        x : `Operator.domain` `element`
             The current point
-        direction : `Operator.domain` element
+        direction : `Operator.domain` `element`
             Search direction in which the line search should be computed
         dir_derivative : `float`
             Directional derivative along the ``direction``
@@ -239,9 +239,9 @@ class BarzilaiBorweinStep(object):
 
         Parameters
         ----------
-        x : `Operator.domain` element
+        x : `Operator.domain` `element`
             The current point
-        x0 : `Operator.domain` element
+        x0 : `Operator.domain` `element`
             The previous point
 
         Returns

--- a/odl/solvers/util/partial.py
+++ b/odl/solvers/util/partial.py
@@ -250,10 +250,10 @@ class ShowPartial(Partial):
 
         Parameters
         ----------
-        *args, **kwargs
-            passed ax ``x.show(*args, **kwargs)``
         display_step : positive `int`
             Number of iterations between plots. Default: 1
+        args, kwargs :
+            Optional arguments passed on to ``x.show``
         """
         self.args = args
         self.kwargs = kwargs
@@ -262,7 +262,7 @@ class ShowPartial(Partial):
         self.iter = 0
 
     def __call__(self, x):
-        """Show the current iteration."""
+        """Show the current iterate."""
         if (self.iter % self.display_step) == 0:
             self.fig = x.show(fig=self.fig, show=True,
                               *self.args, **self.kwargs)
@@ -271,11 +271,13 @@ class ShowPartial(Partial):
 
     def __str__(self):
         """Return ``str(self)``"""
-        return 'ShowPartial(*{}, **{})'.format(self.args, self.kwargs)
+        return '{}(*{}, **{})'.format(self.__class__.__name__, self.args,
+                                      self.kwargs)
 
     def __repr__(self):
         """Return ``repr(self)``"""
-        return 'ShowPartial(*{!r}, **{!r})'.format(self.args, self.kwargs)
+        return '{}(*{!r}, **{!r})'.format(self.__class__.__name__, self.args,
+                                          self.kwargs)
 
 
 if __name__ == '__main__':

--- a/odl/solvers/vector/newton.py
+++ b/odl/solvers/vector/newton.py
@@ -54,7 +54,7 @@ def newtons_method(op, x, line_search, num_iter=10, cg_iter=None,
     ----------
     deriv : `Operator`
         Gradient of the objective function, :math:`x \mapsto grad f(x)`
-    x : element in the domain of ``deriv``
+    x : `element` of the domain of ``deriv``
         Starting point of the iteration
     line_search : `LineSearch`
         Strategy to choose the step length

--- a/odl/space/base_ntuples.py
+++ b/odl/space/base_ntuples.py
@@ -228,7 +228,7 @@ class NtuplesBaseVector(with_metaclass(ABCMeta, object)):
         ----------
         indices : `int` or `slice`
             The position(s) that should be set
-        values : {scalar, array-like, `NtuplesBaseVector`}
+        values : scalar, `array-like` or `NtuplesBaseVector`
             The value(s) that are to be assigned.
 
             If ``index`` is an integer, ``value`` must be single value.

--- a/odl/space/cu_ntuples.py
+++ b/odl/space/cu_ntuples.py
@@ -118,7 +118,7 @@ class CudaNtuples(NtuplesBase):
 
         Parameters
         ----------
-        inp : array-like or scalar, optional
+        inp : `array-like` or scalar, optional
             Input to initialize the new element.
 
             If ``inp`` is a `numpy.ndarray` of shape ``(size,)``
@@ -392,7 +392,7 @@ class CudaNtuplesVector(NtuplesBaseVector, LinearSpaceVector):
         ----------
         indices : `int` or `slice`
             The position(s) that should be set
-        values : {scalar, array-like, `CudaNtuplesVector`}
+        values : scalar, `array-like` or `CudaNtuplesVector`
             The value(s) that are to be assigned.
 
             If ``index`` is an `int`, ``value`` must be single value.
@@ -536,11 +536,8 @@ class CudaFn(FnBase, CudaNtuples):
 
             Only scalar data types are allowed.
 
-        weight : {array-like, `CudaFnVector`, `float`, `None`}
+        weight : `array-like`, `CudaFnVector` or `float`, optional
             Use weighted inner product, norm, and dist.
-
-            `None`:
-                No weighting, use standard functions (default)
 
             `float`:
                 Weighting by a constant
@@ -556,10 +553,12 @@ class CudaFn(FnBase, CudaNtuples):
                 avoided if the ``dtype`` of the vector is the
                 same as this space's ``dtype``.
 
+            Default: no weighting
+
             This option cannot be combined with ``dist``, ``norm``
             or ``inner``.
 
-        exponent : positive `float`
+        exponent : positive `float`, optional
             Exponent of the norm. For values other than 2.0, no
             inner product is defined.
 
@@ -569,12 +568,10 @@ class CudaFn(FnBase, CudaNtuples):
             Default: 2.0
 
         dist : `callable`, optional
-            The distance function defining a metric on
-            :math:`\mathbb{F}^n`.
-            It must accept two `CudaFnVector` arguments,
-            return a `float` and
-            fulfill the following mathematical conditions for any
-            three vectors :math:`x, y, z`:
+            The distance function defining a metric on `CudaFn`.
+            It must accept two `CudaFnVector` arguments, return a
+            `float` and fulfill the following mathematical conditions
+            for any three vectors ``x, y, z``:
 
             - :math:`d(x, y) = d(y, x)`
             - :math:`d(x, y) \geq 0`
@@ -923,7 +920,7 @@ class CudaFnVector(FnBaseVector, CudaNtuplesVector):
         super().__init__(space, data)
 
 
-def CudaRn(size, dtype=np.float32, **kwargs):
+def CudaRn(size, dtype='float32', **kwargs):
 
     """The real space :math:`R^n`, implemented in CUDA.
 
@@ -933,7 +930,7 @@ def CudaRn(size, dtype=np.float32, **kwargs):
     ----------
     size : positive `int`
         The number of dimensions of the space
-    dtype : `object`
+    dtype : optional
         The data type of the storage array. Can be provided in any
         way the `numpy.dtype` function understands, most notably
         as built-in type, as one of NumPy's internal datatype
@@ -944,13 +941,11 @@ def CudaRn(size, dtype=np.float32, **kwargs):
     kwargs : {'weight', 'exponent', 'dist', 'norm', 'inner'}
         See `CudaFn`
     """
-
     rn = CudaFn(size, dtype, **kwargs)
 
     if not rn.is_rn:
         raise TypeError('data type {!r} not a real floating-point type.'
                         ''.format(dtype))
-
     return rn
 
 
@@ -986,7 +981,7 @@ def cu_weighted_inner(weight):
 
     Parameters
     ----------
-    weight : scalar, array-like or `CudaFnVector`
+    weight : scalar, `array-like` or `CudaFnVector`
         Weight of the inner product. A scalar is interpreted as a
         constant weight and a 1-dim. array or a `CudaFnVector`
         as a weighting vector.
@@ -1010,7 +1005,7 @@ def cu_weighted_norm(weight, exponent=2.0):
 
     Parameters
     ----------
-    weight : scalar, array-like or `CudaFnVector`
+    weight : scalar, `array-like` or `CudaFnVector`
         Weight of the inner product. A scalar is interpreted as a
         constant weight and a 1-dim. array or a `CudaFnVector`
         as a weighting vector.
@@ -1037,7 +1032,7 @@ def cu_weighted_dist(weight, exponent=2.0):
 
     Parameters
     ----------
-    weight : scalar, array-like or `CudaFnVector`
+    weight : scalar, `array-like` or `CudaFnVector`
         Weight of the inner product. A scalar is interpreted as a
         constant weight and a 1-dim. array or a `CudaFnVector`
         as a weighting vector.
@@ -1142,7 +1137,7 @@ class CudaFnVectorWeighting(FnWeightingBase):
 
         Parameters
         ----------
-        vector : array-like, one-dim.
+        vector : `array-like`, one-dim.
             Weighting vector of the inner product
         exponent : positive `float`
             Exponent of the norm. For values other than 2.0, the inner

--- a/odl/space/cu_ntuples.py
+++ b/odl/space/cu_ntuples.py
@@ -608,7 +608,7 @@ class CudaFn(FnBase, CudaNtuples):
 
         inner : `callable`, optional
             The inner product implementation. It must accept two
-            `CudaFnVector` arguments, return a element from
+            `CudaFnVector` arguments, return an element from
             the field of the space (real or complex number) and
             satisfy the following conditions for all vectors
             :math:`x, y, z` and scalars :math:`s`:
@@ -675,7 +675,7 @@ class CudaFn(FnBase, CudaNtuples):
 
         Parameters
         ----------
-        a, b : `LinearSpace.field` element
+        a, b : `LinearSpace.field` `element`
             Scalar to multiply ``x`` and ``y`` with.
         x, y : `CudaFnVector`
             The summands

--- a/odl/space/fspace.py
+++ b/odl/space/fspace.py
@@ -34,8 +34,7 @@ from odl.set.space import LinearSpace, LinearSpaceVector
 from odl.util.utility import preload_call_with, preload_default_oop_call_with
 from odl.util.vectorization import (
     is_valid_input_array, is_valid_input_meshgrid,
-    meshgrid_input_order, out_shape_from_array, out_shape_from_meshgrid,
-    vectorize)
+    out_shape_from_array, out_shape_from_meshgrid, vectorize)
 
 
 __all__ = ('FunctionSet', 'FunctionSetVector',
@@ -518,13 +517,14 @@ class FunctionSpace(FunctionSet, LinearSpace):
         def zero_vec(x, out=None):
             """The zero function, vectorized."""
             if is_valid_input_meshgrid(x, self.domain.ndim):
-                order = meshgrid_input_order(x)
+                out_shape = out_shape_from_meshgrid(x)
+            elif is_valid_input_array(x, self.domain.ndim):
+                out_shape = out_shape_from_array(x)
             else:
-                order = 'C'
+                raise TypeError('invalid input type.')
 
-            out_shape = out_shape_from_meshgrid(x)
             if out is None:
-                return np.zeros(out_shape, dtype=dtype, order=order)
+                return np.zeros(out_shape, dtype=dtype)
             else:
                 out.fill(0)
 
@@ -540,13 +540,14 @@ class FunctionSpace(FunctionSet, LinearSpace):
         def one_vec(x, out=None):
             """The one function, vectorized."""
             if is_valid_input_meshgrid(x, self.domain.ndim):
-                order = meshgrid_input_order(x)
+                out_shape = out_shape_from_meshgrid(x)
+            elif is_valid_input_array(x, self.domain.ndim):
+                out_shape = out_shape_from_array(x)
             else:
-                order = 'C'
+                raise TypeError('invalid input type.')
 
-            out_shape = out_shape_from_meshgrid(x)
             if out is None:
-                return np.ones(out_shape, dtype=dtype, order=order)
+                return np.ones(out_shape, dtype=dtype)
             else:
                 out.fill(1)
 

--- a/odl/space/fspace.py
+++ b/odl/space/fspace.py
@@ -251,23 +251,21 @@ class FunctionSetVector(Operator):
             self._call_in_place(x, out=out, **kwargs)
 
     def __call__(self, x, out=None, **kwargs):
-        """Evaluate the function at one or multiple values ``x``.
+        """Return ``self(x[, out, **kwargs])``.
 
         Parameters
         ----------
-        x : object
+        x : domain `element-like`, `meshgrid` or `numpy.ndarray`
             Input argument for the function evaluation. Conditions
-            on ``x`` depend on vectorization:
+            on ``x`` depend on its type:
 
-            `False` : ``x`` must be a domain element
+            element-like: must be a castable to a domain element
 
-            `True` : ``x`` must be a `numpy.ndarray` with shape
-            ``(d, N)``, where ``d`` is the number of dimensions of
-            the function domain
-            OR
-            ``x`` is a sequence of `numpy.ndarray` with length
-            ``space.ndim``, and the arrays can be broadcast
-            against each other.
+            meshgrid: length must be ``space.ndim``, and the arrays must
+            be broadcastable against each other.
+
+            array:  shape must be ``(d, N)``, where ``d`` is the number
+            of dimensions of the function domain
 
         out : `numpy.ndarray`, optional
             Output argument holding the result of the function
@@ -275,12 +273,10 @@ class FunctionSetVector(Operator):
             functions. Its shape must be equal to
             ``np.broadcast(*x).shape``.
 
-        bounds_check : bool
-            Whether or not to check if all input points lie in
-            the function domain. For vectorized evaluation,
-            this requires the domain to implement
-            `Set.contains_all`.
-
+        bounds_check : `bool`
+            If `True`, check if all input points lie in the function
+            domain in the case of vectorized evaluation. This requires
+            the domain to implement `Set.contains_all`.
             Default: `True`
 
         Returns

--- a/odl/space/ntuples.py
+++ b/odl/space/ntuples.py
@@ -838,7 +838,7 @@ class Fn(FnBase, Ntuples):
 
         Returns
         -------
-        inner : `field` element
+        inner : `field` `element`
             Inner product of the vectors
 
         Examples

--- a/odl/space/ntuples.py
+++ b/odl/space/ntuples.py
@@ -68,7 +68,7 @@ class Ntuples(NtuplesBase):
 
         Parameters
         ----------
-        inp : array-like, optional
+        inp : `array-like`, optional
             Input to initialize the new element.
 
             If ``inp`` is `None`, an empty element is created with no
@@ -331,7 +331,7 @@ class NtuplesVector(NtuplesBaseVector):
         ----------
         indices : `int` or `slice`
             The position(s) that should be set
-        values : {scalar, array-like, `NtuplesVector`}
+        values : scalar, `array-like` or `NtuplesVector`
             The value(s) that are to be assigned.
 
             If ``indices`` is an integer, ``value`` must be scalar.
@@ -564,13 +564,12 @@ def _repr_space_funcs(space):
 
 class Fn(FnBase, Ntuples):
 
-    """The vector space :math:`\mathbb{F}^n` with vector multiplication.
+    """The vector space F^n with vector multiplication.
 
-    This space implements n-tuples of elements from a field
-    :math:`\mathbb{F}`, which can be the real or the complex numbers.
+    This space implements n-tuples of elements from a `Field` ``F``,
+    which is usually the real or complex numbers.
 
-    Its elements are represented as instances of the
-    `FnVector` class.
+    Its elements are represented as instances of the `FnVector` class.
     """
 
     def __init__(self, size, dtype, **kwargs):
@@ -587,25 +586,22 @@ class Fn(FnBase, Ntuples):
 
             Only scalar data types are allowed.
 
-        weight : array-like, float or `None`
+        weight : `array-like` or `float`, optional
             Use weighted inner product, norm, and dist.
 
-            `None` (default):
-                No weighting, use standard functions
+            float: Weighting by a constant
 
-            `float`:
-                Weighting by a constant
+            array-like: Weighting by a matrix (2-dim. array) or a vector
+            (1-dim. array, corresponds to a diagonal matrix). A matrix
+            can also be given as a sparse matrix
+            ( ``scipy.sparse.spmatrix``).
 
-            array-like:
-                Weighting by a matrix (2-dim. array) or a vector
-                (1-dim. array, corresponds to a diagonal matrix).
-                A matrix can also be given as a sparse matrix
-                ( ``scipy.sparse.spmatrix``).
+            Default: no weighting
 
             This option cannot be combined with ``dist``,
             ``norm`` or ``inner``.
 
-        exponent : positive `float`
+        exponent : positive `float`, optional
             Exponent of the norm. For values other than 2.0, no
             inner product is defined.
             If ``weight`` is a sparse matrix, only 1.0, 2.0 and
@@ -1075,7 +1071,7 @@ class FnVector(FnBaseVector, NtuplesVector):
 
         Parameters
         ----------
-        newreal : array-like or scalar
+        newreal : `array-like` or scalar
             The new real part for this vector.
 
         Examples
@@ -1133,7 +1129,7 @@ class FnVector(FnBaseVector, NtuplesVector):
 
         Parameters
         ----------
-        newreal : array-like or scalar
+        newreal : `array-like` or scalar
             The new imaginary part for this vector.
 
         Examples
@@ -1267,7 +1263,7 @@ class MatVecOperator(Operator):
 
         Parameters
         ----------
-        matrix : array-like or  ``scipy.sparse.spmatrix``
+        matrix : `array-like` or  ``scipy.sparse.spmatrix``
             Matrix representing the linear operator. Its shape must be
             ``(m, n)``, where ``n`` is the size of ``dom`` and ``m`` the
             size of ``ran``. Its dtype must be castable to the range
@@ -1396,7 +1392,7 @@ def weighted_inner(weight):
 
     Parameters
     ----------
-    weight : scalar or array-like
+    weight : scalar or `array-like`
         Weight of the inner product. A scalar is interpreted as a
         constant weight, a 1-dim. array as a weighting vector and a
         2-dimensional array as a weighting matrix.
@@ -1420,7 +1416,7 @@ def weighted_norm(weight, exponent=2.0):
 
     Parameters
     ----------
-    weight : scalar or array-like
+    weight : scalar or `array-like`
         Weight of the norm. A scalar is interpreted as a
         constant weight, a 1-dim. array as a weighting vector and a
         2-dimensional array as a weighting matrix.
@@ -1447,7 +1443,7 @@ def weighted_dist(weight, exponent=2.0, use_inner=False):
 
     Parameters
     ----------
-    weight : scalar or array-like
+    weight : scalar or `array-like`
         Weight of the distance. A scalar is interpreted as a
         constant weight, a 1-dim. array as a weighting vector and a
         2-dimensional array as a weighting matrix.
@@ -1562,7 +1558,7 @@ class FnMatrixWeighting(FnWeightingBase):
 
         Parameters
         ----------
-        matrix :  ``scipy.sparse.spmatrix`` or array-like, 2-dim.
+        matrix :  ``scipy.sparse.spmatrix`` or `array-like`, 2-dim.
             Square weighting matrix of the inner product
         exponent : positive `float`
             Exponent of the norm. For values other than 2.0, the inner
@@ -1874,7 +1870,7 @@ class FnVectorWeighting(FnWeightingBase):
 
         Parameters
         ----------
-        vector : array-like, one-dim.
+        vector : `array-like`, one-dim.
             Weighting vector of the inner product
         exponent : positive `float`
             Exponent of the norm. For values other than 2.0, the inner

--- a/odl/space/space_utils.py
+++ b/odl/space/space_utils.py
@@ -39,7 +39,7 @@ def vector(array, dtype=None, impl='numpy'):
 
     Parameters
     ----------
-    array : array-like
+    array : `array-like`
         Array from which to create the vector. Scalars become
         one-dimensional vectors.
     dtype : `object`, optional

--- a/odl/trafos/wavelet.py
+++ b/odl/trafos/wavelet.py
@@ -599,7 +599,7 @@ dwt-discrete-wavelet-transform.html#maximum-decomposition-level\
             raise ValueError('domain Lp exponent is {} instead of 2.0.'
                              ''.format(dom.exponent))
 
-        max_level = pywt.dwt_max_level(dom.grid.shape[0],
+        max_level = pywt.dwt_max_level(dom.shape[0],
                                        filter_len=self.wbasis.dec_len)
         # TODO: maybe the error message could tell how to calculate the
         # max number of levels
@@ -607,7 +607,7 @@ dwt-discrete-wavelet-transform.html#maximum-decomposition-level\
             raise ValueError('Cannot use more than {} scaling levels, '
                              'got {}.'.format(max_level, self.nscales))
 
-        self.size_list = coeff_size_list(dom.grid.shape, self.nscales,
+        self.size_list = coeff_size_list(dom.shape, self.nscales,
                                          self.wbasis, self.mode)
 
         ran_size = np.prod(self.size_list[0])
@@ -763,7 +763,7 @@ dwt-discrete-wavelet-transform.html#maximum-decomposition-level\
             raise ValueError('range Lp exponent is {} instead of 2.0.'
                              ''.format(ran.exponent))
 
-        max_level = pywt.dwt_max_level(ran.grid.shape[0],
+        max_level = pywt.dwt_max_level(ran.shape[0],
                                        filter_len=self.wbasis.dec_len)
         # TODO: maybe the error message could tell how to calculate the
         # max number of levels
@@ -771,7 +771,7 @@ dwt-discrete-wavelet-transform.html#maximum-decomposition-level\
             raise ValueError('Cannot use more than {} scaling levels, '
                              'got {}.'.format(max_level, self.nscales))
 
-        self.size_list = coeff_size_list(ran.grid.shape, self.nscales,
+        self.size_list = coeff_size_list(ran.shape, self.nscales,
                                          self.wbasis, self.mode)
 
         dom_size = np.prod(self.size_list[0])
@@ -814,15 +814,15 @@ dwt-discrete-wavelet-transform.html#maximum-decomposition-level\
         arr : `DiscreteLpVector`
 
         """
-        if len(self.range.grid.shape) == 1:
+        if len(self.range.shape) == 1:
             coeff_list = array_to_pywt_coeff(coeff, self.size_list)
             x = pywt.waverec(coeff_list, self.wbasis, self.mode)
             return self.range.element(x)
-        elif len(self.range.grid.shape) == 2:
+        elif len(self.range.shape) == 2:
             coeff_list = array_to_pywt_coeff(coeff, self.size_list)
             x = pywt.waverec2(coeff_list, self.wbasis, self.mode)
             return self.range.element(x)
-        elif len(self.range.grid.shape) == 3:
+        elif len(self.range.shape) == 3:
             coeff_dict = array_to_pywt_coeff(coeff, self.size_list)
             x = wavelet_reconstruction3d(coeff_dict, self.wbasis, self.mode,
                                          self.nscales)

--- a/odl/util/__init__.py
+++ b/odl/util/__init__.py
@@ -37,4 +37,8 @@ from . import graphics
 from .graphics import *
 __all__ += graphics.__all__
 
+from .import numerics
+from .numerics import *
+__all__ += numerics.__all__
+
 from . import ufuncs

--- a/odl/util/graphics.py
+++ b/odl/util/graphics.py
@@ -162,7 +162,7 @@ def show_discrete_data(values, grid, method='', title=None,
             sub_kwargs.update({'projection': '3d'})
         elif method in ('wireframe', 'plot_wireframe'):
             method = 'plot_wireframe'
-            x, y = grid.meshgrid()
+            x, y = grid.meshgrid
             args_re = [x, y, np.rot90(values.real)]
             args_im = ([x, y, np.rot90(values.imag)] if values_are_complex
                        else [])

--- a/odl/util/numerics.py
+++ b/odl/util/numerics.py
@@ -49,7 +49,10 @@ def apply_on_boundary(array, func, only_once=True, which_boundaries=None,
         skipped.
     only_once : `bool`, optional
         If `True`, ensure that each boundary point appears in exactly
-        one slice.
+        one slice. If ``func`` is a list of functions, the
+        ``axis_order`` determines which functions are applied to nodes
+        which appear in multiple slices, according to the principle
+        "first-come, first-served".
     which_boundaries : `sequence`, optional
         If provided, this sequence determines per axis whether to
         apply the function at the boundaries in each axis. The entry
@@ -119,7 +122,7 @@ def apply_on_boundary(array, func, only_once=True, which_boundaries=None,
             slc_l = [slice(None)] * array.ndim
             slc_r = [slice(None)] * array.ndim
 
-        # slc_l and slc_r select left and right boundary in this axis, resp.
+        # slc_l and slc_r select left and right boundary, resp, in this axis.
         slc_l[ax] = 0
         slc_r[ax] = -1
 
@@ -149,6 +152,8 @@ def apply_on_boundary(array, func, only_once=True, which_boundaries=None,
         else:
             end = None
 
+        # Write the information for the processed axis into the slice list.
+        # Start and end include the boundary if it was processed.
         slices[ax] = slice(start, end)
 
 if __name__ == '__main__':

--- a/odl/util/numerics.py
+++ b/odl/util/numerics.py
@@ -108,10 +108,8 @@ def apply_on_boundary(array, func, only_once=True, which_boundaries=None,
     for ax, function, which in zip(axis_order, func, which_boundaries):
         # Make slices selecting left and right
         if only_once:
-            # Exclude first and last in the dimensions which have already
-            # been processed
-            slc_l = slices.copy()
-            slc_r = slices.copy()
+            slc_l = list(slices)  # Make a copy; copy() exists in Py3 only
+            slc_r = list(slices)
         else:
             slc_l = [slice(None)] * array.ndim
             slc_r = [slice(None)] * array.ndim

--- a/odl/util/numerics.py
+++ b/odl/util/numerics.py
@@ -1,0 +1,152 @@
+﻿# Copyright 2014-2016 The ODL development group
+#
+# This file is part of ODL.
+#
+# ODL is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# ODL is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with ODL.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Numerical helper functions for convenience or speed."""
+
+
+# Imports for common Python 2/3 codebase
+from __future__ import print_function, division, absolute_import
+
+from future import standard_library
+standard_library.install_aliases()
+
+# External module imports
+
+
+__all__ = ('apply_on_boundary',)
+
+
+def apply_on_boundary(array, func, only_once=True, which_boundaries=None,
+                      axis_order=None):
+    """Apply a function of the boundary of an n-dimensional array.
+
+    Parameters
+    ----------
+    array : `numpy.ndarray`
+        Modify the boundary of this array in place
+    func : callable or sequence
+        If a single function is given, assign
+        ``array[slice] = func(array[slice])`` on the boundary slices,
+        e.g. use ``lamda x: x / 2`` to divide values by 2.
+        A sequence of functions is applied per axis separately. It
+        must have length ``array.ndim`` and may consist of one function
+        or a 2-tuple of functions per axis.
+    only_once : `bool`, optional
+        If `True`, ensure that each boundary point appears in exactly
+        one slice.
+    which_boundaries : sequence, optional
+        If provided, this sequence determines per axis whether to
+        apply the function at the boundaries in each axis. The entry
+        in each axis may consist in a single `bool` or a 2-tuple of
+        `bool`. In the latter case, the first tuple entry decides for
+        the left, the second for the right boundary. The length of the
+        sequence must be ``array.ndim``. `None` is interpreted as
+        'all boundaries'.
+    axis_order : sequence of `int`
+        Permutation of ``range(array.ndim)`` defining the order in which
+        to process the axes. If combined with ``only_once`` and a
+        function list, this determines which function is evaluated in
+        the points that are potentially processed multiple times.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> arr = np.ones((3, 3))
+    >>> apply_on_boundary(arr, lambda x: x / 2)
+    >>> arr
+    array([[ 0.5,  0.5,  0.5],
+           [ 0.5,  1. ,  0.5],
+           [ 0.5,  0.5,  0.5]])
+    >>>
+    >>> arr = np.ones((3, 3))
+    >>> apply_on_boundary(arr, lambda x: x / 2, only_once=False)
+    >>> arr
+    array([[ 0.25,  0.5 ,  0.25],
+           [ 0.5 ,  1.  ,  0.5 ],
+           [ 0.25,  0.5 ,  0.25]])
+    >>> arr = np.ones((3, 3))
+    >>> apply_on_boundary(arr, lambda x: x / 2, only_once=True,
+    ...                   which_boundaries=((True, False), True))
+    >>> arr
+    array([[ 0.5,  0.5,  0.5],
+           [ 0.5,  1. ,  0.5],
+           [ 0.5,  1. ,  0.5]])
+    """
+    if callable(func):
+        func = [func] * array.ndim
+    elif len(func) != array.ndim:
+        raise ValueError('sequence of functions has length {}, expected {}.'
+                         ''.format(len(func), array.ndim))
+
+    if which_boundaries is None:
+        which_boundaries = ([(True, True)] * array.ndim)
+    elif len(which_boundaries) != array.ndim:
+        raise ValueError('which_boundaries has length {}, expected {}.'
+                         ''.format(len(which_boundaries), array.ndim))
+
+    if axis_order is None:
+        axis_order = list(range(array.ndim))
+    elif len(axis_order) != array.ndim:
+        raise ValueError('axis_order has length {}, expected {}.'
+                         ''.format(len(axis_order), array.ndim))
+
+    slices = [slice(None)] * array.ndim
+    for ax, function, which in zip(axis_order, func, which_boundaries):
+        # Make slices selecting left and right
+        if only_once:
+            # Exclude first and last in the dimensions which have already
+            # been processed
+            slc_l = slices.copy()
+            slc_r = slices.copy()
+        else:
+            slc_l = [slice(None)] * array.ndim
+            slc_r = [slice(None)] * array.ndim
+
+        slc_l[ax] = 0
+        slc_r[ax] = -1
+
+        try:
+            # Tuple of functions in this axis
+            func_l, func_r = function
+        except TypeError:
+            # Single function
+            func_l = func_r = function
+
+        try:
+            # Tuple of bool
+            mod_left, mod_right = which
+        except TypeError:
+            # Single bool
+            mod_left = mod_right = which
+
+        if mod_left:
+            array[slc_l] = func_l(array[slc_l])
+            start = 1
+        else:
+            start = None
+
+        if mod_right:
+            array[slc_r] = func_r(array[slc_r])
+            end = -1
+        else:
+            end = None
+
+        slices[ax] = slice(start, end)
+
+if __name__ == '__main__':
+    from doctest import testmod, NORMALIZE_WHITESPACE
+    testmod(optionflags=NORMALIZE_WHITESPACE)

--- a/odl/util/numerics.py
+++ b/odl/util/numerics.py
@@ -24,6 +24,8 @@ from __future__ import print_function, division, absolute_import
 from future import standard_library
 standard_library.install_aliases()
 
+import numpy as np
+
 
 __all__ = ('apply_on_boundary',)
 
@@ -36,7 +38,7 @@ def apply_on_boundary(array, func, only_once=True, which_boundaries=None,
 
     Parameters
     ----------
-    array : `numpy.ndarray`
+    array : array-like
         Modify the boundary of this array
     func : `callable` or `sequence`
         If a single function is given, assign
@@ -103,6 +105,8 @@ def apply_on_boundary(array, func, only_once=True, which_boundaries=None,
     >>> result is out
     True
     """
+    array = np.asarray(array)
+
     if callable(func):
         func = [func] * array.ndim
     elif len(func) != array.ndim:

--- a/odl/util/numerics.py
+++ b/odl/util/numerics.py
@@ -63,12 +63,12 @@ def apply_on_boundary(array, func, only_once=True, which_boundaries=None,
         the left, the second for the right boundary. The length of the
         sequence must be ``array.ndim``. `None` is interpreted as
         'all boundaries'.
-    axis_order : `sequence` of `int`
+    axis_order : `sequence` of `int`, optional
         Permutation of ``range(array.ndim)`` defining the order in which
         to process the axes. If combined with ``only_once`` and a
         function list, this determines which function is evaluated in
         the points that are potentially processed multiple times.
-    out : `numpy.ndarray`
+    out : `numpy.ndarray`, optional
         Location in which to store the result, can be the same as ``array``.
         Default: copy of ``array``
 

--- a/odl/util/phantom.py
+++ b/odl/util/phantom.py
@@ -269,7 +269,7 @@ def _phantom_3d(space, ellipses):
     p = np.zeros(space.shape)
 
     # Create the pixel grid
-    grid_in = space.grid.meshgrid()
+    grid_in = space.grid.meshgrid
     minp = space.grid.min()
     maxp = space.grid.max()
 

--- a/odl/util/phantom.py
+++ b/odl/util/phantom.py
@@ -449,8 +449,8 @@ def _submarine_phantom_2d_smooth(discr, taper):
         ``(0.8, 0.28)``. For other domains, the values are scaled
         accordingly.
         """
-        halfaxes = np.array([0.8, 0.28]) * discr.domain.extent / 2
-        center = np.array([0.2, -0.4]) * discr.domain.extent / 2
+        halfaxes = np.array([0.8, 0.28]) * discr.domain.extent() / 2
+        center = np.array([0.2, -0.4]) * discr.domain.extent() / 2
 
         # Efficiently calculate |z|^2, z = (x - center) / radii
         sq_ndist = np.zeros_like(x[0])
@@ -470,8 +470,8 @@ def _submarine_phantom_2d_smooth(discr, taper):
         ``(0.52, 0.2)``. For other domains, the values are scaled
         accordingly.
         """
-        xlower = np.array([0.12, -0.2]) * discr.domain.extent / 2
-        xupper = np.array([0.52, 0.2]) * discr.domain.extent / 2
+        xlower = np.array([0.12, -0.2]) * discr.domain.extent() / 2
+        xupper = np.array([0.52, 0.2]) * discr.domain.extent() / 2
 
         out = np.ones_like(x[0])
         for xi, low, upp in zip(x, xlower, xupper):
@@ -496,8 +496,8 @@ def _submarine_phantom_2d_nonsmooth(discr):
         ``(0.8, 0.28)``. For other domains, the values are scaled
         accordingly.
         """
-        halfaxes = np.array([0.8, 0.28]) * discr.domain.extent / 2
-        center = np.array([0.2, -0.4]) * discr.domain.extent / 2
+        halfaxes = np.array([0.8, 0.28]) * discr.domain.extent() / 2
+        center = np.array([0.2, -0.4]) * discr.domain.extent() / 2
 
         sq_ndist = np.zeros_like(x[0])
         for xi, rad, cen in zip(x, halfaxes, center):
@@ -513,8 +513,8 @@ def _submarine_phantom_2d_nonsmooth(discr):
         ``(0.52, 0.2)``. For other domains, the values are scaled
         accordingly.
         """
-        xlower = np.array([0.12, -0.2]) * discr.domain.extent / 2
-        xupper = np.array([0.52, 0.2]) * discr.domain.extent / 2
+        xlower = np.array([0.12, -0.2]) * discr.domain.extent() / 2
+        xupper = np.array([0.52, 0.2]) * discr.domain.extent() / 2
 
         out = np.ones_like(x[0])
         for xi, low, upp in zip(x, xlower, xupper):

--- a/odl/util/vectorization.py
+++ b/odl/util/vectorization.py
@@ -44,7 +44,7 @@ def is_valid_input_array(x, ndim=None):
 
 
 def is_valid_input_meshgrid(x, ndim):
-    """Test if ``x`` is a meshgrid sequence for points in R^d."""
+    """Test if ``x`` is a `meshgrid` sequence for points in R^d."""
     # This case is triggered in FunctionSetVector.__call__ if the
     # domain does not have an 'ndim' attribute. We return False and
     # continue.
@@ -70,7 +70,7 @@ def is_valid_input_meshgrid(x, ndim):
 
 
 def out_shape_from_meshgrid(mesh):
-    """Get the broadcast output shape from a meshgrid."""
+    """Get the broadcast output shape from a `meshgrid`."""
     if len(mesh) == 1:
         return (len(mesh[0]),)
     else:
@@ -175,12 +175,12 @@ class OptionalArgDecorator(object):
 
         Parameters
         ----------
-        func : callable
+        func : `callable`
             Original function to be wrapped
 
         Returns
         -------
-        wrapped : callable
+        wrapped : `callable`
             The wrapped function
         """
         return self._wrapper(func, *self.wrapper_args, **self.wrapper_kwargs)
@@ -252,7 +252,7 @@ class _NumpyVectorizeWrapper(object):
 
         Parameters
         ----------
-        func : callable
+        func : `callable`
             Python function or method to be wrapped
         vect_args :
             positional arguments for `numpy.vectorize`
@@ -269,7 +269,7 @@ class _NumpyVectorizeWrapper(object):
 
         Parameters
         ----------
-        x : array-like or sequence of array-like
+        x : `array-like` or `sequence` of `array-like`
             Input argument(s) to the wrapped function
         out : `numpy.ndarray`, optional
             Appropriately sized array to write to

--- a/test/discr/discr_mappings_test.py
+++ b/test/discr/discr_mappings_test.py
@@ -37,7 +37,7 @@ from odl.util.testutils import all_almost_equal, all_equal, almost_equal
 
 def test_nearest_interpolation_1d_complex():
     intv = odl.Interval(0, 1)
-    part = odl.uniform_partition(intv, 5, nodes_on_bdry=False)
+    part = odl.uniform_partition_fromintv(intv, 5, nodes_on_bdry=False)
     # Coordinate vectors are:
     # [0.1, 0.3, 0.5, 0.7, 0.9]
 
@@ -70,7 +70,7 @@ def test_nearest_interpolation_1d_complex():
 
 def test_nearest_interpolation_1d_variants():
     intv = odl.Interval(0, 1)
-    part = odl.uniform_partition(intv, 5, nodes_on_bdry=False)
+    part = odl.uniform_partition_fromintv(intv, 5, nodes_on_bdry=False)
     # Coordinate vectors are:
     # [0.1, 0.3, 0.5, 0.7, 0.9]
 
@@ -98,7 +98,7 @@ def test_nearest_interpolation_1d_variants():
 
 def test_nearest_interpolation_2d_float():
     rect = odl.Rectangle([0, 0], [1, 1])
-    part = odl.uniform_partition(rect, [4, 2], nodes_on_bdry=False)
+    part = odl.uniform_partition_fromintv(rect, [4, 2], nodes_on_bdry=False)
     # Coordinate vectors are:
     # [0.125, 0.375, 0.625, 0.875], [0.25, 0.75]
 
@@ -131,7 +131,7 @@ def test_nearest_interpolation_2d_float():
 
 def test_nearest_interpolation_2d_string():
     rect = odl.Rectangle([0, 0], [1, 1])
-    part = odl.uniform_partition(rect, [4, 2], nodes_on_bdry=False)
+    part = odl.uniform_partition_fromintv(rect, [4, 2], nodes_on_bdry=False)
     # Coordinate vectors are:
     # [0.125, 0.375, 0.625, 0.875], [0.25, 0.75]
 
@@ -165,7 +165,7 @@ def test_nearest_interpolation_2d_string():
 
 def test_linear_interpolation_1d():
     intv = odl.Interval(0, 1)
-    part = odl.uniform_partition(intv, 5, nodes_on_bdry=False)
+    part = odl.uniform_partition_fromintv(intv, 5, nodes_on_bdry=False)
     # Coordinate vectors are:
     # [0.1, 0.3, 0.5, 0.7, 0.9]
 
@@ -187,7 +187,7 @@ def test_linear_interpolation_1d():
 
 def test_linear_interpolation_2d():
     rect = odl.Rectangle([0, 0], [1, 1])
-    part = odl.uniform_partition(rect, [4, 2], nodes_on_bdry=False)
+    part = odl.uniform_partition_fromintv(rect, [4, 2], nodes_on_bdry=False)
     # Coordinate vectors are:
     # [0.125, 0.375, 0.625, 0.875], [0.25, 0.75]
 
@@ -256,7 +256,7 @@ def test_linear_interpolation_2d():
 
 def test_per_axis_interpolation():
     rect = odl.Rectangle([0, 0], [1, 1])
-    part = odl.uniform_partition(rect, [4, 2], nodes_on_bdry=False)
+    part = odl.uniform_partition_fromintv(rect, [4, 2], nodes_on_bdry=False)
     # Coordinate vectors are:
     # [0.125, 0.375, 0.625, 0.875], [0.25, 0.75]
 
@@ -315,7 +315,7 @@ def test_collocation_interpolation_identity():
     # Check if interpolation followed by collocation on the same grid
     # is the identity
     rect = odl.Rectangle([0, 0], [1, 1])
-    part = odl.uniform_partition(rect, [4, 2])
+    part = odl.uniform_partition_fromintv(rect, [4, 2])
     space = odl.FunctionSpace(rect)
     dspace = odl.Rn(part.size)
 

--- a/test/discr/discr_mappings_test.py
+++ b/test/discr/discr_mappings_test.py
@@ -315,24 +315,23 @@ def test_collocation_interpolation_identity():
     # Check if interpolation followed by collocation on the same grid
     # is the identity
     rect = odl.Rectangle([0, 0], [1, 1])
-    part_c = odl.uniform_partition(rect, [4, 2], order='C')
-    part_f = odl.uniform_partition(rect, [4, 2], order='F')
+    part = odl.uniform_partition(rect, [4, 2])
     space = odl.FunctionSpace(rect)
-    dspace = odl.Rn(part_c.size)
+    dspace = odl.Rn(part.size)
 
-    coll_op_c = PointCollocation(space, part_c, dspace)
-    coll_op_f = PointCollocation(space, part_f, dspace)
+    coll_op_c = PointCollocation(space, part, dspace, order='C')
+    coll_op_f = PointCollocation(space, part, dspace, order='F')
     interp_ops_c = [
-        NearestInterpolation(space, part_c, dspace, variant='left'),
-        NearestInterpolation(space, part_c, dspace, variant='right'),
-        LinearInterpolation(space, part_c, dspace),
-        PerAxisInterpolation(space, part_c, dspace,
+        NearestInterpolation(space, part, dspace, variant='left', order='C'),
+        NearestInterpolation(space, part, dspace, variant='right', order='C'),
+        LinearInterpolation(space, part, dspace, order='C'),
+        PerAxisInterpolation(space, part, dspace, order='C',
                              schemes=['linear', 'nearest'])]
     interp_ops_f = [
-        NearestInterpolation(space, part_f, dspace, variant='left'),
-        NearestInterpolation(space, part_f, dspace, variant='right'),
-        LinearInterpolation(space, part_f, dspace),
-        PerAxisInterpolation(space, part_f, dspace,
+        NearestInterpolation(space, part, dspace, variant='left', order='F'),
+        NearestInterpolation(space, part, dspace, variant='right', order='F'),
+        LinearInterpolation(space, part, dspace, order='F'),
+        PerAxisInterpolation(space, part, dspace, order='F',
                              schemes=['linear', 'nearest'])]
 
     values = np.arange(1, 9, dtype='float64')

--- a/test/discr/discr_ops_test.py
+++ b/test/discr/discr_ops_test.py
@@ -29,10 +29,8 @@ import pytest
 
 # ODL imports
 import odl
-from odl.discr.lp_discr import uniform_discr
 from odl.discr.discr_ops import (finite_diff, PartialDerivative,
                                  Gradient, Divergence)
-from odl.space.ntuples import Rn
 from odl.util.testutils import almost_equal, all_equal, skip_if_no_cuda
 
 
@@ -146,7 +144,7 @@ def test_backward_diff():
 def test_discr_part_deriv():
     """Discretized partial derivative."""
 
-    discr_space = Rn(1)
+    discr_space = odl.Rn(1)
     with pytest.raises(TypeError):
         PartialDerivative(discr_space)
 
@@ -175,7 +173,7 @@ def test_discr_part_deriv():
     assert (dfe0 != dfe1).any()
 
     # discretized space
-    discr_space = uniform_discr([0, 0], [2, 1], data.shape)
+    discr_space = odl.uniform_discr([0, 0], [2, 1], data.shape)
 
     # operator
     partial_0 = PartialDerivative(discr_space, axis=0, zero_padding=True)
@@ -217,7 +215,7 @@ def test_discr_part_deriv_cuda():
     dfe[-1] = -data[-2] / 2.0
 
     # discretized space using CUDA
-    discr_space = uniform_discr(0, data.size, data.shape, impl='cuda')
+    discr_space = odl.uniform_discr(0, data.size, data.shape, impl='cuda')
 
     # operator
     partial = PartialDerivative(discr_space, zero_padding=True)
@@ -255,7 +253,7 @@ def ndvolume(lin_size, ndim, dtype=np.float64):
 def test_discrete_gradient():
     """Discretized spatial gradient operator."""
 
-    discr_space = Rn(1)
+    discr_space = odl.Rn(1)
     with pytest.raises(TypeError):
         Gradient(discr_space)
 
@@ -270,11 +268,11 @@ def test_discrete_gradient():
                      [0., 1., 2., 3., 4.]])
 
     # DiscreteLp Vector
-    discr_space = uniform_discr([0, 0], [6, 2.5], data.shape)
+    discr_space = odl.uniform_discr([0, 0], [6, 2.5], data.shape)
     dom_vec = discr_space.element(data)
 
     # computation of gradient components with helper function
-    dx0, dx1 = discr_space.stride
+    dx0, dx1 = discr_space.cell_size
     df0 = finite_diff(data, axis=0, dx=dx0, zero_padding=True, edge_order=2)
     df1 = finite_diff(data, axis=1, dx=dx1, zero_padding=True, edge_order=2)
 
@@ -299,8 +297,8 @@ def test_discrete_gradient():
     for ndim in range(1, 6):
 
         # DiscreteLp Vector
-        discr_space = uniform_discr([0.] * ndim, [lin_size] * ndim,
-                                    [lin_size] * ndim)
+        discr_space = odl.uniform_discr([0.] * ndim, [lin_size] * ndim,
+                                        [lin_size] * ndim)
         dom_vec = discr_space.element(ndvolume(lin_size, ndim))
 
         # gradient
@@ -319,11 +317,11 @@ def test_discrete_gradient_cuda():
                      [2., 3., 4., 5., 6.]])
 
     # DiscreteLp Vector
-    discr_space = uniform_discr([0, 0], [6, 2.5], data.shape, impl='cuda')
+    discr_space = odl.uniform_discr([0, 0], [6, 2.5], data.shape, impl='cuda')
     dom_vec = discr_space.element(data)
 
     # computation of gradient components with helper function
-    dx0, dx1 = discr_space.stride
+    dx0, dx1 = discr_space.cell_size
     df0 = finite_diff(data, axis=0, dx=dx0, zero_padding=True, edge_order=2)
     df1 = finite_diff(data, axis=1, dx=dx1, zero_padding=True, edge_order=2)
 
@@ -348,7 +346,7 @@ def test_discrete_divergence():
     """Discretized spatial divergence operator."""
 
     # Invalid arguments
-    discr_space = Rn(1)
+    discr_space = odl.Rn(1)
     with pytest.raises(TypeError):
         Divergence(discr_space)
 
@@ -358,7 +356,7 @@ def test_discrete_divergence():
                      [2., 3., 4., 5., 6.]])
 
     # DiscreteLp
-    discr_space = uniform_discr([0, 0], [6, 2.5], data.shape)
+    discr_space = odl.uniform_discr([0, 0], [6, 2.5], data.shape)
 
     # Operator instance
     div = Divergence(discr_space)
@@ -368,7 +366,7 @@ def test_discrete_divergence():
     div_dom_vec = div(dom_vec)
 
     # computation of divergence with helper function
-    dx0, dx1 = discr_space.stride
+    dx0, dx1 = discr_space.cell_size
     df0 = finite_diff(data, axis=0, dx=dx0, zero_padding=True, edge_order=2)
     df1 = finite_diff(data, axis=1, dx=dx1, zero_padding=True, edge_order=2)
 
@@ -390,8 +388,8 @@ def test_discrete_divergence():
     for ndim in range(1, 6):
         # DiscreteLp Vector
         lin_size = 3
-        discr_space = uniform_discr([0.] * ndim, [lin_size] * ndim,
-                                    [lin_size] * ndim)
+        discr_space = odl.uniform_discr([0.] * ndim, [lin_size] * ndim,
+                                        [lin_size] * ndim)
         # Divergence
         div = Divergence(discr_space)
         dom_vec = div.domain.element([ndvolume(lin_size, ndim)] * ndim)
@@ -409,7 +407,7 @@ def test_discrete_divergence_cuda():
                      [2., 3., 4., 5., 6.]])
 
     # DiscreteLp
-    discr_space = uniform_discr([0, 0], [1.5, 10], data.shape, impl='cuda')
+    discr_space = odl.uniform_discr([0, 0], [1.5, 10], data.shape, impl='cuda')
 
     # operator instance
     div = Divergence(discr_space)
@@ -419,7 +417,7 @@ def test_discrete_divergence_cuda():
     div_dom_vec = div(dom_vec)
 
     # computation of divergence with helper function
-    dx0, dx1 = discr_space.stride
+    dx0, dx1 = discr_space.cell_size
     df0 = finite_diff(data, axis=0, dx=dx0, zero_padding=True, edge_order=2)
     df1 = finite_diff(data, axis=1, dx=dx1, zero_padding=True, edge_order=2)
 

--- a/test/discr/discr_ops_test.py
+++ b/test/discr/discr_ops_test.py
@@ -272,7 +272,7 @@ def test_discrete_gradient():
     dom_vec = discr_space.element(data)
 
     # computation of gradient components with helper function
-    dx0, dx1 = discr_space.cell_size
+    dx0, dx1 = discr_space.cell_sides
     df0 = finite_diff(data, axis=0, dx=dx0, zero_padding=True, edge_order=2)
     df1 = finite_diff(data, axis=1, dx=dx1, zero_padding=True, edge_order=2)
 
@@ -321,7 +321,7 @@ def test_discrete_gradient_cuda():
     dom_vec = discr_space.element(data)
 
     # computation of gradient components with helper function
-    dx0, dx1 = discr_space.cell_size
+    dx0, dx1 = discr_space.cell_sides
     df0 = finite_diff(data, axis=0, dx=dx0, zero_padding=True, edge_order=2)
     df1 = finite_diff(data, axis=1, dx=dx1, zero_padding=True, edge_order=2)
 
@@ -366,7 +366,7 @@ def test_discrete_divergence():
     div_dom_vec = div(dom_vec)
 
     # computation of divergence with helper function
-    dx0, dx1 = discr_space.cell_size
+    dx0, dx1 = discr_space.cell_sides
     df0 = finite_diff(data, axis=0, dx=dx0, zero_padding=True, edge_order=2)
     df1 = finite_diff(data, axis=1, dx=dx1, zero_padding=True, edge_order=2)
 
@@ -417,7 +417,7 @@ def test_discrete_divergence_cuda():
     div_dom_vec = div(dom_vec)
 
     # computation of divergence with helper function
-    dx0, dx1 = discr_space.cell_size
+    dx0, dx1 = discr_space.cell_sides
     df0 = finite_diff(data, axis=0, dx=dx0, zero_padding=True, edge_order=2)
     df1 = finite_diff(data, axis=1, dx=dx1, zero_padding=True, edge_order=2)
 

--- a/test/discr/discr_ops_test.py
+++ b/test/discr/discr_ops_test.py
@@ -274,7 +274,7 @@ def test_discrete_gradient():
     dom_vec = discr_space.element(data)
 
     # computation of gradient components with helper function
-    dx0, dx1 = discr_space.grid.stride
+    dx0, dx1 = discr_space.stride
     df0 = finite_diff(data, axis=0, dx=dx0, zero_padding=True, edge_order=2)
     df1 = finite_diff(data, axis=1, dx=dx1, zero_padding=True, edge_order=2)
 
@@ -323,7 +323,7 @@ def test_discrete_gradient_cuda():
     dom_vec = discr_space.element(data)
 
     # computation of gradient components with helper function
-    dx0, dx1 = discr_space.grid.stride
+    dx0, dx1 = discr_space.stride
     df0 = finite_diff(data, axis=0, dx=dx0, zero_padding=True, edge_order=2)
     df1 = finite_diff(data, axis=1, dx=dx1, zero_padding=True, edge_order=2)
 
@@ -368,7 +368,7 @@ def test_discrete_divergence():
     div_dom_vec = div(dom_vec)
 
     # computation of divergence with helper function
-    dx0, dx1 = discr_space.grid.stride
+    dx0, dx1 = discr_space.stride
     df0 = finite_diff(data, axis=0, dx=dx0, zero_padding=True, edge_order=2)
     df1 = finite_diff(data, axis=1, dx=dx1, zero_padding=True, edge_order=2)
 
@@ -419,7 +419,7 @@ def test_discrete_divergence_cuda():
     div_dom_vec = div(dom_vec)
 
     # computation of divergence with helper function
-    dx0, dx1 = discr_space.grid.stride
+    dx0, dx1 = discr_space.stride
     df0 = finite_diff(data, axis=0, dx=dx0, zero_padding=True, edge_order=2)
     df1 = finite_diff(data, axis=1, dx=dx1, zero_padding=True, edge_order=2)
 

--- a/test/discr/grid_test.py
+++ b/test/discr/grid_test.py
@@ -428,12 +428,12 @@ def test_tensorgrid_meshgrid():
     mgz = np.array(vec3)[None, None, :]
 
     grid = TensorGrid(vec1, vec2, vec3)
-    xx, yy, zz = grid.meshgrid()
+    xx, yy, zz = grid.meshgrid
     assert all_equal(mgx, xx)
     assert all_equal(mgy, yy)
     assert all_equal(mgz, zz)
 
-    xx, yy, zz = grid.meshgrid()
+    xx, yy, zz = grid.meshgrid
     assert all_equal(mgx, xx)
     assert all_equal(mgy, yy)
     assert all_equal(mgz, zz)

--- a/test/discr/grid_test.py
+++ b/test/discr/grid_test.py
@@ -46,8 +46,6 @@ def test_tensorgrid_init():
     TensorGrid(sorted1, sorted1)
     TensorGrid(sorted1, sorted2, sorted3)
     TensorGrid(sorted2, scalar, sorted1)
-    TensorGrid(sorted1, sorted2, order='C')
-    TensorGrid(sorted1, sorted2, order='F')
 
 
 def test_tensorgrid_init_error():
@@ -90,9 +88,6 @@ def test_tensorgrid_init_error():
 
     with pytest.raises(ValueError):
         TensorGrid(sorted1, empty, sorted2)
-
-    with pytest.raises(ValueError):
-        TensorGrid(sorted1, sorted2, order='A')
 
 
 def test_tensorgrid_ndim():
@@ -164,14 +159,12 @@ def test_tensorgrid_equals():
     vec2 = np.array([-4, -2, 0, 2, 4])
 
     grid1 = TensorGrid(vec1)
-    grid1_diff_order = TensorGrid(vec1, order='F')
     grid2 = TensorGrid(vec1, vec2)
     grid2_again = TensorGrid(vec1, vec2)
     grid2_rev = TensorGrid(vec2, vec1)
 
     assert grid1 == grid1
     assert not grid1 != grid1
-    assert grid1 == grid1_diff_order
     assert grid2 == grid2
     assert not grid2 != grid2
     assert grid2 == grid2_again
@@ -434,11 +427,6 @@ def test_tensorgrid_meshgrid():
     assert all_equal(mgx, xx)
     assert all_equal(mgy, yy)
     assert all_equal(mgz, zz)
-
-    # Fortran ordering
-    grid = TensorGrid(vec1, vec2, vec3, order='F')
-    xx, yy, zz = grid.meshgrid()
-    assert all(arr.flags.f_contiguous for arr in (xx, yy, zz))
 
 
 def test_tensorgrid_getitem():
@@ -865,24 +853,17 @@ def test_sparse_meshgrid():
     true_mg = (x,)
     assert all_equal(sparse_meshgrid(x), true_mg)
 
-    # Two arrays, 'C' ordering
+    # Two arrays
     x, y = np.zeros(2), np.zeros(3)
     true_mg = (x[:, None], y[None, :])
-    mg = sparse_meshgrid(x, y, order='C')
+    mg = sparse_meshgrid(x, y)
     assert all_equal(mg, true_mg)
     assert all(vec.flags.c_contiguous for vec in mg)
-
-    # Two arrays, 'F' ordering
-    x, y = np.zeros(2), np.zeros(3)
-    true_mg = (x[None, :], y[:, None])
-    mg = sparse_meshgrid(x, y, order='F')
-    assert all_equal(mg, true_mg)
-    assert all(vec.flags.f_contiguous for vec in mg)
 
     # Array-like input
     x, y = [1, 2, 3], [4, 5, 6]
     true_mg = (np.array(x)[:, None], np.array(y)[None, :])
-    mg = sparse_meshgrid(x, y, order='C')
+    mg = sparse_meshgrid(x, y)
     assert all_equal(mg, true_mg)
     assert all(vec.flags.c_contiguous for vec in mg)
 

--- a/test/discr/grid_test.py
+++ b/test/discr/grid_test.py
@@ -35,8 +35,8 @@ from odl.util.testutils import all_equal
 
 
 def test_tensorgrid_init():
-    sorted1 = np.arange(2, 6)
-    sorted2 = np.arange(-4, 5, 2)
+    sorted1 = np.array([2, 3, 4, 5])
+    sorted2 = np.array([-4, -2, 0, 2, 4])
     sorted3 = np.linspace(-1, 2, 50)
     scalar = 0.5
 
@@ -54,8 +54,8 @@ def test_tensorgrid_init_error():
     # Check different error scenarios
 
     # Good input
-    sorted1 = np.arange(2, 6)
-    sorted2 = np.arange(-4, 5, 2)
+    sorted1 = np.array([2, 3, 4, 5])
+    sorted2 = np.array([-4, -2, 0, 2, 4])
 
     # Bad input
     unsorted = np.arange(4)
@@ -96,8 +96,8 @@ def test_tensorgrid_init_error():
 
 
 def test_tensorgrid_ndim():
-    vec1 = np.arange(2, 6)
-    vec2 = np.arange(-4, 5, 2)
+    vec1 = np.array([2, 3, 4, 5])
+    vec2 = np.array([-4, -2, 0, 2, 4])
     vec3 = np.linspace(-2, 2, 50)
 
     grid1 = TensorGrid(vec1)
@@ -108,7 +108,7 @@ def test_tensorgrid_ndim():
 
 
 def test_tensorgrid_shape():
-    vec1 = np.arange(2, 6)
+    vec1 = np.array([2, 3, 4, 5])
     vec2 = np.linspace(-2, 2, 50)
     scalar = 0.5
 
@@ -122,7 +122,7 @@ def test_tensorgrid_shape():
 
 
 def test_tensorgrid_size():
-    vec1 = np.arange(2, 6)
+    vec1 = np.array([2, 3, 4, 5])
     vec2 = np.linspace(-2, 2, 50)
     scalar = 0.5
 
@@ -136,9 +136,9 @@ def test_tensorgrid_size():
 
 
 def test_tensorgrid_minpt_maxpt():
-    vec1 = np.arange(2, 6)
-    vec2 = np.arange(-4, 5, 2)
-    vec3 = np.arange(-1, 1)
+    vec1 = np.array([2, 3, 4, 5])
+    vec2 = np.array([-4, -2, 0, 2, 4])
+    vec3 = np.array([-1, 0])
     scalar = 0.5
 
     grid = TensorGrid(vec1, vec2, vec3)
@@ -151,8 +151,8 @@ def test_tensorgrid_minpt_maxpt():
 
 
 def test_tensorgrid_element():
-    vec1 = np.arange(2, 6)
-    vec2 = np.arange(-4, 5, 2)
+    vec1 = np.array([2, 3, 4, 5])
+    vec2 = np.array([-4, -2, 0, 2, 4])
 
     grid = TensorGrid(vec1, vec2)
     some_pt = grid.element()
@@ -161,9 +161,9 @@ def test_tensorgrid_element():
 
 # TODO: move to Partition tests
 #def test_min_max():
-#    vec1 = np.arange(2, 6)
-#    vec2 = np.arange(-4, 5, 2)
-#    vec3 = np.arange(-1, 1)
+#    vec1 = np.array([2, 3, 4, 5])
+#    vec2 = np.array([-4, -2, 0, 2, 4])
+#    vec3 = np.array([-1, 0])
 #    scalar = 0.5
 #
 #    grid = TensorGrid(vec1, vec2, vec3, as_midp=False)
@@ -184,8 +184,8 @@ def test_tensorgrid_element():
 
 
 def test_tensorgrid_equals():
-    vec1 = np.arange(2, 6)
-    vec2 = np.arange(-4, 5, 2)
+    vec1 = np.array([2, 3, 4, 5])
+    vec2 = np.array([-4, -2, 0, 2, 4])
 
     grid1 = TensorGrid(vec1)
     grid1_diff_order = TensorGrid(vec1, order='F')
@@ -219,8 +219,8 @@ def test_tensorgrid_equals():
 
 
 def test_tensorgrid_contains():
-    vec1 = np.arange(2, 6)
-    vec2 = np.arange(-4, 5, 2)
+    vec1 = np.array([2, 3, 4, 5])
+    vec2 = np.array([-4, -2, 0, 2, 4])
 
     grid = TensorGrid(vec1, vec2)
 
@@ -246,11 +246,11 @@ def test_tensorgrid_contains():
 
 
 def test_tensorgrid_is_subgrid():
-    vec1 = np.arange(2, 6)
-    vec1_sup = np.arange(2, 8)
-    vec2 = np.arange(-4, 5, 2)
-    vec2_sup = np.arange(-6, 7, 2)
-    vec2_sub = np.arange(-4, 3, 2)
+    vec1 = np.array([2, 3, 4, 5])
+    vec1_sup = np.array([2, 3, 4, 5, 6, 7])
+    vec2 = np.array([-4, -2, 0, 2, 4])
+    vec2_sup = np.array([-6, -4, -2, 0, 2, 4, 6])
+    vec2_sub = np.array([-4, -2, 0, 2])
     scalar = 0.5
 
     grid = TensorGrid(vec1, vec2)
@@ -289,9 +289,9 @@ def test_tensorgrid_is_subgrid():
 
 
 def test_tensorgrid_insert():
-    vec1 = np.arange(2, 6)
-    vec2 = np.arange(-4, 5, 2)
-    vec3 = np.arange(-1, 1)
+    vec1 = np.array([2, 3, 4, 5])
+    vec2 = np.array([-4, -2, 0, 2, 4])
+    vec3 = np.array([-1, 0])
     scalar = 0.5
 
     grid = TensorGrid(vec1, vec2)
@@ -318,8 +318,8 @@ def test_tensorgrid_insert():
 
 
 def test_tensorgrid_points():
-    vec1 = np.arange(2, 6)
-    vec2 = np.arange(-4, 5, 2)
+    vec1 = np.array([2, 3, 4, 5])
+    vec2 = np.array([-4, -2, 0, 2, 4])
     scalar = 0.5
 
     # C ordering
@@ -372,9 +372,9 @@ def test_tensorgrid_points():
 
 
 def test_tensorgrid_corners():
-    vec1 = np.arange(2, 6)
-    vec2 = np.arange(-4, 5, 2)
-    vec3 = np.arange(-1, 1)
+    vec1 = np.array([2, 3, 4, 5])
+    vec2 = np.array([-4, -2, 0, 2, 4])
+    vec3 = np.array([-1, 0])
     scalar = 0.5
 
     minmax1 = (vec1[0], vec1[-1])

--- a/test/discr/grid_test.py
+++ b/test/discr/grid_test.py
@@ -288,6 +288,35 @@ def test_tensorgrid_is_subgrid():
     assert grid.is_subgrid(fuzzy_sup_grid, atol=0.15)
 
 
+def test_tensorgrid_insert():
+    vec1 = np.arange(2, 6)
+    vec2 = np.arange(-4, 5, 2)
+    vec3 = np.arange(-1, 1)
+    scalar = 0.5
+
+    grid = TensorGrid(vec1, vec2)
+    grid2 = TensorGrid(scalar, vec3)
+
+    # Test all positions
+    ins_grid = grid.insert(0, grid2)
+    assert ins_grid == TensorGrid(scalar, vec3, vec1, vec2)
+
+    ins_grid = grid.insert(1, grid2)
+    assert ins_grid == TensorGrid(vec1, scalar, vec3, vec2)
+
+    ins_grid = grid.insert(2, grid2)
+    assert ins_grid == TensorGrid(vec1, vec2, scalar, vec3)
+
+    ins_grid = grid.insert(-1, grid2)
+    assert ins_grid == TensorGrid(vec1, scalar, vec3, vec2)
+
+    with pytest.raises(IndexError):
+        grid.insert(3, grid2)
+
+    with pytest.raises(IndexError):
+        grid.insert(-4, grid2)
+
+
 def test_tensorgrid_points():
     vec1 = np.arange(2, 6)
     vec2 = np.arange(-4, 5, 2)
@@ -436,7 +465,7 @@ def test_tensorgrid_meshgrid():
     assert all(arr.flags.f_contiguous for arr in (xx, yy, zz))
 
 
-def test_tensor_getitem():
+def test_tensorgrid_getitem():
     vec1 = (0, 1)
     vec2 = (-1, 0, 1)
     vec3 = (2, 3, 4, 5)
@@ -774,6 +803,53 @@ def test_regulargrid_is_subgrid():
                                  shape_sup)
     assert grid.is_subgrid(fuzzy_sup_grid, atol=0.015)
     assert not grid.is_subgrid(fuzzy_sup_grid, atol=0.005)
+
+
+def test_regulargrid_insert():
+    minpt = (0.75, 0, -5)
+    maxpt = (1.25, 0, 1)
+    shape = (2, 1, 3)
+
+    minpt2 = (1, 1)
+    maxpt2 = (3, 1)
+    shape2 = (5, 1)
+
+    grid = RegularGrid(minpt, maxpt, shape)
+    grid2 = RegularGrid(minpt2, maxpt2, shape2)
+
+    # Test all positions
+    ins_grid = grid.insert(0, grid2)
+    assert isinstance(ins_grid, RegularGrid)
+    ins_minpt = minpt2 + minpt
+    ins_maxpt = maxpt2 + maxpt
+    ins_shape = shape2 + shape
+    assert ins_grid == RegularGrid(ins_minpt, ins_maxpt, ins_shape)
+
+    ins_grid = grid.insert(1, grid2)
+    ins_minpt = minpt[:1] + minpt2 + minpt[1:]
+    ins_maxpt = maxpt[:1] + maxpt2 + maxpt[1:]
+    ins_shape = shape[:1] + shape2 + shape[1:]
+    assert ins_grid == RegularGrid(ins_minpt, ins_maxpt, ins_shape)
+
+    ins_grid = grid.insert(2, grid2)
+    ins_minpt = minpt[:2] + minpt2 + minpt[2:]
+    ins_maxpt = maxpt[:2] + maxpt2 + maxpt[2:]
+    ins_shape = shape[:2] + shape2 + shape[2:]
+    assert ins_grid == RegularGrid(ins_minpt, ins_maxpt, ins_shape)
+    ins_grid = grid.insert(-1, grid2)
+    assert ins_grid == RegularGrid(ins_minpt, ins_maxpt, ins_shape)
+
+    ins_grid = grid.insert(3, grid2)
+    ins_minpt = minpt + minpt2
+    ins_maxpt = maxpt + maxpt2
+    ins_shape = shape + shape2
+    assert ins_grid == RegularGrid(ins_minpt, ins_maxpt, ins_shape)
+
+    with pytest.raises(IndexError):
+        grid.insert(4, grid2)
+
+    with pytest.raises(IndexError):
+        grid.insert(-5, grid2)
 
 
 def test_regulargrid_getitem():

--- a/test/discr/grid_test.py
+++ b/test/discr/grid_test.py
@@ -27,35 +27,37 @@ import pytest
 import numpy as np
 
 # ODL imports
-import odl
 from odl.discr.grid import TensorGrid, RegularGrid, sparse_meshgrid
 from odl.util.testutils import all_equal
 
 
-@pytest.fixture(scope="module",
-                ids=['as_midp=True', 'as_midp=False'],
-                params=[True, False])
-def as_midp(request):
-    return request.param
+# ---- TensorGrid ---- #
 
 
-# ----- TensorGrid ----- #
-
-
-def test_init(as_midp):
+def test_tensorgrid_init():
     sorted1 = np.arange(2, 6)
     sorted2 = np.arange(-4, 5, 2)
     sorted3 = np.linspace(-1, 2, 50)
     scalar = 0.5
 
     # Just test if the code runs
-    TensorGrid(sorted1, as_midp=as_midp)
-    TensorGrid(sorted1, sorted2, as_midp=as_midp)
-    TensorGrid(sorted1, sorted1, as_midp=as_midp)
-    TensorGrid(sorted1, sorted2, sorted3, as_midp=as_midp)
-    TensorGrid(sorted2, scalar, sorted1, as_midp=as_midp)
+    TensorGrid(sorted1)
+    TensorGrid(sorted1, sorted2)
+    TensorGrid(sorted1, sorted1)
+    TensorGrid(sorted1, sorted2, sorted3)
+    TensorGrid(sorted2, scalar, sorted1)
+    TensorGrid(sorted1, sorted2, order='C')
+    TensorGrid(sorted1, sorted2, order='F')
 
+
+def test_tensorgrid_init_error():
     # Check different error scenarios
+
+    # Good input
+    sorted1 = np.arange(2, 6)
+    sorted2 = np.arange(-4, 5, 2)
+
+    # Bad input
     unsorted = np.arange(4)
     unsorted[2] = -1
     with_dups = np.arange(4)
@@ -69,127 +71,131 @@ def test_init(as_midp):
     empty = np.arange(0)
 
     with pytest.raises(ValueError):
-        TensorGrid(as_midp=as_midp)
+        TensorGrid()
 
     with pytest.raises(ValueError):
-        TensorGrid(sorted1, unsorted, sorted2, as_midp=as_midp)
+        TensorGrid(sorted1, unsorted, sorted2)
 
     with pytest.raises(ValueError):
-        TensorGrid(sorted1, with_dups, sorted2, as_midp=as_midp)
+        TensorGrid(sorted1, with_dups, sorted2)
 
     with pytest.raises(ValueError):
-        TensorGrid(sorted1, unsorted_with_dups, sorted2, as_midp=as_midp)
+        TensorGrid(sorted1, unsorted_with_dups, sorted2)
 
     with pytest.raises(ValueError):
-        TensorGrid(sorted1, with_nan, sorted2, as_midp=as_midp)
+        TensorGrid(sorted1, with_nan, sorted2)
 
     with pytest.raises(ValueError):
-        TensorGrid(sorted1, with_inf, sorted2, as_midp=as_midp)
+        TensorGrid(sorted1, with_inf, sorted2)
 
     with pytest.raises(ValueError):
-        TensorGrid(sorted1, empty, sorted2, as_midp=as_midp)
+        TensorGrid(sorted1, empty, sorted2)
+
+    with pytest.raises(ValueError):
+        TensorGrid(sorted1, sorted2, order='A')
 
 
-def test_ndim(as_midp):
+def test_tensorgrid_ndim():
     vec1 = np.arange(2, 6)
     vec2 = np.arange(-4, 5, 2)
     vec3 = np.linspace(-2, 2, 50)
 
-    grid1 = TensorGrid(vec1, as_midp=as_midp)
-    grid2 = TensorGrid(vec1, vec2, vec3, as_midp=as_midp)
+    grid1 = TensorGrid(vec1)
+    grid2 = TensorGrid(vec1, vec2, vec3)
 
     assert grid1.ndim == 1
     assert grid2.ndim == 3
 
 
-def test_shape(as_midp):
+def test_tensorgrid_shape():
     vec1 = np.arange(2, 6)
     vec2 = np.linspace(-2, 2, 50)
     scalar = 0.5
 
-    grid1 = TensorGrid(vec1, as_midp=as_midp)
-    grid2 = TensorGrid(vec1, vec2, as_midp=as_midp)
-    grid3 = TensorGrid(scalar, vec2, as_midp=as_midp)
+    grid1 = TensorGrid(vec1)
+    grid2 = TensorGrid(vec1, vec2)
+    grid3 = TensorGrid(scalar, vec2)
 
     assert grid1.shape == (4,)
     assert grid2.shape == (4, 50)
     assert grid3.shape == (1, 50)
 
 
-def test_size(as_midp):
+def test_tensorgrid_size():
     vec1 = np.arange(2, 6)
     vec2 = np.linspace(-2, 2, 50)
     scalar = 0.5
 
-    grid1 = TensorGrid(vec1, as_midp=as_midp)
-    grid2 = TensorGrid(vec1, vec2, as_midp=as_midp)
-    grid3 = TensorGrid(scalar, vec2, as_midp=as_midp)
+    grid1 = TensorGrid(vec1)
+    grid2 = TensorGrid(vec1, vec2)
+    grid3 = TensorGrid(scalar, vec2)
 
     assert grid1.size == 4
     assert grid2.size == 200
     assert grid3.size == 50
 
 
-def test_minpt_maxpt(as_midp):
+def test_tensorgrid_minpt_maxpt():
     vec1 = np.arange(2, 6)
     vec2 = np.arange(-4, 5, 2)
     vec3 = np.arange(-1, 1)
     scalar = 0.5
 
-    grid = TensorGrid(vec1, vec2, vec3, as_midp=as_midp)
+    grid = TensorGrid(vec1, vec2, vec3)
     assert all_equal(grid.min_pt, (2, -4, -1))
     assert all_equal(grid.max_pt, (5, 4, 0))
 
-    grid = TensorGrid(vec1, scalar, vec2, scalar, as_midp=as_midp)
+    grid = TensorGrid(vec1, scalar, vec2, scalar)
     assert all_equal(grid.min_pt, (2, 0.5, -4, 0.5))
     assert all_equal(grid.max_pt, (5, 0.5, 4, 0.5))
 
 
-def test_element(as_midp):
+def test_tensorgrid_element():
     vec1 = np.arange(2, 6)
     vec2 = np.arange(-4, 5, 2)
 
-    grid = TensorGrid(vec1, vec2, as_midp=as_midp)
+    grid = TensorGrid(vec1, vec2)
     some_pt = grid.element()
     assert some_pt in grid
 
 
-def test_min_max():
+# TODO: move to Partition tests
+#def test_min_max():
+#    vec1 = np.arange(2, 6)
+#    vec2 = np.arange(-4, 5, 2)
+#    vec3 = np.arange(-1, 1)
+#    scalar = 0.5
+#
+#    grid = TensorGrid(vec1, vec2, vec3, as_midp=False)
+#    assert all_equal(grid.min(), (2, -4, -1))
+#    assert all_equal(grid.max(), (5, 4, 0))
+#
+#    grid = TensorGrid(vec1, scalar, vec2, scalar, as_midp=False)
+#    assert all_equal(grid.min(), (2, 0.5, -4, 0.5))
+#    assert all_equal(grid.max(), (5, 0.5, 4, 0.5))
+#
+#    grid = TensorGrid(vec1, vec2, vec3, as_midp=True)
+#    assert all_equal(grid.min(), (1.5, -5, -1.5))
+#    assert all_equal(grid.max(), (5.5, 5, 0.5))
+#
+#    grid = TensorGrid(vec1, scalar, vec2, scalar, as_midp=True)
+#    assert all_equal(grid.min(), (1.5, 0.5, -5, 0.5))
+#    assert all_equal(grid.max(), (5.5, 0.5, 5, 0.5))
+
+
+def test_tensorgrid_equals():
     vec1 = np.arange(2, 6)
     vec2 = np.arange(-4, 5, 2)
-    vec3 = np.arange(-1, 1)
-    scalar = 0.5
 
-    grid = TensorGrid(vec1, vec2, vec3, as_midp=False)
-    assert all_equal(grid.min(), (2, -4, -1))
-    assert all_equal(grid.max(), (5, 4, 0))
-
-    grid = TensorGrid(vec1, scalar, vec2, scalar, as_midp=False)
-    assert all_equal(grid.min(), (2, 0.5, -4, 0.5))
-    assert all_equal(grid.max(), (5, 0.5, 4, 0.5))
-
-    grid = TensorGrid(vec1, vec2, vec3, as_midp=True)
-    assert all_equal(grid.min(), (1.5, -5, -1.5))
-    assert all_equal(grid.max(), (5.5, 5, 0.5))
-
-    grid = TensorGrid(vec1, scalar, vec2, scalar, as_midp=True)
-    assert all_equal(grid.min(), (1.5, 0.5, -5, 0.5))
-    assert all_equal(grid.max(), (5.5, 0.5, 5, 0.5))
-
-
-def test_equals(as_midp):
-    vec1 = np.arange(2, 6)
-    vec2 = np.arange(-4, 5, 2)
-
-    grid1 = TensorGrid(vec1, as_midp=as_midp)
-    grid1_diff_midp = TensorGrid(vec1, as_midp=not as_midp)
-    grid2 = TensorGrid(vec1, vec2, as_midp=as_midp)
-    grid2_again = TensorGrid(vec1, vec2, as_midp=as_midp)
-    grid2_rev = TensorGrid(vec2, vec1, as_midp=as_midp)
+    grid1 = TensorGrid(vec1)
+    grid1_diff_order = TensorGrid(vec1, order='F')
+    grid2 = TensorGrid(vec1, vec2)
+    grid2_again = TensorGrid(vec1, vec2)
+    grid2_rev = TensorGrid(vec2, vec1)
 
     assert grid1 == grid1
     assert not grid1 != grid1
-    assert grid1 != grid1_diff_midp
+    assert grid1 == grid1_diff_order
     assert grid2 == grid2
     assert not grid2 != grid2
     assert grid2 == grid2_again
@@ -201,22 +207,22 @@ def test_equals(as_midp):
     grid1 = TensorGrid(vec1, vec2)
     grid2 = TensorGrid(vec1 + (0.1, 0.05, 0, -0.1),
                        vec2 + (0.1, 0.05, 0, -0.1, -0.1))
-    assert grid1.approx_equals(grid2, tol=0.15)
-    assert grid2.approx_equals(grid1, tol=0.15)
+    assert grid1.approx_equals(grid2, atol=0.15)
+    assert grid2.approx_equals(grid1, atol=0.15)
 
     grid2 = TensorGrid(vec1 + (0.11, 0.05, 0, -0.1),
                        vec2 + (0.1, 0.05, 0, -0.1, -0.1))
-    assert not grid1.approx_equals(grid2, tol=0.1)
+    assert not grid1.approx_equals(grid2, atol=0.1)
     grid2 = TensorGrid(vec1 + (0.1, 0.05, 0, -0.1),
                        vec2 + (0.1, 0.05, 0, -0.11, -0.1))
-    assert not grid1.approx_equals(grid2, tol=0.1)
+    assert not grid1.approx_equals(grid2, atol=0.1)
 
 
-def test_contains(as_midp):
+def test_tensorgrid_contains():
     vec1 = np.arange(2, 6)
     vec2 = np.arange(-4, 5, 2)
 
-    grid = TensorGrid(vec1, vec2, as_midp=as_midp)
+    grid = TensorGrid(vec1, vec2)
 
     point_list = []
     for x in vec1:
@@ -230,16 +236,16 @@ def test_contains(as_midp):
     assert (2, 0, 0) not in grid
 
     # Fuzzy check
-    assert grid.approx_contains((2.1, -2.1), tol=0.15)
-    assert not grid.approx_contains((2.2, -2.1), tol=0.15)
+    assert grid.approx_contains((2.1, -2.1), atol=0.15)
+    assert not grid.approx_contains((2.2, -2.1), atol=0.15)
 
     # 1d points
-    grid = TensorGrid(vec1, as_midp=as_midp)
+    grid = TensorGrid(vec1)
     assert 3 in grid
     assert 7 not in grid
 
 
-def test_tensor_is_subgrid(as_midp):
+def test_tensorgrid_is_subgrid():
     vec1 = np.arange(2, 6)
     vec1_sup = np.arange(2, 8)
     vec2 = np.arange(-4, 5, 2)
@@ -247,45 +253,42 @@ def test_tensor_is_subgrid(as_midp):
     vec2_sub = np.arange(-4, 3, 2)
     scalar = 0.5
 
-    grid = TensorGrid(vec1, vec2, as_midp=as_midp)
+    grid = TensorGrid(vec1, vec2)
     assert grid.is_subgrid(grid)
 
-    sup_grid = TensorGrid(vec1_sup, vec2_sup, as_midp=as_midp)
+    sup_grid = TensorGrid(vec1_sup, vec2_sup)
     assert grid.is_subgrid(sup_grid)
     assert not sup_grid.is_subgrid(grid)
 
-    not_sup_grid = TensorGrid(vec1_sup, vec2_sub, as_midp=as_midp)
+    not_sup_grid = TensorGrid(vec1_sup, vec2_sub)
     assert not grid.is_subgrid(not_sup_grid)
     assert not not_sup_grid.is_subgrid(grid)
 
     # Fuzzy check
     fuzzy_vec1_sup = vec1_sup + (0.1, 0.05, 0, -0.1, 0, 0.1)
     fuzzy_vec2_sup = vec2_sup + (0.1, 0.05, 0, -0.1, 0, 0.1, 0.05)
-    fuzzy_sup_grid = TensorGrid(fuzzy_vec1_sup, fuzzy_vec2_sup,
-                                as_midp=as_midp)
-    assert grid.is_subgrid(fuzzy_sup_grid, tol=0.15)
+    fuzzy_sup_grid = TensorGrid(fuzzy_vec1_sup, fuzzy_vec2_sup)
+    assert grid.is_subgrid(fuzzy_sup_grid, atol=0.15)
 
     fuzzy_vec2_sup = vec2_sup + (0.1, 0.05, 0, -0.1, 0, 0.11, 0.05)
-    fuzzy_sup_grid = TensorGrid(fuzzy_vec1_sup, fuzzy_vec2_sup,
-                                as_midp=as_midp)
-    assert not grid.is_subgrid(fuzzy_sup_grid, tol=0.1)
+    fuzzy_sup_grid = TensorGrid(fuzzy_vec1_sup, fuzzy_vec2_sup)
+    assert not grid.is_subgrid(fuzzy_sup_grid, atol=0.1)
 
     # Changes in the non-overlapping part don't matter
     fuzzy_vec2_sup = vec2_sup + (0.1, 0.05, 0, -0.1, 0, 0.05, 0.11)
-    fuzzy_sup_grid = TensorGrid(fuzzy_vec1_sup, fuzzy_vec2_sup,
-                                as_midp=as_midp)
-    assert grid.is_subgrid(fuzzy_sup_grid, tol=0.15)
+    fuzzy_sup_grid = TensorGrid(fuzzy_vec1_sup, fuzzy_vec2_sup)
+    assert grid.is_subgrid(fuzzy_sup_grid, atol=0.15)
 
     # With degenerate axis
-    grid = TensorGrid(vec1, scalar, vec2, as_midp=as_midp)
-    sup_grid = TensorGrid(vec1_sup, scalar, vec2_sup, as_midp=as_midp)
+    grid = TensorGrid(vec1, scalar, vec2)
+    sup_grid = TensorGrid(vec1_sup, scalar, vec2_sup)
     assert grid.is_subgrid(sup_grid)
 
-    fuzzy_sup_grid = TensorGrid(vec1, scalar + 0.1, vec2, as_midp=as_midp)
-    assert grid.is_subgrid(fuzzy_sup_grid, tol=0.15)
+    fuzzy_sup_grid = TensorGrid(vec1, scalar + 0.1, vec2)
+    assert grid.is_subgrid(fuzzy_sup_grid, atol=0.15)
 
 
-def test_points(as_midp):
+def test_tensorgrid_points():
     vec1 = np.arange(2, 6)
     vec2 = np.arange(-4, 5, 2)
     scalar = 0.5
@@ -296,7 +299,7 @@ def test_points(as_midp):
         for x2 in vec2:
             points.append(np.array((x1, x2), dtype=float))
 
-    grid = TensorGrid(vec1, vec2, as_midp=as_midp)
+    grid = TensorGrid(vec1, vec2)
     assert all_equal(points, grid.points())
     assert all_equal(points, grid.points(order='C'))
     assert all_equal(grid.min_pt, grid.points()[0])
@@ -308,7 +311,7 @@ def test_points(as_midp):
         for x1 in vec1:
             points.append(np.array((x1, x2), dtype=float))
 
-    grid = TensorGrid(vec1, vec2, as_midp=as_midp)
+    grid = TensorGrid(vec1, vec2)
     assert all_equal(points, grid.points(order='F'))
 
     # Degenerate axis 1
@@ -317,7 +320,7 @@ def test_points(as_midp):
         for x2 in vec2:
             points.append(np.array((scalar, x1, x2), dtype=float))
 
-    grid = TensorGrid(scalar, vec1, vec2, as_midp=as_midp)
+    grid = TensorGrid(scalar, vec1, vec2)
     assert all_equal(points, grid.points())
 
     # Degenerate axis 2
@@ -326,7 +329,7 @@ def test_points(as_midp):
         for x2 in vec2:
             points.append(np.array((x1, scalar, x2), dtype=float))
 
-    grid = TensorGrid(vec1, scalar, vec2, as_midp=as_midp)
+    grid = TensorGrid(vec1, scalar, vec2)
     assert all_equal(points, grid.points())
 
     # Degenerate axis 3
@@ -335,11 +338,11 @@ def test_points(as_midp):
         for x2 in vec2:
             points.append(np.array((x1, x2, scalar), dtype=float))
 
-    grid = TensorGrid(vec1, vec2, scalar, as_midp=as_midp)
+    grid = TensorGrid(vec1, vec2, scalar)
     assert all_equal(points, grid.points())
 
 
-def test_corners(as_midp):
+def test_tensorgrid_corners():
     vec1 = np.arange(2, 6)
     vec2 = np.arange(-4, 5, 2)
     vec3 = np.arange(-1, 1)
@@ -356,7 +359,7 @@ def test_corners(as_midp):
             for x3 in minmax3:
                 corners.append(np.array((x1, x2, x3), dtype=float))
 
-    grid = TensorGrid(vec1, vec2, vec3, as_midp=as_midp)
+    grid = TensorGrid(vec1, vec2, vec3)
     assert all_equal(corners, grid.corners())
     assert all_equal(corners, grid.corners(order='C'))
 
@@ -388,7 +391,7 @@ def test_corners(as_midp):
         for x3 in minmax3:
             corners.append(np.array((x1, scalar, x3), dtype=float))
 
-    grid = TensorGrid(vec1, scalar, vec3, as_midp=as_midp)
+    grid = TensorGrid(vec1, scalar, vec3)
     assert all_equal(corners, grid.corners())
 
     # Degenerate axis 3
@@ -397,7 +400,7 @@ def test_corners(as_midp):
         for x2 in minmax2:
             corners.append(np.array((x1, x2, scalar), dtype=float))
 
-    grid = TensorGrid(vec1, vec2, scalar, as_midp=as_midp)
+    grid = TensorGrid(vec1, vec2, scalar)
     assert all_equal(corners, grid.corners())
 
     # All degenerate
@@ -406,17 +409,17 @@ def test_corners(as_midp):
     assert all_equal(corners, grid.corners())
 
 
-def test_meshgrid(as_midp):
+def test_tensorgrid_meshgrid():
     vec1 = (0, 1)
     vec2 = (-1, 0, 1)
     vec3 = (2, 3, 4, 5)
 
     # Sparse meshgrid
-    mgx = np.array(vec1)[:, np.newaxis, np.newaxis]
-    mgy = np.array(vec2)[np.newaxis, :, np.newaxis]
-    mgz = np.array(vec3)[np.newaxis, np.newaxis, :]
+    mgx = np.array(vec1)[:, None, None]
+    mgy = np.array(vec2)[None, :, None]
+    mgz = np.array(vec3)[None, None, :]
 
-    grid = TensorGrid(vec1, vec2, vec3, as_midp=as_midp)
+    grid = TensorGrid(vec1, vec2, vec3)
     xx, yy, zz = grid.meshgrid()
     assert all_equal(mgx, xx)
     assert all_equal(mgy, yy)
@@ -428,12 +431,12 @@ def test_meshgrid(as_midp):
     assert all_equal(mgz, zz)
 
     # Fortran ordering
-    grid = TensorGrid(vec1, vec2, vec3, order='F', as_midp=as_midp)
+    grid = TensorGrid(vec1, vec2, vec3, order='F')
     xx, yy, zz = grid.meshgrid()
     assert all(arr.flags.f_contiguous for arr in (xx, yy, zz))
 
 
-def test_tensor_getitem(as_midp):
+def test_tensor_getitem():
     vec1 = (0, 1)
     vec2 = (-1, 0, 1)
     vec3 = (2, 3, 4, 5)
@@ -443,7 +446,7 @@ def test_tensor_getitem(as_midp):
     vec3_sub = (3, 4)
     vec4_sub = (1,)
 
-    grid = TensorGrid(vec1, vec2, vec3, vec4, as_midp=as_midp)
+    grid = TensorGrid(vec1, vec2, vec3, vec4)
 
     # Single indices yield points as an array
     assert all_equal(grid[1, 0, 1, 0], (1.0, -1.0, 3.0, 1.0))
@@ -457,24 +460,20 @@ def test_tensor_getitem(as_midp):
     # Slices return new TensorGrid's
     assert grid == grid[...]
 
-    sub_grid = TensorGrid(vec1_sub, vec2_sub, vec3_sub, vec4_sub,
-                          as_midp=as_midp)
+    sub_grid = TensorGrid(vec1_sub, vec2_sub, vec3_sub, vec4_sub)
     assert grid[1, 0, 1:3, 0] == sub_grid
     assert grid[-1, :1, 1:3, :1] == sub_grid
     assert grid[1, 0, ..., 1:3, 0] == sub_grid
 
-    sub_grid = TensorGrid(vec1_sub, vec2, vec3, vec4,
-                          as_midp=as_midp)
+    sub_grid = TensorGrid(vec1_sub, vec2, vec3, vec4)
     assert grid[1, :, :, :] == sub_grid
     assert grid[1, ...] == sub_grid
 
-    sub_grid = TensorGrid(vec1, vec2, vec3, vec4_sub,
-                          as_midp=as_midp)
+    sub_grid = TensorGrid(vec1, vec2, vec3, vec4_sub)
     assert grid[:, :, :, 0] == sub_grid
     assert grid[..., 0] == sub_grid
 
-    sub_grid = TensorGrid(vec1_sub, vec2, vec3, vec4_sub,
-                          as_midp=as_midp)
+    sub_grid = TensorGrid(vec1_sub, vec2, vec3, vec4_sub)
     assert grid[1, :, :, 0] == sub_grid
     assert grid[1, ..., 0] == sub_grid
     assert grid[1, :, :, ..., 0] == sub_grid
@@ -489,93 +488,94 @@ def test_tensor_getitem(as_midp):
         grid[1, 0, 1:2, 0, :]
 
     with pytest.raises(IndexError):
-        grid[1, 0, np.newaxis, 1, 0]
+        grid[1, 0, None, 1, 0]
 
     with pytest.raises(IndexError):
         grid[1, 0, None, 1, 0]
 
     # One-dimensional grid
-    grid = TensorGrid(vec3, as_midp=as_midp)
+    grid = TensorGrid(vec3)
     assert grid == grid[...]
 
-    sub_grid = TensorGrid(vec3_sub, as_midp=as_midp)
+    sub_grid = TensorGrid(vec3_sub)
     assert grid[1:3] == sub_grid
 
 
-def test_cell_sizes():
-    vec1 = np.array([1, 3])
-    vec2 = np.array([-1, 0, 1])
-    vec3 = np.array([2, 4, 5, 10])
-    scalar = 0.5
-
-    cs1, cs2, cs3 = [np.diff(vec) for vec in (vec1, vec2, vec3)]
-    csscal = 0
-
-    # Grid as set
-    grid = TensorGrid(vec1, vec2, vec3, as_midp=False)
-    assert all_equal(grid.cell_sizes(), (cs1, cs2, cs3))
-
-    grid = TensorGrid(vec1, scalar, vec3, as_midp=False)
-    assert all_equal(grid.cell_sizes(), (cs1, csscal, cs3))
-
-    # Grid as tesselation
-    cs1 = (2, 2)
-    cs2 = (1, 1, 1)
-    cs3 = (2, 1.5, 3, 5)
-
-    grid = TensorGrid(vec1, vec2, vec3, as_midp=True)
-    assert all_equal(grid.cell_sizes(), (cs1, cs2, cs3))
-
-    grid = TensorGrid(vec1, scalar, vec3, as_midp=True)
-    assert all_equal(grid.cell_sizes(), (cs1, csscal, cs3))
-
-
-def test_convex_hull():
-    vec1 = (1, 3)
-    vec2 = (-1, 0, 1)
-    vec3 = (2, 4, 5, 10)
-    scalar = 0.5
-
-    # Grid as set
-    grid = TensorGrid(vec1, vec2, vec3, as_midp=False)
-    begin = (vec1[0], vec2[0], vec3[0])
-    end = (vec1[-1], vec2[-1], vec3[-1])
-    chull = odl.IntervalProd(begin, end)
-    assert grid.convex_hull() == chull
-
-    # With degenerate axis
-    grid = TensorGrid(vec1, vec2, scalar, as_midp=False)
-    begin = (vec1[0], vec2[0], scalar)
-    end = (vec1[-1], vec2[-1], scalar)
-    chull = odl.IntervalProd(begin, end)
-    assert grid.convex_hull() == chull
-
-    # Grid as tesselation
-    grid = TensorGrid(vec1, vec2, vec3, as_midp=True)
-    cs1 = (2, 2)
-    cs2 = (1, 1, 1)
-    cs3 = (2, 1.5, 3, 5)
-    begin = (vec1[0] - cs1[0] / 2.,
-             vec2[0] - cs2[0] / 2.,
-             vec3[0] - cs3[0] / 2.)
-    end = (vec1[-1] + cs1[-1] / 2.,
-           vec2[-1] + cs2[-1] / 2.,
-           vec3[-1] + cs3[-1] / 2.)
-    chull = odl.IntervalProd(begin, end)
-    assert grid.convex_hull() == chull
-
-    # With degenerate axis
-    grid = TensorGrid(vec1, vec2, scalar, as_midp=True)
-    begin = (vec1[0] - cs1[0] / 2., vec2[0] - cs2[0] / 2., scalar)
-    end = (vec1[-1] + cs1[-1] / 2., vec2[-1] + cs2[-1] / 2., scalar)
-    chull = odl.IntervalProd(begin, end)
-    assert grid.convex_hull() == chull
-
-
-# ----- RegularGrid ----- #
+# TODO: move test to Partition test
+#def test_cell_sizes():
+#    vec1 = np.array([1, 3])
+#    vec2 = np.array([-1, 0, 1])
+#    vec3 = np.array([2, 4, 5, 10])
+#    scalar = 0.5
+#
+#    cs1, cs2, cs3 = [np.diff(vec) for vec in (vec1, vec2, vec3)]
+#    csscal = 0
+#
+#    # Grid as set
+#    grid = TensorGrid(vec1, vec2, vec3, as_midp=False)
+#    assert all_equal(grid.cell_sizes(), (cs1, cs2, cs3))
+#
+#    grid = TensorGrid(vec1, scalar, vec3, as_midp=False)
+#    assert all_equal(grid.cell_sizes(), (cs1, csscal, cs3))
+#
+#    # Grid as tesselation
+#    cs1 = (2, 2)
+#    cs2 = (1, 1, 1)
+#    cs3 = (2, 1.5, 3, 5)
+#
+#    grid = TensorGrid(vec1, vec2, vec3, as_midp=True)
+#    assert all_equal(grid.cell_sizes(), (cs1, cs2, cs3))
+#
+#    grid = TensorGrid(vec1, scalar, vec3, as_midp=True)
+#    assert all_equal(grid.cell_sizes(), (cs1, csscal, cs3))
+#
+#
+#def test_convex_hull():
+#    vec1 = (1, 3)
+#    vec2 = (-1, 0, 1)
+#    vec3 = (2, 4, 5, 10)
+#    scalar = 0.5
+#
+#    # Grid as set
+#    grid = TensorGrid(vec1, vec2, vec3, as_midp=False)
+#    begin = (vec1[0], vec2[0], vec3[0])
+#    end = (vec1[-1], vec2[-1], vec3[-1])
+#    chull = odl.IntervalProd(begin, end)
+#    assert grid.convex_hull() == chull
+#
+#    # With degenerate axis
+#    grid = TensorGrid(vec1, vec2, scalar, as_midp=False)
+#    begin = (vec1[0], vec2[0], scalar)
+#    end = (vec1[-1], vec2[-1], scalar)
+#    chull = odl.IntervalProd(begin, end)
+#    assert grid.convex_hull() == chull
+#
+#    # Grid as tesselation
+#    grid = TensorGrid(vec1, vec2, vec3, as_midp=True)
+#    cs1 = (2, 2)
+#    cs2 = (1, 1, 1)
+#    cs3 = (2, 1.5, 3, 5)
+#    begin = (vec1[0] - cs1[0] / 2.,
+#             vec2[0] - cs2[0] / 2.,
+#             vec3[0] - cs3[0] / 2.)
+#    end = (vec1[-1] + cs1[-1] / 2.,
+#           vec2[-1] + cs2[-1] / 2.,
+#           vec3[-1] + cs3[-1] / 2.)
+#    chull = odl.IntervalProd(begin, end)
+#    assert grid.convex_hull() == chull
+#
+#    # With degenerate axis
+#    grid = TensorGrid(vec1, vec2, scalar, as_midp=True)
+#    begin = (vec1[0] - cs1[0] / 2., vec2[0] - cs2[0] / 2., scalar)
+#    end = (vec1[-1] + cs1[-1] / 2., vec2[-1] + cs2[-1] / 2., scalar)
+#    chull = odl.IntervalProd(begin, end)
+#    assert grid.convex_hull() == chull
 
 
-def test_regular_grid_init():
+# ---- RegularGrid ---- #
+
+
+def test_regulargrid_init():
     minpt = (0.75, 0, -5)
     maxpt = (1.25, 0, 1)
     shape = (2, 1, 3)
@@ -587,15 +587,20 @@ def test_regular_grid_init():
     vec3 = (-5, -2, 1)
     assert all_equal(grid.coord_vectors, (vec1, vec2, vec3))
 
+
+def test_regulargrid_init_error():
     # Check different error scenarios
+    minpt = (0.75, 0, -5)
+    maxpt = (1.25, 0, 1)
+    shape = (2, 1, 3)
     nonpos_shape1 = (2, 0, 3)
     nonpos_shape2 = (-2, 1, 3)
 
     with pytest.raises(ValueError):
-        grid = RegularGrid(minpt, maxpt, nonpos_shape1)
+        RegularGrid(minpt, maxpt, nonpos_shape1)
 
     with pytest.raises(ValueError):
-        grid = RegularGrid(minpt, maxpt, nonpos_shape2)
+        RegularGrid(minpt, maxpt, nonpos_shape2)
 
     minpt_with_nan = (0.75, 0, np.nan)
     minpt_with_inf = (0.75, 0, np.inf)
@@ -605,31 +610,31 @@ def test_regular_grid_init():
     shape_with_inf = (2, np.inf, 3)
 
     with pytest.raises(ValueError):
-        grid = RegularGrid(minpt_with_nan, maxpt, shape)
+        RegularGrid(minpt_with_nan, maxpt, shape)
 
     with pytest.raises(ValueError):
-        grid = RegularGrid(minpt_with_inf, maxpt, shape)
+        RegularGrid(minpt_with_inf, maxpt, shape)
 
     with pytest.raises(ValueError):
-        grid = RegularGrid(minpt, maxpt_with_nan, shape)
+        RegularGrid(minpt, maxpt_with_nan, shape)
 
     with pytest.raises(ValueError):
-        grid = RegularGrid(minpt, maxpt_with_inf, shape)
+        RegularGrid(minpt, maxpt_with_inf, shape)
 
     with pytest.raises(ValueError):
-        grid = RegularGrid(minpt, maxpt, shape_with_nan)
+        RegularGrid(minpt, maxpt, shape_with_nan)
 
     with pytest.raises(ValueError):
-        grid = RegularGrid(minpt, maxpt, shape_with_inf)
+        RegularGrid(minpt, maxpt, shape_with_inf)
 
     maxpt_smaller_minpt1 = (0.7, 0, 1)
     maxpt_smaller_minpt2 = (1.25, -1, 1)
 
     with pytest.raises(ValueError):
-        grid = RegularGrid(minpt, maxpt_smaller_minpt1, shape)
+        RegularGrid(minpt, maxpt_smaller_minpt1, shape)
 
     with pytest.raises(ValueError):
-        grid = RegularGrid(minpt, maxpt_smaller_minpt2, shape)
+        RegularGrid(minpt, maxpt_smaller_minpt2, shape)
 
     too_short_minpt = (0.75, 0)
     too_long_minpt = (0.75, 0, -5, 2)
@@ -639,117 +644,100 @@ def test_regular_grid_init():
     too_long_shape = (2, 1, 4, 3)
 
     with pytest.raises(ValueError):
-        grid = RegularGrid(too_short_minpt, maxpt, shape)
+        RegularGrid(too_short_minpt, maxpt, shape)
 
     with pytest.raises(ValueError):
-        grid = RegularGrid(too_long_minpt, maxpt, shape)
+        RegularGrid(too_long_minpt, maxpt, shape)
 
     with pytest.raises(ValueError):
-        grid = RegularGrid(minpt, too_short_maxpt, shape)
+        RegularGrid(minpt, too_short_maxpt, shape)
 
     with pytest.raises(ValueError):
-        grid = RegularGrid(minpt, too_long_maxpt, shape)
+        RegularGrid(minpt, too_long_maxpt, shape)
 
     with pytest.raises(ValueError):
-        grid = RegularGrid(minpt, maxpt, too_short_shape)
+        RegularGrid(minpt, maxpt, too_short_shape)
 
     with pytest.raises(ValueError):
-        grid = RegularGrid(minpt, maxpt, too_long_shape)
+        RegularGrid(minpt, maxpt, too_long_shape)
 
     maxpt_eq_minpt_at_shape_larger_than_1 = (0.75, 0, 1)
 
     with pytest.raises(ValueError):
-        grid = RegularGrid(minpt, maxpt_eq_minpt_at_shape_larger_than_1,
-                           shape)
-
-    # Overrides for exact min and max
-    exact_min = np.array((0, 1, 0), dtype=float)
-    exact_max = np.array((1, 1, 3), dtype=float)
-    shape = np.array((3, 1, 7), dtype=int)
-    shift = (exact_max - exact_min) / (2 * shape)
-
-    minpt = exact_min + shift
-    maxpt = exact_max - shift
-
-    grid = RegularGrid(minpt, maxpt, shape, as_midp=True,
-                       _exact_min=exact_min, _exact_max=exact_max)
-    assert all_equal(grid.min(), exact_min)
-    assert all_equal(grid.max(), exact_max)
+        RegularGrid(minpt, maxpt_eq_minpt_at_shape_larger_than_1,
+                    shape)
 
 
-def test_center(as_midp):
+def test_regulargrid_center():
     minpt = (0.75, 0, -5)
     maxpt = (1.25, 0, 1)
     shape = (2, 1, 3)
 
     center = (1, 0, -2)
 
-    grid = RegularGrid(minpt, maxpt, shape, as_midp=as_midp)
+    grid = RegularGrid(minpt, maxpt, shape)
     assert all_equal(grid.center, center)
 
 
-def test_stride(as_midp):
+def test_regulargrid_stride():
     minpt = (0.75, 0, -5)
     maxpt = (1.25, 0, 1)
     shape = (2, 1, 3)
 
     stride = (0.5, 0, 3)
 
-    grid = RegularGrid(minpt, maxpt, shape, as_midp=as_midp)
+    grid = RegularGrid(minpt, maxpt, shape)
     assert all_equal(grid.stride, stride)
 
 
-def test_regular_is_subgrid(as_midp):
+def test_regulargrid_is_subgrid():
     minpt = (0.75, 0, -5)
     maxpt = (1.25, 0, 1)
     shape = (2, 1, 5)
 
     # Optimized cases
-    grid = RegularGrid(minpt, maxpt, shape, as_midp=as_midp)
+    grid = RegularGrid(minpt, maxpt, shape)
     assert grid.is_subgrid(grid)
 
     smaller_shape = (1, 1, 5)
-    not_sup_grid = RegularGrid(minpt, maxpt, smaller_shape, as_midp=as_midp)
+    not_sup_grid = RegularGrid(minpt, maxpt, smaller_shape)
     assert not grid.is_subgrid(not_sup_grid)
 
     larger_minpt = (0.85, 0, -4)
-    not_sup_grid = RegularGrid(larger_minpt, maxpt, shape, as_midp=as_midp)
+    not_sup_grid = RegularGrid(larger_minpt, maxpt, shape)
     assert not grid.is_subgrid(not_sup_grid)
 
     smaller_maxpt = (1.15, 0, 0)
-    not_sup_grid = RegularGrid(minpt, smaller_maxpt, shape, as_midp=as_midp)
+    not_sup_grid = RegularGrid(minpt, smaller_maxpt, shape)
     assert not grid.is_subgrid(not_sup_grid)
 
     # Real checks
     minpt_sup1 = (-0.25, -2, -5)
     maxpt_sup1 = (1.25, 2, 1)
     shape_sup1 = (4, 3, 9)
-    sup_grid = RegularGrid(minpt_sup1, maxpt_sup1, shape_sup1, as_midp=as_midp)
+    sup_grid = RegularGrid(minpt_sup1, maxpt_sup1, shape_sup1)
     assert grid.is_subgrid(sup_grid)
     assert not sup_grid.is_subgrid(grid)
 
     minpt_sup2 = (0.5, 0, -5)
     maxpt_sup2 = (1.5, 0, 1)
     shape_sup2 = (5, 1, 9)
-    sup_grid = RegularGrid(minpt_sup2, maxpt_sup2, shape_sup2, as_midp=as_midp)
+    sup_grid = RegularGrid(minpt_sup2, maxpt_sup2, shape_sup2)
     assert grid.is_subgrid(sup_grid)
     assert not sup_grid.is_subgrid(grid)
 
     shape_not_sup1 = (4, 3, 10)
-    not_sup_grid = RegularGrid(minpt_sup1, maxpt_sup1, shape_not_sup1,
-                               as_midp=as_midp)
+    not_sup_grid = RegularGrid(minpt_sup1, maxpt_sup1, shape_not_sup1)
     assert not grid.is_subgrid(not_sup_grid)
     assert not not_sup_grid.is_subgrid(grid)
 
     minpt_not_sup1 = (-0.25, -2.5, -5)
-    not_sup_grid = RegularGrid(minpt_not_sup1, maxpt_sup1, shape_sup1,
-                               as_midp=as_midp)
+    not_sup_grid = RegularGrid(minpt_not_sup1, maxpt_sup1, shape_sup1)
     assert not grid.is_subgrid(not_sup_grid)
     assert not not_sup_grid.is_subgrid(grid)
 
     maxpt_not_sup1 = (1.35, 2.0001, 1)
-    not_sup_grid = RegularGrid(minpt_sup1, maxpt_not_sup1, shape_sup1,
-                               as_midp=as_midp)
+    not_sup_grid = RegularGrid(minpt_sup1, maxpt_not_sup1, shape_sup1)
     assert not grid.is_subgrid(not_sup_grid)
     assert not not_sup_grid.is_subgrid(grid)
 
@@ -758,8 +746,7 @@ def test_regular_is_subgrid(as_midp):
     vec2_sup = (0,)
     vec3_sup = (-5, -3.5, -3, -2, -0.5, 0, 1, 9.5)
 
-    tensor_sup_grid = TensorGrid(vec1_sup, vec2_sup, vec3_sup,
-                                 as_midp=as_midp)
+    tensor_sup_grid = TensorGrid(vec1_sup, vec2_sup, vec3_sup)
     assert grid.is_subgrid(tensor_sup_grid)
 
     vec1_not_sup = (1, 1.25, 7)
@@ -767,7 +754,7 @@ def test_regular_is_subgrid(as_midp):
     vec3_not_sup = (-4, -2, 1)
 
     tensor_not_sup_grid = TensorGrid(vec1_not_sup, vec2_not_sup,
-                                     vec3_not_sup, as_midp=as_midp)
+                                     vec3_not_sup)
     assert not grid.is_subgrid(tensor_not_sup_grid)
 
     # Fuzzy check
@@ -779,17 +766,17 @@ def test_regular_is_subgrid(as_midp):
     maxpt_fuzzy_sup2 = (1.25, 2, 1.01)
 
     fuzzy_sup_grid = RegularGrid(minpt_fuzzy_sup1, maxpt_fuzzy_sup1,
-                                 shape_sup, as_midp=as_midp)
-    assert grid.is_subgrid(fuzzy_sup_grid, tol=0.015)
-    assert not grid.is_subgrid(fuzzy_sup_grid, tol=0.005)
+                                 shape_sup)
+    assert grid.is_subgrid(fuzzy_sup_grid, atol=0.015)
+    assert not grid.is_subgrid(fuzzy_sup_grid, atol=0.005)
 
     fuzzy_sup_grid = RegularGrid(minpt_fuzzy_sup2, maxpt_fuzzy_sup2,
-                                 shape_sup, as_midp=as_midp)
-    assert grid.is_subgrid(fuzzy_sup_grid, tol=0.015)
-    assert not grid.is_subgrid(fuzzy_sup_grid, tol=0.005)
+                                 shape_sup)
+    assert grid.is_subgrid(fuzzy_sup_grid, atol=0.015)
+    assert not grid.is_subgrid(fuzzy_sup_grid, atol=0.005)
 
 
-def test_regular_getitem():
+def test_regulargrid_getitem():
     minpt = (0.75, 0, -5, 4)
     maxpt = (1.25, 0, 1, 13)
     shape = (2, 1, 5, 4)
@@ -821,7 +808,7 @@ def test_regular_getitem():
     assert grid == grid[...]
 
     # Use TensorGrid implementation as reference here
-    tensor_grid = TensorGrid(*grid.coord_vectors, as_midp=as_midp)
+    tensor_grid = TensorGrid(*grid.coord_vectors)
 
     test_slice = np.s_[1, :, ::2, ::3]
     assert all_equal(grid[test_slice].coord_vectors,
@@ -871,18 +858,20 @@ def test_regular_getitem():
         grid[1, 0, 1:2, 0, :]
 
     with pytest.raises(IndexError):
-        grid[1, 0, np.newaxis, 1, 0]
+        grid[1, 0, None, 1, 0]
 
     with pytest.raises(IndexError):
         grid[1, 0, None, 1, 0]
 
     # One-dimensional grid
-    grid = RegularGrid(1, 5, 5, as_midp=as_midp)
+    grid = RegularGrid(1, 5, 5)
     assert grid == grid[...]
 
-    sub_grid = RegularGrid(1, 5, 3, as_midp=as_midp)
+    sub_grid = RegularGrid(1, 5, 3)
     assert grid[::2], sub_grid
 
+
+# ---- Utilities ---- #
 
 def test_sparse_meshgrid():
 

--- a/test/discr/grid_test.py
+++ b/test/discr/grid_test.py
@@ -969,7 +969,7 @@ def test_sparse_meshgrid():
 
     # Two arrays, 'F' ordering
     x, y = np.zeros(2), np.zeros(3)
-    true_mg = (y[None, :], x[:, None])
+    true_mg = (x[None, :], y[:, None])
     mg = sparse_meshgrid(x, y, order='F')
     assert all_equal(mg, true_mg)
     assert all(vec.flags.f_contiguous for vec in mg)

--- a/test/discr/grid_test.py
+++ b/test/discr/grid_test.py
@@ -159,30 +159,6 @@ def test_tensorgrid_element():
     assert some_pt in grid
 
 
-# TODO: move to Partition tests
-#def test_min_max():
-#    vec1 = np.array([2, 3, 4, 5])
-#    vec2 = np.array([-4, -2, 0, 2, 4])
-#    vec3 = np.array([-1, 0])
-#    scalar = 0.5
-#
-#    grid = TensorGrid(vec1, vec2, vec3, as_midp=False)
-#    assert all_equal(grid.min(), (2, -4, -1))
-#    assert all_equal(grid.max(), (5, 4, 0))
-#
-#    grid = TensorGrid(vec1, scalar, vec2, scalar, as_midp=False)
-#    assert all_equal(grid.min(), (2, 0.5, -4, 0.5))
-#    assert all_equal(grid.max(), (5, 0.5, 4, 0.5))
-#
-#    grid = TensorGrid(vec1, vec2, vec3, as_midp=True)
-#    assert all_equal(grid.min(), (1.5, -5, -1.5))
-#    assert all_equal(grid.max(), (5.5, 5, 0.5))
-#
-#    grid = TensorGrid(vec1, scalar, vec2, scalar, as_midp=True)
-#    assert all_equal(grid.min(), (1.5, 0.5, -5, 0.5))
-#    assert all_equal(grid.max(), (5.5, 0.5, 5, 0.5))
-
-
 def test_tensorgrid_equals():
     vec1 = np.array([2, 3, 4, 5])
     vec2 = np.array([-4, -2, 0, 2, 4])
@@ -528,77 +504,6 @@ def test_tensorgrid_getitem():
 
     sub_grid = TensorGrid(vec3_sub)
     assert grid[1:3] == sub_grid
-
-
-# TODO: move test to Partition test
-#def test_cell_sizes():
-#    vec1 = np.array([1, 3])
-#    vec2 = np.array([-1, 0, 1])
-#    vec3 = np.array([2, 4, 5, 10])
-#    scalar = 0.5
-#
-#    cs1, cs2, cs3 = [np.diff(vec) for vec in (vec1, vec2, vec3)]
-#    csscal = 0
-#
-#    # Grid as set
-#    grid = TensorGrid(vec1, vec2, vec3, as_midp=False)
-#    assert all_equal(grid.cell_sizes(), (cs1, cs2, cs3))
-#
-#    grid = TensorGrid(vec1, scalar, vec3, as_midp=False)
-#    assert all_equal(grid.cell_sizes(), (cs1, csscal, cs3))
-#
-#    # Grid as tesselation
-#    cs1 = (2, 2)
-#    cs2 = (1, 1, 1)
-#    cs3 = (2, 1.5, 3, 5)
-#
-#    grid = TensorGrid(vec1, vec2, vec3, as_midp=True)
-#    assert all_equal(grid.cell_sizes(), (cs1, cs2, cs3))
-#
-#    grid = TensorGrid(vec1, scalar, vec3, as_midp=True)
-#    assert all_equal(grid.cell_sizes(), (cs1, csscal, cs3))
-#
-#
-#def test_convex_hull():
-#    vec1 = (1, 3)
-#    vec2 = (-1, 0, 1)
-#    vec3 = (2, 4, 5, 10)
-#    scalar = 0.5
-#
-#    # Grid as set
-#    grid = TensorGrid(vec1, vec2, vec3, as_midp=False)
-#    begin = (vec1[0], vec2[0], vec3[0])
-#    end = (vec1[-1], vec2[-1], vec3[-1])
-#    chull = odl.IntervalProd(begin, end)
-#    assert grid.convex_hull() == chull
-#
-#    # With degenerate axis
-#    grid = TensorGrid(vec1, vec2, scalar, as_midp=False)
-#    begin = (vec1[0], vec2[0], scalar)
-#    end = (vec1[-1], vec2[-1], scalar)
-#    chull = odl.IntervalProd(begin, end)
-#    assert grid.convex_hull() == chull
-#
-#    # Grid as tesselation
-#    grid = TensorGrid(vec1, vec2, vec3, as_midp=True)
-#    cs1 = (2, 2)
-#    cs2 = (1, 1, 1)
-#    cs3 = (2, 1.5, 3, 5)
-#    begin = (vec1[0] - cs1[0] / 2.,
-#             vec2[0] - cs2[0] / 2.,
-#             vec3[0] - cs3[0] / 2.)
-#    end = (vec1[-1] + cs1[-1] / 2.,
-#           vec2[-1] + cs2[-1] / 2.,
-#           vec3[-1] + cs3[-1] / 2.)
-#    chull = odl.IntervalProd(begin, end)
-#    assert grid.convex_hull() == chull
-#
-#    # With degenerate axis
-#    grid = TensorGrid(vec1, vec2, scalar, as_midp=True)
-#    begin = (vec1[0] - cs1[0] / 2., vec2[0] - cs2[0] / 2., scalar)
-#    end = (vec1[-1] + cs1[-1] / 2., vec2[-1] + cs2[-1] / 2., scalar)
-#    chull = odl.IntervalProd(begin, end)
-#    assert grid.convex_hull() == chull
 
 
 # ---- RegularGrid ---- #

--- a/test/discr/lp_discr_test.py
+++ b/test/discr/lp_discr_test.py
@@ -77,37 +77,37 @@ def exponent(request):
 def test_init(exponent):
     # Validate that the different init patterns work and do not crash.
     space = odl.FunctionSpace(odl.Interval(0, 1))
-    grid = odl.uniform_sampling(space.domain, 10)
+    part = odl.uniform_partition(space.domain, 10)
     rn = odl.Rn(10, exponent=exponent)
-    odl.DiscreteLp(space, grid, rn, exponent=exponent)
+    odl.DiscreteLp(space, part, rn, exponent=exponent)
 
     # Normal discretization of unit interval with complex
     complex_space = odl.FunctionSpace(odl.Interval(0, 1),
                                       field=odl.ComplexNumbers())
     cn = odl.Cn(10, exponent=exponent)
-    odl.DiscreteLp(complex_space, grid, cn, exponent=exponent)
+    odl.DiscreteLp(complex_space, part, cn, exponent=exponent)
 
     # Real space should not work with complex
     with pytest.raises(ValueError):
-        odl.DiscreteLp(space, grid, cn)
+        odl.DiscreteLp(space, part, cn)
 
     # Complex space should not work with reals
     with pytest.raises(ValueError):
-        odl.DiscreteLp(complex_space, grid, rn)
+        odl.DiscreteLp(complex_space, part, rn)
 
     # Wrong size of underlying space
     rn_wrong_size = odl.Rn(20)
     with pytest.raises(ValueError):
-        odl.DiscreteLp(space, grid, rn_wrong_size)
+        odl.DiscreteLp(space, part, rn_wrong_size)
 
 
 @skip_if_no_cuda
 def test_init_cuda(exponent):
     # Normal discretization of unit interval
     space = odl.FunctionSpace(odl.Interval(0, 1))
-    grid = odl.uniform_sampling(space.domain, 10)
+    part = odl.uniform_partition(space.domain, 10)
     rn = odl.CudaRn(10, exponent=exponent)
-    odl.DiscreteLp(space, grid, rn, exponent=exponent)
+    odl.DiscreteLp(space, part, rn, exponent=exponent)
 
 
 def test_factory(exponent):
@@ -490,7 +490,7 @@ def test_transpose():
 
 
 def test_cell_size():
-    # Non-degenerated case, should be same as grid stride
+    # Non-degenerated case, should be same as cell size
     discr = odl.uniform_discr([0, 0], [1, 1], [2, 2])
     vec = discr.element()
 

--- a/test/discr/lp_discr_test.py
+++ b/test/discr/lp_discr_test.py
@@ -77,7 +77,7 @@ def exponent(request):
 def test_init(exponent):
     # Validate that the different init patterns work and do not crash.
     space = odl.FunctionSpace(odl.Interval(0, 1))
-    part = odl.uniform_partition(space.domain, 10)
+    part = odl.uniform_partition_fromintv(space.domain, 10)
     rn = odl.Rn(10, exponent=exponent)
     odl.DiscreteLp(space, part, rn, exponent=exponent)
 
@@ -105,7 +105,7 @@ def test_init(exponent):
 def test_init_cuda(exponent):
     # Normal discretization of unit interval
     space = odl.FunctionSpace(odl.Interval(0, 1))
-    part = odl.uniform_partition(space.domain, 10)
+    part = odl.uniform_partition_fromintv(space.domain, 10)
     rn = odl.CudaRn(10, exponent=exponent)
     odl.DiscreteLp(space, part, rn, exponent=exponent)
 
@@ -489,20 +489,20 @@ def test_transpose():
     assert all_equal(x.T.adjoint(1.0), x)
 
 
-def test_cell_size():
+def test_cell_sides():
     # Non-degenerated case, should be same as cell size
     discr = odl.uniform_discr([0, 0], [1, 1], [2, 2])
     vec = discr.element()
 
-    assert all_equal(discr.cell_size, [0.5] * 2)
-    assert all_equal(vec.cell_size, [0.5] * 2)
+    assert all_equal(discr.cell_sides, [0.5] * 2)
+    assert all_equal(vec.cell_sides, [0.5] * 2)
 
     # Degenerated case, uses interval size in 1-point dimensions
     discr = odl.uniform_discr([0, 0], [1, 1], [2, 1])
     vec = discr.element()
 
-    assert all_equal(discr.cell_size, [0.5, 1])
-    assert all_equal(vec.cell_size, [0.5, 1])
+    assert all_equal(discr.cell_sides, [0.5, 1])
+    assert all_equal(vec.cell_sides, [0.5, 1])
 
 
 def test_cell_volume():

--- a/test/discr/partition_test.py
+++ b/test/discr/partition_test.py
@@ -52,7 +52,7 @@ def test_partition_init():
     RectPartition(odl.Rectangle(begin, end), odl.TensorGrid(vec1, vec2))
 
 
-def test_partition_init_error():
+def test_partition_init_raise():
     # Check different error scenarios
     vec1 = np.array([2, 4, 5, 7])
     vec2 = np.array([-4, -3, 0, 1, 4])

--- a/test/discr/partition_test.py
+++ b/test/discr/partition_test.py
@@ -20,7 +20,6 @@
 from __future__ import print_function, division, absolute_import
 from future import standard_library
 standard_library.install_aliases()
-from builtins import zip
 
 # External module imports
 import pytest
@@ -28,42 +27,50 @@ import numpy as np
 
 # ODL imports
 import odl
-from odl.discr.partition import RectPartition
+from odl.discr.partition import RectPartition, uniform_partition
 from odl.set.domain import IntervalProd
-from odl.util.testutils import all_equal
+from odl.util.testutils import all_equal, all_almost_equal
 
 
-# TODO: tests for
-# - cell boundaries
-# - cell sizes
+# ---- RectPartition ---- #
 
 
 def test_partition_init():
-    interv_prod = odl.Rectangle([0, 1], [2, 4])
-    grid = odl.uniform_sampling(interv_prod, (5, 15))
+    vec1 = np.array([2, 4, 5, 7])
+    vec2 = np.array([-4, -3, 0, 1, 4])
+    begin = [2, -5]
+    end = [10, 4]
+    grid = odl.TensorGrid(vec1, vec2)
 
     # Simply test if code runs
     RectPartition(grid)
-    RectPartition(grid, begin=interv_prod.begin)
-    RectPartition(grid, end=interv_prod.end)
-    RectPartition(grid, begin=interv_prod.begin, begin_axes=(1,))
-    RectPartition(grid, end=interv_prod.end, end_axes=(-1,))
+    RectPartition(grid, begin=begin)
+    RectPartition(grid, end=end)
+    RectPartition(grid, begin=begin, begin_axes=(1,))
+    RectPartition(grid, end=end, end_axes=(-1,))
+
+    # 1d
+    grid = odl.TensorGrid(vec1)
+    RectPartition(grid)
 
     # Degenerate dimensions should work with explicit begin / end
     # in corresponding axes
-    grid = odl.uniform_sampling(interv_prod, (5, 1))
-    RectPartition(grid, begin=interv_prod.begin, end=interv_prod.end)
-    RectPartition(grid, begin=interv_prod.begin, end=interv_prod.end,
+    grid = odl.TensorGrid(vec1, [1.0])
+    RectPartition(grid, begin=begin, end=end)
+    RectPartition(grid, begin=begin, end=end,
                   begin_axes=(1,), end_axes=(1,))
 
 
 def test_partition_init_error():
     # Check different error scenarios
-    interv_prod = odl.Rectangle([0, 1], [2, 4])
-    grid = odl.uniform_sampling(interv_prod, (5, 15))
+    vec1 = np.array([2, 4, 5, 7])
+    vec2 = np.array([-4, -3, 0, 1, 4])
+    begin = [2, -5]
+    end = [10, 4]
+    grid = odl.TensorGrid(vec1, vec2)
 
-    beg_toolarge = (0.5, 2)
-    end_toosmall = (1, 3.99)
+    beg_toolarge = (2, -3.5)
+    end_toosmall = (7, 1)
     beg_badshape = (-1, 2, 0)
     end_badshape = (2,)
 
@@ -80,13 +87,13 @@ def test_partition_init_error():
         RectPartition(grid, end=end_badshape)
 
     # Degenerate dimension, needs both explicit begin and end
-    grid = odl.uniform_sampling(interv_prod, (3, 1))
+    grid = odl.TensorGrid(vec1, [1.0])
     with pytest.raises(ValueError):
         RectPartition(grid)
     with pytest.raises(ValueError):
-        RectPartition(grid, begin=interv_prod.begin)
+        RectPartition(grid, begin=begin)
     with pytest.raises(ValueError):
-        RectPartition(grid, end=interv_prod.end)
+        RectPartition(grid, end=end)
 
     # begin_axes (and end_axes, same function, testing only begin)
 
@@ -96,16 +103,16 @@ def test_partition_init_error():
 
     # OOB indices
     with pytest.raises(IndexError):
-        RectPartition(grid, begin=interv_prod.begin, begin_axes=(0, 2))
+        RectPartition(grid, begin=begin, begin_axes=(0, 2))
     with pytest.raises(IndexError):
-        RectPartition(grid, begin=interv_prod.begin, begin_axes=(-3,))
+        RectPartition(grid, begin=begin, begin_axes=(-3,))
 
     # Duplicate indices
     with pytest.raises(ValueError):
-        RectPartition(grid, begin=interv_prod.begin, begin_axes=(0, 0, 1,))
+        RectPartition(grid, begin=begin, begin_axes=(0, 0, 1,))
 
 
-def test_partition_bounding_box():
+def test_partition_bbox():
     vec1 = np.array([2, 4, 5, 7])
     vec2 = np.array([-4, -3, 0, 1, 4])
     grid = odl.TensorGrid(vec1, vec2)
@@ -117,26 +124,159 @@ def test_partition_bounding_box():
 
     # Explicit begin / end
     part = RectPartition(grid, begin=begin, end=end)
-    assert part.bounding_box == IntervalProd(begin, end)
+    assert part.bbox == IntervalProd(begin, end)
 
     # Implicit begin / end
     part = RectPartition(grid, begin=begin)
-    assert part.bounding_box == IntervalProd(begin, maxpt_calc)
+    assert part.bbox == IntervalProd(begin, maxpt_calc)
 
     part = RectPartition(grid, end=end)
-    assert part.bounding_box == IntervalProd(minpt_calc, end)
+    assert part.bbox == IntervalProd(minpt_calc, end)
 
     part = RectPartition(grid)
-    assert part.bounding_box == IntervalProd(minpt_calc, maxpt_calc)
+    assert part.bbox == IntervalProd(minpt_calc, maxpt_calc)
 
     # Mixture
     part = RectPartition(grid, begin=begin, begin_axes=(1,))
     minpt_mix = [minpt_calc[0], begin[1]]
-    assert part.bounding_box == IntervalProd(minpt_mix, maxpt_calc)
+    assert part.bbox == IntervalProd(minpt_mix, maxpt_calc)
 
     part = RectPartition(grid, end=end, end_axes=(-2,))
     maxpt_mix = [end[0], maxpt_calc[1]]
-    assert part.bounding_box == IntervalProd(minpt_calc, maxpt_mix)
+    assert part.bbox == IntervalProd(minpt_calc, maxpt_mix)
+
+
+def test_partition_cell_boundaries():
+    vec1 = np.array([2, 4, 5, 7])
+    vec2 = np.array([-4, -3, 0, 1, 4])
+    grid = odl.TensorGrid(vec1, vec2)
+
+    midpts1 = [3, 4.5, 6]
+    midpts2 = [-3.5, -1.5, 0.5, 2.5]
+
+    # Explicit
+    begin = [2, -6]
+    end = [10, 4]
+    true_bvec1 = [2] + midpts1 + [10]
+    true_bvec2 = [-6] + midpts2 + [4]
+
+    part = RectPartition(grid, begin=begin, end=end)
+    assert all_equal(part.cell_boundaries(), (true_bvec1, true_bvec2))
+
+    # Implicit
+    true_bvec1 = [1] + midpts1 + [8]
+    true_bvec2 = [-4.5] + midpts2 + [5.5]
+
+    part = RectPartition(grid)
+    assert all_equal(part.cell_boundaries(), (true_bvec1, true_bvec2))
+
+
+def test_partition_cell_sizes():
+    vec1 = np.array([2, 4, 5, 7])
+    vec2 = np.array([-4, -3, 0, 1, 4])
+    grid = odl.TensorGrid(vec1, vec2)
+
+    midpts1 = [3, 4.5, 6]
+    midpts2 = [-3.5, -1.5, 0.5, 2.5]
+
+    # Explicit
+    begin = [2, -6]
+    end = [10, 4]
+    bvec1 = np.array([2] + midpts1 + [10])
+    bvec2 = np.array([-6] + midpts2 + [4])
+    true_csizes1 = bvec1[1:] - bvec1[:-1]
+    true_csizes2 = bvec2[1:] - bvec2[:-1]
+
+    part = RectPartition(grid, begin=begin, end=end)
+    assert all_equal(part.cell_sizes(), (true_csizes1, true_csizes2))
+
+    # Implicit
+    bvec1 = np.array([1] + midpts1 + [8])
+    bvec2 = np.array([-4.5] + midpts2 + [5.5])
+
+    true_csizes1 = bvec1[1:] - bvec1[:-1]
+    true_csizes2 = bvec2[1:] - bvec2[:-1]
+
+    part = RectPartition(grid)
+    assert all_equal(part.cell_sizes(), (true_csizes1, true_csizes2))
+
+
+def test_partition_cell_volume():
+    grid = odl.RegularGrid([0, 1], [2, 4], (5, 3))
+    part = RectPartition(grid)
+    true_volume = 0.5 * 1.5
+    assert part.cell_volume == true_volume
+
+
+def test_partition_insert():
+    vec11 = [2, 4, 5, 7]
+    vec12 = [-4, -3, 0, 1, 4]
+    grid1 = odl.TensorGrid(vec11, vec12)
+    part1 = RectPartition(grid1)
+
+    vec21 = [-2, 0, 3]
+    vec22 = [0]
+    grid2 = odl.TensorGrid(vec21, vec22)
+    part2 = RectPartition(grid2, begin=[-2, 0], end=[3, 0])
+
+    part = part1.insert(0, part2)
+    true_beg = [-2, 0, 1, -4.5]
+    true_end = [3, 0, 8, 5.5]
+    assert all_equal(part.begin, true_beg)
+    assert all_equal(part.end, true_end)
+
+    part = part1.insert(1, part2)
+    true_beg = [1, -2, 0, -4.5]
+    true_end = [8, 3, 0, 5.5]
+    assert all_equal(part.begin, true_beg)
+    assert all_equal(part.end, true_end)
+
+
+# ---- Functions ---- #
+
+
+def test_uniform_partition():
+    intvp = odl.IntervalProd([0, 0], [1, 2])
+    nsamp = (4, 10)
+
+    # All nodes at the boundary
+    part = uniform_partition(intvp, nsamp, node_at_bdry=True)
+    assert all_equal(part.begin, intvp.begin)
+    assert all_equal(part.end, intvp.end)
+    assert all_equal(part.grid.min_pt, intvp.begin)
+    assert all_equal(part.grid.max_pt, intvp.end)
+    for cs in part.cell_sizes():
+        # First and last cell sizes are halved
+        assert np.allclose(np.diff(cs[1:-1]), 0)
+        assert all_almost_equal(cs[0], cs[1] / 2)
+        assert all_almost_equal(cs[-1], cs[-2] / 2)
+
+    # All nodes not the boundary
+    part = uniform_partition(intvp, nsamp, node_at_bdry=False)
+    assert all_equal(part.begin, intvp.begin)
+    assert all_equal(part.end, intvp.end)
+    for cs in part.cell_sizes():
+        assert np.allclose(np.diff(cs), 0)
+
+    # Only left nodes at the boundary
+    part = uniform_partition(intvp, nsamp, node_at_bdry=[[True, False]] * 2)
+    assert all_equal(part.begin, intvp.begin)
+    assert all_equal(part.end, intvp.end)
+    assert all_equal(part.grid.min_pt, intvp.begin)
+    for cs in part.cell_sizes():
+        # Last cell sizes is halved
+        assert np.allclose(np.diff(cs[1:]), 0)
+        assert all_almost_equal(cs[0], cs[1] / 2)
+
+    # Only right nodes at the boundary
+    part = uniform_partition(intvp, nsamp, node_at_bdry=[[False, True]] * 2)
+    assert all_equal(part.begin, intvp.begin)
+    assert all_equal(part.end, intvp.end)
+    assert all_equal(part.grid.max_pt, intvp.end)
+    for cs in part.cell_sizes():
+        # First and last cell sizes are halved
+        assert np.allclose(np.diff(cs[:-1]), 0)
+        assert all_almost_equal(cs[-1], cs[-2] / 2)
 
 
 if __name__ == '__main__':

--- a/test/discr/partition_test.py
+++ b/test/discr/partition_test.py
@@ -240,41 +240,43 @@ def test_uniform_partition():
     nsamp = (4, 10)
 
     # All nodes at the boundary
-    part = uniform_partition(intvp, nsamp, node_at_bdry=True)
+    part = uniform_partition(intvp, nsamp, nodes_on_bdry=True)
     assert all_equal(part.begin, intvp.begin)
     assert all_equal(part.end, intvp.end)
     assert all_equal(part.grid.min_pt, intvp.begin)
     assert all_equal(part.grid.max_pt, intvp.end)
     for cs in part.cell_sizes():
-        # First and last cell sizes are halved
+        # Check that all cell sizes are equal (except first and last which
+        # are halved)
         assert np.allclose(np.diff(cs[1:-1]), 0)
         assert all_almost_equal(cs[0], cs[1] / 2)
         assert all_almost_equal(cs[-1], cs[-2] / 2)
 
     # All nodes not the boundary
-    part = uniform_partition(intvp, nsamp, node_at_bdry=False)
+    part = uniform_partition(intvp, nsamp, nodes_on_bdry=False)
     assert all_equal(part.begin, intvp.begin)
     assert all_equal(part.end, intvp.end)
     for cs in part.cell_sizes():
+        # Check that all cell sizes are equal
         assert np.allclose(np.diff(cs), 0)
 
     # Only left nodes at the boundary
-    part = uniform_partition(intvp, nsamp, node_at_bdry=[[True, False]] * 2)
+    part = uniform_partition(intvp, nsamp, nodes_on_bdry=[[True, False]] * 2)
     assert all_equal(part.begin, intvp.begin)
     assert all_equal(part.end, intvp.end)
     assert all_equal(part.grid.min_pt, intvp.begin)
     for cs in part.cell_sizes():
-        # Last cell sizes is halved
+        # Check that all cell sizes are equal (except first)
         assert np.allclose(np.diff(cs[1:]), 0)
         assert all_almost_equal(cs[0], cs[1] / 2)
 
     # Only right nodes at the boundary
-    part = uniform_partition(intvp, nsamp, node_at_bdry=[[False, True]] * 2)
+    part = uniform_partition(intvp, nsamp, nodes_on_bdry=[[False, True]] * 2)
     assert all_equal(part.begin, intvp.begin)
     assert all_equal(part.end, intvp.end)
     assert all_equal(part.grid.max_pt, intvp.end)
     for cs in part.cell_sizes():
-        # First and last cell sizes are halved
+        # Check that all cell sizes are equal (except last)
         assert np.allclose(np.diff(cs[:-1]), 0)
         assert all_almost_equal(cs[-1], cs[-2] / 2)
 

--- a/test/discr/partition_test.py
+++ b/test/discr/partition_test.py
@@ -33,6 +33,11 @@ from odl.set.domain import IntervalProd
 from odl.util.testutils import all_equal
 
 
+# TODO: tests for
+# - cell boundaries
+# - cell sizes
+
+
 def test_partition_init():
     interv_prod = odl.Rectangle([0, 1], [2, 4])
     grid = odl.uniform_sampling(interv_prod, (5, 15))

--- a/test/discr/partition_test.py
+++ b/test/discr/partition_test.py
@@ -1,0 +1,138 @@
+# Copyright 2014, 2015 The ODL development group
+#
+# This file is part of ODL.
+#
+# ODL is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# ODL is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with ODL.  If not, see <http://www.gnu.org/licenses/>.
+
+
+# Imports for common Python 2/3 codebase
+from __future__ import print_function, division, absolute_import
+from future import standard_library
+standard_library.install_aliases()
+from builtins import zip
+
+# External module imports
+import pytest
+import numpy as np
+
+# ODL imports
+import odl
+from odl.discr.partition import RectPartition
+from odl.set.domain import IntervalProd
+from odl.util.testutils import all_equal
+
+
+def test_partition_init():
+    interv_prod = odl.Rectangle([0, 1], [2, 4])
+    grid = odl.uniform_sampling(interv_prod, (5, 15))
+
+    # Simply test if code runs
+    RectPartition(grid)
+    RectPartition(grid, begin=interv_prod.begin)
+    RectPartition(grid, end=interv_prod.end)
+    RectPartition(grid, begin=interv_prod.begin, begin_axes=(1,))
+    RectPartition(grid, end=interv_prod.end, end_axes=(-1,))
+
+    # Degenerate dimensions should work with explicit begin / end
+    # in corresponding axes
+    grid = odl.uniform_sampling(interv_prod, (5, 1))
+    RectPartition(grid, begin=interv_prod.begin, end=interv_prod.end)
+    RectPartition(grid, begin=interv_prod.begin, end=interv_prod.end,
+                  begin_axes=(1,), end_axes=(1,))
+
+
+def test_partition_init_error():
+    # Check different error scenarios
+    interv_prod = odl.Rectangle([0, 1], [2, 4])
+    grid = odl.uniform_sampling(interv_prod, (5, 15))
+
+    beg_toolarge = (0.5, 2)
+    end_toosmall = (1, 3.99)
+    beg_badshape = (-1, 2, 0)
+    end_badshape = (2,)
+
+    with pytest.raises(ValueError):
+        RectPartition(grid, begin=beg_toolarge)
+
+    with pytest.raises(ValueError):
+        RectPartition(grid, end=end_toosmall)
+
+    with pytest.raises(ValueError):
+        RectPartition(grid, begin=beg_badshape)
+
+    with pytest.raises(ValueError):
+        RectPartition(grid, end=end_badshape)
+
+    # Degenerate dimension, needs both explicit begin and end
+    grid = odl.uniform_sampling(interv_prod, (3, 1))
+    with pytest.raises(ValueError):
+        RectPartition(grid)
+    with pytest.raises(ValueError):
+        RectPartition(grid, begin=interv_prod.begin)
+    with pytest.raises(ValueError):
+        RectPartition(grid, end=interv_prod.end)
+
+    # begin_axes (and end_axes, same function, testing only begin)
+
+    # begin is required
+    with pytest.raises(ValueError):
+        RectPartition(grid, begin_axes=(0,))
+
+    # OOB indices
+    with pytest.raises(IndexError):
+        RectPartition(grid, begin=interv_prod.begin, begin_axes=(0, 2))
+    with pytest.raises(IndexError):
+        RectPartition(grid, begin=interv_prod.begin, begin_axes=(-3,))
+
+    # Duplicate indices
+    with pytest.raises(ValueError):
+        RectPartition(grid, begin=interv_prod.begin, begin_axes=(0, 0, 1,))
+
+
+def test_partition_bounding_box():
+    vec1 = np.array([2, 4, 5, 7])
+    vec2 = np.array([-4, -3, 0, 1, 4])
+    grid = odl.TensorGrid(vec1, vec2)
+
+    begin = [1, -4]
+    end = [10, 5]
+    minpt_calc = [2 - (4 - 2) / 2, -4 - (-3 + 4) / 2]
+    maxpt_calc = [7 + (7 - 5) / 2, 4 + (4 - 1) / 2]
+
+    # Explicit begin / end
+    part = RectPartition(grid, begin=begin, end=end)
+    assert part.bounding_box == IntervalProd(begin, end)
+
+    # Implicit begin / end
+    part = RectPartition(grid, begin=begin)
+    assert part.bounding_box == IntervalProd(begin, maxpt_calc)
+
+    part = RectPartition(grid, end=end)
+    assert part.bounding_box == IntervalProd(minpt_calc, end)
+
+    part = RectPartition(grid)
+    assert part.bounding_box == IntervalProd(minpt_calc, maxpt_calc)
+
+    # Mixture
+    part = RectPartition(grid, begin=begin, begin_axes=(1,))
+    minpt_mix = [minpt_calc[0], begin[1]]
+    assert part.bounding_box == IntervalProd(minpt_mix, maxpt_calc)
+
+    part = RectPartition(grid, end=end, end_axes=(-2,))
+    maxpt_mix = [end[0], maxpt_calc[1]]
+    assert part.bounding_box == IntervalProd(minpt_calc, maxpt_mix)
+
+
+if __name__ == '__main__':
+    pytest.main(str(__file__.replace('\\', '/')) + ' -v')

--- a/test/set/domain_test.py
+++ b/test/set/domain_test.py
@@ -127,22 +127,22 @@ def test_true_ndim():
 
 def test_extent():
     set_ = IntervalProd(1, 2)
-    assert set_.extent == 1
+    assert set_.extent() == 1
 
     set_ = IntervalProd(1, 1)
-    assert set_.extent == 0
+    assert set_.extent() == 0
 
     set_ = IntervalProd(0, np.inf)
-    assert set_.extent == np.inf
+    assert set_.extent() == np.inf
 
     set_ = IntervalProd(-np.inf, 0)
-    assert set_.extent == np.inf
+    assert set_.extent() == np.inf
 
     set_ = IntervalProd(-np.inf, np.inf)
-    assert set_.extent == np.inf
+    assert set_.extent() == np.inf
 
     set_ = IntervalProd([1, 2, 3], [5, 6, 7])
-    assert list(set_.extent) == [4, 4, 4]
+    assert list(set_.extent()) == [4, 4, 4]
 
 
 def test_volume():

--- a/test/util/numerics_test.py
+++ b/test/util/numerics_test.py
@@ -1,0 +1,106 @@
+# Copyright 2014, 2015 The ODL development group
+#
+# This file is part of ODL.
+#
+# ODL is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# ODL is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with ODL.  If not, see <http://www.gnu.org/licenses/>.
+
+
+# Imports for common Python 2/3 codebase
+from __future__ import print_function, division, absolute_import
+from future import standard_library
+standard_library.install_aliases()
+
+# External
+import pytest
+import numpy as np
+
+# Internal
+from odl.util.numerics import apply_on_boundary
+from odl.util.testutils import all_equal
+
+
+def test_apply_on_boundary_default():
+
+    # 1d
+    arr = np.ones(5)
+    apply_on_boundary(arr, lambda x: x * 2)
+    assert all_equal(arr, [2, 1, 1, 1, 2])
+
+    # 3d
+    arr = np.ones((3, 4, 5))
+    apply_on_boundary(arr, lambda x: x * 2)
+    true_arr = 2 * np.ones((3, 4, 5))
+    true_arr[1:-1, 1:-1, 1:-1] = 1
+    assert all_equal(arr, true_arr)
+
+
+def test_apply_on_boundary_func_sequence_2d():
+
+    arr = np.ones((3, 5))
+    apply_on_boundary(arr, [lambda x: x * 2, lambda x: x * 3])
+    assert all_equal(arr, [[2, 2, 2, 2, 2],
+                           [3, 1, 1, 1, 3],
+                           [2, 2, 2, 2, 2]])
+
+
+def test_apply_on_boundary_multiple_times_2d():
+
+    arr = np.ones((3, 5))
+    apply_on_boundary(arr, lambda x: x * 2, only_once=False)
+    assert all_equal(arr, [[4, 2, 2, 2, 4],
+                           [2, 1, 1, 1, 2],
+                           [4, 2, 2, 2, 4]])
+
+
+def test_apply_on_boundary_which_boundaries():
+
+    # 1d
+    arr = np.ones(5)
+    which = ((True, False),)
+    apply_on_boundary(arr, lambda x: x * 2, which_boundaries=which)
+    assert all_equal(arr, [2, 1, 1, 1, 1])
+
+    # 2d
+    arr = np.ones((3, 5))
+    which = ((True, False), True)
+    apply_on_boundary(arr, lambda x: x * 2, which_boundaries=which)
+    assert all_equal(arr, [[2, 2, 2, 2, 2],
+                           [2, 1, 1, 1, 2],
+                           [2, 1, 1, 1, 2]])
+
+
+def test_apply_on_boundary_which_boundaries_multiple_times_2d():
+
+    # 2d
+    arr = np.ones((3, 5))
+    which = ((True, False), True)
+    apply_on_boundary(arr, lambda x: x * 2, which_boundaries=which,
+                      only_once=False)
+    assert all_equal(arr, [[4, 2, 2, 2, 4],
+                           [2, 1, 1, 1, 2],
+                           [2, 1, 1, 1, 2]])
+
+
+def test_apply_on_boundary_axis_order_2d():
+
+    arr = np.ones((3, 5))
+    axis_order = (-1, -2)
+    apply_on_boundary(arr, [lambda x: x * 3, lambda x: x * 2],
+                      axis_order=axis_order)
+    assert all_equal(arr, [[3, 2, 2, 2, 3],
+                           [3, 1, 1, 1, 3],
+                           [3, 2, 2, 2, 3]])
+
+if __name__ == '__main__':
+    pytest.main(str(__file__.replace('\\', '/')) + ' -v')

--- a/test/util/numerics_test.py
+++ b/test/util/numerics_test.py
@@ -34,33 +34,34 @@ def test_apply_on_boundary_default():
 
     # 1d
     arr = np.ones(5)
-    apply_on_boundary(arr, lambda x: x * 2)
-    assert all_equal(arr, [2, 1, 1, 1, 2])
+    result = apply_on_boundary(arr, lambda x: x * 2)
+    assert all_equal(arr, [1, 1, 1, 1, 1])
+    assert all_equal(result, [2, 1, 1, 1, 2])
 
     # 3d
     arr = np.ones((3, 4, 5))
-    apply_on_boundary(arr, lambda x: x * 2)
+    result = apply_on_boundary(arr, lambda x: x * 2)
     true_arr = 2 * np.ones((3, 4, 5))
     true_arr[1:-1, 1:-1, 1:-1] = 1
-    assert all_equal(arr, true_arr)
+    assert all_equal(result, true_arr)
 
 
 def test_apply_on_boundary_func_sequence_2d():
 
     arr = np.ones((3, 5))
-    apply_on_boundary(arr, [lambda x: x * 2, lambda x: x * 3])
-    assert all_equal(arr, [[2, 2, 2, 2, 2],
-                           [3, 1, 1, 1, 3],
-                           [2, 2, 2, 2, 2]])
+    result = apply_on_boundary(arr, [lambda x: x * 2, lambda x: x * 3])
+    assert all_equal(result, [[2, 2, 2, 2, 2],
+                              [3, 1, 1, 1, 3],
+                              [2, 2, 2, 2, 2]])
 
 
 def test_apply_on_boundary_multiple_times_2d():
 
     arr = np.ones((3, 5))
-    apply_on_boundary(arr, lambda x: x * 2, only_once=False)
-    assert all_equal(arr, [[4, 2, 2, 2, 4],
-                           [2, 1, 1, 1, 2],
-                           [4, 2, 2, 2, 4]])
+    result = apply_on_boundary(arr, lambda x: x * 2, only_once=False)
+    assert all_equal(result, [[4, 2, 2, 2, 4],
+                              [2, 1, 1, 1, 2],
+                              [4, 2, 2, 2, 4]])
 
 
 def test_apply_on_boundary_which_boundaries():
@@ -68,16 +69,16 @@ def test_apply_on_boundary_which_boundaries():
     # 1d
     arr = np.ones(5)
     which = ((True, False),)
-    apply_on_boundary(arr, lambda x: x * 2, which_boundaries=which)
-    assert all_equal(arr, [2, 1, 1, 1, 1])
+    result = apply_on_boundary(arr, lambda x: x * 2, which_boundaries=which)
+    assert all_equal(result, [2, 1, 1, 1, 1])
 
     # 2d
     arr = np.ones((3, 5))
     which = ((True, False), True)
-    apply_on_boundary(arr, lambda x: x * 2, which_boundaries=which)
-    assert all_equal(arr, [[2, 2, 2, 2, 2],
-                           [2, 1, 1, 1, 2],
-                           [2, 1, 1, 1, 2]])
+    result = apply_on_boundary(arr, lambda x: x * 2, which_boundaries=which)
+    assert all_equal(result, [[2, 2, 2, 2, 2],
+                              [2, 1, 1, 1, 2],
+                              [2, 1, 1, 1, 2]])
 
 
 def test_apply_on_boundary_which_boundaries_multiple_times_2d():
@@ -85,22 +86,22 @@ def test_apply_on_boundary_which_boundaries_multiple_times_2d():
     # 2d
     arr = np.ones((3, 5))
     which = ((True, False), True)
-    apply_on_boundary(arr, lambda x: x * 2, which_boundaries=which,
-                      only_once=False)
-    assert all_equal(arr, [[4, 2, 2, 2, 4],
-                           [2, 1, 1, 1, 2],
-                           [2, 1, 1, 1, 2]])
+    result = apply_on_boundary(arr, lambda x: x * 2, which_boundaries=which,
+                               only_once=False)
+    assert all_equal(result, [[4, 2, 2, 2, 4],
+                              [2, 1, 1, 1, 2],
+                              [2, 1, 1, 1, 2]])
 
 
 def test_apply_on_boundary_axis_order_2d():
 
     arr = np.ones((3, 5))
     axis_order = (-1, -2)
-    apply_on_boundary(arr, [lambda x: x * 3, lambda x: x * 2],
-                      axis_order=axis_order)
-    assert all_equal(arr, [[3, 2, 2, 2, 3],
-                           [3, 1, 1, 1, 3],
-                           [3, 2, 2, 2, 3]])
+    result = apply_on_boundary(arr, [lambda x: x * 3, lambda x: x * 2],
+                               axis_order=axis_order)
+    assert all_equal(result, [[3, 2, 2, 2, 3],
+                              [3, 1, 1, 1, 3],
+                              [3, 2, 2, 2, 3]])
 
 if __name__ == '__main__':
     pytest.main(str(__file__.replace('\\', '/')) + ' -v')

--- a/test/util/vectorization_test.py
+++ b/test/util/vectorization_test.py
@@ -31,7 +31,6 @@ from odl.util.testutils import all_equal
 from odl.util.utility import is_int_dtype
 from odl.util.vectorization import (
     is_valid_input_array, is_valid_input_meshgrid,
-    meshgrid_input_order, vecs_from_meshgrid,
     out_shape_from_meshgrid, out_shape_from_array,
     vectorize)
 
@@ -89,9 +88,6 @@ def test_is_valid_input_meshgrid():
     valid_mg = sparse_meshgrid(x, y, z)
     assert is_valid_input_meshgrid(valid_mg, ndim=3)
 
-    valid_mg = sparse_meshgrid(x, y, z, order='F')
-    assert is_valid_input_meshgrid(valid_mg, ndim=3)
-
     invalid_mg = sparse_meshgrid(x, x, y, z)
     assert not is_valid_input_meshgrid(invalid_mg, ndim=3)
 
@@ -104,113 +100,6 @@ def test_is_valid_input_meshgrid():
     for inp in invalid_input:
         assert not is_valid_input_meshgrid(inp, ndim=1)
         assert not is_valid_input_meshgrid(inp, ndim=2)
-
-
-def test_meshgrid_input_order():
-
-    # 1d
-    x = np.zeros(2)
-
-    mg = sparse_meshgrid(x, order='C')
-    assert meshgrid_input_order(mg) == 'C'
-
-    # Both 'C' and 'F' contiguous, defaults to 'C'
-    mg = sparse_meshgrid(x, order='F')
-    assert meshgrid_input_order(mg) == 'C'
-
-    # 3d
-    x, y, z = np.zeros(2), np.zeros(3), np.zeros(4)
-
-    mg = sparse_meshgrid(x, y, z, order='C')
-    assert meshgrid_input_order(mg) == 'C'
-
-    mg = sparse_meshgrid(x, y, z, order='F')
-    assert meshgrid_input_order(mg) == 'F'
-
-    # 3d including a degenerate axis
-    mg = sparse_meshgrid(x, y, [0.0], order='C')
-    assert meshgrid_input_order(mg) == 'C'
-
-    mg = sparse_meshgrid(x, y, [0.0], order='F')
-    assert meshgrid_input_order(mg) == 'F'
-
-    # 3d, fleshed out meshgrids
-    x, y, z = np.zeros(2), np.zeros(3), np.zeros(4)
-    mg = np.meshgrid(x, y, z, sparse=False, indexing='ij', copy=True)
-    assert meshgrid_input_order(mg) == 'C'
-
-    mg = np.meshgrid(x, y, z, sparse=False, indexing='ij', copy=True)
-    mg = [np.asfortranarray(arr) for arr in mg]
-    assert meshgrid_input_order(mg) == 'F'
-
-    # non-contiguous --> error
-    mg = np.meshgrid(x, y, z, sparse=False, indexing='ij', copy=False)
-    with pytest.raises(ValueError):
-        meshgrid_input_order(mg)
-
-    # messed up tuple
-    mg = list(sparse_meshgrid(x, y, z, order='C'))
-    mg[1] = mg[0]
-    with pytest.raises(ValueError):
-        meshgrid_input_order(mg)
-
-
-def test_vecs_from_meshgrid():
-
-    # 1d
-    x = np.zeros(2)
-
-    mg = sparse_meshgrid(x, order='C')
-    vx = vecs_from_meshgrid(mg, order='C')[0]
-    assert x.shape == vx.shape
-    assert all_equal(x, vx)
-
-    mg = sparse_meshgrid(x, order='F')
-    vx = vecs_from_meshgrid(mg, order='F')[0]
-    assert x.shape == vx.shape
-    assert all_equal(x, vx)
-
-    # 3d
-    x, y, z = np.zeros(2), np.zeros(3), np.zeros(4)
-
-    mg = sparse_meshgrid(x, y, z, order='C')
-    vx, vy, vz = vecs_from_meshgrid(mg, order='C')
-    assert x.shape == vx.shape
-    assert all_equal(x, vx)
-    assert y.shape == vy.shape
-    assert all_equal(y, vy)
-    assert z.shape == vz.shape
-    assert all_equal(z, vz)
-
-    mg = sparse_meshgrid(x, y, z, order='F')
-    vx, vy, vz = vecs_from_meshgrid(mg, order='F')
-    assert x.shape == vx.shape
-    assert all_equal(x, vx)
-    assert y.shape == vy.shape
-    assert all_equal(y, vy)
-    assert z.shape == vz.shape
-    assert all_equal(z, vz)
-
-    # 3d, fleshed out meshgrids
-    x, y, z = np.zeros(2), np.zeros(3), np.zeros(4)
-    mg = np.meshgrid(x, y, z, sparse=False, indexing='ij', copy=True)
-    vx, vy, vz = vecs_from_meshgrid(mg, order='C')
-    assert x.shape == vx.shape
-    assert all_equal(x, vx)
-    assert y.shape == vy.shape
-    assert all_equal(y, vy)
-    assert z.shape == vz.shape
-    assert all_equal(z, vz)
-
-    mg = np.meshgrid(x, y, z, sparse=False, indexing='ij', copy=True)
-    mg = tuple(reversed([np.asfortranarray(arr) for arr in mg]))
-    vx, vy, vz = vecs_from_meshgrid(mg, order='F')
-    assert x.shape == vx.shape
-    assert all_equal(x, vx)
-    assert y.shape == vy.shape
-    assert all_equal(y, vy)
-    assert z.shape == vz.shape
-    assert all_equal(z, vz)
 
 
 def test_out_shape_from_array():
@@ -238,18 +127,12 @@ def test_out_shape_from_meshgrid():
 
     # 1d
     x = np.zeros(2)
-    mg = sparse_meshgrid(x, order='C')
-    assert out_shape_from_meshgrid(mg) == (2,)
-
-    mg = sparse_meshgrid(x, order='F')
+    mg = sparse_meshgrid(x)
     assert out_shape_from_meshgrid(mg) == (2,)
 
     # 3d
     x, y, z = np.zeros(2), np.zeros(3), np.zeros(4)
-    mg = sparse_meshgrid(x, y, z, order='C')
-    assert out_shape_from_meshgrid(mg) == (2, 3, 4)
-
-    mg = sparse_meshgrid(x, y, z, order='F')
+    mg = sparse_meshgrid(x, y, z)
     assert out_shape_from_meshgrid(mg) == (2, 3, 4)
 
     # 3d, fleshed out meshgrids


### PR DESCRIPTION
Major PR again, but the main changes are really only a few, and the high number of code changes is due to the grid usage being very widespread across the code.

Here's what happened:

- A new `RectPartition` class was added which takes over all functionality connected to partition of sets which grids had to handle partly.
- Grids are stripped down to purely handle their points, no extent, no convex hull etc. Much cleaner.
- No more ordering in grids and partitions, this was shifted to `DiscreteLp` and `FunctionSetMapping` since they are the links between grid points and data storage (see also #249).
- Adaption of inner product, norm and dist in `DiscreteLp` where the "cropped cells" at the boundaries have to be accounted for. This currently requires a copy, therefore having nodes at the boundary is not the default. (It is in `RectPartition` but not in `uniform_discr`, we could harmonize that.)
- Done away with some of the LaTeX heavy docstrings plus some more cleanup.

Detailed TODO list:

##### `partition.py`
- [x] Decide what parameters to take in `RectPartition.__init__`. Simplify accordingly and move complexity to helpers if adequate.
- [x] Accept `begin` / `end` as arrays or dictionaries (remove separate `..._axes` parameter), probably in `uniform_partition` helper
- [x] Rename some `cell_...` guys so we don't have almost-clashes
- [x] Add `uniform_partition_from_intv_prod`
- [x] ~~Better name for `nodes_on_boundary`?~~
- [x] Handle vector input for begin/end better (casting, floats, ...)
- [x] Remove `sampling_...` prefix from points and meshgrid methods?
- [x] Cell boundaries as a property?
- [x] Clarify the "weird" behavior of `cell_size` and `cell_volume`, perhaps new init will make that obsolete
- [x] Simplify `sum(on_boundary)`
- [x] Change `uniform_partition` default to not use nodes on the boundary
- [x] Explain the calculation in `uniform_partition` better

##### `lp_discr.py`
- [x] Check and implement behavior for partitions where the last grid point is neither on the boundary nor in the midpoint of the last cell (calculate weight accordingly, 1/2 -> w >= 1/2)
- [x] ~~Avoid copy in `_inner` etc. when there are boundary nodes. This requires something smarter than purely relying on the underlying `dspace` implementation, though.~~ New issue.
- [x] Raise `ValueError` when wrong interpolation type is given
- [x] Find better name for iteration variable `bdry`
- [x] Make overridden space functions more DRY (`nodes_on_boundary`, `apply_on_boundary`, ...)
- [x] Comment on weighting in overridden methods and what the boundary thing does
- [x] Make the boundary thing work with CUDA
- [x] Handle boundary in `__repr__`, don't assume `False`
- [x] Remove "consistent" option from `uniform_discr` for now
- [x] Clarify boundary option in docstring of `uniform_discr`

##### `discr_mappings.py`
- [x] Add order back to `FunctionSetMapping.__eq__`, resurrect the doctest and and a unit test
- [x] Proof-read docstrings of `FunctionSetMapping` and co. (fix formulations, links etc.)

##### `grid.py`
- [x] Improve `TensorGrid` docstring
- [x] Add back "grid" in pretty-print
- [x] Links in doc and comment on min/max
- [x] Remove redundant `ndim` check when comparing shapes in `__eq__`
- [x] Resurrect `convex_hull`
- [x] Remove redundant checks in `uniform_sampling`
- [x] Add `uniform_sampling_from_intv_prod`

##### `numerics.py`
- [x] Improve explanation of `only_once` parameter
- [x] Improve comments
- [x] Fix Py2-related error when copying lists

##### `domain.py`
- [x] Decide what to do with LoL input to `IntervalProd.insert` and add a doctest with index -1

##### In tests
- [x] Test if inner product etc. work properly in all constellations (including CUDA)
- [x] Add min/max tests for grids if not covered by doctests
- [x] ~~Scrap remnants of order in grid tests~~
- [x] `test_..._error` -> `test_..._raise`

##### Across multiple files
- [x] Add missing defaults in docstrings and improve error message
- [x] Avoid rounding when casting indices to integer (add casting rule)
- [x] ~~Simplify imports from basic modules~~
- [x] Cross-reference `min` and `max` methods
- [x] Make things like `callable` and `sequence` links
- [x] Go through the examples and fix them if necessary.
