### PR TITLE
API: change Partial to Callback

### DIFF
--- a/examples/convolution_test.py
+++ b/examples/convolution_test.py
@@ -74,20 +74,20 @@ conv = Convolution(kernel)
 iterations = 100
 omega = 1 / conv.opnorm() ** 2
 
-# Display partial
-partial = solvers.util.ForEachPartial(lambda result: plt.plot(conv(result)))
+# Display callback
+callback = solvers.CallbackApply(lambda result: plt.plot(conv(result)))
 
 # Test CGN
 plt.figure()
 plt.plot(phantom)
 solvers.conjugate_gradient_normal(conv, discr_space.zero(), phantom,
-                                  iterations, partial)
+                                  iterations, callback)
 
 # Landweber
 plt.figure()
 plt.plot(phantom)
 solvers.landweber(conv, discr_space.zero(), phantom,
-                  iterations, omega, partial)
+                  iterations, omega, callback)
 
 # testTimingCG
 with Timer("Optimized CG"):

--- a/examples/convolution_test_cuda.py
+++ b/examples/convolution_test_cuda.py
@@ -77,20 +77,20 @@ conv = CudaConvolution(kernel)
 iterations = 100
 omega = 1.0 / conv.opnorm() ** 2
 
-# Display partial
-partial = solvers.util.ForEachPartial(
+# Display callback
+callback = solvers.CallbackApply(
     lambda result: plt.plot(conv(result).asarray()))
 
 # Test CGN
 plt.figure()
 plt.plot(data)
 solvers.conjugate_gradient_normal(conv, discr_space.zero(), data, iterations,
-                                  partial)
+                                  callback)
 
 # Landweber
 plt.figure()
 plt.plot(data)
-solvers.landweber(conv, discr_space.zero(), data, iterations, omega, partial)
+solvers.landweber(conv, discr_space.zero(), data, iterations, omega, callback)
 
 
 plt.show()

--- a/examples/solvers/chambolle_pock_deconvolve.py
+++ b/examples/solvers/chambolle_pock_deconvolve.py
@@ -99,9 +99,9 @@ tau = 1.0 / op_norm  # Step size for the primal variable
 sigma = 1.0 / op_norm  # Step size for the dual variable
 
 
-# Optionally pass partial to the solver to display intermediate results
-partial = (odl.solvers.PrintIterationPartial() &
-           odl.solvers.ShowPartial(display_step=20))
+# Optionally pass callback to the solver to display intermediate results
+callback = (odl.solvers.CallbackPrintIteration() &
+            odl.solvers.CallbackShow(display_step=20))
 
 # Choose a starting point
 x = op.domain.zero()
@@ -109,7 +109,7 @@ x = op.domain.zero()
 # Run the algorithm
 odl.solvers.chambolle_pock_solver(
     op, x, tau=tau, sigma=sigma, proximal_primal=proximal_primal,
-    proximal_dual=proximal_dual, niter=niter, partial=partial)
+    proximal_dual=proximal_dual, niter=niter, callback=callback)
 
 # Display images
 phantom.show(title='original image')

--- a/examples/solvers/chambolle_pock_denoising.py
+++ b/examples/solvers/chambolle_pock_denoising.py
@@ -92,9 +92,9 @@ niter = 400  # Number of iterations
 tau = 1.0 / op_norm  # Step size for the primal variable
 sigma = 1.0 / op_norm  # Step size for the dual variable
 
-# Optional: pass partial objects to solver
-partial = (odl.solvers.PrintIterationPartial() &
-           odl.solvers.ShowPartial(display_step=20))
+# Optional: pass callback objects to solver
+callback = (odl.solvers.CallbackPrintIteration() &
+            odl.solvers.CallbackShow(display_step=20))
 
 # Starting point
 x = op.domain.zero()
@@ -102,7 +102,7 @@ x = op.domain.zero()
 # Run algorithms (and display intermediates)
 odl.solvers.chambolle_pock_solver(
     op, x, tau=tau, sigma=sigma, proximal_primal=proximal_primal,
-    proximal_dual=proximal_dual, niter=niter, partial=partial)
+    proximal_dual=proximal_dual, niter=niter, callback=callback)
 
 # Display images
 orig.show(title='original image')

--- a/examples/solvers/chambolle_pock_tomography.py
+++ b/examples/solvers/chambolle_pock_tomography.py
@@ -108,9 +108,9 @@ niter = 400  # Number of iterations
 tau = 1.0 / op_norm  # Step size for the primal variable
 sigma = 1.0 / op_norm  # Step size for the dual variable
 
-# Optionally pass partial to the solver to display intermediate results
-partial = (odl.solvers.PrintIterationPartial() &
-           odl.solvers.ShowPartial())
+# Optionally pass callback to the solver to display intermediate results
+callback = (odl.solvers.CallbackPrintIteration() &
+            odl.solvers.CallbackShow())
 
 # Choose a starting point
 x = op.domain.zero()
@@ -118,7 +118,7 @@ x = op.domain.zero()
 # Run the algorithm
 odl.solvers.chambolle_pock_solver(
     op, x, tau=tau, sigma=sigma, proximal_primal=proximal_primal,
-    proximal_dual=proximal_dual, niter=niter, partial=partial)
+    proximal_dual=proximal_dual, niter=niter, callback=callback)
 
 # Display images
 discr_phantom.show(title='original image')

--- a/examples/solvers/denoising_with_entropy_type_regularization.py
+++ b/examples/solvers/denoising_with_entropy_type_regularization.py
@@ -82,9 +82,9 @@ prox_convconj_l1 = odl.solvers.proximal_cconj_l1(gradient.range, lam=0.1,
 proximal_dual = odl.solvers.combine_proximals(prox_convconj_kl,
                                               prox_convconj_l1)
 
-# Optional: pass partial objects to solver
-partial = (odl.solvers.PrintIterationPartial() &
-           odl.solvers.ShowPartial(display_step=20))
+# Optional: pass callback objects to solver
+callback = (odl.solvers.CallbackPrintIteration() &
+            odl.solvers.CallbackShow(display_step=20))
 
 
 # --- Select solver parameters and solve using Chambolle-Pock --- #
@@ -103,7 +103,7 @@ x = op.domain.zero()
 # Run algorithms (and display intermediates)
 odl.solvers.chambolle_pock_solver(
     op, x, tau=tau, sigma=sigma, proximal_primal=proximal_primal,
-    proximal_dual=proximal_dual, niter=niter, partial=partial)
+    proximal_dual=proximal_dual, niter=niter, callback=callback)
 
 # Display images
 orig.show(title='original image')

--- a/odl/solvers/advanced/chambolle_pock.py
+++ b/odl/solvers/advanced/chambolle_pock.py
@@ -30,7 +30,6 @@ standard_library.install_aliases()
 import numpy as np
 
 from odl.operator.operator import Operator
-from odl.solvers.util import Partial
 
 
 __all__ = ('chambolle_pock_solver',)
@@ -97,8 +96,8 @@ def chambolle_pock_solver(op, x, tau, sigma, proximal_primal, proximal_dual,
         variable relaxation parameter and step sizes with ``tau`` and
         ``sigma`` as initial values. Requires G or F^* to be uniformly
         convex. Default: `None`
-    partial : `Partial`, optional
-        If not `None` the `Partial` instance(s) are executed in each
+    callback : `callable`, optional
+        If not `None` the ``callback`` instance(s) are executed in each
         iteration, e.g. plotting each iterate. Default: `None`
     x_relax : element in the domain of ``op``, optional
         Required to resume iteration. If `None` it is a copy of the primal
@@ -166,11 +165,11 @@ def chambolle_pock_solver(op, x, tau, sigma, proximal_primal, proximal_dual,
         else:
             gamma = float(gamma)
 
-    # Partial object
-    partial = kwargs.pop('partial', None)
-    if partial is not None and not callable(partial):
-        raise TypeError('partial {} is not an instance of {}'
-                        ''.format(op, Partial))
+    # Callback object
+    callback = kwargs.pop('callback', None)
+    if callback is not None and not callable(callback):
+        raise TypeError('`callback` {} is not ``callable``'
+                        ''.format(callback))
 
     # Initialize the relaxation variable
     x_relax = kwargs.pop('x_relax', None)
@@ -217,8 +216,8 @@ def chambolle_pock_solver(op, x, tau, sigma, proximal_primal, proximal_dual,
         # Over-relaxation in the primal variable x
         x_relax.lincomb(1 + theta, x, -theta, x_old)
 
-        if partial is not None:
-            partial(x)
+        if callback is not None:
+            callback(x)
 
 
 if __name__ == '__main__':

--- a/odl/solvers/advanced/chambolle_pock.py
+++ b/odl/solvers/advanced/chambolle_pock.py
@@ -168,7 +168,7 @@ def chambolle_pock_solver(op, x, tau, sigma, proximal_primal, proximal_dual,
     # Callback object
     callback = kwargs.pop('callback', None)
     if callback is not None and not callable(callback):
-        raise TypeError('`callback` {} is not ``callable``'
+        raise TypeError('`callback` {} is not `callable`'
                         ''.format(callback))
 
     # Initialize the relaxation variable

--- a/odl/solvers/findroot/newton.py
+++ b/odl/solvers/findroot/newton.py
@@ -31,7 +31,7 @@ __all__ = ('bfgs_method', 'broydens_first_method', 'broydens_second_method')
 # TODO: update all docs
 
 
-def bfgs_method(grad, x, line_search, niter=1, partial=None):
+def bfgs_method(grad, x, line_search, niter=1, callback=None):
     """Quasi-Newton BFGS method to minimize a differentiable function.
 
     This is a general and optimized implementation of a quasi-Newton
@@ -67,8 +67,8 @@ Goldfarb%E2%80%93Shanno_algorithm>`_
         Strategy to choose the step length
     niter : `int`, optional
         Number of iterations
-    partial : `Partial`, optional
-        Object executing code per iteration, e.g. plotting each iterate
+    callback : `callable`, optional
+        Object executing code per iteration, e.g. plotting each iterate.
 
     Returns
     -------
@@ -100,11 +100,11 @@ Goldfarb%E2%80%93Shanno_algorithm>`_
                 (ident - grad_diff * x_update.T / y_inner_s) +
                 x_update * x_update.T / y_inner_s)
 
-        if partial is not None:
-            partial(x)
+        if callback is not None:
+            callback(x)
 
 
-def broydens_first_method(grad, x, line_search, niter=1, partial=None):
+def broydens_first_method(grad, x, line_search, niter=1, callback=None):
     """Broyden's first method, a quasi-Newton scheme.
 
     This is a general and optimized implementation of Broyden's first
@@ -136,8 +136,8 @@ def broydens_first_method(grad, x, line_search, niter=1, partial=None):
         Strategy to choose the step length
     niter : `int`, optional
         Number of iterations
-    partial : `Partial`, optional
-        Object executing code per iteration, e.g. plotting each iterate
+    callback : `callable`, optional
+        Object executing code per iteration, e.g. plotting each iterate.
 
     Returns
     -------
@@ -172,11 +172,11 @@ def broydens_first_method(grad, x, line_search, niter=1, partial=None):
         u /= scalprod
         hess -= u * v.T
 
-        if partial is not None:
-            partial(x)
+        if callback is not None:
+            callback(x)
 
 
-def broydens_second_method(grad, x, line_search, niter=1, partial=None):
+def broydens_second_method(grad, x, line_search, niter=1, callback=None):
     """Broyden's first method, a quasi-Newton scheme.
 
     This is a general and optimized implementation of Broyden's second
@@ -208,7 +208,7 @@ def broydens_second_method(grad, x, line_search, niter=1, partial=None):
         Strategy to choose the step length
     niter : `int`, optional
         Number of iterations
-    partial : `Partial`, optional
+    callback : `callable`, optional
         Object executing code per iteration, e.g. plotting each iterate
     """
     # TODO: potentially make the implementation faster by considering
@@ -235,8 +235,8 @@ def broydens_second_method(grad, x, line_search, niter=1, partial=None):
         u = (x_update + hess(grad_diff)) / grad_diff_norm2
         hess -= u * grad_diff.T
 
-        if partial is not None:
-            partial(x)
+        if callback is not None:
+            callback(x)
 
 
 if __name__ == '__main__':

--- a/odl/solvers/iterative/iterative.py
+++ b/odl/solvers/iterative/iterative.py
@@ -33,7 +33,7 @@ __all__ = ('landweber', 'conjugate_gradient', 'conjugate_gradient_normal',
 # TODO: update all docs
 
 
-def landweber(op, x, rhs, niter=1, omega=1, projection=None, partial=None):
+def landweber(op, x, rhs, niter=1, omega=1, projection=None, callback=None):
     """Optimized implementation of Landweber's method.
 
     This method calculates an approximate least-squares solution of
@@ -94,7 +94,7 @@ def landweber(op, x, rhs, niter=1, omega=1, projection=None, partial=None):
         Function that can be used to modify the iterates in each iteration,
         for example enforcing positivity. The function should take one
         argument and modify it in place.
-    partial : `Partial`, optional
+    callback : `callable`, optional
         Object executing code per iteration, e.g. plotting each iterate
 
     Returns
@@ -116,11 +116,11 @@ def landweber(op, x, rhs, niter=1, omega=1, projection=None, partial=None):
         if projection is not None:
             projection(x)
 
-        if partial is not None:
-            partial(x)
+        if callback is not None:
+            callback(x)
 
 
-def conjugate_gradient(op, x, rhs, niter=1, partial=None):
+def conjugate_gradient(op, x, rhs, niter=1, callback=None):
     """Optimized implementation of CG for self-adjoint operators.
 
     This method solves the inverse problem (of the first kind)
@@ -150,7 +150,7 @@ def conjugate_gradient(op, x, rhs, niter=1, partial=None):
         Right-hand side of the equation defining the inverse problem
     niter : int, optional
         Maximum number of iterations
-    partial : `Partial`, optional
+    callback : `callable`, optional
         Object executing code per iteration, e.g. plotting each iterate
 
     Returns
@@ -197,11 +197,11 @@ def conjugate_gradient(op, x, rhs, niter=1, partial=None):
 
         p.lincomb(1, r, beta, p)                       # p = s + b * p
 
-        if partial is not None:
-            partial(x)
+        if callback is not None:
+            callback(x)
 
 
-def conjugate_gradient_normal(op, x, rhs, niter=1, partial=None):
+def conjugate_gradient_normal(op, x, rhs, niter=1, callback=None):
     """Optimized implementation of CG for the normal equation.
 
     This method solves the normal equation
@@ -237,7 +237,7 @@ Conjugate_gradient_on_the_normal_equations>`_.
         Right-hand side of the equation defining the inverse problem
     niter : int, optional
         Maximum number of iterations
-    partial : `Partial`, optional
+    callback : `callable`, optional
         Object executing code per iteration, e.g. plotting each iterate
 
     Returns
@@ -275,8 +275,8 @@ Conjugate_gradient_on_the_normal_equations>`_.
 
         p.lincomb(1, s, b, p)               # p = s + b * p
 
-        if partial is not None:
-            partial(x)
+        if callback is not None:
+            callback(x)
 
 
 def exp_zero_seq(base):
@@ -309,7 +309,7 @@ def exp_zero_seq(base):
 
 
 def gauss_newton(op, x, rhs, niter=1, zero_seq=exp_zero_seq(2.0),
-                 partial=None):
+                 callback=None):
     """Optimized implementation of a Gauss-Newton method.
 
     This method solves the inverse problem (of the first kind)
@@ -345,7 +345,7 @@ def gauss_newton(op, x, rhs, niter=1, zero_seq=exp_zero_seq(2.0),
     zero_seq : `iterable`, optional
         Zero sequence whose values are used for the regularization of
         the linearized problem in each Newton step
-    partial : `Partial`, optional
+    callback : `callable`, optional
         Object executing code per iteration, e.g. plotting each iterate
 
     Returns
@@ -386,8 +386,8 @@ def gauss_newton(op, x, rhs, niter=1, zero_seq=exp_zero_seq(2.0),
         # Update x
         x.lincomb(1, x0, 1, dx)  # x = x0 + dx
 
-        if partial is not None:
-            partial(x)
+        if callback is not None:
+            callback(x)
 
 if __name__ == '__main__':
     # pylint: disable=wrong-import-position

--- a/odl/solvers/scalar/gradient.py
+++ b/odl/solvers/scalar/gradient.py
@@ -30,7 +30,7 @@ __all__ = ('steepest_descent',)
 
 
 def steepest_descent(grad, x, niter=1, line_search=1, projection=None,
-                     partial=None):
+                     callback=None):
     """Steepest descent method to minimize an objective function.
 
     General implementation of steepest decent (also known as gradient
@@ -68,7 +68,7 @@ def steepest_descent(grad, x, niter=1, line_search=1, projection=None,
         Function that can be used to modify the iterates in each iteration,
         for example enforcing positivity. The function should take one
         argument and modify it inplace.
-    partial : `Partial`, optional
+    callback : `callable`, optional
         Object executing code per iteration, e.g. plotting each iterate
 
     See Also
@@ -98,8 +98,8 @@ def steepest_descent(grad, x, niter=1, line_search=1, projection=None,
         if projection is not None:
             projection(x)
 
-        if partial is not None:
-            partial(x)
+        if callback is not None:
+            callback(x)
 
 
 if __name__ == '__main__':

--- a/odl/solvers/util/__init__.py
+++ b/odl/solvers/util/__init__.py
@@ -19,6 +19,6 @@ from __future__ import absolute_import
 
 __all__ = ()
 
-from . import partial
-from .partial import *
-__all__ += partial.__all__
+from . import callback
+from .callback import *
+__all__ += callback.__all__

--- a/odl/solvers/util/callback.py
+++ b/odl/solvers/util/callback.py
@@ -15,30 +15,27 @@
 # You should have received a copy of the GNU General Public License
 # along with ODL.  If not, see <http://www.gnu.org/licenses/>.
 
-"""Partial objects for per-iterate actions in iterative methods."""
+"""Callback objects for per-iterate actions in iterative methods."""
 
 # Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
 from future import standard_library
 standard_library.install_aliases()
 
-from abc import ABCMeta, abstractmethod
 import time
 
-from odl.util.utility import with_metaclass
+
+__all__ = ('SolverCallback', 'CallbackStore', 'CallbackApply',
+           'CallbackPrintTiming', 'CallbackPrintIteration',
+           'CallbackPrintNorm', 'CallbackShow')
 
 
-__all__ = ('Partial', 'StorePartial', 'ForEachPartial', 'PrintTimingPartial',
-           'PrintIterationPartial', 'PrintNormPartial', 'ShowPartial')
-
-
-class Partial(with_metaclass(ABCMeta, object)):
+class SolverCallback(object):
 
     """Abstract base class for sending partial results of iterations."""
 
-    @abstractmethod
     def __call__(self, result):
-        """Apply the partial object to result.
+        """Apply the callback object to result.
 
         Parameters
         ----------
@@ -53,62 +50,62 @@ class Partial(with_metaclass(ABCMeta, object)):
     def __and__(self, other):
         """Return ``self & other``
 
-        Compose partials, calls both in sequence.
+        Compose callbacks, calls both in sequence.
 
         Parameters
         ----------
-        other : `Partial`
+        other : `Partial` or `callable`
             The other partial to compose with
 
         Returns
         -------
-        result : `Partial`
+        result : `SolverCallback`
             A partial whose `__call__` method calls both constituents
             partials.
 
         Examples
         --------
-        >>> store = StorePartial()
-        >>> iter = PrintIterationPartial()
+        >>> store = CallbackStore()
+        >>> iter = CallbackPrintIteration()
         >>> both = store & iter
         >>> both
-        StorePartial() & PrintIterationPartial()
+        CallbackStore() & CallbackPrintIteration()
         """
-        return AndPartial(self, other)
+        return _CallbackAnd(self, other)
 
     def __repr__(self):
         """Return ``repr(self)``"""
         return '{}()'.format(self.__class__.__name__)
 
 
-class AndPartial(Partial):
+class _CallbackAnd(SolverCallback):
 
-    """Partial used for combining several partials"""
+    """Callback used for combining several callbacks"""
 
     def __init__(self, *callbacks):
         """Initialize an instance.
 
         Parameters
         ----------
-        *callbacks : `callable` or `Partial`'s
-            Partials to be called in sequence as listed.
+        *callbacks : `callable` or `SolverCallback`'s
+            Callbacks to be called in sequence as listed.
         """
-        partials = [c if isinstance(c, Partial) else ForEachPartial(c)
-                    for c in callbacks]
+        callbacks = [c if isinstance(c, SolverCallback) else CallbackApply(c)
+                     for c in callbacks]
 
-        self.partials = partials
+        self.callbacks = callbacks
 
     def __call__(self, result):
         """Apply all partials to result."""
-        for p in self.partials:
+        for p in self.callbacks:
             p(result)
 
     def __repr__(self):
         """Return ``repr(self)``"""
-        return ' & '.join('{}'.format(p) for p in self.partials)
+        return ' & '.join('{}'.format(p) for p in self.callbacks)
 
 
-class StorePartial(Partial):
+class CallbackStore(SolverCallback):
 
     """Simple object for storing all partial results of the solvers.
 
@@ -132,17 +129,17 @@ class StorePartial(Partial):
         --------
         Store results as is
 
-        >>> partial = StorePartial()
+        >>> callback = CallbackStore()
 
         Provide list to store partial results in.
 
         >>> results = []
-        >>> partial = StorePartial(results=results)
+        >>> callback = CallbackStore(results=results)
 
         Store the norm of the results
 
         >>> norm_function = lambda x: x.norm()
-        >>> partial = StorePartial(function=norm_function)
+        >>> callback = CallbackStore(function=norm_function)
         """
         self._results = [] if results is None else results
         self._function = function
@@ -174,15 +171,15 @@ class StorePartial(Partial):
     def __str__(self):
         """Return ``str(self)``"""
         resultstr = '' if self.results == [] else str(self.results)
-        return 'StorePartial({})'.format(resultstr)
+        return 'CallbackStore({})'.format(resultstr)
 
     def __repr__(self):
         """Return ``repr(self)``"""
         resultrepr = '' if self.results == [] else repr(self.results)
-        return 'StorePartial({})'.format(resultrepr)
+        return 'CallbackStore({})'.format(resultrepr)
 
 
-class ForEachPartial(Partial):
+class CallbackApply(SolverCallback):
 
     """Simple object for applying a function to each iterate."""
 
@@ -203,14 +200,14 @@ class ForEachPartial(Partial):
 
     def __str__(self):
         """Return ``str(self)``"""
-        return 'ForEachPartial({})'.format(self.function)
+        return 'CallbackApply({})'.format(self.function)
 
     def __repr__(self):
         """Return ``repr(self)``"""
-        return 'ForEachPartial({!r})'.format(self.function)
+        return 'CallbackApply({!r})'.format(self.function)
 
 
-class PrintIterationPartial(Partial):
+class CallbackPrintIteration(SolverCallback):
 
     """Print the iteration count."""
 
@@ -234,10 +231,10 @@ class PrintIterationPartial(Partial):
 
     def __repr__(self):
         textstr = '' if self.text == self._default_text else self.text
-        return 'PrintIterationPartial({})'.format(textstr)
+        return 'CallbackPrintIteration({})'.format(textstr)
 
 
-class PrintTimingPartial(Partial):
+class CallbackPrintTiming(SolverCallback):
 
     """Print the time elapsed since the previous iteration."""
 
@@ -252,7 +249,7 @@ class PrintTimingPartial(Partial):
         self.time = t
 
 
-class PrintNormPartial(Partial):
+class CallbackPrintNorm(SolverCallback):
 
     """Print the current norm."""
 
@@ -266,7 +263,7 @@ class PrintNormPartial(Partial):
         self.iter += 1
 
 
-class ShowPartial(Partial):
+class CallbackShow(SolverCallback):
 
     """Show the partial result."""
 

--- a/odl/solvers/vector/newton.py
+++ b/odl/solvers/vector/newton.py
@@ -29,7 +29,7 @@ __all__ = ('newtons_method',)
 
 
 def newtons_method(op, x, line_search, num_iter=10, cg_iter=None,
-                   partial=None):
+                   callback=None):
     """Newton's method for solving a system of equations.
 
     This is a general and optimized implementation of Newton's method
@@ -60,7 +60,7 @@ def newtons_method(op, x, line_search, num_iter=10, cg_iter=None,
     cg_iter : `int`, optional
         Number of iterations in the the conjugate gradient solver,
         for computing the search direction.
-    partial : `Partial`, optional
+    callback : `callable`, optional
         Object executing code per iteration, e.g. plotting each iterate
 
     Notes
@@ -105,8 +105,8 @@ def newtons_method(op, x, line_search, num_iter=10, cg_iter=None,
         # Updating
         x += step_length * search_direction
 
-        if partial is not None:
-            partial(x)
+        if callback is not None:
+            callback(x)
 
 if __name__ == '__main__':
     # pylint: disable=wrong-import-position

--- a/odl/util/graphics.py
+++ b/odl/util/graphics.py
@@ -334,7 +334,7 @@ def show_discrete_data(values, grid, title=None, method='',
 
     if updatefig or plt.isinteractive():
         # If we are running in interactive mode, we can always show the fig
-        # This causes an artifact, where users of ShowPartial without
+        # This causes an artifact, where users of `CallbackShow` without
         # interactive mode only shows the figure after the second iteration.
         plt.show(block=False)
         plt.draw()

--- a/test/solvers/advanced/chambolle_pock_test.py
+++ b/test/solvers/advanced/chambolle_pock_test.py
@@ -67,7 +67,7 @@ def test_chambolle_pock_solver_simple_space():
     # Run the algorithm
     chambolle_pock_solver(op, discr_vec, tau=TAU, sigma=SIGMA,
                           proximal_primal=prox, proximal_dual=prox,
-                          theta=THETA, niter=1, partial=None,
+                          theta=THETA, niter=1, callback=None,
                           x_relax=discr_vec_relax, y=discr_dual)
 
     # Explicit computation
@@ -123,11 +123,11 @@ def test_chambolle_pock_solver_simple_space():
     assert discr_vec != discr_vec_relax_no_gamma
     assert all_almost_equal(discr_vec_relax_no_gamma, discr_vec_relax_g0)
 
-    # Test partial execution
+    # Test callback execution
     chambolle_pock_solver(op, discr_vec, tau=TAU, sigma=SIGMA,
                           proximal_primal=prox, proximal_dual=prox,
                           theta=THETA, niter=1,
-                          partial=odl.solvers.util.PrintIterationPartial())
+                          callback=odl.solvers.CallbackPrintIteration())
 
 
 def test_chambolle_pock_solver_produce_space():


### PR DESCRIPTION
Changes any mention of `Partial` to the more standardized `Callback`

This agrees precisely with how scipy does it, down to naming, for example [scipy.optimize.minimize](http://docs.scipy.org/doc/scipy-0.14.0/reference/generated/scipy.optimize.minimize.html):

> callback : callable, optional
> Called after each iteration, as callback(xk), where xk is the current parameter vector.

The interface of all solvers has also been changed so only `callable` is required, the extra features provided by `SolverCallback` (such as the `&` operator) are thus only optional and not needed by the solvers.