### PR TITLE
Updates to test skipping and fixtures

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -21,6 +21,8 @@ from __future__ import print_function, division, absolute_import
 from future import standard_library
 standard_library.install_aliases()
 
+import pytest
+import odl
 from odl.space.cu_ntuples import CUDA_AVAILABLE
 from odl.trafos.wavelet import PYWAVELETS_AVAILABLE
 
@@ -38,3 +40,22 @@ def pytest_addoption(parser):
 
     parser.addoption('--benchmark', action='store_true',
                      help='Run benchmarks')
+
+
+# reusable fixtures
+ufunc_params = [ufunc for ufunc in odl.util.ufuncs.UFUNCS]
+ufunc_ids = [' ufunc={} '.format(p[0]) for p in ufunc_params]
+
+
+@pytest.fixture(scope="module", ids=ufunc_ids, params=ufunc_params)
+def ufunc(request):
+    return request.param
+
+
+reduction_params = [reduction for reduction in odl.util.ufuncs.REDUCTIONS]
+reduction_ids = [' reduction={} '.format(p[0]) for p in reduction_params]
+
+
+@pytest.fixture(scope="module", ids=reduction_ids, params=reduction_params)
+def reduction(request):
+    return request.param

--- a/odl/util/testutils.py
+++ b/odl/util/testutils.py
@@ -30,7 +30,7 @@ import sys
 from time import time
 
 
-__all__ = ('almost_equal', 'all_equal', 'all_almost_equal',
+__all__ = ('almost_equal', 'all_equal', 'all_almost_equal', 'never_skip',
            'skip_if_no_cuda', 'skip_if_no_pywavelets', 'skip_if_no_pyfftw',
            'skip_if_no_largescale',
            'Timer', 'timeit', 'ProgressBar', 'ProgressRange',
@@ -184,6 +184,12 @@ def _pass(function):
 try:
     # Try catch in case user does not have pytest
     import pytest
+
+    # Used in lists where the elements should all be skipifs
+    never_skip = pytest.mark.skipif(
+        "False",
+        reason='Fill in, never skips'
+    )
 
     skip_if_no_cuda = pytest.mark.skipif(
         "not odl.CUDA_AVAILABLE",

--- a/test/largescale/tomo/ray_transform_slow_test.py
+++ b/test/largescale/tomo/ray_transform_slow_test.py
@@ -29,12 +29,9 @@ import numpy as np
 # Internal
 import odl
 import odl.tomo as tomo
+from odl.util.testutils import skip_if_no_largescale
 from odl.tomo.util.testutils import (skip_if_no_astra, skip_if_no_astra_cuda,
                                      skip_if_no_scikit)
-
-
-pytestmark = odl.util.skip_if_no_largescale
-
 
 # Find the valid projectors
 projectors = [skip_if_no_astra('par2d astra_cpu uniform'),
@@ -60,6 +57,12 @@ projectors = [skip_if_no_astra('par2d astra_cpu uniform'),
 
 projector_ids = ['geom={}, impl={}, angles={}'
                  ''.format(*p.args[1].split()) for p in projectors]
+
+
+# bug in pytest (ignores pytestmark) forces us to do this this
+largescale = " or not pytest.config.getoption('--largescale')"
+projectors = [pytest.mark.skipif(p.args[0] + largescale, p.args[1])
+              for p in projectors]
 
 
 @pytest.fixture(scope="module", params=projectors, ids=projector_ids)
@@ -163,6 +166,7 @@ def projector(request):
         raise ValueError('param not valid')
 
 
+@skip_if_no_largescale
 def test_reconstruction(projector):
     """Test discrete Ray transform using ASTRA for reconstruction."""
 

--- a/test/tomo/backends/astra_setup_test.py
+++ b/test/tomo/backends/astra_setup_test.py
@@ -31,8 +31,10 @@ if ASTRA_AVAILABLE:
 
 # Internal
 import odl
-from odl.tomo.util.testutils import skip_if_no_astra
 from odl.util.testutils import is_subdict
+
+
+pytestmark = pytest.mark.skipif("not odl.tomo.ASTRA_AVAILABLE")
 
 
 def _discrete_domain(ndim, interp):
@@ -81,7 +83,6 @@ def _discrete_domain_anisotropic(ndim, interp):
                              dtype='float32')
 
 
-@skip_if_no_astra
 def test_vol_geom_2d():
     """Create ASTRA 2D volume geometry."""
 
@@ -110,7 +111,6 @@ def test_vol_geom_2d():
     print('\n', vol_geom)
 
 
-@skip_if_no_astra
 def test_vol_geom_3d():
     """Create ASTRA 2D volume geometry."""
 
@@ -144,7 +144,6 @@ def test_vol_geom_3d():
     print('\n', vol_geom)
 
 
-@skip_if_no_astra
 def test_proj_geom_parallel_2d():
     """Create ASTRA 2D projection geometry."""
 
@@ -162,7 +161,6 @@ def test_proj_geom_parallel_2d():
     assert 'ProjectionAngles' in proj_geom
 
 
-@skip_if_no_astra
 def test_astra_projection_geometry():
     """Create ASTRA projection geometry from geometry objects."""
 
@@ -222,7 +220,6 @@ VOL_GEOM_2D = {
                'WindowMinY': -1.0, 'WindowMaxY': 1.0}}
 
 
-@skip_if_no_astra
 def test_volume_data_2d():
     """Create ASTRA data structure in 2D."""
 
@@ -244,7 +241,6 @@ VOL_GEOM_3D = {
     'option': {}}
 
 
-@skip_if_no_astra
 def test_volume_data_3d():
     """Create ASTRA data structure in 2D."""
 
@@ -273,7 +269,6 @@ PROJ_GEOM_3D = {
     'ProjectionAngles': np.linspace(0, 2, 5)}
 
 
-@skip_if_no_astra
 def test_parallel_2d_projector():
     """Create ASTRA 2D projectors."""
 
@@ -284,7 +279,6 @@ def test_parallel_2d_projector():
                              ndim=2, impl='cpu')
 
 
-@skip_if_no_astra
 def test_parallel_3d_projector():
     """Create ASTRA 3D projectors."""
 
@@ -301,7 +295,6 @@ def test_parallel_3d_projector():
                                  ndim=3, impl='cpu')
 
 
-@skip_if_no_astra
 def test_astra_algorithm():
     """Create ASTRA algorithm object."""
 
@@ -366,7 +359,6 @@ def test_astra_algorithm():
                                  proj_id=proj_id, impl='cuda')
 
 
-@skip_if_no_astra
 def test_geom_to_vec():
     """Create ASTRA projection geometries vectors using ODL geometries."""
 


### PR DESCRIPTION
Did some fixes to test skipping etc, the number of tests should now be the same across all platforms and with any combination of optional packages, any non-usable package will properly show as `skipped` instead of staying silent.