### PR TITLE
ENH: add point-wise norm and inner product for vector fields

### DIFF
--- a/odl/discr/__init__.py
+++ b/odl/discr/__init__.py
@@ -44,3 +44,6 @@ __all__ += lp_discr.__all__
 from . import discr_ops
 from .discr_ops import *
 __all__ += discr_ops.__all__
+
+from .tensor_ops import *
+__all__ += tensor_ops.__all__

--- a/odl/discr/tensor_ops.py
+++ b/odl/discr/tensor_ops.py
@@ -1,0 +1,409 @@
+﻿# Copyright 2014-2016 The ODL development group
+#
+# This file is part of ODL.
+#
+# ODL is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# ODL is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with ODL.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Operators defined for tensor fields."""
+
+# Imports for common Python 2/3 codebase
+from __future__ import print_function, division, absolute_import
+from future import standard_library
+standard_library.install_aliases()
+from builtins import super
+from future.utils import raise_from
+
+import numpy as np
+
+from odl.operator.operator import Operator
+from odl.set.sets import RealNumbers
+from odl.space.fspace import FunctionSpace
+from odl.space.pspace import ProductSpace
+
+
+__all__ = ('PointwiseOperator', 'PointwiseNorm')
+
+
+class PointwiseOperator(Operator):
+
+    """Abstract operator for point-wise tensor field manipulations.
+
+    A point-wise operator acts on a space of vector or tensor fields,
+    i.e. a power space ``X^d`` of a discretized function space ``X``.
+    Its range is the power space ``X^k`` with a possibly different
+    number ``k`` of components.
+
+    For example, if ``X`` is a `DiscreteLp` space, then
+    ``ProductSpace(X, d)`` is a valid domain for any positive integer
+    ``d``.
+
+    Currently, only vector fields, i.e. one-dimensional products of
+    ``X``, are supported.
+
+    See also
+    --------
+    ProductSpace
+    """
+
+    def __init__(self, domain, ran_size, linear=False):
+        """Initialize a new instance.
+
+        Parameters
+        ----------
+        domain : `ProductSpace` of `Discretization`
+            Space of vector fields on which the operator acts.
+            It has to be a product space of identical discretized
+            function spaces, i.e. a power space.
+        ran_size : positive `int`
+            Number of components of the range
+        linear : `bool`, optional
+            If `True`, assume that the operator is linear.
+        """
+        if not isinstance(domain, ProductSpace):
+            raise TypeError('domain {!r} is not a ProductSpace instance.'
+                            ''.format(domain))
+        if not domain.is_power_space:
+            raise TypeError('domain {!r} is not a power space.'.format(domain))
+
+        if not isinstance(domain[0].uspace, FunctionSpace):
+            raise TypeError('domain component {!r} is not a function space '
+                            'discretization.'.format(domain[0]))
+
+        ran_size, ran_size_in = int(ran_size), ran_size
+        if ran_size <= 0:
+            raise ValueError('number of range components must be positive, '
+                             'got {}.'.format(ran_size_in))
+        self._ran_size = ran_size
+
+        # Range will be just 'X' if there is only one component
+        if self.ran_size == 1:
+            ran = domain[0]
+        else:
+            ran = ProductSpace(domain[0], self.ran_size)
+        super().__init__(domain=domain, range=ran, linear=linear)
+
+    @property
+    def discr_fspace(self):
+        """The base space ``X`` of this operator's domain and range."""
+        return self.domain[0]
+
+    @property
+    def ran_size(self):
+        """Number of component spaces in the range."""
+        return self._ran_size
+
+
+class PointwiseNorm(PointwiseOperator):
+
+    """Take the point-wise norm of a tensor field.
+
+    This operator takes the (weighted) ``p``-norm
+
+        ``||F(x)|| = [ sum_j( w_j * |F_j(x)|^p ) ]^(1/p)``
+
+    for ``p`` finite and
+
+        ``||F(x)|| = max_j( w_j * |F_j(x)| )``
+
+    for ``p = inf``, where ``F`` is a tensor field. This implies that
+    the `Operator.domain` is a power space of a discretized function
+    space. For example, if ``X`` is a `DiscreteLp` space, then
+    ``ProductSpace(X, d)`` is a valid domain for any positive integer
+    ``d``.
+
+    Currently only vector fields, i.e. product spaces with lenght-1
+    shape, are supported.
+    """
+
+    def __init__(self, domain, exponent=None, weight=None):
+        """Initialize a new instance.
+
+        Parameters
+        ----------
+        domain : `ProductSpace`
+            Space of vector fields on which the operator acts.
+            It has to be a product space of identical discretized
+            function spaces, i.e. a power space. Its
+            `ProductSpace.shape` must have length 1.
+        exponent : non-zero `float`, optional
+            Exponent of the norm in each point. Values between
+            0 and 1 are currently not supported due to numerical
+            instability.
+            Default: ``domain.exponent``
+        weight : `array-like` or `float`, optional
+            Weighting array or constant for the norm. If an array is
+            given, its length must be equal to ``domain.size``, and
+            all entries must be positive. A provided constant must be
+            positive.
+            By default, the weights are is taken from
+            ``domain.weighting``. Note that this excludes unusual
+            weightings with custom inner product, norm or dist.
+        """
+        super().__init__(domain, ran_size=1, linear=False)
+        if len(self.domain.shape) != 1:
+            raise NotImplementedError
+
+        if exponent is None:
+            if domain.exponent is None:
+                raise ValueError('cannot determine exponent from {}.'
+                                 ''.format(self.domain))
+            self._exponent = self.domain.exponent
+        elif 0 <= exponent < 1:
+            raise ValueError('exponent between 0 and 1 not allowed.')
+        else:
+            self._exponent = float(exponent)
+
+        # Handle weighting, including sanity checks
+        if weight is None:
+            if hasattr(self.domain.weighting, 'vector'):
+                self._weights = self.domain.weighting.vector
+            elif hasattr(self.domain.weighting, 'const'):
+                self._weights = (self.domain.weighting.const *
+                                 np.ones(len(self.domain)))
+            else:
+                raise ValueError('weighting scheme {!r} of the domain does '
+                                 'not define a weighting vector or constant.'
+                                 ''.format(self.domain.weighting))
+        elif np.isscalar(weight):
+            if weight <= 0:
+                raise ValueError('weighting constant must be positive, got '
+                                 '{}.'.format(weight))
+            self._weights = float(weight) * np.ones(self.domain.size)
+        else:
+            self._weights = np.asarray(weight, dtype='float64')
+            if (not np.all(self.weights > 0) or
+                    not np.all(np.isfinite(self.weights))):
+                raise ValueError('weighting array {} contains invalid '
+                                 'entries.'.format(weight))
+        self._is_weighted = (not np.all(np.array_equiv(self.weights, 1.0)))
+
+    @property
+    def exponent(self):
+        """Exponent ``p`` of this norm."""
+        return self._exponent
+
+    @property
+    def weights(self):
+        """Weighting vector of this norm."""
+        return self._weights
+
+    @property
+    def is_weighted(self):
+        """`True` if weighting is not 1 or all ones."""
+        return self._is_weighted
+
+    def _call(self, f, out):
+        """Implement ``self(f, out)``."""
+        if len(self.domain.shape) > 1:
+            raise NotImplementedError
+
+        if self.exponent == 1.0:
+            self._call_vecfield_1(f, out)
+        elif self.exponent == float('inf'):
+            self._call_vecfield_inf(f, out)
+        else:
+            self._call_vecfield_p(f, out)
+
+    def _call_vecfield_1(self, vf, out):
+        """Implement ``self(vf, out)`` for exponent 1."""
+        vf[0].ufunc.absolute(out=out)
+        if self.is_weighted:
+            out *= self.weights[0]
+
+        if self.domain.size == 1:
+            return
+
+        tmp = self.range.element()
+        for fi, w in zip(vf[1:], self.weights[1:]):
+            fi.ufunc.absolute(out=tmp)
+            if self.is_weighted:
+                tmp *= w
+            out += tmp
+
+    def _call_vecfield_inf(self, vf, out):
+        """Implement ``self(vf, out)`` for exponent ``inf``."""
+        vf[0].ufunc.absolute(out=out)
+        if self.is_weighted:
+            out *= self.weights[0]
+
+        if self.domain.size == 1:
+            return
+
+        tmp = self.range.element()
+        for fi, w in zip(vf[1:], self.weights[1:]):
+            fi.ufunc.absolute(out=tmp)
+            if self.is_weighted:
+                tmp *= w
+            out.ufunc.maximum(tmp, out=out)
+
+    def _call_vecfield_p(self, vf, out):
+        """Implement ``self(vf, out)`` for exponent 1 < p < ``inf``."""
+        # Optimization for 1 component - just absolute value (maybe weighted)
+        if self.domain.size == 1:
+            vf[0].ufunc.absolute(out=out)
+            if self.is_weighted:
+                out *= self.weights[0] ** (1 / self.exponent)
+            return
+
+        # Initialize out, avoiding one copy
+        self._abs_pow_ufunc(vf[0], out=out)
+        if self.is_weighted:
+            out *= self.weights[0]
+
+        tmp = self.range.element()
+        for fi, w in zip(vf[1:], self.weights[1:]):
+            self._abs_pow_ufunc(fi, out=tmp)
+            if self.is_weighted:
+                tmp *= w
+            out += tmp
+
+        out.ufunc.power(1 / self.exponent, out=out)
+
+    def _abs_pow_ufunc(self, fi, out):
+        """Compute |F_i(x)|^p point-wise and write to ``out``."""
+        # Optimization for a very common case
+        if self.exponent == 2.0 and self.discr_fspace.field == RealNumbers():
+            out.multiply(fi, fi)
+        else:
+            fi.ufunc.absolute(out=out)
+            out.ufunc.power(self.exponent, out=out)
+
+
+class PointwiseInner(PointwiseOperator):
+
+    """Take the point-wise norm of a vector field.
+
+    This operator takes the (weighted) inner product
+
+        ``<F(x), G(x)> = sum_j ( w_j * F_j(x) * conj(G_j(x)) )
+
+    for a given vector field ``G``, where ``F`` is the vector field
+    acting as a variable to this operator.
+
+    This implies that the `Operator.domain` is a power space of a
+    discretized function space. For example, if ``X`` is a `DiscreteLp`
+    space, then ``ProductSpace(X, d)`` is a valid domain for any
+    positive integer ``d``.
+    """
+
+    def __init__(self, domain, vecfield, weight=None):
+        """Initialize a new instance.
+
+        Parameters
+        ----------
+        domain : `ProductSpace`
+            Space of vector fields on which the operator acts.
+            It has to be a product space of identical discretized
+            function spaces, i.e. a power space.
+        vecfield : domain `element-like`
+            Vector field with which to calculate the point-wise inner
+            product of an input vector field
+        weight : `array-like` or `float`, optional
+            Weighting array or constant for the norm. If an array is
+            given, its length must be equal to ``domain.size``, and
+            all entries must be positive. A provided constant must be
+            positive.
+            By default, the weights are is taken from
+            ``domain.weighting``. Note that this excludes unusual
+            weightings with custom inner product, norm or dist.
+        """
+        super().__init__(domain, ran_size=1, linear=False)
+        if len(self.domain.shape) != 1:
+            raise NotImplementedError
+
+        if self.domain.field == RealNumbers():
+            self._vecfield_conj = self.domain.element(vecfield)
+        else:
+            if not hasattr(self.discr_fspace.element_type, 'conj'):
+                raise NotImplementedError(
+                    'base space element type {!r} does not implement conj() '
+                    'method required for complex inner products.'
+                    ''.format(self.discr_fspace.element_type))
+            try:
+                self._vecfield_conj = self.domain.element(
+                    [self.discr_fspace.element(vfi).conj()
+                     for vfi in vecfield])
+            except TypeError as err:
+                raise_from(TypeError(
+                    'unable to create an element of {!r} from {!r}.'
+                    ''.format(self.domain, vecfield)), err)
+
+        # Handle weighting, including sanity checks
+        if weight is None:
+            if hasattr(self.domain.weighting, 'vector'):
+                self._weights = self.domain.weighting.vector
+            elif hasattr(self.domain.weighting, 'const'):
+                self._weights = (self.domain.weighting.const *
+                                 np.ones(len(self.domain)))
+            else:
+                raise ValueError('weighting scheme {!r} of the domain does '
+                                 'not define a weighting vector or constant.'
+                                 ''.format(self.domain.weighting))
+        elif np.isscalar(weight):
+            if weight <= 0:
+                raise ValueError('weighting constant must be positive, got '
+                                 '{}.'.format(weight))
+            self._weights = float(weight) * np.ones(self.domain.size)
+        else:
+            self._weights = np.asarray(weight, dtype='float64')
+            if (not np.all(self.weights > 0) or
+                    not np.all(np.isfinite(self.weights))):
+                raise ValueError('weighting array {} contains invalid '
+                                 'entries.'.format(weight))
+        self._is_weighted = (not np.all(np.array_equiv(self.weights, 1.0)))
+
+    def vecfield(self):
+        """Fixed vector field ``G`` of this inner product.
+
+        Internally, the complex conjugate of the vector field is
+        stored for efficiency reasons, so for a complex domain, this
+        method does not run in constant time.
+        """
+        if self.domain.field == RealNumbers():
+            return self._vecfield_conj
+        else:
+            return self._vecfield_conj.conj()
+
+    @property
+    def weights(self):
+        """Weighting vector of this norm."""
+        return self._weights
+
+    @property
+    def is_weighted(self):
+        """`True` if weighting is not 1 or all ones."""
+        return self._is_weighted
+
+    def _call(self, vf, out):
+        """Implement ``self(vf, out)``."""
+        out.multiply(vf[0], self._vecfield_conj[0])
+        if self.is_weighted:
+            out *= self.weights[0]
+
+        if self.domain.size == 1:
+            return
+
+        tmp = self.range.element()
+        for fi, gi_conj, w in zip(vf[1:], self._vecfield_conj[1:],
+                                  self.weights[1:]):
+            tmp.multiply(fi, gi_conj)
+            if self.is_weighted:
+                tmp *= w
+            out += tmp
+
+
+if __name__ == '__main__':
+    # pylint: disable=wrong-import-position
+    from odl.util.testutils import run_doctests
+    run_doctests()

--- a/odl/discr/tensor_ops.py
+++ b/odl/discr/tensor_ops.py
@@ -31,7 +31,7 @@ from odl.space.fspace import FunctionSpace
 from odl.space.pspace import ProductSpace
 
 
-__all__ = ('PointwiseOperator', 'PointwiseNorm')
+__all__ = ('PointwiseOperator', 'PointwiseNorm', 'PointwiseInner')
 
 
 class PointwiseOperator(Operator):

--- a/odl/discr/tensor_ops.py
+++ b/odl/discr/tensor_ops.py
@@ -109,7 +109,7 @@ class PointwiseOperator(Operator):
 
 class PointwiseNorm(PointwiseOperator):
 
-    """Take the point-wise norm of a tensor field.
+    """Take the point-wise norm of a vector field.
 
     This operator takes the (weighted) ``p``-norm
 
@@ -119,14 +119,11 @@ class PointwiseNorm(PointwiseOperator):
 
         ``||F(x)|| = max_j( w_j * |F_j(x)| )``
 
-    for ``p = inf``, where ``F`` is a tensor field. This implies that
+    for ``p = inf``, where ``F`` is a vector field. This implies that
     the `Operator.domain` is a power space of a discretized function
     space. For example, if ``X`` is a `DiscreteLp` space, then
     ``ProductSpace(X, d)`` is a valid domain for any positive integer
     ``d``.
-
-    Currently only vector fields, i.e. product spaces with lenght-1
-    shape, are supported.
     """
 
     def __init__(self, vfspace, exponent=None, weight=None):
@@ -324,7 +321,8 @@ class PointwiseNorm(PointwiseOperator):
                                       'for exponent = inf.')
 
         vf = self.domain.element(vf)
-        vf_pwnorm_fac = self(vf) ** (self.exponent - 1)
+        vf_pwnorm_fac = self(vf)
+        vf_pwnorm_fac **= (self.exponent - 1)
 
         inner_vf = vf.copy()
 
@@ -389,7 +387,6 @@ class PointwiseInner(PointwiseOperator):
                 'method required for complex inner products.'
                 ''.format(self.base_space.element_type))
 
-        # Store vector field and complex conjugate if desired
         self._vecfield = self.domain.element(vecfield)
 
         # Handle weighting, including sanity checks
@@ -418,8 +415,7 @@ class PointwiseInner(PointwiseOperator):
 
     @property
     def vecfield(self):
-        """Fixed vector field ``G`` of this inner product.
-        """
+        """Fixed vector field ``G`` of this inner product."""
         return self._vecfield
 
     @property

--- a/odl/discr/tensor_ops.py
+++ b/odl/discr/tensor_ops.py
@@ -149,6 +149,41 @@ class PointwiseNorm(PointwiseOperator):
             By default, the weights are is taken from
             ``domain.weighting``. Note that this excludes unusual
             weightings with custom inner product, norm or dist.
+
+        Examples
+        --------
+        We make a tiny vector field space in 2D and create the
+        standard point-wise norm operator on that space. The operator
+        maps a vector field to a scalar function:
+
+        >>> import odl
+        >>> spc = odl.uniform_discr([-1, -1], [1, 1], (2, 2))
+        >>> vfspace = odl.ProductSpace(spc, 2)
+        >>> pw_norm = PointwiseNorm(vfspace)
+        >>> pw_norm.range == spc
+        True
+
+        Now we can calculate the 2-norm in each point:
+
+        >>> x = vfspace.element([[[1, 2], [0, 3]],
+        ...                      [[0, 0], [2, 4]]])
+        >>> print(pw_norm(x))
+        [[1.0, 2.0],
+         [2.0, 5.0]]
+
+        We can change the exponent either in the vector field space
+        or in the operator directly:
+
+        >>> vfspace = odl.ProductSpace(spc, 2, exponent=1)
+        >>> pw_norm = PointwiseNorm(vfspace)
+        >>> print(pw_norm(x))
+        [[1.0, 2.0],
+         [2.0, 7.0]]
+        >>> vfspace = odl.ProductSpace(spc, 2)
+        >>> pw_norm = PointwiseNorm(vfspace, exponent=1)
+        >>> print(pw_norm(x))
+        [[1.0, 2.0],
+         [2.0, 7.0]]
         """
         if not isinstance(vfspace, ProductSpace):
             raise TypeError('vector field space {!r} is not a ProductSpace '
@@ -369,6 +404,29 @@ class PointwiseInner(PointwiseOperator):
             By default, the weights are is taken from
             ``domain.weighting``. Note that this excludes unusual
             weightings with custom inner product, norm or dist.
+
+        Examples
+        --------
+        We make a tiny vector field space in 2D and create the
+        point-wise inner product operator with a fixed vector field.
+        The operator maps a vector field to a scalar function:
+
+        >>> import odl
+        >>> spc = odl.uniform_discr([-1, -1], [1, 1], (2, 2))
+        >>> vfspace = odl.ProductSpace(spc, 2)
+        >>> fixed_vf = np.array([[[0, 1], [-1, 1]],
+        ...                      [[1, -1], [1, -1]]])
+        >>> pw_inner = PointwiseInner(vfspace, fixed_vf)
+        >>> pw_inner.range == spc
+        True
+
+        Now we can calculate the inner product in each point:
+
+        >>> x = vfspace.element([[[1, 2], [0, 3]],
+        ...                      [[0, 0], [2, 4]]])
+        >>> print(pw_inner(x))
+        [[0.0, 2.0],
+         [2.0, -1.0]]
         """
         if not isinstance(vfspace, ProductSpace):
             raise TypeError('vector field space {!r} is not a ProductSpace '

--- a/odl/discr/tensor_ops.py
+++ b/odl/discr/tensor_ops.py
@@ -64,6 +64,7 @@ class PointwiseTensorFieldOperator(Operator):
             Spaces of vector fields between which the operator maps.
             They have to be either power spaces of the same base space
             ``X`` or the base space itself (only one of them).
+            Empty product spaces are not allowed.
         linear : `bool`, optional
             If `True`, assume that the operator is linear.
         """
@@ -160,7 +161,7 @@ class PointwiseNorm(PointwiseTensorFieldOperator):
         maps a vector field to a scalar function:
 
         >>> import odl
-        >>> spc = odl.uniform_discr([-1, -1], [1, 1], (2, 2))
+        >>> spc = odl.uniform_discr([-1, -1], [1, 1], (1, 2))
         >>> vfspace = odl.ProductSpace(spc, 2)
         >>> pw_norm = PointwiseNorm(vfspace)
         >>> pw_norm.range == spc
@@ -168,11 +169,10 @@ class PointwiseNorm(PointwiseTensorFieldOperator):
 
         Now we can calculate the 2-norm in each point:
 
-        >>> x = vfspace.element([[[1, 2], [0, 3]],
-        ...                      [[0, 0], [2, 4]]])
+        >>> x = vfspace.element([[[1, -4]],
+        ...                      [[0, 3]]])
         >>> print(pw_norm(x))
-        [[1.0, 2.0],
-         [2.0, 5.0]]
+        [[1.0, 5.0]]
 
         We can change the exponent either in the vector field space
         or in the operator directly:
@@ -180,13 +180,11 @@ class PointwiseNorm(PointwiseTensorFieldOperator):
         >>> vfspace = odl.ProductSpace(spc, 2, exponent=1)
         >>> pw_norm = PointwiseNorm(vfspace)
         >>> print(pw_norm(x))
-        [[1.0, 2.0],
-         [2.0, 7.0]]
+        [[1.0, 7.0]]
         >>> vfspace = odl.ProductSpace(spc, 2)
         >>> pw_norm = PointwiseNorm(vfspace, exponent=1)
         >>> print(pw_norm(x))
-        [[1.0, 2.0],
-         [2.0, 7.0]]
+        [[1.0, 7.0]]
         """
         if not isinstance(vfspace, ProductSpace):
             raise TypeError('vector field space {!r} is not a ProductSpace '
@@ -412,21 +410,20 @@ class PointwiseInner(PointwiseTensorFieldOperator):
         The operator maps a vector field to a scalar function:
 
         >>> import odl
-        >>> spc = odl.uniform_discr([-1, -1], [1, 1], (2, 2))
+        >>> spc = odl.uniform_discr([-1, -1], [1, 1], (1, 2))
         >>> vfspace = odl.ProductSpace(spc, 2)
-        >>> fixed_vf = np.array([[[0, 1], [-1, 1]],
-        ...                      [[1, -1], [1, -1]]])
+        >>> fixed_vf = np.array([[[0, 1]],
+        ...                      [[1, -1]]])
         >>> pw_inner = PointwiseInner(vfspace, fixed_vf)
         >>> pw_inner.range == spc
         True
 
         Now we can calculate the inner product in each point:
 
-        >>> x = vfspace.element([[[1, 2], [0, 3]],
-        ...                      [[0, 0], [2, 4]]])
+        >>> x = vfspace.element([[[1, -4]],
+        ...                      [[0, 3]]])
         >>> print(pw_inner(x))
-        [[0.0, 2.0],
-         [2.0, -1.0]]
+        [[0.0, -7.0]]
         """
         if not isinstance(vfspace, ProductSpace):
             raise TypeError('vector field space {!r} is not a ProductSpace '

--- a/odl/discr/tensor_ops.py
+++ b/odl/discr/tensor_ops.py
@@ -307,7 +307,22 @@ class PointwiseNorm(PointwiseOperator):
         -------
         deriv : `PointwiseInner`
             Derivative operator at the given point ``vf``
+
+        Raises
+        ------
+        NotImplementedError
+            * if the vector field space is complex, since the derivative
+              is not linear in that case
+            * if the exponent is ``inf``
         """
+        if self.domain.field == ComplexNumbers():
+            raise NotImplementedError('operator not Frechet-differentiable '
+                                      'on a complex space.')
+
+        if self.exponent == float('inf'):
+            raise NotImplementedError('operator not Frechet-differentiable '
+                                      'for exponent = inf.')
+
         vf = self.domain.element(vf)
         vf_pwnorm_fac = self(vf) ** (self.exponent - 1)
 

--- a/odl/discr/tensor_ops.py
+++ b/odl/discr/tensor_ops.py
@@ -31,7 +31,7 @@ from odl.set.space import LinearSpace
 from odl.space.pspace import ProductSpace
 
 
-__all__ = ('PointwiseTensorFieldOperator', 'PointwiseNorm', 'PointwiseInner')
+__all__ = ('PointwiseNorm', 'PointwiseInner')
 
 
 class PointwiseTensorFieldOperator(Operator):

--- a/odl/space/pspace.py
+++ b/odl/space/pspace.py
@@ -306,6 +306,12 @@ class ProductSpace(LinearSpace):
         return self._size
 
     @property
+    def shape(self):
+        """Number of spaces per axis."""
+        # Currently supporting only 1d product spaces
+        return (self.size,)
+
+    @property
     def spaces(self):
         """A tuple containing all spaces."""
         return self._spaces

--- a/odl/space/pspace.py
+++ b/odl/space/pspace.py
@@ -519,6 +519,7 @@ class ProductSpace(LinearSpace):
         else:
             return (isinstance(other, ProductSpace) and
                     len(self) == len(other) and
+                    self.weighting == other.weighting and
                     all(x == y for x, y in zip(self.spaces,
                                                other.spaces)))
 

--- a/odl/space/pspace.py
+++ b/odl/space/pspace.py
@@ -524,7 +524,7 @@ class ProductSpace(LinearSpace):
             return True
         else:
             return (isinstance(other, ProductSpace) and
-                    len(self) == len(other) and
+                    self.shape == other.shape and
                     self.weighting == other.weighting and
                     all(x == y for x, y in zip(self.spaces,
                                                other.spaces)))

--- a/test/discr/tensor_ops_test.py
+++ b/test/discr/tensor_ops_test.py
@@ -1,0 +1,344 @@
+# Copyright 2014-2016 The ODL development group
+#
+# This file is part of ODL.
+#
+# ODL is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# ODL is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with ODL.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Unit tests for `tensor_ops`."""
+
+# Imports for common Python 2/3 codebase
+from __future__ import print_function, division, absolute_import
+from future import standard_library
+standard_library.install_aliases()
+
+import pytest
+import numpy as np
+
+import odl
+from odl.discr.tensor_ops import PointwiseNorm, PointwiseInner
+from odl.space.pspace import ProductSpace
+from odl.util.testutils import all_almost_equal, all_equal, almost_equal
+
+
+exp_params = [2.0, 1.0, float('inf'), 3.5, 1.5]
+exp_ids = [' p = {} '.format(p) for p in exp_params]
+
+
+@pytest.fixture(scope="module", ids=exp_ids, params=exp_params)
+def exponent(request):
+    return request.param
+
+
+# ---- PointwiseNorm ---- #
+
+
+def test_pointwise_norm_init_properties():
+    # 1d
+    fspace = odl.uniform_discr([0, 0], [1, 1], (2, 2))
+    vfspace = ProductSpace(fspace, 1, exponent=1)
+
+    # Make sure the code runs and test the properties
+    pwnorm = PointwiseNorm(vfspace)
+    assert pwnorm.discr_fspace == fspace
+    assert pwnorm.ran_size == 1
+    assert all_equal(pwnorm.weights, [1])
+    assert not pwnorm.is_weighted
+    assert pwnorm.exponent == 1.0
+    repr(pwnorm)
+
+    pwnorm = PointwiseNorm(vfspace, exponent=2)
+    assert pwnorm.exponent == 2
+
+    pwnorm = PointwiseNorm(vfspace, weight=2)
+    assert all_equal(pwnorm.weights, [2])
+    assert pwnorm.is_weighted
+
+    # 3d
+    fspace = odl.uniform_discr([0, 0], [1, 1], (2, 2))
+    vfspace = ProductSpace(fspace, 3, exponent=1)
+
+    # Make sure the code runs and test the properties
+    pwnorm = PointwiseNorm(vfspace)
+    assert pwnorm.discr_fspace == fspace
+    assert pwnorm.ran_size == 1
+    assert all_equal(pwnorm.weights, [1, 1, 1])
+    assert not pwnorm.is_weighted
+    assert pwnorm.exponent == 1.0
+    repr(pwnorm)
+
+    pwnorm = PointwiseNorm(vfspace, exponent=2)
+    assert pwnorm.exponent == 2
+
+    pwnorm = PointwiseNorm(vfspace, weight=[1, 2, 3])
+    assert all_equal(pwnorm.weights, [1, 2, 3])
+    assert pwnorm.is_weighted
+
+    # Bad input
+    with pytest.raises(TypeError):
+        PointwiseNorm(odl.Rn(3))  # No power space
+
+    with pytest.raises(ValueError):
+        PointwiseNorm(vfspace, exponent=0.5)  # < 1 not allowed
+
+    with pytest.raises(ValueError):
+        PointwiseNorm(vfspace, weight=-1)  # < 0 not allowed
+
+    with pytest.raises(ValueError):
+        PointwiseNorm(vfspace, weight=[1, 0, 1])  # 0 invalid
+
+
+def test_pointwise_norm_real(exponent):
+    # 1d
+    fspace = odl.uniform_discr([0, 0], [1, 1], (2, 2))
+    vfspace = ProductSpace(fspace, 1)
+    pwnorm = PointwiseNorm(vfspace, exponent)
+
+    testarr = np.array([[[1, 2],
+                         [3, 4]]])
+
+    true_norm = np.linalg.norm(testarr, ord=exponent, axis=0)
+
+    func = vfspace.element(testarr)
+    func_pwnorm = pwnorm(func)
+    assert all_almost_equal(func_pwnorm, true_norm.reshape(-1))
+
+    out = fspace.element()
+    pwnorm(func, out=out)
+    assert all_almost_equal(out, true_norm.reshape(-1))
+
+    # 3d
+    fspace = odl.uniform_discr([0, 0], [1, 1], (2, 2))
+    vfspace = ProductSpace(fspace, 3)
+    pwnorm = PointwiseNorm(vfspace, exponent)
+
+    testarr = np.array([[[1, 2],
+                         [3, 4]],
+                        [[0, -1],
+                         [0, 1]],
+                        [[1, 1],
+                         [1, 1]]])
+
+    true_norm = np.linalg.norm(testarr, ord=exponent, axis=0)
+
+    func = vfspace.element(testarr)
+    func_pwnorm = pwnorm(func)
+    assert all_almost_equal(func_pwnorm, true_norm.reshape(-1))
+
+    out = fspace.element()
+    pwnorm(func, out=out)
+    assert all_almost_equal(out, true_norm.reshape(-1))
+
+
+def test_pointwise_norm_complex(exponent):
+    fspace = odl.uniform_discr([0, 0], [1, 1], (2, 2), dtype=complex)
+    vfspace = ProductSpace(fspace, 3)
+    pwnorm = PointwiseNorm(vfspace, exponent)
+
+    testarr = np.array([[[1 + 1j, 2],
+                         [3, 4 - 2j]],
+                        [[0, -1],
+                         [0, 1]],
+                        [[1j, 1j],
+                         [1j, 1j]]])
+
+    true_norm = np.linalg.norm(testarr, ord=exponent, axis=0)
+
+    func = vfspace.element(testarr)
+    func_pwnorm = pwnorm(func)
+    assert all_almost_equal(func_pwnorm, true_norm.reshape(-1))
+
+    out = fspace.element()
+    pwnorm(func, out=out)
+    assert all_almost_equal(out, true_norm.reshape(-1))
+
+
+def test_pointwise_norm_weighted(exponent):
+    fspace = odl.uniform_discr([0, 0], [1, 1], (2, 2))
+    vfspace = ProductSpace(fspace, 3)
+    weight = np.array([1.0, 2.0, 3.0])
+    pwnorm = PointwiseNorm(vfspace, exponent, weight=weight)
+
+    testarr = np.array([[[1, 2],
+                         [3, 4]],
+                        [[0, -1],
+                         [0, 1]],
+                        [[1, 1],
+                         [1, 1]]])
+
+    if exponent in (1.0, float('inf')):
+        true_norm = np.linalg.norm(weight[:, None, None] * testarr,
+                                   ord=exponent, axis=0)
+    else:
+        true_norm = np.linalg.norm(
+            weight[:, None, None] ** (1 / exponent) * testarr, ord=exponent,
+            axis=0)
+
+    func = vfspace.element(testarr)
+    func_pwnorm = pwnorm(func)
+    assert all_almost_equal(func_pwnorm, true_norm.reshape(-1))
+
+    out = fspace.element()
+    pwnorm(func, out=out)
+    assert all_almost_equal(out, true_norm.reshape(-1))
+
+
+# ---- PointwiseInner ---- #
+
+
+def test_pointwise_inner_init_properties():
+    fspace = odl.uniform_discr([0, 0], [1, 1], (2, 2))
+    vfspace = ProductSpace(fspace, 3, exponent=2)
+
+    # Make sure the code runs and test the properties
+    pwinner = PointwiseInner(vfspace, vfspace.one())
+    assert pwinner.discr_fspace == fspace
+    assert pwinner.ran_size == 1
+    assert all_equal(pwinner.weights, [1, 1, 1])
+    assert not pwinner.is_weighted
+    repr(pwinner)
+
+    pwinner = PointwiseInner(vfspace, vfspace.one(), weight=[1, 2, 3])
+    assert all_equal(pwinner.weights, [1, 2, 3])
+    assert pwinner.is_weighted
+
+    # Bad input
+    with pytest.raises(TypeError):
+        PointwiseInner(odl.Rn(3), odl.Rn(3).one())  # No power space
+
+    # TODO: Does not raise currently, although bad_vecfield not in vfspace!
+    """
+    bad_vecfield = ProductSpace(fspace, 3, exponent=1).one()
+    with pytest.raises(TypeError):
+        PointwiseInner(vfspace, bad_vecfield)
+    """
+
+    with pytest.raises(ValueError):
+        PointwiseInner(vfspace, vfspace.one(), weight=-1)  # < 0 not allowed
+
+    with pytest.raises(ValueError):
+        PointwiseInner(vfspace, vfspace.one(), weight=[1, 0, 1])  # 0 invalid
+
+
+def test_pointwise_inner_real():
+    # 1d
+    fspace = odl.uniform_discr([0, 0], [1, 1], (2, 2))
+    vfspace = ProductSpace(fspace, 1)
+    array = np.array([[[-1, -3],
+                       [2, 0]]])
+    pwinner = PointwiseInner(vfspace, vecfield=array)
+
+    testarr = np.array([[[1, 2],
+                         [3, 4]]])
+
+    true_inner = np.sum(testarr * array, axis=0)
+
+    func = vfspace.element(testarr)
+    func_pwinner = pwinner(func)
+    assert all_almost_equal(func_pwinner, true_inner.reshape(-1))
+
+    out = fspace.element()
+    pwinner(func, out=out)
+    assert all_almost_equal(out, true_inner.reshape(-1))
+
+    # 3d
+    fspace = odl.uniform_discr([0, 0], [1, 1], (2, 2))
+    vfspace = ProductSpace(fspace, 3)
+    array = np.array([[[-1, -3],
+                       [2, 0]],
+                      [[0, 0],
+                       [0, 1]],
+                      [[-1, 1],
+                       [1, 1]]])
+    pwinner = PointwiseInner(vfspace, vecfield=array)
+
+    testarr = np.array([[[1, 2],
+                         [3, 4]],
+                        [[0, -1],
+                         [0, 1]],
+                        [[1, 1],
+                         [1, 1]]])
+
+    true_inner = np.sum(testarr * array, axis=0)
+
+    func = vfspace.element(testarr)
+    func_pwinner = pwinner(func)
+    assert all_almost_equal(func_pwinner, true_inner.reshape(-1))
+
+    out = fspace.element()
+    pwinner(func, out=out)
+    assert all_almost_equal(out, true_inner.reshape(-1))
+
+
+def test_pointwise_inner_complex():
+    fspace = odl.uniform_discr([0, 0], [1, 1], (2, 2), dtype=complex)
+    vfspace = ProductSpace(fspace, 3)
+    array = np.array([[[-1 - 1j, -3],
+                       [2, 2j]],
+                      [[-1j, 0],
+                       [0, 1]],
+                      [[-1, 1 + 2j],
+                       [1, 1]]])
+    pwinner = PointwiseInner(vfspace, vecfield=array)
+
+    testarr = np.array([[[1 + 1j, 2],
+                         [3, 4 - 2j]],
+                        [[0, -1],
+                         [0, 1]],
+                        [[1j, 1j],
+                         [1j, 1j]]])
+
+    true_inner = np.sum(testarr * array.conj(), axis=0)
+
+    func = vfspace.element(testarr)
+    func_pwinner = pwinner(func)
+    assert all_almost_equal(func_pwinner, true_inner.reshape(-1))
+
+    out = fspace.element()
+    pwinner(func, out=out)
+    assert all_almost_equal(out, true_inner.reshape(-1))
+
+
+def test_pointwise_inner_weighted(exponent):
+    fspace = odl.uniform_discr([0, 0], [1, 1], (2, 2))
+    vfspace = ProductSpace(fspace, 3)
+    array = np.array([[[-1, -3],
+                       [2, 0]],
+                      [[0, 0],
+                       [0, 1]],
+                      [[-1, 1],
+                       [1, 1]]])
+
+    weight = np.array([1.0, 2.0, 3.0])
+    pwinner = PointwiseInner(vfspace, vecfield=array, weight=weight)
+
+    testarr = np.array([[[1, 2],
+                         [3, 4]],
+                        [[0, -1],
+                         [0, 1]],
+                        [[1, 1],
+                         [1, 1]]])
+
+    true_inner = np.sum(weight[:, None, None] * testarr * array, axis=0)
+
+    func = vfspace.element(testarr)
+    func_pwinner = pwinner(func)
+    assert all_almost_equal(func_pwinner, true_inner.reshape(-1))
+
+    out = fspace.element()
+    pwinner(func, out=out)
+    assert all_almost_equal(out, true_inner.reshape(-1))
+
+
+if __name__ == '__main__':
+    pytest.main(str(__file__.replace('\\', '/')) + ' -v')

--- a/test/space/cu_ntuples_test.py
+++ b/test/space/cu_ntuples_test.py
@@ -980,9 +980,7 @@ def test_custom_inner(fn):
     # Using 3 places (single precision default) since the result is always
     # double even if the underlying computation was only single precision
     assert almost_equal(w.dist(x, y), true_dist, places=3)
-    assert almost_equal(w.dist(x, x), 0, places=3)
     assert almost_equal(w_d.dist(x, y), true_dist)
-    assert almost_equal(w_d.dist(x, x), 0)
 
     with pytest.raises(TypeError):
         CudaFnCustomInnerProduct(1)
@@ -1012,7 +1010,6 @@ def test_custom_norm(fn):
 
     true_dist = np.linalg.norm(xarr - yarr)
     assert almost_equal(w.dist(x, y), true_dist)
-    assert almost_equal(w.dist(x, x), 0)
 
     with pytest.raises(TypeError):
         CudaFnCustomNorm(1)
@@ -1043,7 +1040,6 @@ def test_custom_dist(fn):
 
     true_dist = np.linalg.norm(xarr - yarr)
     assert almost_equal(w.dist(x, y), true_dist)
-    assert almost_equal(w.dist(x, x), 0)
 
     with pytest.raises(TypeError):
         CudaFnCustomDist(1)

--- a/test/space/ntuples_test.py
+++ b/test/space/ntuples_test.py
@@ -1185,7 +1185,6 @@ def test_matrix_dist_using_inner(fn):
     # With free function
     w_dist = weighted_dist(mat, use_inner=True)
     assert almost_equal(w_dist(x, y), true_dist)
-    assert almost_equal(w.dist(x, x), 0, places=3)
 
 
 def test_vector_init(exponent):
@@ -1344,10 +1343,9 @@ def test_vector_dist_using_inner(fn):
     w = FnVectorWeighting(weight_vec)
 
     true_dist = np.linalg.norm(np.sqrt(weight_vec) * (xarr - yarr))
-    assert almost_equal(w.dist(x, y), true_dist)
     # Using 3 places (single precision default) since the result is always
     # double even if the underlying computation was only single precision
-    assert almost_equal(w.dist(x, x), 0, places=3)
+    assert almost_equal(w.dist(x, y), true_dist, places=3)
 
     # Only possible for exponent=2
     with pytest.raises(ValueError):
@@ -1489,7 +1487,6 @@ def test_const_dist_using_inner(fn):
     # Using 3 places (single precision default) since the result is always
     # double even if the underlying computation was only single precision
     assert almost_equal(w.dist(x, y), true_dist, places=3)
-    assert almost_equal(w.dist(x, x), 0)
 
     # Only possible for exponent=2
     with pytest.raises(ValueError):
@@ -1547,9 +1544,7 @@ def test_custom_inner(fn):
     # Using 3 places (single precision default) since the result is always
     # double even if the underlying computation was only single precision
     assert almost_equal(w.dist(x, y), true_dist, places=3)
-    assert almost_equal(w.dist(x, x), 0, places=3)
     assert almost_equal(w_d.dist(x, y), true_dist)
-    assert almost_equal(w_d.dist(x, x), 0)
 
     with pytest.raises(TypeError):
         FnCustomInnerProduct(1)
@@ -1579,7 +1574,6 @@ def test_custom_norm(fn):
 
     true_dist = np.linalg.norm(xarr - yarr)
     assert almost_equal(w.dist(x, y), true_dist)
-    assert almost_equal(w.dist(x, x), 0)
 
     with pytest.raises(TypeError):
         FnCustomNorm(1)
@@ -1610,7 +1604,6 @@ def test_custom_dist(fn):
 
     true_dist = np.linalg.norm(xarr - yarr)
     assert almost_equal(w.dist(x, y), true_dist)
-    assert almost_equal(w.dist(x, x), 0)
 
     with pytest.raises(TypeError):
         FnCustomDist(1)


### PR DESCRIPTION
This is convenience functionality useful when working with vector fields. It adds the pointwise norm and inner product operators, the first with derivative, the second with adjoint.

Not sure about the place in the ecosystem. If we plan to support vector and tensor fields properly in the future, this module may want to go to the same place. Some things could be simplified then, of course, this is what we can do right now.

I left out variable exponent for now, perhaps I'll add that in short. Haven't decided yet.

The tests run fine, and I also checked that the adjoint and derivatives are correct (not with zero, of course). As a side remark, these operators handle weighting of the product spaces correctly. We should fix that also for the `ProductSpaceOperator` in general (see #322).