### PR TITLE
Issue 450  clintec spect data

### DIFF
--- a/doc/source/refs.rst
+++ b/doc/source/refs.rst
@@ -20,6 +20,11 @@ References
    simultaneous equations*. Mathematics of computation, 33 (1965),
    pp 577--593.
 
+.. [Bro+2008] Brown, S, and Bailey, D L, and Willowson, K, and Baldock, C
+   *Investigation of the relationship between linear attenuation
+   coefficients and CT Houndsfield units using radionuclides for SPECT*.
+   Applied Radiation and Isotopes, 66 (2008), pp 1206--1212
+
 .. [BV2004] Boyd, S, and Vandenberghe, L. *Convex optimization*.
    Cambridge university press, 2004.
 

--- a/doc/source/refs.rst
+++ b/doc/source/refs.rst
@@ -26,13 +26,13 @@ References
 .. [Bro+2008] Brown, S, and Bailey, D L, and Willowson, K, and Baldock, C
    *Investigation of the relationship between linear attenuation
    coefficients and CT Houndsfield units using radionuclides for SPECT*.
-   Applied Radiation and Isotopes, 66 (2008), pp 1206--1212
+   Applied Radiation and Isotopes, 66 (2008), pp 1206--1212.
 
-..  Burger, C, and Goerres, G, and Schoenes, S, and Buck, A,
+.. [Bur+2002] Burger, C, and Goerres, G, and Schoenes, S, and Buck, A,
    and Lonn, A H R, and von Schulthess, G K *PET attenuation coefficient
    from CT images: experimental evaluation of the transformation of CT into
    PET 511-keV attenuation coefficients*.
-   European Journal of Nuclear Medicine, 29 (2002), pp 922--927
+   European Journal of Nuclear Medicine, 29 (2002), pp 922--927.
 
 .. [CP2011a] Chambolle, A and Pock, T. *A First-Order
    Primal-Dual Algorithm for Convex Problems with Applications to

--- a/doc/source/refs.rst
+++ b/doc/source/refs.rst
@@ -16,6 +16,9 @@ References
    composite and parallel-sum type monotone operators*. SIAM Journal
    on Optimization, 23.4 (2013), pp 2541--2565.
 
+.. [BV2004] Boyd, S, and Vandenberghe, L. *Convex optimization*.
+   Cambridge university press, 2004.
+
 .. [Bro1965] Broyden, C G. *A class of methods for solving nonlinear
    simultaneous equations*. Mathematics of computation, 33 (1965),
    pp 577--593.
@@ -25,8 +28,11 @@ References
    coefficients and CT Houndsfield units using radionuclides for SPECT*.
    Applied Radiation and Isotopes, 66 (2008), pp 1206--1212
 
-.. [BV2004] Boyd, S, and Vandenberghe, L. *Convex optimization*.
-   Cambridge university press, 2004.
+..  Burger, C, and Goerres, G, and Schoenes, S, and Buck, A,
+   and Lonn, A H R, and von Schulthess, G K *PET attenuation coefficient
+   from CT images: experimental evaluation of the transformation of CT into
+   PET 511-keV attenuation coefficients*.
+   European Journal of Nuclear Medicine, 29 (2002), pp 922--927
 
 .. [CP2011a] Chambolle, A and Pock, T. *A First-Order
    Primal-Dual Algorithm for Convex Problems with Applications to

--- a/odl/tomo/data/__init__.py
+++ b/odl/tomo/data/__init__.py
@@ -1,3 +1,4 @@
+
 # Copyright 2014-2016 The ODL development group
 #
 # This file is part of ODL.
@@ -15,25 +16,14 @@
 # You should have received a copy of the GNU General Public License
 # along with ODL.  If not, see <http://www.gnu.org/licenses/>.
 
-"""Tomography related operators and geometries."""
 
+"""Helpers for reading in standardized projection data formats."""
 
 from __future__ import absolute_import
 
 __all__ = ()
 
-from . import geometry
-from .geometry import *
-__all__ += geometry.__all__
 
-from . import backends
-from .backends import *
-__all__ += backends.__all__
-
-from . import operators
-from .operators import *
-__all__ += operators.__all__
-
-from . import data
-from .data import *
-__all__ += data.__all__
+from . import clintec_spect
+from .clintec_spect import *
+__all__ += clintec_spect.__all__

--- a/odl/tomo/data/clintec_spect.py
+++ b/odl/tomo/data/clintec_spect.py
@@ -1,0 +1,120 @@
+# Copyright 2014-2016 The ODL development group
+#
+# This file is part of ODL.
+#
+# ODL is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# ODL is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with ODL.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Helpers for reading CLINTEC SPECT data formats.
+
+For the bilinear relationship of linear attenuation coefficients and
+Houndsfield units see, for example
+
+Investigation of the relationship between linear attenuation
+coefficients and CT Houndsfield units using radionuclides for SPECT
+S. Brown et al, Applied Radiation and Isotopes 66 (2008) 1206-1212
+
+and references therein.
+"""
+
+# Imports for common Python 2/3 codebase
+from __future__ import print_function, division, absolute_import
+from future import standard_library
+standard_library.install_aliases()
+
+import numpy as np
+import dicom
+import os
+from natsort import natsorted
+
+
+def read_clintec_CT_reconstruction(path):
+    """Reads the data in Dicom format and returns a HU CT volume.
+
+    Parameters
+    ----------
+    path : a `path` to the folder where Dicom data is
+
+    """
+
+    lstFilesDCM = []  # create an empty list
+    for dirName, subdirList, fileList in os.walk(path):
+        for filename in natsorted(fileList):
+            if ".dcm" in filename.lower():
+                # check whether the file ends by .dcm
+                lstFilesDCM.append(os.path.join(dirName, filename))
+            else:
+                lstFilesDCM.append(os.path.join(dirName, filename))
+
+    dataset = dicom.read_file(lstFilesDCM[0])
+
+    # Load dimensions based on the number of rows, columns, and slices
+    shape = (int(dataset.Rows), int(dataset.Columns), len(lstFilesDCM))
+    data_array = np.zeros(shape, dtype=dataset.pixel_array.dtype)
+    # loop through all the DICOM files
+    for filenameDCM in lstFilesDCM:
+        # read the file
+        ds = dicom.read_file(filenameDCM)
+        # store the raw image data
+        data_array[:, :, lstFilesDCM.index(filenameDCM)] = ds.pixel_array
+
+    rescale_intercept = int(dataset.RescaleIntercept)
+    rescale_slope = int(dataset.RescaleSlope)
+
+    ct_volume = rescale_slope*np.float32(data_array) + rescale_intercept
+
+    return ct_volume, dataset
+
+
+def linear_attenuation_map_from_HU_data(path, a, b):
+    """Converts HU data to linear attenuation map.
+
+    Parameters
+    ----------
+    path : a `path` to the data folder
+    a, b : `tuple`
+        a = (a1, a2) where a1 `float` and a2 `float` are the intercepts
+            of the bilinear curve
+        b = (b1, b2) where b1 `float` and b2 `float` are the slopes
+            of the bilinear curve
+        a and b are parameters of a bilinear curve for converting
+        HU-values to linear attenuation map, such that
+        mu = a1 + b1 * ct_volume for HU < 0
+        mu = a2 + b2 * ct_volume for HU >= 0
+
+    """
+    a1, a2 = a
+    b1, b2 = b
+
+    ct_volume, dataset = read_clintec_CT_reconstruction(path)
+    (i1, j1, k1) = np.where(ct_volume < 0)
+    (i2, j2, k2) = np.where(ct_volume >= 0)
+
+    attenuation_map = np.zeros_like(ct_volume)
+    attenuation_map = np.zeros_like(ct_volume)
+    attenuation_map[i1, j1, k1] = a1 + b1 * ct_volume[i1, j1, k1]
+    attenuation_map[i2, j2, k2] = a2 + b2 * ct_volume[i2, j2, k2]
+    attenuation_map = np.absolute(attenuation_map)
+
+    return attenuation_map
+
+
+def read_clintec_raw_spect_data(path):
+    """Reads the raw spect Dicom data and retuns an array of the data."""
+
+    filenames = [f for f in os.listdir(path)]
+    data_dicom = os.path.join(path, filenames[0])
+    dataset = dicom.read_file(data_dicom)
+    spect_data = np.float32(dataset.pixel_array)
+
+    return spect_data

--- a/odl/tomo/data/clintec_spect.py
+++ b/odl/tomo/data/clintec_spect.py
@@ -71,7 +71,7 @@ def read_clintec_CT_reconstruction(path):
     rescale_intercept = int(dataset.RescaleIntercept)
     rescale_slope = int(dataset.RescaleSlope)
 
-    ct_volume = rescale_slope*np.float32(data_array) + rescale_intercept
+    ct_volume = rescale_slope * np.float32(data_array) + rescale_intercept
 
     return ct_volume, dataset
 

--- a/odl/tomo/data/clintec_spect.py
+++ b/odl/tomo/data/clintec_spect.py
@@ -19,7 +19,6 @@
 
 For the bilinear relationship of linear attenuation coefficients and
 Houndsfield units see [Bro+2008]_ and references therein, for example.
-
 """
 
 # Imports for common Python 2/3 codebase
@@ -28,102 +27,126 @@ from future import standard_library
 standard_library.install_aliases()
 
 import numpy as np
-import dicom
+try:
+    import dicom
+    DICOM_AVAILABLE = True
+except ImportError:
+    DICOM_AVAILABLE = False
+
 import os
+import re
+
+__all__ = ('read_clintec_CT_reconstruction', 'linear_attenuation_from_HU',
+           'read_clintec_raw_spect_data', 'DICOM_AVAILABLE')
+
+
+def natural_sort_key(s, _nsre=re.compile('([0-9]+)')):
+    return [int(text) if text.isdigit() else text.lower()
+            for text in re.split(_nsre, s)]
 
 
 def read_clintec_CT_reconstruction(path):
-    """Reads the data in DICOM format and returns a HU CT volume.
+    """Read DICOM format data to array.
 
     Parameters
     ----------
     path : `str`
-        a path to the folder where DICOM data is
+        Path of the folder where DICOM data is stored.
 
     Returns
     -------
-    ct_volume : `numpy.ndarray`
-        an array of CT reconstruction in Houndsfield units.
-    dataset : `DICOM` File Meta Information
+    ct_volume : `array-like`
+        Array of CT reconstruction in Houndsfield units.
+
+    dataset : DICOM File Meta Information
 
     """
 
     dcm_file_list = []
-    for dirName, subdirList, fileList in os.walk(path):
-        for filename in sorted(fileList):
-            dcm_file_list.append(os.path.join(dirName, filename))
+    for dir_name, _, file_list in os.walk(path):
+        for filename in sorted(file_list, key=natural_sort_key):
+            dcm_file_list.append(os.path.join(dir_name, filename))
 
     dataset = dicom.read_file(dcm_file_list[0])
 
     shape = (int(dataset.Rows), int(dataset.Columns), len(dcm_file_list))
-    data_array = np.zeros(shape, dtype=dataset.pixel_array.dtype)
+    data_array = np.empty(shape, dtype=dataset.pixel_array.dtype)
 
     for i, fname in enumerate(dcm_file_list):
         ds = dicom.read_file(fname)
         data_array[:, :, i] = ds.pixel_array
 
-    rescale_intercept = int(dataset.RescaleIntercept)
-    rescale_slope = int(dataset.RescaleSlope)
+    rescale_intercept = float(dataset.RescaleIntercept)
+    rescale_slope = float(dataset.RescaleSlope)
 
-    ct_volume = rescale_slope * np.float32(data_array) + rescale_intercept
+    ct_volume = rescale_slope * data_array + rescale_intercept
 
     return ct_volume, dataset
 
 
-def linear_attenuation_map_from_HU(volume, a, b):
-    """Converts Houndsfield units to a linear attenuation map.
+def linear_attenuation_from_HU(volume, a, b):
+    """Convert Houndsfield units to linear attenuation coefficient.
 
     Parameters
     ----------
-    volume : `numpy.ndarray`
-        an array of Houndsfield units to be converted
+    volume : `array-like`
+        array of Houndsfield units to be converted
+
     a, b : `sequence`
         a = (a1, a2) where a1 `float` and a2 `float` are the intercepts
             of the bilinear curve
         b = (b1, b2) where b1 `float` and b2 `float` are the slopes
             of the bilinear curve
-        see `Notes` for furher information
-
-    Notes
-    -----
-        a and b are parameters of a bilinear curve for converting
-        Houndsfield units to linear attenuation map, such that
-        mu = a1 + b1 * ct_volume for HU < 0
-        mu = a2 + b2 * ct_volume for HU >= 0
+        see Notes_ for furher information.
 
     Returns
     -------
-    attenuation_map : `numpy.ndarray`
-        An array of linear attenuation values.
+    attenuation : `array-like`
+        array of linear attenuation values.
+
+    Notes
+    -----
+        `a` and `b` are parameters of a bilinear curve for converting
+        Houndsfield units (HU) to linear attenuation coefficients, such that
+
+        mu = a1 + b1 * ct_volume for HU < 0
+
+        mu = a2 + b2 * ct_volume for HU >= 0
+
+        See [Bro+2008]_ and [Bur+2002]_ for example.
+
     """
     a1, a2 = a
     b1, b2 = b
     mask = np.less(volume, 0)
-    attenuation_map = np.empty_like(volume)
-    attenuation_map[mask] = a1 + b1 * volume[mask]
-    attenuation_map[~mask] = a2 + b2 * volume[~mask]
-    attenuation_map = np.absolute(attenuation_map)
-    return attenuation_map
+    attenuation = np.empty_like(volume)
+    attenuation[mask] = a1 + b1 * volume[mask]
+    attenuation[~mask] = a2 + b2 * volume[~mask]
+    attenuation = np.absolute(attenuation)
+    return attenuation
 
 
 def read_clintec_raw_spect_data(path):
-    """Reads the raw spect DICOM data and retuns an array of the data.
+    """Read raw SPECT DICOM data to array.
 
     Parameters
     ----------
     path : `str`
-        a path to the data folder
+        Path of the folder where DICOM data is stored.
 
     Returns
     -------
-    spect_data : `numpy.ndarray`
-        an array of SPECT projection data
-    dataset : `DICOM` File Meta Information
+    spect_data : `array-like`
+        SPECT projection data
+    dataset : DICOM File Meta Information
     """
 
     filenames = list(os.listdir(path))
-    data_dicom = os.path.join(path, filenames[0])
-    dataset = dicom.read_file(data_dicom)
-    spect_data = dataset.pixel_array
+    if len(filenames) == 1:
+        data_dicom = os.path.join(path, filenames[0])
+        dataset = dicom.read_file(data_dicom)
+        spect_data = dataset.pixel_array
+    else:
+        raise NotImplementedError('folder contais more than one item')
 
     return spect_data, dataset

--- a/odl/tomo/data/clintec_spect.py
+++ b/odl/tomo/data/clintec_spect.py
@@ -126,13 +126,13 @@ def linear_attenuation_from_HU(volume, a, b):
     return attenuation
 
 
-def read_clintec_raw_spect_data(path):
+def read_clintec_raw_spect_data(file_dicom):
     """Read raw SPECT DICOM data to array.
 
     Parameters
     ----------
     path : `str`
-        Path of the folder where DICOM data is stored.
+        Name of the file where DICOM data is stored.
 
     Returns
     -------
@@ -141,12 +141,7 @@ def read_clintec_raw_spect_data(path):
     dataset : DICOM File Meta Information
     """
 
-    filenames = list(os.listdir(path))
-    if len(filenames) == 1:
-        data_dicom = os.path.join(path, filenames[0])
-        dataset = dicom.read_file(data_dicom)
-        spect_data = dataset.pixel_array
-    else:
-        raise NotImplementedError('folder contais more than one item')
+    dataset = dicom.read_file(file_dicom)
+    spect_data = dataset.pixel_array
 
     return spect_data, dataset

--- a/setup.py
+++ b/setup.py
@@ -137,8 +137,9 @@ setup(
         'show': 'matplotlib',
         'fftw': 'pyfftw',
         'pywavelets': 'Pywavelets',
-        'scikit' : 'scikit-image',
-        'all': test_requires + ['matplotlib', 'pyfftw', 'Pywavelets', 'scikit-image']
+        'scikit': 'scikit-image',
+        'dicom': 'dicom',
+        'all': test_requires + ['matplotlib', 'pyfftw', 'Pywavelets', 'scikit-image', 'dicom']
     },
 
     cmdclass={'test': PyTest},

--- a/setup.py
+++ b/setup.py
@@ -138,8 +138,8 @@ setup(
         'fftw': 'pyfftw',
         'pywavelets': 'Pywavelets',
         'scikit': 'scikit-image',
-        'dicom': 'dicom',
-        'all': test_requires + ['matplotlib', 'pyfftw', 'Pywavelets', 'scikit-image', 'dicom']
+        'dicom': 'pydicom',
+        'all': test_requires + ['matplotlib', 'pyfftw', 'Pywavelets', 'scikit-image', 'pydicom']
     },
 
     cmdclass={'test': PyTest},


### PR DESCRIPTION
Added functionality to read in CLINTEC SPECT/CT data
`clintec_spect.py` contains 3 functions

- `read_clintec_CT_reconstruction` reads in CT reconstructions in Dicom form and returns an array of  Houndsfield units

- `linear_attenuation_map_from_HU_data` calls `read_clintec_CT_reconstruction` and converts HU to linear attenuation map and returns the corresponding array

- `read_clintec_raw_spect_data` reads the Dicom SPECT data and returns to and array
