### PR TITLE
ENH: Add new proximals with slow tests

### DIFF
--- a/examples/solvers/chambolle_pock_deconvolve.py
+++ b/examples/solvers/chambolle_pock_deconvolve.py
@@ -101,12 +101,10 @@ proximal_primal = odl.solvers.proximal_zero(op.domain)
 # Create proximal operators for the dual variable
 
 # l2-data matching
-prox_convconj_l2 = odl.solvers.proximal_convexconjugate_l2_squared(space,
-                                                                   g=data)
+prox_convconj_l2 = odl.solvers.proximal_cconj_l2_squared(space, g=data)
 
 # TV-regularization i.e. the l1-norm
-prox_convconj_l1 = odl.solvers.proximal_convexconjugate_l1(
-    gradient.range, lam=0.0005)
+prox_convconj_l1 = odl.solvers.proximal_cconj_l1(gradient.range, lam=0.0005)
 
 # Combine proximal operators, order must correspond to the operator K
 proximal_dual = odl.solvers.combine_proximals(

--- a/examples/solvers/chambolle_pock_deconvolve.py
+++ b/examples/solvers/chambolle_pock_deconvolve.py
@@ -74,7 +74,7 @@ space = odl.uniform_discr([0, 0], [n, n], [n, n])
 filter_width = 2.0  # standard deviation of the Gaussian filter
 ft = odl.trafos.FourierTransform(space)
 c = filter_width**2 / 4.0**2
-gaussian = ft.range.element(lambda x: np.exp(-(x[0]**2 + x[1]**2) * c))
+gaussian = ft.range.element(lambda x: np.exp(-(x[0] ** 2 + x[1] ** 2) * c))
 convolution = ft.inverse * gaussian * ft
 
 # Optional: Run diagnostics to assure the adjoint is properly implemented

--- a/examples/solvers/chambolle_pock_deconvolve.py
+++ b/examples/solvers/chambolle_pock_deconvolve.py
@@ -108,8 +108,8 @@ prox_convconj_l1 = odl.solvers.proximal_cconj_l1(gradient.range, lam=0.0005,
                                                  isotropic=True)
 
 # Combine proximal operators, order must correspond to the operator K
-proximal_dual = odl.solvers.combine_proximals(
-    [prox_convconj_l2, prox_convconj_l1])
+proximal_dual = odl.solvers.combine_proximals(prox_convconj_l2,
+                                              prox_convconj_l1)
 
 
 # --- Select solver parameters and solve using Chambolle-Pock --- #

--- a/examples/solvers/chambolle_pock_deconvolve.py
+++ b/examples/solvers/chambolle_pock_deconvolve.py
@@ -97,7 +97,8 @@ proximal_primal = odl.solvers.proximal_zero(op.domain)
 # Create proximal operators for the dual variable
 
 # l2-data matching
-prox_convconj_l2 = odl.solvers.proximal_convexconjugate_l2(space, g=data)
+prox_convconj_l2 = odl.solvers.proximal_convexconjugate_l2_squared(space,
+                                                                   g=data)
 
 # TV-regularization i.e. the l1-norm
 prox_convconj_l1 = odl.solvers.proximal_convexconjugate_l1(

--- a/examples/solvers/chambolle_pock_deconvolve.py
+++ b/examples/solvers/chambolle_pock_deconvolve.py
@@ -34,7 +34,7 @@ and
    G(x) = 0 ,
 
 respectively. Here, conv denotes the convolution operator, g the image to
-deconvolve, ||.||_2 the l2-norm, ||.||_1  the l1-semi-norm, grad the spatial
+deconvolve, ||.||_2 the l2-norm, ||.||_1  the l1-norm, grad the spatial
 gradient, lam the regularization parameter, |.| the point-wise magnitude
 across the vector components of grad(x), and K is a column vector of
 operators K = (conv, grad)^T.
@@ -103,8 +103,9 @@ proximal_primal = odl.solvers.proximal_zero(op.domain)
 # l2-data matching
 prox_convconj_l2 = odl.solvers.proximal_cconj_l2_squared(space, g=data)
 
-# TV-regularization i.e. the l1-norm
-prox_convconj_l1 = odl.solvers.proximal_cconj_l1(gradient.range, lam=0.0005)
+# Isotropic TV-regularization i.e. the l1-norm
+prox_convconj_l1 = odl.solvers.proximal_cconj_l1(gradient.range, lam=0.0005,
+                                                 isotropic=True)
 
 # Combine proximal operators, order must correspond to the operator K
 proximal_dual = odl.solvers.combine_proximals(

--- a/examples/solvers/chambolle_pock_denoising.py
+++ b/examples/solvers/chambolle_pock_denoising.py
@@ -70,22 +70,22 @@ shape = image.shape
 image /= image.max()
 
 # Discretized spaces
-discr_space = odl.uniform_discr([0, 0], shape, shape)
+space = odl.uniform_discr([0, 0], shape, shape)
 
 # Original image
-orig = discr_space.element(image)
+orig = space.element(image)
 
 # Add noise
 image += np.random.normal(0, 0.1, shape)
 
 # Data of noisy image
-noisy = discr_space.element(image)
+noisy = space.element(image)
 
 # Gradient operator
-gradient = odl.Gradient(discr_space, method='forward')
+gradient = odl.Gradient(space, method='forward')
 
 # Matrix of operators
-op = odl.BroadcastOperator(odl.IdentityOperator(discr_space), gradient)
+op = odl.BroadcastOperator(odl.IdentityOperator(space), gradient)
 
 # Starting point
 x = op.domain.zero()
@@ -97,12 +97,10 @@ print('Norm of the product space operator: {}'.format(prod_op_norm))
 # Proximal operators related to the dual variable
 
 # l2-data matching
-prox_convconj_l2 = odl.solvers.proximal_convexconjugate_l2_squared(discr_space,
-                                                                   lam=1,
-                                                                   g=noisy)
+prox_convconj_l2 = odl.solvers.proximal_cconj_l2_squared(space, lam=1, g=noisy)
 
 # TV-regularization: l1-semi norm of grad(x)
-prox_convconj_l1 = odl.solvers.proximal_convexconjugate_l1(gradient.range,
+prox_convconj_l1 = odl.solvers.proximal_cconj_l1(gradient.range,
                                                            lam=1/16.0)
 
 # Combine proximal operators: the order must match the order of operators in K

--- a/examples/solvers/chambolle_pock_denoising.py
+++ b/examples/solvers/chambolle_pock_denoising.py
@@ -34,7 +34,7 @@ and by the indicator function for the set fo non-negative components of x
    G(x) = {0 if x >=0, infinity if x < 0} ,
 
 respectively. Here, g denotes the image to denoise, ||.||_2 the l2-norm,
-||.||_1 the l1-semi-norm, grad the spatial gradient, lam the regularization
+||.||_1 the l1-norm, grad the spatial gradient, lam the regularization
 parameter, |.| the point-wise magnitude across the vector components of
 grad(x), and K is a column vector of operators K = (id, grad)^T with
 identity mapping id.
@@ -99,13 +99,13 @@ print('Norm of the product space operator: {}'.format(prod_op_norm))
 # l2-data matching
 prox_convconj_l2 = odl.solvers.proximal_cconj_l2_squared(space, lam=1, g=noisy)
 
-# TV-regularization: l1-semi norm of grad(x)
-prox_convconj_l1 = odl.solvers.proximal_cconj_l1(gradient.range,
-                                                           lam=1/16.0)
+# Isotropic TV-regularization: l1-norm of grad(x)
+prox_convconj_l1 = odl.solvers.proximal_cconj_l1(gradient.range, lam=1/16.0,
+                                                 isotropic=True)
 
 # Combine proximal operators: the order must match the order of operators in K
-proximal_dual = odl.solvers.combine_proximals([prox_convconj_l2,
-                                               prox_convconj_l1])
+proximal_dual = odl.solvers.combine_proximals(
+    [prox_convconj_l2, prox_convconj_l1])
 
 # Proximal operator related to the primal variable
 

--- a/examples/solvers/chambolle_pock_denoising.py
+++ b/examples/solvers/chambolle_pock_denoising.py
@@ -97,8 +97,9 @@ print('Norm of the product space operator: {}'.format(prod_op_norm))
 # Proximal operators related to the dual variable
 
 # l2-data matching
-prox_convconj_l2 = odl.solvers.proximal_convexconjugate_l2(discr_space,
-                                                           lam=1, g=noisy)
+prox_convconj_l2 = odl.solvers.proximal_convexconjugate_l2_squared(discr_space,
+                                                                   lam=1,
+                                                                   g=noisy)
 
 # TV-regularization: l1-semi norm of grad(x)
 prox_convconj_l1 = odl.solvers.proximal_convexconjugate_l1(gradient.range,

--- a/examples/solvers/chambolle_pock_denoising.py
+++ b/examples/solvers/chambolle_pock_denoising.py
@@ -102,7 +102,7 @@ prox_convconj_l2 = odl.solvers.proximal_convexconjugate_l2(discr_space,
 
 # TV-regularization: l1-semi norm of grad(x)
 prox_convconj_l1 = odl.solvers.proximal_convexconjugate_l1(gradient.range,
-                                                           lam=1/16)
+                                                           lam=1/16.0)
 
 # Combine proximal operators: the order must match the order of operators in K
 proximal_dual = odl.solvers.combine_proximals([prox_convconj_l2,

--- a/examples/solvers/chambolle_pock_denoising.py
+++ b/examples/solvers/chambolle_pock_denoising.py
@@ -104,8 +104,8 @@ prox_convconj_l1 = odl.solvers.proximal_cconj_l1(gradient.range, lam=1/16.0,
                                                  isotropic=True)
 
 # Combine proximal operators: the order must match the order of operators in K
-proximal_dual = odl.solvers.combine_proximals(
-    [prox_convconj_l2, prox_convconj_l1])
+proximal_dual = odl.solvers.combine_proximals(prox_convconj_l2,
+                                              prox_convconj_l1)
 
 # Proximal operator related to the primal variable
 

--- a/examples/solvers/chambolle_pock_tomography.py
+++ b/examples/solvers/chambolle_pock_tomography.py
@@ -86,8 +86,9 @@ proximal_primal = odl.solvers.proximal_zero(op.domain)
 prox_convconj_l2 = odl.solvers.proximal_cconj_l2_squared(ray_trafo.range,
                                                          g=data)
 
-# TV-regularization i.e. the l1-norm
-prox_convconj_l1 = odl.solvers.proximal_cconj_l1(gradient.range, lam=0.01)
+# Isotropic TV-regularization i.e. the l1-norm
+prox_convconj_l1 = odl.solvers.proximal_cconj_l1(gradient.range, lam=0.01,
+                                                 isotropic=True)
 
 # Combine proximal operators, order must correspond to the operator K
 proximal_dual = odl.solvers.combine_proximals(

--- a/examples/solvers/chambolle_pock_tomography.py
+++ b/examples/solvers/chambolle_pock_tomography.py
@@ -83,8 +83,8 @@ proximal_primal = odl.solvers.proximal_zero(op.domain)
 # Create proximal operators for the dual variable
 
 # l2-data matching
-prox_convconj_l2 = odl.solvers.proximal_convexconjugate_l2(ray_trafo.range,
-                                                           g=data)
+prox_convconj_l2 = odl.solvers.proximal_convexconjugate_l2_squared(ray_trafo.range,
+                                                                   g=data)
 
 # TV-regularization i.e. the l1-norm
 prox_convconj_l1 = odl.solvers.proximal_convexconjugate_l1(

--- a/examples/solvers/chambolle_pock_tomography.py
+++ b/examples/solvers/chambolle_pock_tomography.py
@@ -83,12 +83,11 @@ proximal_primal = odl.solvers.proximal_zero(op.domain)
 # Create proximal operators for the dual variable
 
 # l2-data matching
-prox_convconj_l2 = odl.solvers.proximal_convexconjugate_l2_squared(ray_trafo.range,
-                                                                   g=data)
+prox_convconj_l2 = odl.solvers.proximal_cconj_l2_squared(ray_trafo.range,
+                                                         g=data)
 
 # TV-regularization i.e. the l1-norm
-prox_convconj_l1 = odl.solvers.proximal_convexconjugate_l1(
-    gradient.range, lam=0.01)
+prox_convconj_l1 = odl.solvers.proximal_cconj_l1(gradient.range, lam=0.01)
 
 # Combine proximal operators, order must correspond to the operator K
 proximal_dual = odl.solvers.combine_proximals(

--- a/examples/solvers/chambolle_pock_tomography.py
+++ b/examples/solvers/chambolle_pock_tomography.py
@@ -91,8 +91,8 @@ prox_convconj_l1 = odl.solvers.proximal_cconj_l1(gradient.range, lam=0.01,
                                                  isotropic=True)
 
 # Combine proximal operators, order must correspond to the operator K
-proximal_dual = odl.solvers.combine_proximals(
-    [prox_convconj_l2, prox_convconj_l1])
+proximal_dual = odl.solvers.combine_proximals(prox_convconj_l2,
+                                              prox_convconj_l1)
 
 
 # --- Select solver parameters and solve using Chambolle-Pock --- #

--- a/examples/solvers/denoising_with_entropy_type_regularization.py
+++ b/examples/solvers/denoising_with_entropy_type_regularization.py
@@ -74,8 +74,9 @@ proximal_primal = odl.solvers.proximal_nonnegativity(op.domain)
 # l2-data matching
 prox_convconj_kl = odl.solvers.proximal_cconj_kl(discr_space, lam=1.0, g=noisy)
 
-# TV-regularization: l1-semi norm of grad(x)
-prox_convconj_l1 = odl.solvers.proximal_cconj_l1(gradient.range, lam=0.1)
+# Isotropic TV-regularization: l1-norm of grad(x)
+prox_convconj_l1 = odl.solvers.proximal_cconj_l1(gradient.range, lam=0.1,
+                                                 isotropic=True)
 
 # Combine proximal operators: the order must match the order of operators in K
 proximal_dual = odl.solvers.combine_proximals([prox_convconj_kl,

--- a/examples/solvers/denoising_with_entropy_type_regularization.py
+++ b/examples/solvers/denoising_with_entropy_type_regularization.py
@@ -79,8 +79,8 @@ prox_convconj_l1 = odl.solvers.proximal_cconj_l1(gradient.range, lam=0.1,
                                                  isotropic=True)
 
 # Combine proximal operators: the order must match the order of operators in K
-proximal_dual = odl.solvers.combine_proximals([prox_convconj_kl,
-                                               prox_convconj_l1])
+proximal_dual = odl.solvers.combine_proximals(prox_convconj_kl,
+                                              prox_convconj_l1)
 
 # Optional: pass partial objects to solver
 partial = (odl.solvers.PrintIterationPartial() &

--- a/examples/solvers/denoising_with_entropy_type_regularization.py
+++ b/examples/solvers/denoising_with_entropy_type_regularization.py
@@ -72,12 +72,10 @@ proximal_primal = odl.solvers.proximal_nonnegativity(op.domain)
 # Proximal operators related to the dual variable
 
 # l2-data matching
-prox_convconj_kl = odl.solvers.proximal_convexconjugate_kl(discr_space,
-                                                           lam=1.0, g=noisy)
+prox_convconj_kl = odl.solvers.proximal_cconj_kl(discr_space, lam=1.0, g=noisy)
 
 # TV-regularization: l1-semi norm of grad(x)
-prox_convconj_l1 = odl.solvers.proximal_convexconjugate_l1(gradient.range,
-                                                           lam=0.1)
+prox_convconj_l1 = odl.solvers.proximal_cconj_l1(gradient.range, lam=0.1)
 
 # Combine proximal operators: the order must match the order of operators in K
 proximal_dual = odl.solvers.combine_proximals([prox_convconj_kl,

--- a/odl/solvers/advanced/chambolle_pock.py
+++ b/odl/solvers/advanced/chambolle_pock.py
@@ -74,16 +74,16 @@ def chambolle_pock_solver(op, x, tau, sigma, proximal_primal, proximal_dual,
     sigma : positive `float`
         Step size parameter for the update of the dual variable y. Controls
         the extent to which ``proximal_dual`` maps points towards the
-        minimum of F_cc.
+        minimum of F^*.
     proximal_primal : `callable`
         Evaluated at ``tau``, the function returns the proximal operator,
-        prox_tau[G](x), of the functional G. The domain of G and its
+        prox[tau * G](x), of the functional G. The domain of G and its
         proximal operator instance are the space, X, of the primal variable
         x  i.e. the domain of ``op``.
     proximal_dual : `callable`
         Evaluated at ``sigma``, the function returns the proximal operator,
-        prox_sigma[F_cc](x), of the convex conjugate, F_cc, of the function
-        F. The domain of F_cc and its proximal operator instance are the
+        prox[sigma * F^*](x), of the convex conjugate, F^*, of the function
+        F. The domain of F^* and its proximal operator instance are the
         space, Y, of the dual variable y i.e. the range of ``op``.
     niter : non-negative `int`, optional
         Number of iterations
@@ -95,7 +95,7 @@ def chambolle_pock_solver(op, x, tau, sigma, proximal_primal, proximal_dual,
     gamma : non-negative `float`, optional
         Acceleration parameter. If not `None` overwrites ``theta`` and uses
         variable relaxation parameter and step sizes with ``tau`` and
-        ``sigma`` as initial values. Requires G or F_cc to be uniformly
+        ``sigma`` as initial values. Requires G or F^* to be uniformly
         convex. Default: `None`
     partial : `Partial`, optional
         If not `None` the `Partial` instance(s) are executed in each

--- a/odl/solvers/advanced/proximal_operators.py
+++ b/odl/solvers/advanced/proximal_operators.py
@@ -48,7 +48,7 @@ __all__ = ('combine_proximals', 'proximal_cconj',
 
 
 # TODO: remove diagonal op once available on master
-def combine_proximals(factory_list):
+def combine_proximals(*factory_list):
     """Combine proximal operators into a diagonal product space operator.
 
     This assumes the functional to be separable across variables in order to
@@ -69,29 +69,6 @@ def combine_proximals(factory_list):
         with the same step size parameter
     """
 
-    def diagonal_operator(operators, dom=None, ran=None):
-        """Broadcast argument to set of operators.
-
-        Parameters
-        ----------
-        operators : array-like
-            An array of `Operator`s
-        dom : `ProductSpace`, optional
-            Domain of the operator. If not provided, it is tried to be
-            inferred from the operators. This requires each **column**
-            to contain at least one operator.
-        ran : `ProductSpace`, optional
-            Range of the operator. If not provided, it is tried to be
-            inferred from the operators. This requires each **row**
-            to contain at least one operator.
-        """
-
-        indices = [range(len(operators)), range(len(operators))]
-        shape = (len(operators), len(operators))
-        op_matrix = sp.sparse.coo_matrix((operators, indices), shape)
-
-        return ProductSpaceOperator(op_matrix, dom=dom, ran=ran)
-
     def make_diag(step_size):
         """Diagonal matrix of operators
 
@@ -104,8 +81,13 @@ def combine_proximals(factory_list):
         -------
         diag_op : `Operator`
         """
-        return diagonal_operator(
-            [factory(step_size) for factory in factory_list])
+        operators = [factory(step_size) for factory in factory_list]
+
+        indices = [range(len(operators)), range(len(operators))]
+        shape = (len(operators), len(operators))
+        op_matrix = sp.sparse.coo_matrix((operators, indices), shape)
+
+        return ProductSpaceOperator(op_matrix)
 
     return make_diag
 

--- a/odl/solvers/advanced/proximal_operators.py
+++ b/odl/solvers/advanced/proximal_operators.py
@@ -37,7 +37,7 @@ from odl.space.pspace import ProductSpace
 
 __all__ = ('combine_proximals', 'proximal_convexconjugate',
            'proximal_composition', 'proximal_zero',
-           'proximal_clamp', 'proximal_nonnegativity',
+           'proximal_box_constraint', 'proximal_nonnegativity',
            'proximal_l1', 'proximal_convexconjugate_l1',
            'proximal_l2', 'proximal_convexconjugate_l2',
            'proximal_l2_squared', 'proximal_convexconjugate_l2_squared',
@@ -601,7 +601,7 @@ def proximal_l2_squared(space, lam=1, g=None):
     ----------
     space : `DiscreteLp` or `ProductSpace` of `DiscreteLp`
         Domain of F(x)
-    g : `DiscreteLpVector`
+    g : ``space`` element
         An element in ``space``
     lam : positive `float`
         Scaling factor or regularization parameter

--- a/odl/util/testutils.py
+++ b/odl/util/testutils.py
@@ -32,8 +32,8 @@ from time import time
 
 
 __all__ = ('almost_equal', 'all_equal', 'all_almost_equal', 'never_skip',
-           'skip_if_no_cuda', 'skip_if_no_pywavelets', 'skip_if_no_pyfftw',
-           'skip_if_no_largescale',
+           'skip_if_no_cuda', 'skip_if_no_stir', 'skip_if_no_pywavelets',
+           'skip_if_no_pyfftw', 'skip_if_no_largescale',
            'Timer', 'timeit', 'ProgressBar', 'ProgressRange',
            'test', 'run_doctests')
 
@@ -177,11 +177,6 @@ def is_subdict(subdict, dictionary):
     return all(item in dictionary.items() for item in subdict.items())
 
 
-def _pass(function):
-    """Trivial decorator used if pytest marks are not available."""
-    return function
-
-
 try:
     # Try catch in case user does not have pytest
     import pytest
@@ -195,6 +190,11 @@ try:
     skip_if_no_cuda = pytest.mark.skipif(
         "not odl.CUDA_AVAILABLE",
         reason='CUDA not available'
+    )
+
+    skip_if_no_stir = pytest.mark.skipif(
+        "not odl.tomo.backends.stir_bindings.STIR_AVAILABLE",
+        reason='STIR not available'
     )
 
     skip_if_no_pywavelets = pytest.mark.skipif(
@@ -217,8 +217,13 @@ try:
     )
 
 except ImportError:
+    def _pass(function):
+        """Trivial decorator used if pytest marks are not available."""
+        return function
+
     never_skip = _pass
     skip_if_no_cuda = _pass
+    skip_if_no_stir = _pass
     skip_if_no_pywavelets = _pass
     skip_if_no_pyfftw = _pass
     skip_if_no_largescale = _pass

--- a/odl/util/testutils.py
+++ b/odl/util/testutils.py
@@ -230,11 +230,11 @@ def example_array(space):
     """Generate an example array that is compatible with ``space``"""
     # Generate numpy vectors, real or complex or int
     if np.issubdtype(space.dtype, np.floating):
-        arr = np.random.rand(space.size)
+        arr = np.random.randn(space.size)
     elif np.issubdtype(space.dtype, np.integer):
-        arr = np.random.randint(0, 10, space.size)
+        arr = np.random.randint(-10, 10, space.size)
     else:
-        arr = np.random.rand(space.size) + 1j * np.random.rand(space.size)
+        arr = np.random.randn(space.size) + 1j * np.random.randn(space.size)
 
     return arr.astype(space.dtype, copy=False)
 

--- a/test/largescale/solvers/advanced/proximal_operator_slow_test.py
+++ b/test/largescale/solvers/advanced/proximal_operator_slow_test.py
@@ -30,10 +30,10 @@ import pytest
 import odl
 from odl.solvers.advanced.proximal_operators import (
     combine_proximals, proximal_zero, proximal_nonnegativity,
-    proximal_l1, proximal_convexconjugate_l1,
-    proximal_l2, proximal_convexconjugate_l2,
-    proximal_l2_squared, proximal_convexconjugate_l2_squared,
-    proximal_convexconjugate_kl)
+    proximal_l1, proximal_cconj_l1,
+    proximal_l2, proximal_cconj_l2,
+    proximal_l2_squared, proximal_cconj_l2_squared,
+    proximal_cconj_kl)
 from odl.util.testutils import example_element
 
 
@@ -87,7 +87,7 @@ def proximal_and_function(request):
             else:
                 return np.Infinity
 
-        prox = proximal_convexconjugate_l1(space)
+        prox = proximal_cconj_l1(space)
 
         return prox, l1_cc_norm
 
@@ -106,7 +106,7 @@ def proximal_and_function(request):
             else:
                 return np.Infinity
 
-        prox = proximal_convexconjugate_l2(space)
+        prox = proximal_cconj_l2(space)
 
         return prox, l2_norm_dual
 
@@ -122,7 +122,7 @@ def proximal_and_function(request):
         def l2_norm_squared(x):
             return 0.5 * x.norm() ** 2
 
-        prox = proximal_convexconjugate_l2_squared(space)
+        prox = proximal_cconj_l2_squared(space)
 
         return prox, l2_norm_squared
 
@@ -157,17 +157,12 @@ def test_proximal_defintion(proximal_and_function, stepsize):
     prox_x = proximal(x)
     f_prox_x = proximal_objective(function, stepsize, x, prox_x)
 
-    print(prox_x, x)
-    print(prox_x.norm(), x.norm())
-    print(f_prox_x, f_x)
     assert f_prox_x <= f_x
 
     for i in range(100):
         y = example_element(proximal.domain)
         f_y = proximal_objective(function, stepsize, x, y)
 
-        print(prox_x, y)
-        print(f_prox_x, f_y)
         assert f_prox_x <= f_y
 
 if __name__ == '__main__':

--- a/test/largescale/solvers/advanced/proximal_operator_slow_test.py
+++ b/test/largescale/solvers/advanced/proximal_operator_slow_test.py
@@ -132,7 +132,7 @@ def proximal_and_function(request):
 
 def proximal_objective(function, step_size, x, y):
     """Calculate the objective function of the proximal optimization problem"""
-    return function(y) + 1.0/(2.0 * step_size) * (x - y).norm() ** 2
+    return function(y) + 1.0 / (2.0 * step_size) * (x - y).norm() ** 2
 
 
 def test_proximal_defintion(proximal_and_function, stepsize):

--- a/test/largescale/solvers/advanced/proximal_operator_slow_test.py
+++ b/test/largescale/solvers/advanced/proximal_operator_slow_test.py
@@ -1,0 +1,137 @@
+# Copyright 2014-2016 The ODL development group
+#
+# This file is part of ODL.
+#
+# ODL is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# ODL is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with ODL.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Tests for the factory functions to create proximal operators."""
+
+# Imports for common Python 2/3 codebase
+from __future__ import print_function, division, absolute_import
+from future import standard_library
+standard_library.install_aliases()
+
+# External
+import numpy as np
+import pytest
+
+# Internal
+import odl
+from odl.solvers.advanced.proximal_operators import (
+    combine_proximals, proximal_zero, proximal_nonnegativity,
+    proximal_l1, proximal_convexconjugate_l1,
+    proximal_l2, proximal_convexconjugate_l2,
+    proximal_convexconjugate_kl)
+
+
+pytestmark = odl.util.skip_if_no_largescale
+
+
+step_params = [0.1, 1.0, 10.0]
+step_ids = [' stepsize = {} '.format(p) for p in step_params]
+
+
+@pytest.fixture(scope="module", ids=step_ids, params=step_params)
+def stepsize(request):
+    return request.param
+
+
+prox_params = ['l1', 'l1_dual',
+               'l2', 'l2_dual']
+prox_ids = [' f = {} '.format(p) for p in prox_params]
+
+
+@pytest.fixture(scope="module", ids=prox_ids, params=prox_params)
+def proximal_and_function(request):
+    """Return a proximal factory and the corresponding function."""
+    name = request.param
+
+    space = odl.uniform_discr(0, 1, 10)
+
+    if name == 'l1':
+        def l1_norm(x):
+            return np.abs(x).inner(x.space.one())
+
+        prox = proximal_l1(space)
+
+        return prox, l1_norm
+
+    if name == 'l1_dual':
+        def l1_cc_norm(x):
+            sup_norm = np.max(np.abs(x))
+            if sup_norm <= 1.0:
+                return 0.0
+            else:
+                return np.Infinity
+
+        prox = proximal_convexconjugate_l1(space)
+
+        return prox, l1_cc_norm
+
+    elif name == 'l2':
+        def l2_norm(x):
+            return 0.5 * x.norm() ** 2
+
+        prox = proximal_l2(space)
+
+        return prox, l2_norm
+
+    elif name == 'l2_dual':
+        def l2_norm(x):
+            return 0.5 * x.norm() ** 2
+
+        prox = proximal_convexconjugate_l2(space)
+
+        return prox, l2_norm
+    else:
+        assert False
+
+
+def proximal_objective(function, step_size, x, y):
+    """Calculate the objective function of the proximal optimization problem"""
+    return function(y) + 1.0/(2.0 * step_size) * (x - y).norm() ** 2
+
+
+def test_proximal_defintion(stepsize, proximal_and_function):
+    """Test the defintion of the proximal:
+
+        prox[lam * f](x) = argmin_y {f(y) + 1/(2 lam) ||x-y||}
+
+    Hence we expect for all x in the domain of the proximal
+
+        x* = prox[lam * f](x)
+        f(x*) + 1/(2 lam) ||x*-y|| < f(y) + 1/(2 lam) ||x-y||
+    """
+
+    proximal_factory, function = proximal_and_function
+
+    proximal = proximal_factory(stepsize)
+
+    assert proximal.domain == proximal.range
+
+    x = odl.util.testutils.example_element(proximal.domain)
+    f_x = proximal_objective(function, stepsize, x, x)
+    prox_x = proximal(x)
+    f_prox_x = proximal_objective(function, stepsize, x, prox_x)
+
+    assert f_prox_x <= f_x
+
+    for i in range(100):
+        y = odl.util.testutils.example_element(proximal.domain)
+        f_y = proximal_objective(function, stepsize, x, y)
+
+        assert f_prox_x <= f_y
+
+if __name__ == '__main__':
+    pytest.main(str(__file__.replace('\\', '/') + ' -v --largescale'))

--- a/test/largescale/tomo/stir_slow_test.py
+++ b/test/largescale/tomo/stir_slow_test.py
@@ -31,6 +31,7 @@ from odl.tomo.backends.stir_bindings import stir_projector_from_file
 pytestmark = odl.util.skip_if_no_largescale
 
 
+@odl.util.skip_if_no_stir
 def test_from_file():
     # Set path to input files
     base = pth.join(pth.dirname(pth.abspath(__file__)), 'data', 'stir')

--- a/test/solvers/advanced/proximal_operator_test.py
+++ b/test/solvers/advanced/proximal_operator_test.py
@@ -31,10 +31,10 @@ import odl
 from odl.solvers.advanced.proximal_operators import (
     combine_proximals, proximal_zero,
     proximal_box_constraint, proximal_nonnegativity,
-    proximal_l1, proximal_convexconjugate_l1,
+    proximal_l1, proximal_cconj_l1,
     proximal_l2,
-    proximal_l2_squared, proximal_convexconjugate_l2_squared,
-    proximal_convexconjugate_kl)
+    proximal_l2_squared, proximal_cconj_l2_squared,
+    proximal_cconj_kl)
 from odl.util.testutils import all_almost_equal
 
 
@@ -234,7 +234,7 @@ def test_proximal_factory_convconj_l2_sq_wo_data():
 
     # Factory function returning the proximal operator
     lam = 2
-    make_prox = proximal_convexconjugate_l2_squared(space, lam=lam, g=g)
+    make_prox = proximal_cconj_l2_squared(space, lam=lam, g=g)
 
     # Initialize the proximal operator
     sigma = 0.5
@@ -269,7 +269,7 @@ def test_proximal_factory_convconj_l2_sq_with_data():
 
     # Factory function returning the proximal operator
     lam = 2
-    make_prox = proximal_convexconjugate_l2_squared(space, lam=lam, g=g)
+    make_prox = proximal_cconj_l2_squared(space, lam=lam, g=g)
 
     # Initialize the proximal operator
     sigma = 0.5
@@ -301,7 +301,7 @@ def test_proximal_factory_convconj_l1_simple_space_without_data():
 
     # Factory function returning the proximal operator
     lam = 2
-    make_prox = proximal_convexconjugate_l1(space, lam=lam)
+    make_prox = proximal_cconj_l1(space, lam=lam)
 
     # Initialize the proximal operator of F^*
     sigma = 0.5
@@ -334,7 +334,7 @@ def test_proximal_factory_convconj_l1_simple_space_with_data():
 
     # Factory function returning the proximal operator
     lam = 2
-    make_prox = proximal_convexconjugate_l1(space, lam=lam, g=g)
+    make_prox = proximal_cconj_l1(space, lam=lam, g=g)
 
     # Initialize the proximal operator of F^*
     sigma = 0.5
@@ -373,7 +373,7 @@ def test_proximal_factory_convconj_l1_product_space():
 
     # Factory function returning the proximal operator
     lam = 2
-    make_prox = proximal_convexconjugate_l1(op_domain, lam=lam, g=g)
+    make_prox = proximal_cconj_l1(op_domain, lam=lam, g=g)
 
     # Initialize the proximal operator
     sigma = 0.5
@@ -413,7 +413,7 @@ def test_proximal_factory_convconj_kl_simple_space():
 
     # Factory function returning the proximal operator
     lam = 2
-    make_prox = proximal_convexconjugate_kl(space, lam=lam, g=g)
+    make_prox = proximal_cconj_kl(space, lam=lam, g=g)
 
     # Initialize the proximal operator of F^*
     sigma = 0.5
@@ -452,7 +452,7 @@ def test_proximal_factory_convconj_kl_product_space():
 
     # Factory function returning the proximal operator
     lam = 2
-    make_prox = proximal_convexconjugate_kl(op_domain, lam=lam, g=g)
+    make_prox = proximal_cconj_kl(op_domain, lam=lam, g=g)
 
     # Initialize the proximal operator
     sigma = 0.5

--- a/test/solvers/advanced/proximal_operator_test.py
+++ b/test/solvers/advanced/proximal_operator_test.py
@@ -52,10 +52,10 @@ def test_proximal_zero():
     x = space.element(np.arange(-5, 5))
 
     # Factory function returning the proximal operator
-    make_prox = proximal_zero(space)
+    prox_factory = proximal_zero(space)
 
     # Initialize proximal operator of G (with an unused parameter)
-    prox = make_prox(None)
+    prox = prox_factory(None)
 
     # prox_tau[G](x) = x = identity operator
     assert isinstance(prox, odl.IdentityOperator)
@@ -90,7 +90,7 @@ def test_proximal_box_constraint():
             result_np = np.minimum(np.maximum(x, lower_np), upper_np).asarray()
 
             # Verify equal result
-            assert all(result_np == result)
+            assert all_almost_equal(result_np, result)
 
 
 def test_proximal_nonnegativity():
@@ -103,10 +103,10 @@ def test_proximal_nonnegativity():
     x = space.element(np.arange(-5, 5))
 
     # Factory function returning the proximal operator
-    make_prox = proximal_nonnegativity(space)
+    prox_factory = proximal_nonnegativity(space)
 
     # Initialize proximal operator of G (with an unused parameter)
-    prox = make_prox(1.0)
+    prox = prox_factory(1.0)
 
     # Optimal point returned by the proximal operator
     result = prox(x)
@@ -125,13 +125,13 @@ def test_combine_proximal():
     space = odl.uniform_discr(0, 1, 10)
 
     # Factory function returning the proximal operator
-    make_prox = proximal_zero(space)
+    prox_factory = proximal_zero(space)
 
     # Combine factory function of proximal operators
-    combined_make_prox = combine_proximals(make_prox, make_prox)
+    combined_prox_factory = combine_proximals(prox_factory, prox_factory)
 
     # Initialize combine proximal operator
-    prox = combined_make_prox(1)
+    prox = combined_prox_factory(1)
 
     assert isinstance(prox, odl.Operator)
 
@@ -157,7 +157,7 @@ def test_combine_proximal():
     assert out == x
 
 
-def test_proximal_factory_l2_wo_data():
+def test_proximal_l2_wo_data():
     """Proximal factory for the L2-norm."""
 
     # Image space
@@ -165,11 +165,11 @@ def test_proximal_factory_l2_wo_data():
 
     # Factory function returning the proximal operator
     lam = 2.0
-    make_prox = proximal_l2(space, lam=lam)
+    prox_factory = proximal_l2(space, lam=lam)
 
     # Initialize the proximal operator
     sigma = 3.0
-    prox = make_prox(sigma)
+    prox = prox_factory(sigma)
 
     assert isinstance(prox, odl.Operator)
 
@@ -186,7 +186,7 @@ def test_proximal_factory_l2_wo_data():
     assert all_almost_equal(prox(x_big), x_big_opt, PLACES)
 
 
-def test_proximal_factory_l2_with_data():
+def test_proximal_l2_with_data():
     """Proximal factory for the L2-norm with data term."""
 
     # Image space
@@ -197,11 +197,11 @@ def test_proximal_factory_l2_with_data():
 
     # Factory function returning the proximal operator
     lam = 2.0
-    make_prox = proximal_l2(space, lam=lam, g=g)
+    prox_factory = proximal_l2(space, lam=lam, g=g)
 
     # Initialize the proximal operator
     sigma = 3.0
-    prox = make_prox(sigma)
+    prox = prox_factory(sigma)
 
     assert isinstance(prox, odl.Operator)
 
@@ -219,7 +219,7 @@ def test_proximal_factory_l2_with_data():
     assert all_almost_equal(prox(x_big), x_big_opt, PLACES)
 
 
-def test_proximal_factory_convconj_l2_sq_wo_data():
+def test_proximal_convconj_l2_sq_wo_data():
     """Proximal factory for the convex conjugate of the L2-norm."""
 
     # Image space
@@ -234,11 +234,11 @@ def test_proximal_factory_convconj_l2_sq_wo_data():
 
     # Factory function returning the proximal operator
     lam = 2
-    make_prox = proximal_cconj_l2_squared(space, lam=lam, g=g)
+    prox_factory = proximal_cconj_l2_squared(space, lam=lam, g=g)
 
     # Initialize the proximal operator
     sigma = 0.25
-    prox = make_prox(sigma)
+    prox = prox_factory(sigma)
 
     assert isinstance(prox, odl.Operator)
 
@@ -248,13 +248,13 @@ def test_proximal_factory_convconj_l2_sq_wo_data():
     # Optimal point returned by the proximal operator
     prox(x, x_out)
 
-    # Explicit computation: (x - sigma * g) / (1 + sigma / lambda)
-    x_verify = (x - sigma * g) / (1 + sigma / lam)
+    # Explicit computation: (x - sigma * g) / (1 + sigma / (2 * lambda))
+    x_verify = (x - sigma * g) / (1 + sigma / (2 * lam))
 
     assert all_almost_equal(x_out, x_verify, PLACES)
 
 
-def test_proximal_factory_convconj_l2_sq_with_data():
+def test_proximal_convconj_l2_sq_with_data():
     """Proximal factory for the convex conjugate of the L2-norm."""
 
     # Image space
@@ -269,11 +269,11 @@ def test_proximal_factory_convconj_l2_sq_with_data():
 
     # Factory function returning the proximal operator
     lam = 2
-    make_prox = proximal_cconj_l2_squared(space, lam=lam, g=g)
+    prox_factory = proximal_cconj_l2_squared(space, lam=lam, g=g)
 
     # Initialize the proximal operator
     sigma = 0.25
-    prox = make_prox(sigma)
+    prox = prox_factory(sigma)
 
     assert isinstance(prox, odl.Operator)
 
@@ -283,13 +283,13 @@ def test_proximal_factory_convconj_l2_sq_with_data():
     # Optimal point returned by the proximal operator
     prox(x, x_out)
 
-    # Explicit computation: (x - sigma * g) / (1 + sigma / lambda)
-    x_verify = (x - sigma * g) / (1 + sigma / lam)
+    # Explicit computation: (x - sigma * g) / (1 + sigma / (2 * lambda))
+    x_verify = (x - sigma * g) / (1 + sigma / (2 * lam))
 
     assert all_almost_equal(x_out, x_verify, PLACES)
 
 
-def test_proximal_factory_convconj_l1_simple_space_without_data():
+def test_proximal_convconj_l1_simple_space_without_data():
     """Proximal factory for the convex conjugate of the L1-norm."""
 
     # Image space
@@ -301,11 +301,11 @@ def test_proximal_factory_convconj_l1_simple_space_without_data():
 
     # Factory function returning the proximal operator
     lam = 2
-    make_prox = proximal_cconj_l1(space, lam=lam)
+    prox_factory = proximal_cconj_l1(space, lam=lam)
 
     # Initialize the proximal operator of F^*
     sigma = 0.25
-    prox = make_prox(sigma)
+    prox = prox_factory(sigma)
 
     assert isinstance(prox, odl.Operator)
 
@@ -320,7 +320,7 @@ def test_proximal_factory_convconj_l1_simple_space_without_data():
     assert all_almost_equal(x_opt, x_verify, PLACES)
 
 
-def test_proximal_factory_convconj_l1_simple_space_with_data():
+def test_proximal_convconj_l1_simple_space_with_data():
     """Proximal factory for the convex conjugate of the L1-norm."""
 
     # Image space
@@ -334,11 +334,11 @@ def test_proximal_factory_convconj_l1_simple_space_with_data():
 
     # Factory function returning the proximal operator
     lam = 2
-    make_prox = proximal_cconj_l1(space, lam=lam, g=g)
+    prox_factory = proximal_cconj_l1(space, lam=lam, g=g)
 
     # Initialize the proximal operator of F^*
     sigma = 0.25
-    prox = make_prox(sigma)
+    prox = prox_factory(sigma)
 
     assert isinstance(prox, odl.Operator)
 
@@ -353,7 +353,7 @@ def test_proximal_factory_convconj_l1_simple_space_with_data():
     assert all_almost_equal(x_opt, x0_verify, PLACES)
 
 
-def test_proximal_factory_convconj_l1_product_space():
+def test_proximal_convconj_l1_product_space():
     """Proximal factory for the convex conjugate of the L1-norm using
     product spaces."""
 
@@ -372,11 +372,11 @@ def test_proximal_factory_convconj_l1_product_space():
 
     # Factory function returning the proximal operator
     lam = 2
-    make_prox = proximal_cconj_l1(op_domain, lam=lam, g=g, isotropic=True)
+    prox_factory = proximal_cconj_l1(op_domain, lam=lam, g=g, isotropic=True)
 
     # Initialize the proximal operator
     sigma = 0.25
-    prox = make_prox(sigma)
+    prox = prox_factory(sigma)
 
     assert isinstance(prox, odl.Operator)
 
@@ -393,7 +393,7 @@ def test_proximal_factory_convconj_l1_product_space():
     assert all_almost_equal(x_verify, x_opt)
 
 
-def test_proximal_factory_convconj_kl_simple_space():
+def test_proximal_convconj_kl_simple_space():
     """Proximal factory for the convex conjugate of KL divergence."""
 
     # Image space
@@ -407,11 +407,11 @@ def test_proximal_factory_convconj_kl_simple_space():
 
     # Factory function returning the proximal operator
     lam = 2
-    make_prox = proximal_cconj_kl(space, lam=lam, g=g)
+    prox_factory = proximal_cconj_kl(space, lam=lam, g=g)
 
     # Initialize the proximal operator of F^*
     sigma = 0.25
-    prox = make_prox(sigma)
+    prox = prox_factory(sigma)
 
     assert isinstance(prox, odl.Operator)
 
@@ -427,7 +427,7 @@ def test_proximal_factory_convconj_kl_simple_space():
     assert all_almost_equal(x_opt, x_verify, PLACES)
 
 
-def test_proximal_factory_convconj_kl_product_space():
+def test_proximal_convconj_kl_product_space():
     """Proximal factory for the convex conjugate of the KL divergence using
     product spaces."""
 
@@ -446,11 +446,11 @@ def test_proximal_factory_convconj_kl_product_space():
 
     # Factory function returning the proximal operator
     lam = 2
-    make_prox = proximal_cconj_kl(op_domain, lam=lam, g=g)
+    prox_factory = proximal_cconj_kl(op_domain, lam=lam, g=g)
 
     # Initialize the proximal operator
     sigma = 0.25
-    prox = make_prox(sigma)
+    prox = prox_factory(sigma)
 
     assert isinstance(prox, odl.Operator)
 

--- a/test/solvers/advanced/proximal_operator_test.py
+++ b/test/solvers/advanced/proximal_operator_test.py
@@ -128,7 +128,7 @@ def test_combine_proximal():
     make_prox = proximal_zero(space)
 
     # Combine factory function of proximal operators
-    combined_make_prox = combine_proximals([make_prox, make_prox])
+    combined_make_prox = combine_proximals(make_prox, make_prox)
 
     # Initialize combine proximal operator
     prox = combined_make_prox(1)

--- a/test/solvers/advanced/proximal_operator_test.py
+++ b/test/solvers/advanced/proximal_operator_test.py
@@ -30,13 +30,42 @@ import pytest
 import odl
 from odl.solvers.advanced.proximal_operators import (
     combine_proximals, proximal_zero, proximal_nonnegativity,
-    proximal_convexconjugate_l1, proximal_convexconjugate_l2,
+    proximal_l1, proximal_convexconjugate_l1,
+    proximal_l2, proximal_convexconjugate_l2,
     proximal_convexconjugate_kl)
 from odl.util.testutils import all_almost_equal
 
 
 # Places for the accepted error when comparing results
 PLACES = 8
+
+
+prox_params = ['l1', 'l2']
+prox_ids = [' f = {} '.format(p) for p in prox_params]
+
+
+@pytest.fixture(scope="module", ids=prox_ids, params=prox_params)
+def proximal_and_function(request):
+    """Return a proximal factory and the corresponding function."""
+    name = request.param
+
+    space = odl.uniform_discr(0, 1, 2)
+
+    if name == 'l1':
+        def l1_norm(x):
+            return np.abs(x).inner(x.space.one())
+
+        prox = proximal_l1(space)
+
+        return prox, l1_norm
+
+    if name == 'l2':
+        def l2_norm(x):
+            return x.norm() ** 2
+
+        prox = proximal_l2(space)
+
+        return prox, l2_norm
 
 
 def test_proximal_zero():
@@ -80,7 +109,7 @@ def test_proximal_nonnegativity():
     make_prox = proximal_nonnegativity(space)
 
     # Initialize proximal operator of G (with an unused parameter)
-    prox = make_prox(None)
+    prox = make_prox(1.0)
 
     # Optimal point returned by the proximal operator
     prox(x, out)
@@ -380,6 +409,40 @@ def test_proximal_factory_convconj_kl_product_space():
     # Compare components
     assert all_almost_equal(x_verify, x_opt)
 
+
+def proximal_objective(function, step_size, x_0, y):
+    return function(y) + 1/(2.0 * step_size) * (x_0 - y).norm() ** 2
+
+
+def test_proximal_defintion(proximal_and_function):
+    """Test the defintion of the proximal:
+
+        prox[lam * f](x) = argmin_y {f(y) + 1/(2 lam) ||x-y||}
+
+    Hence we expect for all x in the domain of the proximal
+
+        x* = prox[lam * f](x)
+        f(x*) + 1/(2 lam) ||x*-y|| < f(y) + 1/(2 lam) ||x-y||
+    """
+
+    proximal_factory, function = proximal_and_function
+
+    step_size = 0.1
+
+    proximal = proximal_factory(step_size)
+
+    assert proximal.domain == proximal.range
+
+    x_0 = odl.util.testutils.example_element(proximal.domain)
+    f_x = proximal_objective(function, step_size, x_0, x_0)
+    prox_x = proximal(x_0)
+    f_prox_x = proximal_objective(function, step_size, x_0, prox_x)
+
+    assert f_prox_x < f_x
+
+    for i in range(1000):
+        y = odl.util.testutils.example_element(proximal.domain)
+        assert f_prox_x < proximal_objective(function, step_size, x_0, y)
 
 if __name__ == '__main__':
     pytest.main(str(__file__.replace('\\', '/') + ' -v'))

--- a/test/solvers/advanced/proximal_operator_test.py
+++ b/test/solvers/advanced/proximal_operator_test.py
@@ -237,7 +237,7 @@ def test_proximal_factory_convconj_l2_sq_wo_data():
     make_prox = proximal_cconj_l2_squared(space, lam=lam, g=g)
 
     # Initialize the proximal operator
-    sigma = 0.5
+    sigma = 0.25
     prox = make_prox(sigma)
 
     assert isinstance(prox, odl.Operator)
@@ -272,7 +272,7 @@ def test_proximal_factory_convconj_l2_sq_with_data():
     make_prox = proximal_cconj_l2_squared(space, lam=lam, g=g)
 
     # Initialize the proximal operator
-    sigma = 0.5
+    sigma = 0.25
     prox = make_prox(sigma)
 
     assert isinstance(prox, odl.Operator)
@@ -290,7 +290,7 @@ def test_proximal_factory_convconj_l2_sq_with_data():
 
 
 def test_proximal_factory_convconj_l1_simple_space_without_data():
-    """Proximal factory for the convex conjugate of the L1-semi-norm."""
+    """Proximal factory for the convex conjugate of the L1-norm."""
 
     # Image space
     space = odl.uniform_discr(0, 1, 10)
@@ -304,7 +304,7 @@ def test_proximal_factory_convconj_l1_simple_space_without_data():
     make_prox = proximal_cconj_l1(space, lam=lam)
 
     # Initialize the proximal operator of F^*
-    sigma = 0.5
+    sigma = 0.25
     prox = make_prox(sigma)
 
     assert isinstance(prox, odl.Operator)
@@ -314,14 +314,14 @@ def test_proximal_factory_convconj_l1_simple_space_without_data():
     prox(x, x_opt)
 
     # Explicit computation: x / max(lam, |x|)
-    denom = np.maximum(lam * np.ones(x_arr.shape), np.sqrt(x_arr ** 2))
+    denom = np.maximum(lam, np.sqrt(x_arr ** 2))
     x_verify = lam * x_arr / denom
 
     assert all_almost_equal(x_opt, x_verify, PLACES)
 
 
 def test_proximal_factory_convconj_l1_simple_space_with_data():
-    """Proximal factory for the convex conjugate of the L1-semi-norm."""
+    """Proximal factory for the convex conjugate of the L1-norm."""
 
     # Image space
     space = odl.uniform_discr(0, 1, 10)
@@ -337,7 +337,7 @@ def test_proximal_factory_convconj_l1_simple_space_with_data():
     make_prox = proximal_cconj_l1(space, lam=lam, g=g)
 
     # Initialize the proximal operator of F^*
-    sigma = 0.5
+    sigma = 0.25
     prox = make_prox(sigma)
 
     assert isinstance(prox, odl.Operator)
@@ -347,15 +347,14 @@ def test_proximal_factory_convconj_l1_simple_space_with_data():
     prox(x, x_opt)
 
     # Explicit computation: (x - sigma * g) / max(lam, |x - sigma * g|)
-    denom = np.maximum(lam * np.ones(x_arr.shape),
-                       np.sqrt((x_arr - sigma * g_arr) ** 2))
+    denom = np.maximum(lam, np.abs(x_arr - sigma * g_arr))
     x0_verify = lam * (x_arr - sigma * g_arr) / denom
 
     assert all_almost_equal(x_opt, x0_verify, PLACES)
 
 
 def test_proximal_factory_convconj_l1_product_space():
-    """Proximal factory for the convex conjugate of the L1-semi-norm using
+    """Proximal factory for the convex conjugate of the L1-norm using
     product spaces."""
 
     # Product space for matrix of operators
@@ -373,30 +372,25 @@ def test_proximal_factory_convconj_l1_product_space():
 
     # Factory function returning the proximal operator
     lam = 2
-    make_prox = proximal_cconj_l1(op_domain, lam=lam, g=g)
+    make_prox = proximal_cconj_l1(op_domain, lam=lam, g=g, isotropic=True)
 
     # Initialize the proximal operator
-    sigma = 0.5
+    sigma = 0.25
     prox = make_prox(sigma)
 
     assert isinstance(prox, odl.Operator)
 
-    # Allocate output vector
-    x_opt = op_domain.element()
-
     # Apply the proximal operator returning its optimal point
-    prox(x, x_opt)
+    x_opt = prox(x)
 
     # Explicit computation: (x - sigma * g) / max(lam, |x - sigma * g|)
-    denom = np.maximum(
-        lam * np.ones(x0_arr.shape),
-        np.sqrt((x0_arr - sigma * g0_arr) ** 2 +
-                (x1_arr - sigma * g1_arr) ** 2))
-    x0_verify = lam * (x0_arr - sigma * g0_arr) / denom
-    x1_verify = lam * (x1_arr - sigma * g1_arr) / denom
+    denom = np.maximum(lam,
+                       np.sqrt((x0_arr - sigma * g0_arr) ** 2 +
+                               (x1_arr - sigma * g1_arr) ** 2))
+    x_verify = lam * (x - sigma * g) / denom
 
     # Compare components
-    assert all_almost_equal([x0_verify, x1_verify], x_opt)
+    assert all_almost_equal(x_verify, x_opt)
 
 
 def test_proximal_factory_convconj_kl_simple_space():
@@ -416,7 +410,7 @@ def test_proximal_factory_convconj_kl_simple_space():
     make_prox = proximal_cconj_kl(space, lam=lam, g=g)
 
     # Initialize the proximal operator of F^*
-    sigma = 0.5
+    sigma = 0.25
     prox = make_prox(sigma)
 
     assert isinstance(prox, odl.Operator)
@@ -455,7 +449,7 @@ def test_proximal_factory_convconj_kl_product_space():
     make_prox = proximal_cconj_kl(op_domain, lam=lam, g=g)
 
     # Initialize the proximal operator
-    sigma = 0.5
+    sigma = 0.25
     prox = make_prox(sigma)
 
     assert isinstance(prox, odl.Operator)

--- a/test/solvers/advanced/proximal_operator_test.py
+++ b/test/solvers/advanced/proximal_operator_test.py
@@ -29,7 +29,8 @@ import pytest
 # Internal
 import odl
 from odl.solvers.advanced.proximal_operators import (
-    combine_proximals, proximal_zero, proximal_clamp, proximal_nonnegativity,
+    combine_proximals, proximal_zero,
+    proximal_box_constraint, proximal_nonnegativity,
     proximal_l1, proximal_convexconjugate_l1,
     proximal_l2,
     proximal_l2_squared, proximal_convexconjugate_l2_squared,
@@ -66,7 +67,7 @@ def test_proximal_zero():
     assert x == x_opt
 
 
-def test_proximal_clamp():
+def test_proximal_box_constraint():
     """Proximal factory for indicator function for non-negativity ."""
 
     # Image space
@@ -75,13 +76,12 @@ def test_proximal_clamp():
     # Element in the image space where the proximal operator is evaluated
     x = space.element(np.arange(-5, 5))
 
-    lower_vector = -2.0 * space.one()
-    upper_vector = 2.0 * space.one()
-
-    for lower in [None, -2, lower_vector]:
-        for upper in [None, 2, upper_vector]:
+    for lower in [None, -2, -2.0 * space.one()]:
+        for upper in [None, 2, 2.0 * space.one()]:
             # Factory function returning the proximal operator
-            prox = proximal_clamp(space, lower=lower, upper=upper)(1.0)
+            prox_factory = proximal_box_constraint(space,
+                                                   lower=lower, upper=upper)
+            prox = prox_factory(1.0)
             result = prox(x).asarray()
 
             # Create reference

--- a/test/space/fspace_test.py
+++ b/test/space/fspace_test.py
@@ -498,7 +498,7 @@ def test_fspace_lincomb(a, b):
     g_novec = fspace.element(other_func_2d_novec, vectorized=False)
     out_novec = fspace.element(vectorized=False)
     fspace.lincomb(a, f_novec, b, g_novec, out_novec)
-    assert out_novec(point) == true_novec
+    assert almost_equal(out_novec(point), true_novec)
 
     # Vectorized
     true_arr = (a * func_2d_vec_oop(points) +
@@ -513,7 +513,7 @@ def test_fspace_lincomb(a, b):
 
     assert all_equal(out_vec(points), true_arr)
     assert all_equal(out_vec(mg), true_mg)
-    assert out_vec(point) == true_novec
+    assert almost_equal(out_vec(point), true_novec)
     out_arr = np.empty((5,), dtype=float)
     out_mg = np.empty((2, 3), dtype=float)
     out_vec(points, out=out_arr)
@@ -529,7 +529,7 @@ def test_fspace_lincomb(a, b):
 
     assert all_equal(out_vec(points), true_arr)
     assert all_equal(out_vec(mg), true_mg)
-    assert out_vec(point) == true_novec
+    assert almost_equal(out_vec(point), true_novec)
     out_arr = np.empty((5,), dtype=float)
     out_mg = np.empty((2, 3), dtype=float)
     out_vec(points, out=out_arr)
@@ -545,7 +545,7 @@ def test_fspace_lincomb(a, b):
 
     assert all_equal(out_vec(points), true_arr)
     assert all_equal(out_vec(mg), true_mg)
-    assert out_vec(point) == true_novec
+    assert almost_equal(out_vec(point), true_novec)
     out_arr = np.empty((5,), dtype=float)
     out_mg = np.empty((2, 3), dtype=float)
     out_vec(points, out=out_arr)
@@ -710,7 +710,7 @@ def test_fspace_vector_arithmetic(variant, op):
     out_novec = _op(test_l_novec, op, test_r_novec)
     out_vec = _op(test_l_vec, op, test_r_vec)
 
-    assert out_novec(point) == true_novec
+    assert almost_equal(out_novec(point), true_novec)
     assert all_equal(out_vec(points), true_arr)
     out_vec(points, out=array_out)
     assert all_equal(array_out, true_arr)

--- a/test/tomo/backends/astra_setup_test.py
+++ b/test/tomo/backends/astra_setup_test.py
@@ -108,7 +108,6 @@ def test_vol_geom_2d():
     discr_dom = _discrete_domain_anisotropic(2, 'nearest')
     with pytest.raises(NotImplementedError):
         odl.tomo.astra_volume_geometry(discr_dom)
-    print('\n', vol_geom)
 
 
 def test_vol_geom_3d():
@@ -141,7 +140,6 @@ def test_vol_geom_3d():
     discr_dom = _discrete_domain_anisotropic(3, 'nearest')
     with pytest.raises(NotImplementedError):
         odl.tomo.astra_volume_geometry(discr_dom)
-    print('\n', vol_geom)
 
 
 def test_proj_geom_parallel_2d():


### PR DESCRIPTION
* Add proximal_convexconjugate
* Add proximal_clamp
* Add proximal_l1 for the primal l1 norm
* Add proximal_l2 for the primal l2 norm squared
* Add proximal_composition for the composition with a special kind of linear operators
* Add largescale tests that verify the proximal property
* Improved the chambolle pock deconvolve example

We should get this in rather quickly. Some things remain:

- [x] Fix failing pep8 test
- [x] Make sure all uses of `proximal_convexconjugate_l2` instead use `proximal_convexconjugate_l2_square`, especially in examples.'
- [x] Tests for the newly added proximals.