### PR TITLE
Issue 419  proximal rules

### DIFF
--- a/doc/source/refs.rst
+++ b/doc/source/refs.rst
@@ -5,11 +5,11 @@ References
    gradient methods*. IMA Journal of Numerical Analysis, 8 (1988),
    pp 141--148.
 
-.. [BC2015] Bot, R.I, and Csetnek, E.R. *On the convergence rate of
+.. [BC2015] Bot, R I, and Csetnek, E R. *On the convergence rate of
    a forward-backward type primal-dual splitting algorithm for convex
    optimization problems*. Optimization, 64.1 (2015), pp 5--23.
 
-.. [BH2013] Bot, R.I, and Hendrich, C. *A Douglas-Rachford type
+.. [BH2013] Bot, R I, and Hendrich, C. *A Douglas-Rachford type
    primal-dual method for solving inclusions with mixtures of
    composite and parallel-sum type monotone operators*. SIAM Journal
    on Optimization, 23.4 (2013), pp 2541--2565.
@@ -21,15 +21,21 @@ References
 .. [BV2004] Boyd, S, and Vandenberghe, L. *Convex optimization*.
    Cambridge university press, 2004.
 
-.. [CP2011a] Chambolle, Antonin and Pock, Thomas. *A First-Order
+.. [CP2011a] Chambolle, A and Pock, T. *A First-Order
    Primal-Dual Algorithm for Convex Problems with Applications to
    Imaging*. Journal of Mathematical Imaging and Vision, 40 (2011),
    pp 120-145.
 
-.. [CP2011b] Chambolle, Antonin and Pock, Thomas. *Diagonal
+.. [CP2011b] Chambolle, A and Pock, T. *Diagonal
    preconditioning for first order primal-dual algorithms in convex
    optimization*. 2011 IEEE International Conference on Computer Vision
    (ICCV), 2011, pp 1762-1769.
+
+.. [CP2011c] Combettes, P L, and Pesquet, J-C. *Proximal splitting
+   methods in signal processing.* In:  Bauschke, H H, Burachik, R S,
+   Combettes, P L, Elser, V, Luke, D R, and Wolkowicz, H. Fixed-point
+   algorithms for inverse problems in science and engineering, Springer,
+   2011.
 
 .. [GNS2009] Griva, I, Nash, S G, and Sofer, A. *Linear and nonlinear
    optimization*. Siam, 2009.
@@ -41,7 +47,7 @@ References
    Scherzer, O. Handbook of Mathematical Methods in Imaging.
    Springer, 2015, pp 937--1031.
 
-.. [PB2014] Parikh, Neal and Boyd, Stephen. *Proximal Algorithms*.
+.. [PB2014] Parikh, N, and Boyd, S. *Proximal Algorithms*.
    Foundations and Trends in Optimization, 1 (2014), pp 127-239.
 
 .. [Pre+2007] Press, W H, Teukolsky, S A, Vetterling, W T, and Flannery, B P.
@@ -55,12 +61,12 @@ References
 .. [Roc1970] Rockafellar, R. Tyrrell. *Convex analysis*. Princeton
    University Press, 1970.
 
-.. [Sid+2012] Sidky, Emil Y, Jorgensen, Jakob H, and Pan, Xiaochuan.
+.. [Sid+2012] Sidky, E Y, Jorgensen, J H, and Pan, X.
    *Convex optimization problem prototyping for image reconstruction in
    computed tomography with the Chambolle-Pock algorithm*. Physics in
    Medicine and Biology, 57 (2012), pp 3065-3091.
 
-.. [SW1971] Stein, E and Weiss, G.
+.. [SW1971] Stein, E, and Weiss, G.
    *Introduction to Fourier Analysis on Euclidean Spaces*.
    Princeton University Press, 1971.
 

--- a/test/solvers/advanced/proximal_operator_test.py
+++ b/test/solvers/advanced/proximal_operator_test.py
@@ -229,12 +229,9 @@ def test_proximal_convconj_l2_sq_wo_data():
     x_arr = np.arange(-5, 5)
     x = space.element(x_arr)
 
-    # Create data
-    g = space.element(-2 * x_arr)
-
     # Factory function returning the proximal operator
     lam = 2
-    prox_factory = proximal_cconj_l2_squared(space, lam=lam, g=g)
+    prox_factory = proximal_cconj_l2_squared(space, lam=lam)
 
     # Initialize the proximal operator
     sigma = 0.25
@@ -248,8 +245,8 @@ def test_proximal_convconj_l2_sq_wo_data():
     # Optimal point returned by the proximal operator
     prox(x, x_out)
 
-    # Explicit computation: (x - sigma * g) / (1 + sigma / (2 * lambda))
-    x_verify = (x - sigma * g) / (1 + sigma / (2 * lam))
+    # Explicit computation: x / (1 + sigma / (2 * lambda))
+    x_verify = x / (1 + sigma / (2 * lam))
 
     assert all_almost_equal(x_out, x_verify, PLACES)
 

--- a/test/solvers/advanced/proximal_utils_test.py
+++ b/test/solvers/advanced/proximal_utils_test.py
@@ -1,0 +1,172 @@
+# Copyright 2014-2016 The ODL development group
+#
+# This file is part of ODL.
+#
+# ODL is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# ODL is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with ODL.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Tests for the utility functions for proximal operators."""
+
+
+# Imports for common Python 2/3 codebase
+from __future__ import print_function, division, absolute_import
+from future import standard_library
+standard_library.install_aliases()
+
+# External
+import numpy as np
+import pytest
+
+# Internal
+import odl
+import odl.solvers as odls
+
+from odl.util.testutils import all_almost_equal, example_element
+
+# Places for the accepted error when comparing results
+PLACES = 8
+
+
+def test_proximal_translation():
+    """Test for the proximal of a translation: prox[F(. - g)]"""
+
+    # Image space
+    space = odl.uniform_discr(0, 1, 10)
+
+    # Element in the image space where the proximal operator is evaluated
+    translation = example_element(space)
+
+    # Factory function returning the proximal operators
+    lam = float(np.random.randn(1))
+    prox_factory = odls.proximal_l2_squared(space, lam=lam)
+
+    # Initialize proximal operators
+    step_size = float(np.random.rand(1))  # Non-negative step size
+    prox = odls.proximal_translation(prox_factory, translation)(step_size)
+
+    # Create an element in the space, in which to evaluate the proximals
+    x = example_element(space)
+
+    # Explicit computation:
+    expected_result = ((x + 2 * step_size * lam * translation) /
+                       (1 + 2 * step_size * lam))
+
+    assert all_almost_equal(prox(x), expected_result, places=PLACES)
+
+
+def test_proximal_arg_scaling():
+    """Test for the proximal of scaling: prox[F(. * a)]"""
+
+    # Image space
+    space = odl.uniform_discr(0, 1, 10)
+
+    # Factory function returning the proximal operators
+    lam = float(np.random.randn(1))
+    prox_factory = odls.proximal_l2_squared(space, lam=lam)
+
+    # Initialize proximal operators
+    step_size = float(np.random.rand(1))   # Non-negative step size
+    scaling_param = float(np.random.randn(1))
+    prox = odls.proximal_arg_scaling(prox_factory, scaling_param)(step_size)
+
+    # Create an element in the space, in which to evaluate the proximals
+    x = example_element(space)
+
+    # Explicit computation:
+    expected_result = x / (2 * step_size * lam * scaling_param ** 2 + 1)
+
+    assert all_almost_equal(prox(x), expected_result, places=PLACES)
+
+
+def test_proximal_arg_scaling_zero():
+    """Test for the proximal of scaling: prox[F(. * a)] when a = 0"""
+
+    # Image space
+    space = odl.uniform_discr(0, 1, 10)
+
+    # Factory function returning the proximal operators
+    prox_factory = odls.proximal_l1(space, lam=1)
+
+    # Initialize proximal operators
+    scaling_param = 0.0
+    step_size = float(np.random.rand(1))   # Non-negative step size
+    prox = odls.proximal_arg_scaling(prox_factory, scaling_param)(step_size)
+
+    # Create an element in the space, in which to evaluate the proximals
+    x = example_element(space)
+
+    # Check that the scaling with zero returns proximal facotry for the
+    # proximal_zero, which ersults in the identity operator
+    assert all_almost_equal(prox(x), x, places=PLACES)
+
+
+def test_proximal_quadratic_perturbation_quadratic():
+    """Test for the proximal of quadratic perturbation with quadratic term"""
+
+    # Image space
+    space = odl.uniform_discr(0, 1, 10)
+
+    # The parameter for the quadratic perturbation
+    a = float(np.random.rand(1))  # This needs to be non-negative
+    lam = float(np.random.randn(1))
+
+    # Factory function returning the proximal operators
+    prox_factory = odls.proximal_l2_squared(space, lam=lam)
+
+    # Verify fail with negative a
+    with pytest.raises(ValueError):
+        odls.proximal_quadratic_perturbation(prox_factory, -a)
+
+    # Initialize proximal operators
+    step_size = float(np.random.rand(1))  # Non-negative step size
+    prox = odls.proximal_quadratic_perturbation(prox_factory, a)(step_size)
+
+    # Create an element in the space, in which to evaluate the proximals
+    x = example_element(space)
+
+    # Explicit computation:
+    expected_result = x / (2 * step_size * (lam + a) + 1)
+
+    assert all_almost_equal(prox(x), expected_result, places=PLACES)
+
+
+def test_proximal_quadratic_perturbation_linear_and_quadratic():
+    """Test for the proximal of quadratic perturbation with both terms"""
+
+    # Image space
+    space = odl.uniform_discr(0, 1, 10)
+
+    # The parameter for the quadratic perturbation
+    a = float(np.random.rand(1))  # This needs to be non-negative
+    u = example_element(space)
+    lam = float(np.random.randn(1))
+
+    # Factory function returning the proximal operators
+    prox_factory = odls.proximal_l2_squared(space, lam=lam)
+
+    # Initialize proximal operators
+    step_size = float(np.random.rand(1))  # Non-negative step size
+    prox = odls.proximal_quadratic_perturbation(prox_factory,
+                                                a, u)(step_size)
+
+    # Create an element in the space, in which to evaluate the proximals
+    x = example_element(space)
+
+    # Explicit computation:
+    expected_result = (x - step_size * u) / (2 * step_size * (lam + a) + 1)
+
+    assert all_almost_equal(prox(x), expected_result, places=PLACES)
+
+
+if __name__ == '__main__':
+    pytest.main(str(__file__.replace('\\', '/') + ' -v'))


### PR DESCRIPTION
This adds three identities for proximal operators; when the function is
1) translated
2) the argument is scaled
3) when the function is perturbed by a quadratic term.
(see i), ii) and iv) in table 10.1 in https://www.ljll.math.upmc.fr/~plc/prox.pdf, i.e. chapter 10 in http://link.springer.com/book/10.1007/978-1-4419-9569-8).

It also adds three tests to check these implementations.

(This relates to issue #419 )