### PR TITLE
ENH: add append to RectPartition, closes #351

### DIFF
--- a/odl/discr/grid.py
+++ b/odl/discr/grid.py
@@ -520,8 +520,8 @@ class TensorGrid(Set):
 
         Parameters
         ----------
-        other : `TensorGrid`, `float` or `array-like`
-            The set to be inserted.
+        other : `TensorGrid`
+            The set to be inserted
 
         Examples
         --------

--- a/odl/discr/grid.py
+++ b/odl/discr/grid.py
@@ -484,7 +484,7 @@ class TensorGrid(Set):
             The index of the dimension before which ``other`` is to
             be inserted. Negative indices count backwards from
             ``self.ndim``.
-        other :  `TensorGrid`, `float` or `array-like`
+        other :  `TensorGrid`
             The grid to be inserted
 
         Returns
@@ -520,9 +520,8 @@ class TensorGrid(Set):
 
         Parameters
         ----------
-        other : `IntervalProd`, `float` or `array-like`
-            The set to be inserted. A `float` or array a is
-            treated as an ``IntervalProd(a, a)``.
+        other : `TensorGrid`, `float` or `array-like`
+            The set to be inserted.
 
         Examples
         --------

--- a/odl/discr/partition.py
+++ b/odl/discr/partition.py
@@ -378,10 +378,39 @@ class RectPartition(object):
 
         Examples
         --------
+        >>> part1 = uniform_partition([0, -1], [1, 2], (3, 3))
+        >>> part2 = uniform_partition(0, 1, 5)
+        >>> part1.insert(2, part2)
+        uniform_partition([0.0, -1.0, 0.0], [1.0, 2.0, 1.0], [3, 3, 5])
+
+        See Also
+        --------
+        append
         """
         newgrid = self.grid.insert(index, other.grid)
         newset = self.set.insert(index, other.set)
         return RectPartition(newset, newgrid)
+
+    def append(self, other):
+        """Insert at the end.
+
+        Parameters
+        ----------
+        other : `RectPartition`,
+            The set to be inserted.
+
+        Examples
+        --------
+        >>> part1 = uniform_partition([0, -1], [1, 2], (3, 3))
+        >>> part2 = uniform_partition(0, 1, 5)
+        >>> part1.insert(2, part2)
+        uniform_partition([0.0, -1.0, 0.0], [1.0, 2.0, 1.0], [3, 3, 5])
+
+        See Also
+        --------
+        insert
+        """
+        return self.insert(self.ndim, other)
 
     def __str__(self):
         """Return ``str(self)``."""
@@ -389,8 +418,20 @@ class RectPartition(object):
 
     def __repr__(self):
         """Return ``repr(self)``."""
-        inner_str = '\n    {!r},\n    {!r}'.format(self.set, self.grid)
-        return '{}({})'.format(self.__class__.__name__, inner_str)
+        if uniform_partition_fromintv(self.set, self.shape) == self:
+
+            if self.ndim == 1:
+                inner_str = '{}, {}, {}'.format(float(self.set.begin),
+                                                float(self.set.end),
+                                                self.size)
+            else:
+                inner_str = '{}, {}, {}'.format(list(self.set.begin),
+                                                list(self.set.end),
+                                                list(self.shape))
+            return 'uniform_partition({})'.format(inner_str)
+        else:
+            inner_str = '\n    {!r},\n    {!r}'.format(self.set, self.grid)
+            return '{}({})'.format(self.__class__.__name__, inner_str)
 
 
 def uniform_partition_fromintv(intv_prod, num_nodes, nodes_on_bdry=False):

--- a/odl/discr/partition.py
+++ b/odl/discr/partition.py
@@ -380,8 +380,8 @@ class RectPartition(object):
         --------
         >>> part1 = uniform_partition([0, -1], [1, 2], (3, 3))
         >>> part2 = uniform_partition(0, 1, 5)
-        >>> part1.insert(2, part2)
-        uniform_partition([0.0, -1.0, 0.0], [1.0, 2.0, 1.0], [3, 3, 5])
+        >>> part1.insert(1, part2)
+        uniform_partition([0.0, 0.0, -1.0], [1.0, 1.0, 2.0], [3, 5, 3])
 
         See Also
         --------
@@ -403,7 +403,7 @@ class RectPartition(object):
         --------
         >>> part1 = uniform_partition([0, -1], [1, 2], (3, 3))
         >>> part2 = uniform_partition(0, 1, 5)
-        >>> part1.insert(2, part2)
+        >>> part1.append(part2)
         uniform_partition([0.0, -1.0, 0.0], [1.0, 2.0, 1.0], [3, 3, 5])
 
         See Also


### PR DESCRIPTION
Issue was wrongly named, should be `append`. Added this.

Also added a shorthand to `uniform_partition` in `RectPartition.__repr__`.