### PR TITLE
ENH: made apply_on_boundary use out parameter

### DIFF
--- a/odl/discr/lp_discr.py
+++ b/odl/discr/lp_discr.py
@@ -249,12 +249,7 @@ class DiscreteLp(Discretization):
             # TODO: implement without copying x
             func_list = _scaling_func_list(bdry_fracs)
 
-            x_arr = x.asarray()
-            if not x_arr.flags.owndata:
-                x_arr = x_arr.copy()
-
-            apply_on_boundary(x_arr, func=func_list, only_once=False,
-                              out=x_arr)
+            x_arr = apply_on_boundary(x, func=func_list, only_once=False)
             return super()._inner(self.element(x_arr), y)
 
     def _norm(self, x):
@@ -265,14 +260,9 @@ class DiscreteLp(Discretization):
             return super()._norm(x)
         else:
             # TODO: implement without copying x
-            func_list = _scaling_func_list(bdry_fracs,
-                                           exponent=self.exponent)
-            x_arr = x.asarray()
-            if not x_arr.flags.owndata:
-                x_arr = x_arr.copy()
+            func_list = _scaling_func_list(bdry_fracs, exponent=self.exponent)
 
-            apply_on_boundary(x_arr, func=func_list, only_once=False,
-                              out=x_arr)
+            x_arr = apply_on_boundary(x, func=func_list, only_once=False)
             return super()._norm(self.element(x_arr))
 
     def _dist(self, x, y):
@@ -283,20 +273,12 @@ class DiscreteLp(Discretization):
             return super()._dist(x, y)
         else:
             # TODO: implement without copying x
-            func_list = _scaling_func_list(bdry_fracs,
-                                           exponent=self.exponent)
+            func_list = _scaling_func_list(bdry_fracs, exponent=self.exponent)
 
-            x_arr, y_arr = x.asarray(), y.asarray()
-            if not x_arr.flags.owndata:
-                x_arr = x_arr.copy()
-            if not y_arr.flags.owndata:
-                y_arr = y_arr.copy()
+            arrs = [apply_on_boundary(vec, func=func_list, only_once=False)
+                    for vec in (x, y)]
 
-            for arr in (x_arr, y_arr):
-                apply_on_boundary(arr, func=func_list, only_once=False,
-                                  out=x_arr)
-
-            return super()._dist(self.element(x_arr), self.element(y_arr))
+            return super()._dist(self.element(arrs[0]), self.element(arrs[1]))
 
     def __repr__(self):
         """Return ``repr(self).``"""

--- a/odl/discr/lp_discr.py
+++ b/odl/discr/lp_discr.py
@@ -253,7 +253,8 @@ class DiscreteLp(Discretization):
             if not x_arr.flags.owndata:
                 x_arr = x_arr.copy()
 
-            apply_on_boundary(x_arr, func=func_list, only_once=False)
+            apply_on_boundary(x_arr, func=func_list, only_once=False,
+                              out=x_arr)
             return super()._inner(self.element(x_arr), y)
 
     def _norm(self, x):
@@ -270,7 +271,8 @@ class DiscreteLp(Discretization):
             if not x_arr.flags.owndata:
                 x_arr = x_arr.copy()
 
-            apply_on_boundary(x_arr, func=func_list, only_once=False)
+            apply_on_boundary(x_arr, func=func_list, only_once=False,
+                              out=x_arr)
             return super()._norm(self.element(x_arr))
 
     def _dist(self, x, y):
@@ -291,7 +293,8 @@ class DiscreteLp(Discretization):
                 y_arr = y_arr.copy()
 
             for arr in (x_arr, y_arr):
-                apply_on_boundary(arr, func=func_list, only_once=False)
+                apply_on_boundary(arr, func=func_list, only_once=False,
+                                  out=x_arr)
 
             return super()._dist(self.element(x_arr), self.element(y_arr))
 

--- a/odl/util/__init__.py
+++ b/odl/util/__init__.py
@@ -37,4 +37,8 @@ from . import graphics
 from .graphics import *
 __all__ += graphics.__all__
 
+from .import numerics
+from .numerics import *
+__all__ += numerics.__all__
+
 from . import ufuncs

--- a/odl/util/numerics.py
+++ b/odl/util/numerics.py
@@ -24,6 +24,8 @@ from __future__ import print_function, division, absolute_import
 from future import standard_library
 standard_library.install_aliases()
 
+import numpy as np
+
 
 __all__ = ('apply_on_boundary',)
 
@@ -36,7 +38,7 @@ def apply_on_boundary(array, func, only_once=True, which_boundaries=None,
 
     Parameters
     ----------
-    array : `numpy.ndarray`
+    array : array-like
         Modify the boundary of this array
     func : `callable` or `sequence`
         If a single function is given, assign
@@ -103,6 +105,8 @@ def apply_on_boundary(array, func, only_once=True, which_boundaries=None,
     >>> result is out
     True
     """
+    array = np.asarray(array)
+
     if callable(func):
         func = [func] * array.ndim
     elif len(func) != array.ndim:

--- a/odl/util/numerics.py
+++ b/odl/util/numerics.py
@@ -63,12 +63,12 @@ def apply_on_boundary(array, func, only_once=True, which_boundaries=None,
         the left, the second for the right boundary. The length of the
         sequence must be ``array.ndim``. `None` is interpreted as
         'all boundaries'.
-    axis_order : `sequence` of `int`
+    axis_order : `sequence` of `int`, optional
         Permutation of ``range(array.ndim)`` defining the order in which
         to process the axes. If combined with ``only_once`` and a
         function list, this determines which function is evaluated in
         the points that are potentially processed multiple times.
-    out : `numpy.ndarray`
+    out : `numpy.ndarray`, optional
         Location in which to store the result, can be the same as ``array``.
         Default: copy of ``array``
 

--- a/test/util/numerics_test.py
+++ b/test/util/numerics_test.py
@@ -34,33 +34,34 @@ def test_apply_on_boundary_default():
 
     # 1d
     arr = np.ones(5)
-    apply_on_boundary(arr, lambda x: x * 2)
-    assert all_equal(arr, [2, 1, 1, 1, 2])
+    result = apply_on_boundary(arr, lambda x: x * 2)
+    assert all_equal(arr, [1, 1, 1, 1, 1])
+    assert all_equal(result, [2, 1, 1, 1, 2])
 
     # 3d
     arr = np.ones((3, 4, 5))
-    apply_on_boundary(arr, lambda x: x * 2)
+    result = apply_on_boundary(arr, lambda x: x * 2)
     true_arr = 2 * np.ones((3, 4, 5))
     true_arr[1:-1, 1:-1, 1:-1] = 1
-    assert all_equal(arr, true_arr)
+    assert all_equal(result, true_arr)
 
 
 def test_apply_on_boundary_func_sequence_2d():
 
     arr = np.ones((3, 5))
-    apply_on_boundary(arr, [lambda x: x * 2, lambda x: x * 3])
-    assert all_equal(arr, [[2, 2, 2, 2, 2],
-                           [3, 1, 1, 1, 3],
-                           [2, 2, 2, 2, 2]])
+    result = apply_on_boundary(arr, [lambda x: x * 2, lambda x: x * 3])
+    assert all_equal(result, [[2, 2, 2, 2, 2],
+                              [3, 1, 1, 1, 3],
+                              [2, 2, 2, 2, 2]])
 
 
 def test_apply_on_boundary_multiple_times_2d():
 
     arr = np.ones((3, 5))
-    apply_on_boundary(arr, lambda x: x * 2, only_once=False)
-    assert all_equal(arr, [[4, 2, 2, 2, 4],
-                           [2, 1, 1, 1, 2],
-                           [4, 2, 2, 2, 4]])
+    result = apply_on_boundary(arr, lambda x: x * 2, only_once=False)
+    assert all_equal(result, [[4, 2, 2, 2, 4],
+                              [2, 1, 1, 1, 2],
+                              [4, 2, 2, 2, 4]])
 
 
 def test_apply_on_boundary_which_boundaries():
@@ -68,16 +69,16 @@ def test_apply_on_boundary_which_boundaries():
     # 1d
     arr = np.ones(5)
     which = ((True, False),)
-    apply_on_boundary(arr, lambda x: x * 2, which_boundaries=which)
-    assert all_equal(arr, [2, 1, 1, 1, 1])
+    result = apply_on_boundary(arr, lambda x: x * 2, which_boundaries=which)
+    assert all_equal(result, [2, 1, 1, 1, 1])
 
     # 2d
     arr = np.ones((3, 5))
     which = ((True, False), True)
-    apply_on_boundary(arr, lambda x: x * 2, which_boundaries=which)
-    assert all_equal(arr, [[2, 2, 2, 2, 2],
-                           [2, 1, 1, 1, 2],
-                           [2, 1, 1, 1, 2]])
+    result = apply_on_boundary(arr, lambda x: x * 2, which_boundaries=which)
+    assert all_equal(result, [[2, 2, 2, 2, 2],
+                              [2, 1, 1, 1, 2],
+                              [2, 1, 1, 1, 2]])
 
 
 def test_apply_on_boundary_which_boundaries_multiple_times_2d():
@@ -85,22 +86,22 @@ def test_apply_on_boundary_which_boundaries_multiple_times_2d():
     # 2d
     arr = np.ones((3, 5))
     which = ((True, False), True)
-    apply_on_boundary(arr, lambda x: x * 2, which_boundaries=which,
-                      only_once=False)
-    assert all_equal(arr, [[4, 2, 2, 2, 4],
-                           [2, 1, 1, 1, 2],
-                           [2, 1, 1, 1, 2]])
+    result = apply_on_boundary(arr, lambda x: x * 2, which_boundaries=which,
+                               only_once=False)
+    assert all_equal(result, [[4, 2, 2, 2, 4],
+                              [2, 1, 1, 1, 2],
+                              [2, 1, 1, 1, 2]])
 
 
 def test_apply_on_boundary_axis_order_2d():
 
     arr = np.ones((3, 5))
     axis_order = (-1, -2)
-    apply_on_boundary(arr, [lambda x: x * 3, lambda x: x * 2],
-                      axis_order=axis_order)
-    assert all_equal(arr, [[3, 2, 2, 2, 3],
-                           [3, 1, 1, 1, 3],
-                           [3, 2, 2, 2, 3]])
+    result = apply_on_boundary(arr, [lambda x: x * 3, lambda x: x * 2],
+                               axis_order=axis_order)
+    assert all_equal(result, [[3, 2, 2, 2, 3],
+                              [3, 1, 1, 1, 3],
+                              [3, 2, 2, 2, 3]])
 
 if __name__ == '__main__':
     pytest.main(str(__file__.replace('\\', '/')) + ' -v')


### PR DESCRIPTION
Did the change I proposed to `apply_on_boundary` now conforms to 

Profiling:

```python
arr = np.zeros([10] * 5)

# old
for i in range(10**6):
    apply_on_boundary(arr, lambda x: x / 2)
    
# new
for i in range(10**6):
    apply_on_boundary(arr, lambda x: x / 2, out=arr)
```

Time:

old: 21.015s
new: 21.115s

Also simplifies the implementation of `_norm` etc notably.