### PR TITLE
Pass kwargs to sampling in DiscretizedSet.element

### DIFF
--- a/odl/discr/discr_ops.py
+++ b/odl/discr/discr_ops.py
@@ -31,14 +31,15 @@ __all__ = ('Resampling',)
 
 
 class Resampling(Operator):
-    """A operator that resamples a vector on another grid.
 
-    The operator uses the underlying `Discretization.sampling` and
-    `Discretization.interpolation` operators to achieve this.
+    """An operator that resamples a vector on another grid.
 
-    The spaces need to have the same `Discretization.uspace` in order for this
-    to work. The dspace types may however be different, although performance
-    may vary drastically.
+    The operator uses the underlying `DiscretizedSet.sampling` and
+    `DiscretizedSet.interpolation` operators to achieve this.
+
+    The spaces need to have the same `DiscretizedSet.uspace` in order
+    for this to work. The data space types may be different, although
+    performance may vary drastically.
     """
 
     def __init__(self, domain, range):
@@ -53,7 +54,7 @@ class Resampling(Operator):
 
         Examples
         --------
-        Create two spaces with different number of points and create resampling
+        Create two spaces with different number of points and a resampling
         operator.
 
         >>> import odl

--- a/odl/discr/discretization.py
+++ b/odl/discr/discretization.py
@@ -310,10 +310,8 @@ class DiscretizedSetVector(NtuplesBaseVector):
             to the size of the slice (same size, shape (1,)
             or single value).
         """
-        if isinstance(values, DiscretizedSetVector):
-            self.ntuple.__setitem__(indices, values.ntuple)
-        else:
-            self.ntuple.__setitem__(indices, values)
+        input_data = getattr(values, 'ntuple', values)
+        self.ntuple.__setitem__(indices, input_data)
 
     def sampling(self, ufunc, **kwargs):
         """Restrict a continuous function and assign to this vector

--- a/odl/discr/discretization.py
+++ b/odl/discr/discretization.py
@@ -36,13 +36,13 @@ from odl.util.utility import (
 CudaCn = type(None)
 
 
-__all__ = ('RawDiscretization', 'RawDiscretizationVector',
-           'Discretization', 'DiscretizationVector')
+__all__ = ('DiscretizedSet', 'DiscretizedSetVector',
+           'DiscretizedSpace', 'DiscretizedSpaceVector')
 
 
-class RawDiscretization(NtuplesBase):
+class DiscretizedSet(NtuplesBase):
 
-    """Abstract raw discretization class.
+    """Abstract discretization class for general sets.
 
     A discretization in ODL is a way to encode the transition from
     an arbitrary set to a set of n-tuples explicitly representable
@@ -172,7 +172,7 @@ class RawDiscretization(NtuplesBase):
 
         Returns
         -------
-        element : `RawDiscretizationVector`
+        element : `DiscretizedSetVector`
             The discretized element, calculated as
             ``dspace.element(inp)`` or
             ``sampling(uspace.element(inp))``, tried in this order.
@@ -191,9 +191,9 @@ class RawDiscretization(NtuplesBase):
         Returns
         -------
         equals : `bool`
-            `True` if ``other`` is a `RawDiscretization`
+            `True` if ``other`` is a `DiscretizedSet`
             instance and all attributes `uspace`, `dspace`,
-            `RawDiscretization.sampling` and `RawDiscretization.interpolation`
+            `DiscretizedSet.sampling` and `DiscretizedSet.interpolation`
             of ``other`` and this discretization are equal, `False` otherwise.
         """
         if other is self:
@@ -212,19 +212,19 @@ class RawDiscretization(NtuplesBase):
 
     @property
     def element_type(self):
-        """ `RawDiscretizationVector` """
-        return RawDiscretizationVector
+        """ `DiscretizedSetVector` """
+        return DiscretizedSetVector
 
 
-class RawDiscretizationVector(NtuplesBaseVector):
+class DiscretizedSetVector(NtuplesBaseVector):
 
-    """Representation of a `RawDiscretization` element.
+    """Representation of a `DiscretizedSet` element.
 
     Basically only a wrapper class for dspace's vector class."""
 
     def __init__(self, space, ntuple):
         """Initialize a new instance."""
-        assert isinstance(space, RawDiscretization)
+        assert isinstance(space, DiscretizedSet)
         assert ntuple in space.dspace
 
         NtuplesBaseVector.__init__(self, space)
@@ -303,7 +303,7 @@ class RawDiscretizationVector(NtuplesBaseVector):
             to the size of the slice (same size, shape (1,)
             or single value).
         """
-        if isinstance(values, RawDiscretizationVector):
+        if isinstance(values, DiscretizedSetVector):
             self.ntuple.__setitem__(indices, values.ntuple)
         else:
             self.ntuple.__setitem__(indices, values)
@@ -336,7 +336,7 @@ class RawDiscretizationVector(NtuplesBaseVector):
 
         See Also
         --------
-        RawDiscretization.sampling : For full description
+        DiscretizedSet.sampling : For full description
         """
         self.space.sampling(ufunc, out=self.ntuple, **kwargs)
 
@@ -372,7 +372,7 @@ class RawDiscretizationVector(NtuplesBaseVector):
 
         See Also
         --------
-        RawDiscretization.interpolation : For full description
+        DiscretizedSet.interpolation : For full description
         """
         return self.space.interpolation(self.ntuple)
 
@@ -386,17 +386,17 @@ class RawDiscretizationVector(NtuplesBaseVector):
                                          arraynd_repr(self.asarray()))
 
 
-class Discretization(RawDiscretization, FnBase):
+class DiscretizedSpace(DiscretizedSet, FnBase):
 
     """Abstract class for discretizations of linear vector spaces.
 
-    This variant of `RawDiscretization` adds linear structure
-    to all its members. The `RawDiscretization.uspace` is a
-    `LinearSpace`, the `RawDiscretization.dspace`
+    This variant of `DiscretizedSet` adds linear structure
+    to all its members. The `DiscretizedSet.uspace` is a
+    `LinearSpace`, the `DiscretizedSet.dspace`
     for the data representation is an implementation of
     :math:`\mathbb{F}^n`, where :math:`\mathbb{F}` is some
-    `Field`, and both `RawDiscretization.sampling`
-    and `RawDiscretization.interpolation` are linear
+    `Field`, and both `DiscretizedSet.sampling`
+    and `DiscretizedSet.interpolation` are linear
     `Operator`'s.
     """
 
@@ -415,15 +415,15 @@ class Discretization(RawDiscretization, FnBase):
             discretized object. Its `FnBase.field` attribute
             must be the same as ``uspace.field``.
         sampling : `Operator`, linear, optional
-            Operator mapping a `RawDiscretization.uspace` element
-            to a `RawDiscretization.dspace` element. Must satisfy
+            Operator mapping a `DiscretizedSet.uspace` element
+            to a `DiscretizedSet.dspace` element. Must satisfy
             ``sampling.domain == uspace``, ``sampling.range == dspace``
         interpol : `Operator`, linear, optional
-            Operator mapping a `RawDiscretization.dspace` element
-            to a `RawDiscretization.uspace` element. Must satisfy
+            Operator mapping a `DiscretizedSet.dspace` element
+            to a `DiscretizedSet.uspace` element. Must satisfy
             ``interpol.domain == dspace``, ``interpol.range == uspace``.
         """
-        RawDiscretization.__init__(self, uspace, dspace, sampling, interpol)
+        DiscretizedSet.__init__(self, uspace, dspace, sampling, interpol)
         FnBase.__init__(self, dspace.size, dspace.dtype)
 
         if not isinstance(uspace, LinearSpace):
@@ -515,18 +515,18 @@ class Discretization(RawDiscretization, FnBase):
 
     @property
     def element_type(self):
-        """ `DiscretizationVector` """
-        return DiscretizationVector
+        """ `DiscretizedSpaceVector` """
+        return DiscretizedSpaceVector
 
 
-class DiscretizationVector(RawDiscretizationVector, FnBaseVector):
+class DiscretizedSpaceVector(DiscretizedSetVector, FnBaseVector):
 
-    """Representation of a `Discretization` element."""
+    """Representation of a `DiscretizedSpace` element."""
 
     def __init__(self, space, data):
         """Initialize a new instance."""
-        assert isinstance(space, Discretization)
-        RawDiscretizationVector.__init__(self, space, data)
+        assert isinstance(space, DiscretizedSpace)
+        DiscretizedSetVector.__init__(self, space, data)
 
 
 def dspace_type(space, impl, dtype=None):

--- a/odl/discr/discretization.py
+++ b/odl/discr/discretization.py
@@ -160,27 +160,33 @@ class DiscretizedSet(NtuplesBase):
         else:
             raise NotImplementedError('no interpolation operator provided.')
 
-    def element(self, inp=None):
+    def element(self, inp=None, **kwargs):
         """Create an element from ``inp`` or from scratch.
 
         Parameters
         ----------
-        inp : `object`, optional
-            The input data to create an element from. Must be
-            recognizable by the `LinearSpace.element`
-            method of either `dspace` or `uspace`.
+        inp : optional
+            The input data to create an element from. It needs to be
+            understood by either the `sampling` operator of this
+            instance or by its ``dspace.element`` method.
+        kwargs :
+            Additional arguments passed on to `sampling`. This can be
+            used e.g. for functions with parameters.
 
         Returns
         -------
         element : `DiscretizedSetVector`
-            The discretized element, calculated as
-            ``dspace.element(inp)`` or
-            ``sampling(uspace.element(inp))``, tried in this order.
+            The discretized element, calculated as ``sampling(inp)`` or
+            ``dspace.element(inp)``, tried in this order.
+
+        See also
+        --------
+        sampling : create a discrete element from an undiscretized one
         """
         if inp is None:
             return self.element_type(self, self.dspace.element())
         try:
-            return self.element_type(self, self.sampling(inp))
+            return self.element_type(self, self.sampling(inp, **kwargs))
         except TypeError:
             # Sequence-type input
             return self.element_type(self, self.dspace.element(inp))

--- a/odl/discr/discretization.py
+++ b/odl/discr/discretization.py
@@ -170,8 +170,9 @@ class DiscretizedSet(NtuplesBase):
             understood by either the `sampling` operator of this
             instance or by its ``dspace.element`` method.
         kwargs :
-            Additional arguments passed on to `sampling`. This can be
-            used e.g. for functions with parameters.
+            Additional arguments passed on to `sampling` when called
+            on ``inp``, in the form ``sampling(inp, **kwargs)``.
+            This can be used e.g. for functions with parameters.
 
         Returns
         -------

--- a/odl/discr/lp_discr.py
+++ b/odl/discr/lp_discr.py
@@ -28,7 +28,7 @@ import numpy as np
 from numbers import Integral
 
 from odl.discr.discretization import (
-    Discretization, DiscretizationVector, dspace_type)
+    DiscretizedSpace, DiscretizedSpaceVector, dspace_type)
 from odl.discr.discr_mappings import (
     PointCollocation, NearestInterpolation, LinearInterpolation,
     PerAxisInterpolation)
@@ -50,7 +50,7 @@ __all__ = ('DiscreteLp', 'DiscreteLpVector',
 _SUPPORTED_INTERP = ('nearest', 'linear')
 
 
-class DiscreteLp(Discretization):
+class DiscreteLp(DiscretizedSpace):
 
     """Discretization of a Lebesgue :math:`L^p` space."""
 
@@ -141,7 +141,7 @@ class DiscreteLp(Discretization):
             interpol = PerAxisInterpolation(
                 fspace, self.partition, dspace, self.interp, order=self.order)
 
-        Discretization.__init__(self, fspace, dspace, sampling, interpol)
+        DiscretizedSpace.__init__(self, fspace, dspace, sampling, interpol)
         self._exponent = float(exponent)
         if (hasattr(self.dspace, 'exponent') and
                 self.exponent != dspace.exponent):
@@ -220,8 +220,8 @@ class DiscreteLp(Discretization):
         inp : `object`, optional
             The input data to create an element from. Must be
             recognizable by the `LinearSpace.element` method
-            of either `RawDiscretization.dspace` or
-            `RawDiscretization.uspace`.
+            of either `DiscretizedSet.dspace` or
+            `DiscretizedSet.uspace`.
 
         Returns
         -------
@@ -413,7 +413,7 @@ class DiscreteLp(Discretization):
         return DiscreteLpVector
 
 
-class DiscreteLpVector(DiscretizationVector):
+class DiscreteLpVector(DiscretizedSpaceVector):
 
     """Representation of a `DiscreteLp` element."""
 
@@ -570,7 +570,7 @@ class DiscreteLpVector(DiscretizationVector):
             shape is allowed as ``values``.
         """
         if values in self.space:
-            # For RawDiscretizationVector of the same type, use ntuple directly
+            # For DiscretizedSetVector of the same type, use ntuple directly
             self.ntuple[indices] = values.ntuple
         else:
             # Other sequence types are piped through a Numpy array. Equivalent

--- a/odl/discr/lp_discr.py
+++ b/odl/discr/lp_discr.py
@@ -212,23 +212,28 @@ class DiscreteLp(DiscretizedSpace):
         """The exponent ``p`` in ``L^p``."""
         return self._exponent
 
-    def element(self, inp=None):
+    def element(self, inp=None, **kwargs):
         """Create an element from ``inp`` or from scratch.
 
         Parameters
         ----------
         inp : `object`, optional
-            The input data to create an element from. Must be
-            recognizable by the `LinearSpace.element` method
-            of either `DiscretizedSet.dspace` or
-            `DiscretizedSet.uspace`.
+            The input data to create an element from. It needs to be
+            understood by either the `sampling` operator of this
+            instance or by its ``dspace.element`` method.
+        kwargs :
+            Additional arguments passed on to `sampling`. This can be
+            used e.g. for functions with parameters.
 
         Returns
         -------
-        element : `DiscreteLpVector`
-            The discretized element, calculated as
-            ``dspace.element(inp)`` or
-            ``sampling(uspace.element(inp))``, tried in this order.
+        element : `DiscretizedSetVector`
+            The discretized element, calculated as ``sampling(inp)`` or
+            ``dspace.element(inp)``, tried in this order.
+
+        See also
+        --------
+        sampling : create a discrete element from an undiscretized one
         """
         if inp is None:
             return self.element_type(self, self.dspace.element())
@@ -242,7 +247,7 @@ class DiscreteLp(DiscretizedSpace):
         # uspace element -> discretize
         try:
             inp_elem = self.uspace.element(inp)
-            return self.element_type(self, self.sampling(inp_elem))
+            return self.element_type(self, self.sampling(inp_elem, **kwargs))
         except TypeError:
             pass
 

--- a/odl/discr/lp_discr.py
+++ b/odl/discr/lp_discr.py
@@ -217,19 +217,54 @@ class DiscreteLp(DiscretizedSpace):
 
         Parameters
         ----------
-        inp : `object`, optional
+        inp : optional
             The input data to create an element from. It needs to be
             understood by either the `sampling` operator of this
             instance or by its ``dspace.element`` method.
         kwargs :
-            Additional arguments passed on to `sampling`. This can be
-            used e.g. for functions with parameters.
+            Additional arguments passed on to `sampling` when called
+            on ``inp``, in the form ``sampling(inp, **kwargs)``.
+            This can be used e.g. for functions with parameters.
 
         Returns
         -------
         element : `DiscretizedSetVector`
             The discretized element, calculated as ``sampling(inp)`` or
             ``dspace.element(inp)``, tried in this order.
+
+        Examples
+        --------
+        Elements can be created from array-like objects that represent
+        an already discretized function:
+
+        >>> import odl
+        >>> space = odl.uniform_discr(-1, 1, 4)
+        >>> space.element([1, 2, 3, 4])
+        uniform_discr(-1.0, 1.0, 4).element([1.0, 2.0, 3.0, 4.0])
+        >>> vector = odl.Rn(4).element([0, 1, 2, 3])
+        >>> space.element(vector)
+        uniform_discr(-1.0, 1.0, 4).element([0.0, 1.0, 2.0, 3.0])
+
+        On the other hand, non-discretized objects like Python functions
+        can be discretized "on the fly":
+
+        >>> def f(x):
+        ...     return x * 2
+        ...
+        >>> space.element(f)
+        uniform_discr(-1.0, 1.0, 4).element([-1.5, -0.5, 0.5, 1.5])
+
+        This works also with parameterized functions, however only
+        through keyword arguments (not positional arguments with
+        defaults):
+
+        >>> def f(x, **kwargs):
+        ...     c = kwargs.pop('c', 0.0)
+        ...     return np.maximum(x, c)
+        ...
+        >>> space = odl.uniform_discr(-1, 1, 4)
+        >>> space.element(f, c=0.5)
+        uniform_discr(-1.0, 1.0, 4).element([0.5, 0.5, 0.5, 0.75])
 
         See also
         --------

--- a/odl/util/phantom.py
+++ b/odl/util/phantom.py
@@ -545,7 +545,7 @@ def cuboid(discr_space, begin, end):
 
     Parameters
     ----------
-    discr_space : `Discretization`
+    discr_space : `DiscretizedSpace`
         Discretized space in which the phantom is supposed to be created
     begin : array-like or `float` in [0, 1]
         The lower left corner of the cuboid within the space grid relative
@@ -605,7 +605,7 @@ def indicate_proj_axis(discr_space, scale_structures=0.5):
 
     Parameters
     ----------
-    discr_space : `Discretization`
+    discr_space : `DiscretizedSpace`
         Discretized space in which the phantom is supposed to be created
     scale_structures : positive `float` in (0, 1]
         Scales objects (cube, cuboids)

--- a/test/discr/lp_discr_test.py
+++ b/test/discr/lp_discr_test.py
@@ -273,6 +273,60 @@ def test_element_from_array_2d_shape():
                        [3, 4]])
 
 
+def test_element_from_function_1d():
+
+    space = odl.uniform_discr(-1, 1, 4)
+    points = space.grid.points().squeeze()
+
+    # Without parameter
+    def f(x):
+        return x * 2 + np.maximum(x, 0)
+
+    elem_f = space.element(f)
+    true_elem = [x * 2 + max(x, 0) for x in points]
+    assert all_equal(elem_f, true_elem)
+
+    # With parameter
+    def f(x, **kwargs):
+        c = kwargs.pop('c', 0)
+        return x * c + np.maximum(x, 0)
+
+    elem_f_default = space.element(f)
+    true_elem = [x * 0 + max(x, 0) for x in points]
+    assert all_equal(elem_f_default, true_elem)
+
+    elem_f_2 = space.element(f, c=2)
+    true_elem = [x * 2 + max(x, 0) for x in points]
+    assert all_equal(elem_f_2, true_elem)
+
+
+def test_element_from_function_2d():
+
+    space = odl.uniform_discr([-1, -1], [1, 1], (2, 3))
+    points = space.grid.points()
+
+    # Without parameter
+    def f(x):
+        return x[0] ** 2 + np.maximum(x[1], 0)
+
+    elem_f = space.element(f)
+    true_elem = [x[0] ** 2 + max(x[1], 0) for x in points]
+    assert all_equal(elem_f, true_elem)
+
+    # With parameter
+    def f(x, **kwargs):
+        c = kwargs.pop('c', 0)
+        return x[0] ** 2 + np.maximum(x[1], c)
+
+    elem_f_default = space.element(f)
+    true_elem = [x[0] ** 2 + max(x[1], 0) for x in points]
+    assert all_equal(elem_f_default, true_elem)
+
+    elem_f_2 = space.element(f, c=1)
+    true_elem = [x[0] ** 2 + max(x[1], 1) for x in points]
+    assert all_equal(elem_f_2, true_elem)
+
+
 def test_zero():
     discr = odl.uniform_discr(0, 1, 3)
     vec = discr.zero()

--- a/test/discr/lp_discr_test.py
+++ b/test/discr/lp_discr_test.py
@@ -276,11 +276,19 @@ def test_element_from_array_2d_shape():
 def test_element_from_function_1d():
 
     space = odl.uniform_discr(-1, 1, 4)
-    points = space.grid.points().squeeze()
+    points = space.points().squeeze()
 
     # Without parameter
     def f(x):
         return x * 2 + np.maximum(x, 0)
+
+    elem_f = space.element(f)
+    true_elem = [x * 2 + max(x, 0) for x in points]
+    assert all_equal(elem_f, true_elem)
+
+    # Without parameter, using same syntax as in higher dimensions
+    def f(x):
+        return x[0] * 2 + np.maximum(x[0], 0)
 
     elem_f = space.element(f)
     true_elem = [x * 2 + max(x, 0) for x in points]
@@ -299,11 +307,16 @@ def test_element_from_function_1d():
     true_elem = [x * 2 + max(x, 0) for x in points]
     assert all_equal(elem_f_2, true_elem)
 
+    # Using a lambda
+    elem_lam = space.element(lambda x: -x ** 2)
+    true_elem = [-x ** 2 for x in points]
+    assert all_equal(elem_lam, true_elem)
+
 
 def test_element_from_function_2d():
 
     space = odl.uniform_discr([-1, -1], [1, 1], (2, 3))
-    points = space.grid.points()
+    points = space.points()
 
     # Without parameter
     def f(x):
@@ -325,6 +338,11 @@ def test_element_from_function_2d():
     elem_f_2 = space.element(f, c=1)
     true_elem = [x[0] ** 2 + max(x[1], 1) for x in points]
     assert all_equal(elem_f_2, true_elem)
+
+    # Using a lambda
+    elem_lam = space.element(lambda x: x[0] - x[1])
+    true_elem = [x[0] - x[1] for x in points]
+    assert all_equal(elem_lam, true_elem)
 
 
 def test_zero():


### PR DESCRIPTION
This change makes it possible to do this:

```python
>>> def f(x, **kwargs):
...     c = kwargs.pop('c', 0.0)
...     return np.maximum(x, c)
...
>>> space = odl.uniform_discr(-1, 1, 4)
>>> space.element(f, c=0.5)
uniform_discr(-1.0, 1.0, 4).element([0.5, 0.5, 0.5, 0.75])
```

We won't get simpler than that since positional arguments with defaults are forbidden due to the subclassing of `Operator`. Better than nothing.

Furthermore, `RawDiscretization` and `Discretization` were renamed to `DiscretizedSet` and `DiscretizedSpace`, resp.