### PR TITLE
ENH: add __getitem__ to RectPartition

### DIFF
--- a/odl/discr/grid.py
+++ b/odl/discr/grid.py
@@ -722,6 +722,11 @@ class TensorGrid(Set):
         >>> g[0] == g[0, :, :, :] == g[0, ...]
         True
         """
+        if isinstance(indices, list):
+            new_coord_vecs = [self.coord_vectors[0][indices]]
+            new_coord_vecs += self.coord_vectors[1:]
+            return TensorGrid(*new_coord_vecs)
+
         indices = normalized_index_expression(indices, self.shape,
                                               int_to_slice=False)
 
@@ -937,7 +942,7 @@ class RegularGrid(TensorGrid):
                 other.approx_contains(self.max_pt, atol=atol))
             check_idx = np.zeros(self.ndim, dtype=int)
             check_idx[np.array(self.shape) >= 3] = 1
-            checkpt_contained = other.approx_contains(self[check_idx.tolist()],
+            checkpt_contained = other.approx_contains(self[tuple(check_idx)],
                                                       atol=atol)
 
             return minmax_contained and checkpt_contained
@@ -1054,6 +1059,10 @@ class RegularGrid(TensorGrid):
         >>> g[..., ::3]
         RegularGrid([-1.5, -3.0, -1.0], [-0.5, 7.0, 2.0], (2, 3, 2))
         """
+        # Index list results in a tensor grid
+        if isinstance(indices, list):
+            return super().__getitem__(indices)
+
         indices = normalized_index_expression(indices, self.shape,
                                               int_to_slice=False)
 

--- a/odl/discr/partition.py
+++ b/odl/discr/partition.py
@@ -403,6 +403,18 @@ class RectPartition(object):
             IntervalProd([-0.5, 1.0, 4.0, 2.0], [1.5, 6.0, 5.0, 7.0]),
             TensorGrid([0.0], [2.0, 4.0], [5.0], [2.0, 4.0, 7.0]))
         """
+        # Special case of index list: slice along first axis
+        if isinstance(indices, list):
+            new_begin = [self.cell_boundary_vecs[0][:-1][indices][0]]
+            new_end = [self.cell_boundary_vecs[0][1:][indices][-1]]
+            for cvec in self.cell_boundary_vecs[1:]:
+                new_begin.append(cvec[0])
+                new_end.append(cvec[-1])
+
+            new_intvp = IntervalProd(new_begin, new_end)
+            new_grid = self.grid[indices]
+            return RectPartition(new_intvp, new_grid)
+
         indices = normalized_index_expression(indices, self.shape,
                                               int_to_slice=True)
         # Build the new partition

--- a/odl/util/utility.py
+++ b/odl/util/utility.py
@@ -341,6 +341,82 @@ def preload_first_arg(instance, mode):
     return decorator
 
 
+def normalized_index_expression(indices, shape, int_to_slice=False):
+    """Enable indexing with almost Numpy-like capabilities.
+
+    Implements the following features:
+
+    - Usage of general slices and sequences of slices
+    - Conversion of `Ellipsis` into an adequate number of ``slice(None)``
+      objects
+    - Fewer indices than axes by filling up with an `Ellipsis`
+    - Error checking with respect to a given shape
+    - Conversion of integer indices into corresponding slices
+
+    Parameters
+    ----------
+    indices : `int`, `slice` or `sequence` of those
+        Index expression to be normalized
+    shape : `sequence` of `int`
+        Target shape for error checking of out-of-bounds indices.
+        Also needed to determine the number of axes.
+    int_to_slice : `bool`, optional
+        If `True`, turn integers into corresponding slice objects.
+
+    Returns
+    -------
+    normalized : `tuple` of `slice`
+        Normalized index expression
+    """
+    ndim = len(shape)
+    # Support indexing with fewer indices as indexing along the first
+    # corresponding axes. In the other cases, normalize the input.
+    if np.isscalar(indices):
+        indices = [indices, Ellipsis]
+    elif (isinstance(indices, slice) or indices is Ellipsis):
+        indices = [indices]
+
+    indices = list(indices)
+    if len(indices) < ndim and Ellipsis not in indices:
+        indices.append(Ellipsis)
+
+    # Turn Ellipsis into the correct number of slice(None)
+    if Ellipsis in indices:
+        if indices.count(Ellipsis) > 1:
+            raise ValueError('cannot use more than one Ellipsis.')
+
+        eidx = indices.index(Ellipsis)
+        extra_dims = ndim - len(indices) + 1
+        indices = (indices[:eidx] + [slice(None)] * extra_dims +
+                   indices[eidx + 1:])
+
+    # Turn single indices into length-1 slices if desired
+    for (i, idx), n in zip(enumerate(indices), shape):
+        if np.isscalar(idx):
+            if idx < 0:
+                idx += n
+
+            if idx >= n:
+                raise IndexError('Index {} is out of bounds for axis '
+                                 '{} with size {}.'
+                                 ''.format(idx, i, n))
+            if int_to_slice:
+                indices[i] = slice(idx, idx + 1)
+
+    # Catch most common errors
+    if any(s.start == s.stop and s.start is not None or
+           s.start == n
+           for s, n in zip(indices, shape) if isinstance(s, slice)):
+        raise ValueError('Slices with empty axes not allowed.')
+    if None in indices:
+        raise ValueError('creating new axes is not supported.')
+    if len(indices) > ndim:
+        raise IndexError('too may indices: {} > {}.'
+                         ''.format(len(indices), ndim))
+
+    return tuple(indices)
+
+
 if __name__ == '__main__':
     # pylint: disable=wrong-import-position
     from odl.util.testutils import run_doctests

--- a/test/discr/grid_test.py
+++ b/test/discr/grid_test.py
@@ -440,7 +440,7 @@ def test_tensorgrid_meshgrid():
 
 
 def test_tensorgrid_getitem():
-    vec1 = (0, 1)
+    vec1 = (0, 1, 2)
     vec2 = (-1, 0, 1)
     vec3 = (2, 3, 4, 5)
     vec4 = (1, 3)
@@ -457,12 +457,15 @@ def test_tensorgrid_getitem():
     with pytest.raises(IndexError):
         grid[1, 0, 1, 0, 0]
 
+    with pytest.raises(IndexError):
+        grid[0, 3, 0, 0]
+
     # Slices return new TensorGrid's
     assert grid == grid[...]
 
     sub_grid = TensorGrid(vec1_sub, vec2_sub, vec3_sub, vec4_sub)
     assert grid[1, 0, 1:3, 0] == sub_grid
-    assert grid[-1, :1, 1:3, :1] == sub_grid
+    assert grid[-2, :1, 1:3, :1] == sub_grid
     assert grid[1, 0, ..., 1:3, 0] == sub_grid
 
     sub_grid = TensorGrid(vec1_sub, vec2, vec3, vec4)
@@ -483,6 +486,11 @@ def test_tensorgrid_getitem():
     assert grid[0] == grid[0, :, :, :]
     assert grid[0, 1:] == grid[0, 1:, :, :]
     assert grid[0, 1:, :-1] == grid[0, 1:, :-1, :]
+
+    # Indexing with lists
+    sub_grid = TensorGrid([0, 2], vec2, vec3, vec4)
+    assert grid[[0, 2]] == sub_grid
+    assert grid[[0, 1]] == grid[0:2, ...]
 
     # Two ellipses not allowed
     with pytest.raises(ValueError):

--- a/test/discr/grid_test.py
+++ b/test/discr/grid_test.py
@@ -455,9 +455,6 @@ def test_tensorgrid_getitem():
     assert all_equal(grid[1, 0, 1, 0], (1.0, -1.0, 3.0, 1.0))
 
     with pytest.raises(IndexError):
-        grid[1, 0, 1]
-
-    with pytest.raises(IndexError):
         grid[1, 0, 1, 0, 0]
 
     # Slices return new TensorGrid's
@@ -471,6 +468,7 @@ def test_tensorgrid_getitem():
     sub_grid = TensorGrid(vec1_sub, vec2, vec3, vec4)
     assert grid[1, :, :, :] == sub_grid
     assert grid[1, ...] == sub_grid
+    assert grid[1] == sub_grid
 
     sub_grid = TensorGrid(vec1, vec2, vec3, vec4_sub)
     assert grid[:, :, :, 0] == sub_grid
@@ -481,20 +479,21 @@ def test_tensorgrid_getitem():
     assert grid[1, ..., 0] == sub_grid
     assert grid[1, :, :, ..., 0] == sub_grid
 
-    # Two ellipses not allowed
-    with pytest.raises(IndexError):
-        grid[1, ..., ..., 0]
+    # Fewer indices
+    assert grid[0] == grid[0, :, :, :]
+    assert grid[0, 1:] == grid[0, 1:, :, :]
+    assert grid[0, 1:, :-1] == grid[0, 1:, :-1, :]
 
-    # Too few indices
-    with pytest.raises(IndexError):
-        grid[1, :, 1]
+    # Two ellipses not allowed
+    with pytest.raises(ValueError):
+        grid[1, ..., ..., 0]
 
     # Too many indices
     with pytest.raises(IndexError):
         grid[1, 0, 1:2, 0, :]
 
     # Empty axes not allowed
-    with pytest.raises(IndexError):
+    with pytest.raises(ValueError):
         grid[1, 0, None, 0]
 
     # One-dimensional grid
@@ -788,9 +787,6 @@ def test_regulargrid_getitem():
     assert all_equal(grid[0, 0, 4, 3], values)
 
     with pytest.raises(IndexError):
-        grid[1, 0, 1]
-
-    with pytest.raises(IndexError):
         grid[1, 0, 1, 2, 0]
 
     with pytest.raises(IndexError):
@@ -843,25 +839,28 @@ def test_regulargrid_getitem():
     assert all_equal(grid[:, :, 1, :].coord_vectors,
                      tensor_grid[test_slice].coord_vectors)
 
-    # Two ellipses not allowed
-    with pytest.raises(IndexError):
-        grid[1, ..., ..., 0]
+    # Fewer indices
+    assert grid[1:] == grid[1:, :, :, :]
+    assert grid[1:, 0] == grid[1:, 0, :, :]
+    assert grid[1:, 0, :-1] == grid[1:, 0, :-1, :]
 
-    # Too few axes
-    with pytest.raises(IndexError):
-        grid[1, :, 1]
+    # Two ellipses not allowed
+    with pytest.raises(ValueError):
+        grid[1, ..., ..., 0]
 
     # Too many axes
     with pytest.raises(IndexError):
         grid[1, 0, 1:2, 0, :]
 
     # New axes not supported
-    with pytest.raises(IndexError):
+    with pytest.raises(ValueError):
         grid[1, 0, None, 1, 0]
 
     # Empty axes not allowed
-    with pytest.raises(IndexError):
+    with pytest.raises(ValueError):
         grid[1, 0, 0:0, 1]
+    with pytest.raises(ValueError):
+        grid[1, 1:, 0, 1]
 
     # One-dimensional grid
     grid = RegularGrid(1, 5, 5)

--- a/test/discr/partition_test.py
+++ b/test/discr/partition_test.py
@@ -184,6 +184,41 @@ def test_partition_insert():
     assert all_equal(part.grid.max_pt, [7, 3, 0, 4])
 
 
+def test_partition_getitem():
+    vec1 = [2, 4, 5, 7]
+    vec2 = [-4, -3, 0, 1, 4]
+    vec3 = [-2, 0, 3]
+    vec4 = [0]
+    vecs = [vec1, vec2, vec3, vec4]
+    begin = [1, -4, -2, -2]
+    end = [7, 5, 4, 0]
+    grid = odl.TensorGrid(*vecs)
+    intv = odl.IntervalProd(begin, end)
+    part = RectPartition(intv, grid)
+
+    # Test a couple of slices
+    slc = (1, -2, 2, 0)
+    slc_vecs = [v[i] for i, v in zip(slc, vecs)]
+    slc_part = part[slc]
+    assert slc_part.grid == odl.TensorGrid(*slc_vecs)
+    slc_beg = [3, 0.5, 1.5, -2]
+    slc_end = [4.5, 2.5, 4, 0]
+    assert slc_part.set == odl.IntervalProd(slc_beg, slc_end)
+
+    slc = (slice(None), slice(None, None, 2), slice(None, 2), 0)
+    slc_vecs = [v[i] for i, v in zip(slc, vecs)]
+    slc_part = part[slc]
+    assert slc_part.grid == odl.TensorGrid(*slc_vecs)
+    slc_beg = [1, -4, -2, -2]
+    slc_end = [7, 5, 1.5, 0]
+    assert slc_part.set == odl.IntervalProd(slc_beg, slc_end)
+
+    # Fewer indices
+    assert part[1] == part[1, :, :, :] == part[1, ...]
+    assert part[1, 2:] == part[1, 2:, :, :] == part[1, 2:, ...]
+    assert part[1, 2:, ::2] == part[1, 2:, ::2, :] == part[1, 2:, ::2, ...]
+
+
 # ---- Functions ---- #
 
 
@@ -290,6 +325,9 @@ def test_uniform_partition():
         assert np.allclose(np.diff(cs[1:-1]), 0)
         assert all_almost_equal(cs[0], cs[1] / 2)
         assert all_almost_equal(cs[-1], cs[-2] / 2)
+
+    assert part[1:, 2:5].is_regular
+    assert part[1:, ::3].is_regular
 
 
 if __name__ == '__main__':

--- a/test/discr/partition_test.py
+++ b/test/discr/partition_test.py
@@ -218,6 +218,15 @@ def test_partition_getitem():
     assert part[1, 2:] == part[1, 2:, :, :] == part[1, 2:, ...]
     assert part[1, 2:, ::2] == part[1, 2:, ::2, :] == part[1, 2:, ::2, ...]
 
+    # Index list using indices 0 and 2
+    lst_beg = [1, -4, -2, -2]
+    lst_end = [6, 5, 4, 0]
+    lst_intv = odl.IntervalProd(lst_beg, lst_end)
+    lst_vec1 = [2, 5]
+    lst_grid = odl.TensorGrid(lst_vec1, vec2, vec3, vec4)
+    lst_part = RectPartition(lst_intv, lst_grid)
+    assert part[[0, 2]] == lst_part
+
 
 # ---- Functions ---- #
 


### PR DESCRIPTION
Initial PR. Seems to work fine with regular partitions. Remaining TODOs:

- [x] Tests
- [x] Subpartitions of uniform partitions don't always print themselves as uniform, probably due to numerical error. ~~If possible, this should be fixed.~~ WONTFIX
- [x] Indexing with one integer index `idx` should be implemented (also for `TensorGrid` - probably the latter could be significantly simplified) as equivalent to `partition[idx, ...]`.
- [x] Relates to the above: `Ellipsis` should be handled.

EDIT: Added 2 points to the list.
EDIT2: Probably the self-printing problem is not easily solvable.

Fixes: #381 