### PR TITLE
Issue 443  uniform partition

### DIFF
--- a/odl/discr/grid.py
+++ b/odl/discr/grid.py
@@ -1200,9 +1200,11 @@ def uniform_sampling_fromintv(intv_prod, num_nodes, nodes_on_bdry=True):
     if np.shape(nodes_on_bdry) == ():
         nodes_on_bdry = ([(bool(nodes_on_bdry), bool(nodes_on_bdry))] *
                          intv_prod.ndim)
+    elif intv_prod.ndim == 1 and len(nodes_on_bdry) == 2:
+        nodes_on_bdry = [nodes_on_bdry]
     elif len(nodes_on_bdry) != intv_prod.ndim:
-        raise ValueError('nodes_on_bdry has length {}, expected {}.'
-                         ''.format(len(nodes_on_bdry), intv_prod.ndim, 2))
+        raise ValueError('`nodes_on_bdry` has length {}, expected {}.'
+                         ''.format(len(nodes_on_bdry), intv_prod.ndim))
     else:
         num_nodes = tuple(int(n) for n in num_nodes)
 

--- a/odl/discr/grid.py
+++ b/odl/discr/grid.py
@@ -1211,7 +1211,7 @@ def uniform_sampling_fromintv(intv_prod, num_nodes, nodes_on_bdry=True):
     # and for a given side (left or right), the entry is True, the node lies
     # on the boundary, so this coordinate can simply be taken as-is.
     #
-    # Otherwise, the following conditionsmust be met:
+    # Otherwise, the following conditions must be met:
     #
     # 1. The node should be half a stride s away from the boundary
     # 2. Adding or subtracting (n-1)*s should give the other extremal node.

--- a/odl/set/domain.py
+++ b/odl/set/domain.py
@@ -183,14 +183,14 @@ class IntervalProd(Set):
             raise TypeError('inp {!r} not a valid element in {!r}.'
                             ''.format(inp, self))
 
-    def approx_equals(self, other, tol):
-        """Test if ``other`` is equal to this set up to ``tol``.
+    def approx_equals(self, other, atol):
+        """Test if ``other`` is equal to this set up to ``atol``.
 
         Parameters
         ----------
         other : `object`
             The object to be tested
-        tol : `float`
+        atol : `float`
             The maximum allowed difference in 'inf'-norm between the
             interval endpoints.
 
@@ -199,9 +199,9 @@ class IntervalProd(Set):
         >>> from math import sqrt
         >>> rbox1 = IntervalProd(0, 0.5)
         >>> rbox2 = IntervalProd(0, sqrt(0.5)**2)
-        >>> rbox1.approx_equals(rbox2, tol=0)  # Num error
+        >>> rbox1.approx_equals(rbox2, atol=0)  # Num error
         False
-        >>> rbox1.approx_equals(rbox2, tol=1e-15)
+        >>> rbox1.approx_equals(rbox2, atol=1e-15)
         True
         """
         if other is self:
@@ -209,14 +209,14 @@ class IntervalProd(Set):
         elif not isinstance(other, IntervalProd):
             return False
 
-        return (np.allclose(self.begin, other.begin, atol=tol, rtol=0.0) and
-                np.allclose(self.end, other.end, atol=tol, rtol=0.0))
+        return (np.allclose(self.begin, other.begin, atol=atol, rtol=0.0) and
+                np.allclose(self.end, other.end, atol=atol, rtol=0.0))
 
     def __eq__(self, other):
         """Return ``self == other``."""
-        return self.approx_equals(other, tol=0.0)
+        return self.approx_equals(other, atol=0.0)
 
-    def approx_contains(self, point, tol):
+    def approx_contains(self, point, atol):
         """Test if a point is contained.
 
         Parameters
@@ -225,7 +225,7 @@ class IntervalProd(Set):
             The point to be tested. Its length must be equal
             to the set's dimension. In the 1d case, 'point'
             can be given as a `float`.
-        tol : `float`
+        atol : `float`
             The maximum allowed distance in 'inf'-norm between the
             point and the set.
             Default: 0.0
@@ -236,9 +236,9 @@ class IntervalProd(Set):
         >>> b, e = [-1, 0, 2], [-0.5, 0, 3]
         >>> rbox = IntervalProd(b, e)
         >>> # Numerical error
-        >>> rbox.approx_contains([-1 + sqrt(0.5)**2, 0., 2.9], tol=0)
+        >>> rbox.approx_contains([-1 + sqrt(0.5)**2, 0., 2.9], atol=0)
         False
-        >>> rbox.approx_contains([-1 + sqrt(0.5)**2, 0., 2.9], tol=1e-9)
+        >>> rbox.approx_contains([-1 + sqrt(0.5)**2, 0., 2.9], atol=1e-9)
         True
         """
         point = np.atleast_1d(point)
@@ -246,7 +246,7 @@ class IntervalProd(Set):
             return False
         if not is_real_dtype(point.dtype):
             return False
-        return self.dist(point, exponent=np.inf) <= tol
+        return self.dist(point, exponent=np.inf) <= atol
 
     def __contains__(self, other):
         """Return ``other in self``.

--- a/test/discr/partition_test.py
+++ b/test/discr/partition_test.py
@@ -27,10 +27,6 @@ import numpy as np
 
 # ODL imports
 import odl
-from odl.discr.partition import (
-    RectPartition, uniform_partition_fromintv, uniform_partition_fromgrid,
-    uniform_partition)
-from odl.set.domain import IntervalProd
 from odl.util.testutils import all_equal, all_almost_equal
 
 
@@ -44,12 +40,12 @@ def test_partition_init():
     end = [10, 4]
 
     # Simply test if code runs
-    RectPartition(odl.Rectangle(begin, end), odl.TensorGrid(vec1, vec2))
-    RectPartition(odl.Interval(begin[0], end[0]), odl.TensorGrid(vec1))
+    odl.RectPartition(odl.Rectangle(begin, end), odl.TensorGrid(vec1, vec2))
+    odl.RectPartition(odl.Interval(begin[0], end[0]), odl.TensorGrid(vec1))
 
     # Degenerate dimensions should work, too
     vec2 = np.array([1.0])
-    RectPartition(odl.Rectangle(begin, end), odl.TensorGrid(vec1, vec2))
+    odl.RectPartition(odl.Rectangle(begin, end), odl.TensorGrid(vec1, vec2))
 
 
 def test_partition_init_raise():
@@ -66,19 +62,19 @@ def test_partition_init_raise():
     end_badshape = (2,)
 
     with pytest.raises(ValueError):
-        RectPartition(odl.IntervalProd(beg_toolarge, end), grid)
+        odl.RectPartition(odl.IntervalProd(beg_toolarge, end), grid)
 
     with pytest.raises(ValueError):
-        RectPartition(odl.IntervalProd(begin, end_toosmall), grid)
+        odl.RectPartition(odl.IntervalProd(begin, end_toosmall), grid)
 
     with pytest.raises(ValueError):
-        RectPartition(odl.IntervalProd(beg_badshape, end_badshape), grid)
+        odl.RectPartition(odl.IntervalProd(beg_badshape, end_badshape), grid)
 
     with pytest.raises(TypeError):
-        RectPartition(None, grid)
+        odl.RectPartition(None, grid)
 
     with pytest.raises(TypeError):
-        RectPartition(odl.IntervalProd(beg_toolarge, end), None)
+        odl.RectPartition(odl.IntervalProd(beg_toolarge, end), None)
 
 
 def test_partition_set():
@@ -90,8 +86,8 @@ def test_partition_set():
     end = [10, 5]
     intv = odl.IntervalProd(begin, end)
 
-    part = RectPartition(intv, grid)
-    assert part.set == IntervalProd(begin, end)
+    part = odl.RectPartition(intv, grid)
+    assert part.set == odl.IntervalProd(begin, end)
     assert all_equal(part.begin, begin)
     assert all_equal(part.min(), begin)
     assert all_equal(part.end, end)
@@ -113,7 +109,7 @@ def test_partition_cell_boundary_vecs():
     true_bvec1 = [2] + midpts1 + [10]
     true_bvec2 = [-6] + midpts2 + [4]
 
-    part = RectPartition(intv, grid)
+    part = odl.RectPartition(intv, grid)
     assert all_equal(part.cell_boundary_vecs, (true_bvec1, true_bvec2))
 
 
@@ -134,14 +130,14 @@ def test_partition_cell_sizes_vecs():
     true_csizes1 = bvec1[1:] - bvec1[:-1]
     true_csizes2 = bvec2[1:] - bvec2[:-1]
 
-    part = RectPartition(intv, grid)
+    part = odl.RectPartition(intv, grid)
     assert all_equal(part.cell_sizes_vecs, (true_csizes1, true_csizes2))
 
 
 def test_partition_cell_sides():
     grid = odl.RegularGrid([0, 1], [2, 4], (5, 3))
     intv = odl.IntervalProd([0, 1], [2, 4])
-    part = RectPartition(intv, grid)
+    part = odl.RectPartition(intv, grid)
     true_sides = [0.5, 1.5]
     assert all_equal(part.cell_sides, true_sides)
 
@@ -149,7 +145,7 @@ def test_partition_cell_sides():
 def test_partition_cell_volume():
     grid = odl.RegularGrid([0, 1], [2, 4], (5, 3))
     intv = odl.IntervalProd([0, 1], [2, 4])
-    part = RectPartition(intv, grid)
+    part = odl.RectPartition(intv, grid)
     true_volume = 0.5 * 1.5
     assert part.cell_volume == true_volume
 
@@ -161,7 +157,7 @@ def test_partition_insert():
     end1 = [7, 5]
     grid1 = odl.TensorGrid(vec11, vec12)
     intv1 = odl.IntervalProd(begin1, end1)
-    part1 = RectPartition(intv1, grid1)
+    part1 = odl.RectPartition(intv1, grid1)
 
     vec21 = [-2, 0, 3]
     vec22 = [0]
@@ -169,7 +165,7 @@ def test_partition_insert():
     end2 = [4, 0]
     grid2 = odl.TensorGrid(vec21, vec22)
     intv2 = odl.IntervalProd(begin2, end2)
-    part2 = RectPartition(intv2, grid2)
+    part2 = odl.RectPartition(intv2, grid2)
 
     part = part1.insert(0, part2)
     assert all_equal(part.begin, [-2, -2, 1, -4])
@@ -194,7 +190,7 @@ def test_partition_getitem():
     end = [7, 5, 4, 0]
     grid = odl.TensorGrid(*vecs)
     intv = odl.IntervalProd(begin, end)
-    part = RectPartition(intv, grid)
+    part = odl.RectPartition(intv, grid)
 
     # Test a couple of slices
     slc = (1, -2, 2, 0)
@@ -224,7 +220,7 @@ def test_partition_getitem():
     lst_intv = odl.IntervalProd(lst_beg, lst_end)
     lst_vec1 = [2, 5]
     lst_grid = odl.TensorGrid(lst_vec1, vec2, vec3, vec4)
-    lst_part = RectPartition(lst_intv, lst_grid)
+    lst_part = odl.RectPartition(lst_intv, lst_grid)
     assert part[[0, 2]] == lst_part
 
 
@@ -236,7 +232,7 @@ def test_uniform_partition_fromintv():
     nsamp = (4, 10)
 
     # All nodes at the boundary
-    part = uniform_partition_fromintv(intvp, nsamp, nodes_on_bdry=True)
+    part = odl.uniform_partition_fromintv(intvp, nsamp, nodes_on_bdry=True)
     assert all_equal(part.begin, intvp.begin)
     assert all_equal(part.end, intvp.end)
     assert all_equal(part.grid.min_pt, intvp.begin)
@@ -249,7 +245,7 @@ def test_uniform_partition_fromintv():
         assert all_almost_equal(cs[-1], cs[-2] / 2)
 
     # All nodes not the boundary
-    part = uniform_partition_fromintv(intvp, nsamp, nodes_on_bdry=False)
+    part = odl.uniform_partition_fromintv(intvp, nsamp, nodes_on_bdry=False)
     assert all_equal(part.begin, intvp.begin)
     assert all_equal(part.end, intvp.end)
     for cs in part.cell_sizes_vecs:
@@ -257,8 +253,8 @@ def test_uniform_partition_fromintv():
         assert np.allclose(np.diff(cs), 0)
 
     # Only left nodes at the boundary
-    part = uniform_partition_fromintv(intvp, nsamp,
-                                      nodes_on_bdry=[[True, False]] * 2)
+    part = odl.uniform_partition_fromintv(intvp, nsamp,
+                                          nodes_on_bdry=[[True, False]] * 2)
     assert all_equal(part.begin, intvp.begin)
     assert all_equal(part.end, intvp.end)
     assert all_equal(part.grid.min_pt, intvp.begin)
@@ -268,8 +264,8 @@ def test_uniform_partition_fromintv():
         assert all_almost_equal(cs[0], cs[1] / 2)
 
     # Only right nodes at the boundary
-    part = uniform_partition_fromintv(intvp, nsamp,
-                                      nodes_on_bdry=[[False, True]] * 2)
+    part = odl.uniform_partition_fromintv(intvp, nsamp,
+                                          nodes_on_bdry=[[False, True]] * 2)
     assert all_equal(part.begin, intvp.begin)
     assert all_equal(part.end, intvp.end)
     assert all_equal(part.grid.max_pt, intvp.end)
@@ -289,40 +285,40 @@ def test_uniform_partition_fromgrid():
 
     # Default case
     grid = odl.TensorGrid(vec1, vec2)
-    part = uniform_partition_fromgrid(grid)
-    assert part.set == IntervalProd(beg_calc, end_calc)
+    part = odl.uniform_partition_fromgrid(grid)
+    assert part.set == odl.IntervalProd(beg_calc, end_calc)
 
     # Explicit begin / end, full vectors
-    part = uniform_partition_fromgrid(grid, begin=begin)
-    assert part.set == IntervalProd(begin, end_calc)
-    part = uniform_partition_fromgrid(grid, end=end)
-    assert part.set == IntervalProd(beg_calc, end)
+    part = odl.uniform_partition_fromgrid(grid, begin=begin)
+    assert part.set == odl.IntervalProd(begin, end_calc)
+    part = odl.uniform_partition_fromgrid(grid, end=end)
+    assert part.set == odl.IntervalProd(beg_calc, end)
 
     # begin / end as dictionaries
     beg_dict = {0: 0.5}
     end_dict = {-1: 8}
-    part = uniform_partition_fromgrid(grid, begin=beg_dict, end=end_dict)
+    part = odl.uniform_partition_fromgrid(grid, begin=beg_dict, end=end_dict)
     true_beg = [0.5, beg_calc[1]]
     true_end = [end_calc[0], 8]
-    assert part.set == IntervalProd(true_beg, true_end)
+    assert part.set == odl.IntervalProd(true_beg, true_end)
 
     # Degenerate dimension, needs both explicit begin and end
     grid = odl.TensorGrid(vec1, [1.0])
     with pytest.raises(ValueError):
-        uniform_partition_fromgrid(grid)
+        odl.uniform_partition_fromgrid(grid)
     with pytest.raises(ValueError):
-        uniform_partition_fromgrid(grid, begin=begin)
+        odl.uniform_partition_fromgrid(grid, begin=begin)
     with pytest.raises(ValueError):
-        uniform_partition_fromgrid(grid, end=end)
+        odl.uniform_partition_fromgrid(grid, end=end)
 
 
 def test_uniform_partition():
     # Testing just the standard case, everything else is covered by
-    # uniform_partition_frominterv
+    # odl.uniform_partition_frominterv
     begin = [0, 0]
     end = [1, 2]
     nsamp = (4, 10)
-    part = uniform_partition(begin, end, nsamp, nodes_on_bdry=True)
+    part = odl.uniform_partition(begin, end, nsamp, nodes_on_bdry=True)
 
     assert all_equal(part.begin, begin)
     assert all_equal(part.end, end)

--- a/test/set/domain_test.py
+++ b/test/set/domain_test.py
@@ -409,7 +409,7 @@ def test_div():
     quotient = IntervalProd([1 / 2., 2 / 3., 3 / 4., 4 / 5., 5 / 6.],
                             [2 / 1., 3 / 2., 4 / 3., 5 / 4., 6 / 5.])
 
-    assert (interv1 / interv2).approx_equals(quotient, tol=10 ** -10)
+    assert (interv1 / interv2).approx_equals(quotient, atol=10 ** -10)
 
 
 def test_interval_init():

--- a/test/set/domain_test.py
+++ b/test/set/domain_test.py
@@ -409,7 +409,7 @@ def test_div():
     quotient = IntervalProd([1 / 2., 2 / 3., 3 / 4., 4 / 5., 5 / 6.],
                             [2 / 1., 3 / 2., 4 / 3., 5 / 4., 6 / 5.])
 
-    assert (interv1 / interv2).approx_equals(quotient, atol=10 ** -10)
+    assert (interv1 / interv2).approx_equals(quotient, atol=1e-10)
 
 
 def test_interval_init():


### PR DESCRIPTION
Implements `uniform_partition_options` as mentioned in #443. The name is sub-optimal but quite clearly, the function should be separate from `uniform_partition`.

Closes #443