### PR TITLE
WIP: Implement convolution operator(s)

### DIFF
--- a/examples/trafos/convolution.py
+++ b/examples/trafos/convolution.py
@@ -1,0 +1,90 @@
+# Copyright 2014-2016 The ODL development group
+#
+# This file is part of ODL.
+#
+# ODL is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# ODL is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with ODL.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Example for the usage of the convolution operator."""
+
+# Imports for common Python 2/3 codebase
+from __future__ import print_function, division, absolute_import
+from future import standard_library
+standard_library.install_aliases()
+
+import numpy as np
+import odl
+
+
+# Parameters for the gaussian kernel
+gamma = 0.1
+norm_const = 2 * np.pi * gamma ** 2
+
+
+def gaussian(x):
+    sum_sq = sum(xi ** 2 for xi in x)
+    return np.exp(-sum_sq / (2 * gamma ** 2)) / norm_const
+
+
+# Test function
+def square(x):
+    onedim_arrs = [np.where((xi >= -1) & (xi <= 1), 1.0, 0.0) for xi in x]
+    out = onedim_arrs[0]
+    for arr in onedim_arrs[1:]:
+        out = out * arr
+    return out
+
+
+space = odl.uniform_discr([-2, -2], [2, 2], (2048, 2048))
+
+# Showing just for fun
+real_ker = space.element(gaussian)
+real_ker.show(title='Gaussian kernel')
+func = space.element(square)
+func.show(title='Test function, a square')
+
+conv = odl.Convolution(space, kernel=gaussian, kernel_mode='real',
+                       impl='pyfftw_ft')
+
+out = space.element()
+conv.transform.create_temporaries()
+conv.transform.init_fftw_plan()
+
+with odl.util.testutils.Timer('first run, mode real'):
+    func_conv = conv(func, out=out)
+
+with odl.util.testutils.Timer('second run, mode real'):
+    func_conv = conv(func, out=out)
+
+conv.transform.create_temporaries()
+with odl.util.testutils.Timer('third run, mode real, with tmp'):
+    func_conv = conv(func, out=out)
+
+func_conv.show(title='Convolved function')
+
+# Giving the kernel via FT
+ft = odl.trafos.FourierTransform(space, impl='pyfftw')
+ker_ft = ft(gaussian)
+ker_ft.show(title='FT of Gaussian kernel, half-complex')
+
+conv_with_ker_ft = odl.Convolution(space, kernel=ker_ft, kernel_mode='ft_hc',
+                                   impl='pyfftw_ft')
+
+with odl.util.testutils.Timer('first run, mode ft_hc'):
+    func_conv = conv_with_ker_ft(func, out=out)
+
+conv_with_ker_ft.transform.create_temporaries()
+with odl.util.testutils.Timer('second run, mode ft_hc, using tmp'):
+    func_conv = conv_with_ker_ft(func, out=out)
+
+func_conv.show(title='Convolved function, using kernel ft')

--- a/odl/discr/lp_discr.py
+++ b/odl/discr/lp_discr.py
@@ -192,6 +192,11 @@ class DiscreteLp(DiscretizedSpace):
         return self.partition.max_pt
 
     @property
+    def mid_pt(self):
+        """Midpoint of the function domain."""
+        return self.partition.mid_pt
+
+    @property
     def order(self):
         """Axis ordering for array flattening."""
         return self.__order

--- a/odl/discr/lp_discr.py
+++ b/odl/discr/lp_discr.py
@@ -480,14 +480,13 @@ class DiscreteLp(DiscretizedSpace):
             arg_fstr = '''
     {!r},
     {!r},
-    {!r}
-    '''
+    {!r}'''
             if self.exponent != 2.0:
-                arg_fstr += ', exponent={ex}'
-            if self.interp != 'nearest':
-                arg_fstr += ', interp={interp!r}'
+                arg_fstr += ',\n    exponent={ex}'
+            if self.interp != ['nearest'] * self.ndim:
+                arg_fstr += ',\n    interp={interp!r}'
             if self.order != 'C':
-                arg_fstr += ', order={order!r}'
+                arg_fstr += ',\n    order={order!r}'
 
             arg_str = arg_fstr.format(
                 self.uspace, self.partition, self.dspace, interp=self.interp,
@@ -1539,6 +1538,8 @@ def uniform_discr_fromdiscr(discr, min_pt=None, max_pt=None,
 
     return uniform_discr_frompartition(new_part, exponent=discr.exponent,
                                        interp=discr.interp, impl=discr.impl,
+                                       order=discr.order, dtype=discr.dtype,
+                                       weighting=discr.weighting,
                                        **kwargs)
 
 

--- a/odl/discr/partition.py
+++ b/odl/discr/partition.py
@@ -159,6 +159,11 @@ class RectPartition(object):
         return self.set.extent()
 
     @property
+    def midpoint(self):
+        """Midpoint of this partition."""
+        return self.set.midpoint
+
+    @property
     def grid(self):
         """`TensorGrid` defining this partition."""
         return self.__grid

--- a/odl/discr/partition.py
+++ b/odl/discr/partition.py
@@ -159,11 +159,6 @@ class RectPartition(object):
         return self.set.extent()
 
     @property
-    def midpoint(self):
-        """Midpoint of this partition."""
-        return self.set.midpoint
-
-    @property
     def grid(self):
         """`TensorGrid` defining this partition."""
         return self.__grid

--- a/odl/trafos/__init__.py
+++ b/odl/trafos/__init__.py
@@ -33,3 +33,6 @@ __all__ += fourier.__all__
 
 from .wavelet import *
 __all__ += wavelet.__all__
+
+from .convolution import *
+__all__ += convolution.__all__

--- a/odl/trafos/convolution.py
+++ b/odl/trafos/convolution.py
@@ -40,7 +40,6 @@ __all__ = ('Convolution', 'FourierSpaceConvolution', 'RealSpaceConvolution')
 
 _REAL_CONV_SUPPORTED_IMPL = ('scipy_convolve',)
 _FOURIER_CONV_SUPPORTED_IMPL = ('default', 'pyfftw')
-_FOURIER_CONV_SUPPORTED_KER_MODES = ('real', 'fourier')
 
 
 class Convolution(Operator):
@@ -222,18 +221,20 @@ class FourierSpaceConvolution(Convolution):
         # Handle kernel mode and impl
         impl = kwargs.pop('impl', 'default_ft')
         impl, impl_in = str(impl).lower(), impl
-        if impl not in _CONV_SUPPORTED_IMPL:
-            raise ValueError("implementation '{}' not understood."
+        if impl not in _FOURIER_CONV_SUPPORTED_IMPL:
+            raise ValueError("`impl` '{}' not understood."
                              ''.format(impl_in))
         self._impl = impl
 
-        ker_mode = kwargs.pop('kernel_mode', 'real')
-        ker_mode, ker_mode_in = str(ker_mode).lower(), ker_mode
-        if ker_mode not in _CONV_SUPPORTED_KER_MODES:
-            raise ValueError("kernel mode '{}' not understood."
-                             ''.format(ker_mode_in))
+        kernel_mode = kwargs.pop('kernel_mode', 'real')
+        kernel_mode, kernel_mode_in = str(kernel_mode).lower(), kernel_mode
+        if kernel_mode not in ('real', 'fourier'):
+            raise ValueError("`kernel_mode` '{}' not understood."
+                             ''.format(kernel_mode_in))
 
-        self._kernel_mode = ker_mode
+        self._kernel_mode = kernel_mode
+
+        # TODO: continue here
 
         use_own_ft = (self.impl in ('default_ft', 'pyfftw_ft'))
         if not use_own_ft and self.kernel_mode != 'real':

--- a/odl/trafos/convolution.py
+++ b/odl/trafos/convolution.py
@@ -1,0 +1,709 @@
+# Copyright 2014-2016 The ODL development group
+#
+# This file is part of ODL.
+#
+# ODL is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# ODL is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with ODL.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Operators based on (integral) transformations."""
+
+# Imports for common Python 2/3 codebase
+from __future__ import print_function, division, absolute_import
+from future import standard_library
+standard_library.install_aliases()
+from builtins import super
+
+import numpy as np
+import scipy.signal as signal
+
+from odl.discr.discr_ops import Resampling
+from odl.discr.lp_discr import (
+    DiscreteLp, DiscreteLpVector, uniform_discr, uniform_discr_fromdiscr)
+from odl.operator.operator import Operator
+from odl.space.ntuples import Ntuples
+from odl.space.cu_ntuples import CudaNtuples
+from odl.set.sets import ComplexNumbers
+from odl.trafos.fourier import FourierTransform
+from odl.util.normalize import normalized_scalar_param_list
+
+
+__all__ = ('Convolution', 'FourierSpaceConvolution', 'RealSpaceConvolution')
+
+
+_REAL_CONV_SUPPORTED_IMPL = ('scipy_convolve',)
+_FOURIER_CONV_SUPPORTED_IMPL = ('default_ft', 'pyfftw_ft')
+_FOURIER_CONV_SUPPORTED_KER_MODES = ('real', 'ft', 'ft_hc')
+
+
+class Convolution(Operator):
+    pass
+
+
+class FourierSpaceConvolution(Convolution):
+
+    """Discretization of the convolution integral as an operator.
+
+    This operator implements a discrete approximation to the continuous
+    convolution with a fixed kernel. It supports real-space and
+    Fourier based back-ends.
+    """
+
+    def __init__(self, dom, kernel, ran=None, **kwargs):
+        """Initialize a new instance.
+
+        Parameters
+        ----------
+        dom : `DiscreteLp`
+            Domain of the operator
+        ran : `DiscreteLp`, optional
+            Range of the operator, by default the same as ``dom``
+        kernel :
+            The kernel can be specified in several ways, depending on
+            the choice of ``impl``:
+
+            domain `element-like` : The object is interpreted as the
+            real-space kernel representation (mode ``'real'``).
+            Valid for ``impl``: ``'numpy_ft', 'pyfftw_ft',
+            'scipy_convolve'``
+
+            `element-like` for the range of `FourierTransform` defined
+            on ``dom`` : The object is interpreted as the Fourier
+            transform of a real-space kernel (mode ``ft`` or ``'ft_hc'``).
+            The correct space can be calculated with `reciprocal_space`.
+            Valid for ``impl``: ``'default_ft', 'pyfftw_ft'``
+
+            `array-like`, arbitrary length : The object is interpreted as
+            real-space kernel (mode ``'real'``) and can be shorter than
+            the convolved function.
+            Valid for ``impl``: ``'scipy_convolve'``
+
+        kernel_mode : {'real', 'ft', 'ft_hc'}, optional
+            How the provided kernel is to be interpreted. If not
+            provided, the kernel is tried to be converted into an element
+            of ``dom`` or a "sliced" version of it according to ``axes``.
+
+            'real' : element of ``dom`` (default)
+
+            'ft' : function in the range of the Fourier transform
+
+            'ft_hc' : function in the range of the half-complex
+            (real-to-complex) Fourier transform
+
+        impl : `str`, optional
+            Implementation of the convolution. Available options are:
+
+            'scipy_convolve': Real-space convolution using
+            `scipy.signal.convolve` (default, fast for short kernels)
+
+            'default_ft' : Fourier transform using the default FFT
+            implementation
+
+            'pyfftw_ft' : Fourier transform using pyFFTW (faster than
+            the default FT)
+
+        axes : sequence of `int`, optional
+            Dimensions in which to convolve. Default: all axes
+
+        scale : `bool`, optional
+            If `True`, scale the discrete convolution such that it
+            corresponds to a continuous convolution. The scaling
+            factor is ``2*pi ** (ndim/2)`` for FT-based convolutions
+            and the `DiscreteLp.cell_volume` for the SciPy
+            implementation.
+            Default: `True`
+
+        kwargs :
+            Extra arguments are passed to the transform when the
+            kernel FT is calculated.
+
+        See also
+        --------
+        FourierTransform : discretization of the continuous FT
+        scipy.signal.convolve : real-space convolution
+
+        Notes
+        -----
+        - For Fourier-based convolutions, only the Fourier transform
+          of the kernel is stored. The real-space kernel can be retrieved
+          with ``conv.transform.inverse(conv.kernel_ft)`` if ``conv``
+          is the convolution operator.
+
+        - The continuous convolution of two functions
+          :math:`f` and :math:`g` defined on :math:`\mathbb{R^d}` is
+
+              :math:`[f \\ast g](x) =
+              \int_{\mathbb{R^d}} f(x - y) g(y) \mathrm{d}y`.
+
+          With the help of the Fourier transform, this operation can be
+          expressed as a multiplication,
+
+              :math:`\\big[\mathcal{F}(f \\ast g)\\big](\\xi)
+              = (2\pi)^{\\frac{d}{2}}\,
+              \\big[\mathcal{F}(f)\\big](\\xi) \cdot
+              \\big[\mathcal{F}(g)\\big](\\xi)`.
+
+          This implementation covers the case of a fixed convolution
+          kernel :math:`k`, i.e. the linear operator
+
+              :math:`\\big[\mathcal{C}_k(f)\\big](x) = [k \\ast f](x)`
+
+          mapping the Lebesgue space :math:`L^p(\mathbb{R^d})` to itself
+          (provided :math:`k \\in L^1(\mathbb{R^d})`), according to
+          `Young's inequality for convolutions
+          <https://en.wikipedia.org/wiki/Young's_inequality#\
+Young.27s_inequality_for_convolutions>`_.
+        """
+        # Basic checks
+        if not isinstance(dom, DiscreteLp):
+            raise TypeError('domain {!r} is not a DiscreteLp instance.'
+                            ''.format(dom))
+
+        if ran is not None:
+            # TODO
+            raise NotImplementedError('custom range not implemented')
+        else:
+            ran = dom
+
+        super().__init__(dom, ran, linear=True)
+
+        # Handle kernel mode and impl
+        impl = kwargs.pop('impl', 'default_ft')
+        impl, impl_in = str(impl).lower(), impl
+        if impl not in _CONV_SUPPORTED_IMPL:
+            raise ValueError("implementation '{}' not understood."
+                             ''.format(impl_in))
+        self._impl = impl
+
+        ker_mode = kwargs.pop('kernel_mode', 'real')
+        ker_mode, ker_mode_in = str(ker_mode).lower(), ker_mode
+        if ker_mode not in _CONV_SUPPORTED_KER_MODES:
+            raise ValueError("kernel mode '{}' not understood."
+                             ''.format(ker_mode_in))
+
+        self._kernel_mode = ker_mode
+
+        use_own_ft = (self.impl in ('default_ft', 'pyfftw_ft'))
+        if not use_own_ft and self.kernel_mode != 'real':
+            raise ValueError("kernel mode 'real' is required for impl "
+                             "{}.".format(impl_in))
+
+        self._axes = list(kwargs.pop('axes', (range(self.domain.ndim))))
+        if ker_mode == 'real':
+            halfcomplex = True  # efficient
+        else:
+            halfcomplex = ker_mode.endswith('hc')
+
+        if use_own_ft:
+            fft_impl = self.impl.split('_')[0]
+            self._transform = FourierTransform(
+                self.domain, axes=self.axes, halfcomplex=halfcomplex,
+                impl=fft_impl)
+        else:
+            self._transform = None
+
+        scale = kwargs.pop('scale', True)
+
+        # TODO: handle case if axes are given, but the kernel is the same
+        # for each point along the other axes
+        if ker_mode == 'real':
+            # Kernel given as real space element
+            if use_own_ft:
+                self._kernel = None
+                self._kernel_transform = self.transform(kernel, **kwargs)
+                if scale:
+                    self._kernel_transform *= (np.sqrt(2 * np.pi) **
+                                               self.domain.ndim)
+            else:
+                if not self.domain.partition.is_regular:
+                    raise NotImplementedError(
+                        'real-space convolution not implemented for '
+                        'irregular sampling.')
+                try:
+                    # Function or other element-like as input. All axes
+                    # must be used, otherwise we get an error.
+                    # TODO: make a zero-centered space by default and
+                    # adapt the range otherwise
+                    self._kernel = self._kernel_elem(
+                        self.domain.element(kernel).asarray(), self.axes)
+                except (TypeError, ValueError):
+                    # Got an array-like, axes can be used
+                    self._kernel = self._kernel_elem(kernel, self.axes)
+                finally:
+                    self._kernel_transform = None
+                    if scale:
+                        self._kernel *= self.domain.cell_volume
+        else:
+            # Kernel given as Fourier space element
+            self._kernel = None
+            self._kernel_transform = self.transform.range.element(kernel)
+            if scale:
+                self._kernel_transform *= (np.sqrt(2 * np.pi) **
+                                           self.domain.ndim)
+
+    def _kernel_elem(self, kernel, axes):
+        """Return kernel with adapted shape for real space convolution."""
+        kernel = np.asarray(kernel)
+        extra_dims = self.domain.ndim - kernel.ndim
+
+        if extra_dims == 0:
+            return self.domain.element(kernel)
+        else:
+            if len(axes) != extra_dims:
+                raise ValueError('kernel dim {} + number of axes {} '
+                                 '!= space dimension {}.'
+                                 ''.format(kernel.ndim, len(axes),
+                                           self.domain.ndim))
+
+            # Sparse kernel (less dimensions), blow up
+            slc = [None] * self.domain.ndim
+            for ax in axes:
+                slc[ax] = slice(None)
+
+            kernel = kernel[slc]
+            # Assuming uniform discretization
+            min_corner = -self.domain.cell_sides * self.domain.shape / 2
+            max_corner = self.domain.cell_sides * self.domain.shape / 2
+            if isinstance(self.domain.dspace, Ntuples):
+                impl = 'numpy'
+            elif isinstance(self.domain.dspace, CudaNtuples):
+                impl = 'cuda'
+            else:
+                raise RuntimeError
+
+            space = uniform_discr(min_corner, max_corner, kernel.shape,
+                                  self.domain.exponent, self.domain.interp,
+                                  impl, dtype=self.domain.dspace.dtype,
+                                  order=self.domain.order,
+                                  weighting=self.domain.weighting)
+            return space.element(kernel)
+
+    @property
+    def impl(self):
+        """Implementation of this operator."""
+        return self._impl
+
+    @property
+    def kernel_mode(self):
+        """The way in which the kernel is specified."""
+        return self._kernel_mode
+
+    @property
+    def transform(self):
+        """Fourier transform operator back-end if used, else `None`."""
+        return self._transform
+
+    @property
+    def axes(self):
+        """Axes along which the convolution is taken."""
+        return self._axes
+
+    @property
+    def kernel(self):
+        """Real-space kernel if used, else `None`.
+
+        Note that this is the scaled version ``kernel * cell_volume``
+        if ``scale=True`` was specified. Scaling here is more efficient
+        than scaling the result.
+        """
+        return self._kernel
+
+    @property
+    def kernel_space(self):
+        """Space of the convolution kernel."""
+        return getattr(self.kernel, 'space', None)
+
+    @property
+    def kernel_transform(self):
+        """Fourier-space kernel if used, else `None`.
+
+        Note that this is the scaled version
+        ``kernel_ft * (2*pi) ** (ndim/2)`` of the FT of the input
+        kernel if ``scale=True`` was specified. Scaling here is more
+        efficient than scaling the result.
+        """
+        return self._kernel_transform
+
+    def _call(self, x, out, **kwargs):
+        """Implement ``self(x, out[, **kwargs])``.
+
+        Keyword arguments are passed on to the transform.
+        """
+        if self.kernel is not None:
+            # Scipy based convolution
+            out[:] = signal.convolve(x, self.kernel, mode='same')
+        elif self.kernel_transform is not None:
+            # Convolution based on our own transforms
+            if self.domain.field == ComplexNumbers():
+                # Use out as a temporary, has the same size
+                # TODO: won't work for CUDA
+                tmp = self.transform.range.element(out.asarray())
+            else:
+                # No temporary since out has reduced size (halfcomplex)
+                tmp = None
+
+            x_trafo = self.transform(x, out=tmp, **kwargs)
+            x_trafo *= self.kernel_transform
+
+            self.transform.inverse(x_trafo, out=out, **kwargs)
+        else:
+            raise RuntimeError('both kernel and kernel_transform are None.')
+
+    def _adj_kernel(self, kernel, axes):
+        """Return adjoint kernel with adapted shape."""
+        kernel = np.asarray(kernel).conj()
+        extra_dims = self.domain.ndim - kernel.ndim
+
+        if extra_dims == 0:
+            slc = [slice(None, None, -1)] * self.domain.ndim
+            return kernel[slc]
+        else:
+            if len(axes) != extra_dims:
+                raise ValueError('kernel dim ({}) + number of axes ({}) '
+                                 'does not add up to the space dimension '
+                                 '({}).'.format(kernel.ndim, len(axes),
+                                                self.domain.ndim))
+
+            # Sparse kernel (less dimensions), blow up
+            slc = [None] * self.domain.ndim
+            for ax in axes:
+                slc[ax] = slice(None, None, -1)
+            return kernel[slc]
+
+    @property
+    def adjoint(self):
+        """Adjoint operator."""
+        if self.kernel is not None:
+            # TODO: this could be expensive. Move to init?
+            adj_kernel = self._adj_kernel(self.kernel, self.axes)
+            return Convolution(dom=self.domain,
+                               kernel=adj_kernel, kernel_mode='real',
+                               impl=self.impl, axes=self.axes)
+
+        elif self.kernel_transform is not None:
+            # TODO: this could be expensive. Move to init?
+            adj_kernel_ft = self.kernel_transform.conj()
+
+            if self.transform.halfcomplex:
+                kernel_mode = 'ft_hc'
+            else:
+                kernel_mode = 'ft'
+            return Convolution(dom=self.domain,
+                               kernel=adj_kernel_ft, kernel_mode=kernel_mode,
+                               impl=self.impl, axes=self.axes)
+        else:
+            raise RuntimeError('both kernel and kernel_transform are None.')
+
+
+class RealSpaceConvolution(Convolution):
+
+    """Convolution implemented in real space."""
+
+    def __init__(self, domain, kernel, range=None, **kwargs):
+        """Initialize a new instance.
+
+        Parameters
+        ----------
+        domain : `DiscreteLp`
+            Domain of the operator
+        kernel :
+            The kernel can be specified in several ways, depending on
+            the choice of ``impl``:
+
+            `DiscreteLpVector` :
+            Valid for ``impl``: ``'scipy_convolve'``
+
+            `array-like`, arbitrary shape : The object is interpreted as
+            real-space kernel (mode ``'real'``) and can be differently
+            sized than the convolved function. It is assumed to be an
+            element of a space with same `DiscreteLp.cell_sides` as
+            ``domain``. Note that the ``scipy_convolve`` back-end does
+            not allow the kernel to be larger.
+            Valid for ``impl``: ``'scipy_convolve'``
+
+        range : `DiscreteLp`, optional
+            Range of the operator. By default, the range is calculated
+            from the kernel.
+            Note: custom range is currently not supported.
+
+        impl : string, optional
+            Implementation of the convolution. Available options are:
+
+            'scipy_convolve': Real-space convolution using
+            `scipy.signal.convolve` (default, fast for short kernels)
+
+        scale : `bool`, optional
+            If `True`, scale the discrete convolution with
+            `DiscreteLp.cell_volume`, such that it
+            corresponds to a continuous convolution.
+            Default: `True`
+
+        resample : string or sequence of strings
+            If ``kernel`` and ``domain`` have different cell sizes,
+            this option defines the behavior of the evaluation. The
+            following values can be given (per axis in the case of a
+            sequence):
+
+            'down' : Use the larger one of the two cell sizes (default).
+
+            'up' : Use the smaller one of the two cell sizes. Note that
+            this can be computationally expensive.
+
+        kernel_kwargs : dict, optional
+            Keyword arguments passed to the call of the kernel function
+            if given as a callable.
+
+        See also
+        --------
+        scipy.signal.convolve : real-space convolution
+
+        Notes
+        -----
+        - The continuous convolution of two functions
+          :math:`f` and :math:`g` defined on :math:`\mathbb{R^d}` is
+
+              :math:`[f \\ast g](x) =
+              \int_{\mathbb{R^d}} f(x - y) g(y) \mathrm{d}y`.
+
+          This implementation covers the case of a fixed convolution
+          kernel :math:`k`, i.e. the linear operator :math:`\mathcal{C}_k`
+          given by
+
+              :math:`\mathcal{C}_k(f): x \mapsto [k \\ast f](x)`.
+
+        - If the convolution kernel :math:`k` is defined on a rectangular
+          domain :math:`\Omega_0` with midpoint :math:`m_0`, then the
+          convolution :math:`k \\ast f` of a function
+          :math:`f:\Omega \\to \mathbb{R}` with :math:`k` has a support
+          that is a superset of :math:`\Omega + m_0`. Therefore, we
+          choose to keep the size of the domain and take
+          :math:`\Omega + m_0` as the domain of definition of functions
+          in the range of the convolution operator.
+
+          In fact, the support of the convolution is contained in the
+          `Minkowski sum
+          <https://en.wikipedia.org/wiki/Minkowski_addition>`_
+          :math:`\Omega + \Omega_0`.
+
+          For example, if :math:`\Omega = [0, 5]` and
+          :math:`\Omega_0 = [1, 3]`, i.e. :math:`m_0 = 2`, then
+          :math:`\Omega + \Omega_0 = [1, 8]`. However, we choose the
+          shifted interval :math:`\Omega + m_0 = [2, 7]` for the range
+          of the convolution since it contains the "main mass" of the
+          result.
+        """
+        # Basic checks
+        if not isinstance(domain, DiscreteLp):
+            raise TypeError('domain {!r} is not a DiscreteLp instance'
+                            ''.format(domain))
+        if not domain.partition.is_regular:
+            raise NotImplementedError('irregular sampling not supported')
+
+        if range is not None:
+            # TODO
+            raise NotImplementedError('custom range not implemented')
+        else:
+            kernel_kwargs = kwargs.pop('kernel_kwargs', {})
+            self._kernel, range = self._compute_kernel_and_range(
+                kernel, domain, kernel_kwargs)
+
+        super().__init__(domain, range, linear=True)
+
+        # Handle kernel mode and impl
+        impl = kwargs.pop('impl', 'scipy_convolve')
+        impl, impl_in = str(impl).lower(), impl
+        if impl not in _REAL_CONV_SUPPORTED_IMPL:
+            raise ValueError("implementation '{}' not understood"
+                             ''.format(impl_in))
+
+        self._impl = impl
+
+        # Handle the `resample` input parameter
+        resample = normalized_scalar_param_list(kwargs.pop('resample', 'down'),
+                                                length=self.domain.ndim,
+                                                param_conv=str)
+
+        for i, r in enumerate(resample):
+            if r.lower() not in ('up', 'down'):
+                raise ValueError("in axis {}: `resample` '{}' not understood"
+                                 ''.format(i, r))
+            else:
+                resample[i] = r.lower()
+
+        self._resample = resample
+
+        # Initialize resampling operators
+        new_kernel_csides, new_domain_csides = self._get_resamp_csides(
+            self.resample, self._kernel.space.cell_sides,
+            self.domain.cell_sides)
+
+        domain_resamp_space = uniform_discr_fromdiscr(
+            self.domain, cell_sides=new_domain_csides)
+        self._domain_resampling_op = Resampling(self.domain,
+                                                domain_resamp_space)
+
+        kernel_resamp_space = uniform_discr_fromdiscr(
+            self._kernel.space, cell_sides=new_kernel_csides)
+        self._kernel_resampling_op = Resampling(self._kernel.space,
+                                                kernel_resamp_space)
+
+        # Scale the kernel if desired
+        self._kernel_scaling = np.prod(new_kernel_csides)
+        self._scale = bool(kwargs.pop('scale', True))
+        if self._scale:
+            # Don't modify the input
+            self._kernel = self._kernel * self._kernel_scaling
+
+    @staticmethod
+    def _compute_kernel_and_range(kernel, domain, kernel_kwargs):
+        """Return the kernel and the operator range based on the domain.
+
+        This helper function computes an adequate zero-centered domain
+        for the kernel if necessary (i.e. if the kernel is not a
+        `DiscreteLpVector`) and calculates the operator range based
+        on the operator domain and the kernel space.
+
+        Parameters
+        ----------
+        kernel : `DiscreteLpVector` or array-like
+            Kernel of the convolution.
+        domain : `DiscreteLp`
+            Domain of the convolution operator.
+        kernel_kwargs : dict
+            Used as ``space.element(kernel, **kernel_kwargs)`` if
+            ``kernel`` is callable.
+
+        Returns
+        -------
+        kernel : `DiscreteLpVector`
+            Element in an adequate space.
+        range : `DiscreteLp`
+            Range of the convolution operator.
+        """
+        if isinstance(kernel, DiscreteLpVector) and kernel not in domain:
+            if kernel.ndim != domain.ndim:
+                raise ValueError('`kernel` has dimension {}, expected {}'
+                                 ''.format(kernel.ndim, domain.ndim))
+            # The kernel lies in a different space. We first zero-center
+            # its domain and set the range to the domain shifted by
+            # the the midpoint of the kernel domain.
+
+            # TODO: DiscreteLp.element should probably bail out if
+            # kernel is a DiscreteLpVector but not in the same space
+            kernel_shift = kernel.space.partition.midpoint
+            range = uniform_discr_fromdiscr(
+                domain, min_corner=domain.min_corner + kernel_shift)
+
+        elif callable(kernel):
+            # The kernel is a Python function or some other callable object.
+            kernel = domain.element(kernel, **kernel_kwargs)
+            range = domain
+        else:
+            try:
+                # kernel is an array-like of the correct shape or an
+                # element of `domain`
+                kernel = domain.element(kernel)
+            except (TypeError, ValueError):
+                # Array-like of wrong shape -> find adequate space for the
+                # kernel. Assume 0-centering and same cell size.
+
+                # TODO: handle the case when the outer cells are of
+                # different size
+                kernel = np.asarray(kernel, dtype=domain.dtype)
+                nsamples = kernel.shape
+                extent = domain.cell_sides * nsamples
+                kernel_space = uniform_discr_fromdiscr(
+                    domain, min_corner=-extent / 2, max_corner=extent / 2,
+                    nsamples=nsamples)
+                kernel = kernel_space.element(kernel)
+
+            range = domain
+
+        return kernel, range
+
+    @staticmethod
+    def _get_resamp_csides(resample, ker_csides, dom_csides):
+        """Return cell sides for kernel and domain resampling."""
+        new_ker_csides = []
+        new_dom_csides = []
+        for resamp, ks, ds in zip(resample, ker_csides, dom_csides):
+
+            if np.isclose(ks, ds):
+                # Keep old if both csides are the same
+                new_ker_csides.append(ks)
+                new_dom_csides.append(ds)
+            else:
+                # Pick the coarser one if 'down' or the finer one if 'up'
+                if ((ks < ds and resamp == 'up') or
+                        (ks > ds and resamp == 'down')):
+                    new_ker_csides.append(ks)
+                    new_dom_csides.append(ks)
+                else:
+                    new_ker_csides.append(ds)
+                    new_dom_csides.append(ds)
+
+        return new_ker_csides, new_dom_csides
+
+    @property
+    def impl(self):
+        """Implementation of this operator."""
+        return self._impl
+
+    @property
+    def resample(self):
+        """Resampling used during evaluation."""
+        return self._resample
+
+    def kernel(self):
+        """Return the real-space kernel of this convolution operator.
+
+        Note that internally, the scaled kernel is stored if
+        ``scale=True`` was chosen during initialization, i.e. calculating
+        the original kernel requires to reverse the scaling.
+        Otherwise, the original unscaled kernel is returned.
+        """
+        if self._scale:
+            return self._kernel / self._kernel_scaling
+        else:
+            return self._kernel
+
+    def _call(self, x):
+        """Implement ``self(x)``."""
+        if np.allclose(self._kernel.space.cell_sides, self.domain.cell_sides):
+            # No resampling needed
+            print('no resampling')
+
+            # According to the documentation of scipy.signal.convolve, we
+            # would need to switch order of x and kernel since `convolve`
+            # expects the larger array first. However, this does not seem
+            # to be needed.
+            return signal.convolve(x, self._kernel, mode='same')
+        else:
+            if self.domain != self._domain_resampling_op.range:
+                # Only resample if necessary
+                print('resample function')
+                x = self._domain_resampling_op(x)
+
+            if self._kernel.space != self._kernel_resampling_op.range:
+                print('resample kernel')
+                kernel = self._kernel_resampling_op(self._kernel)
+            else:
+                kernel = self._kernel
+
+            conv = signal.convolve(x, kernel, mode='same')
+            return self._domain_resampling_op.inverse(conv)
+
+
+if __name__ == '__main__':
+    # pylint: disable=wrong-import-position
+    from odl.util.testutils import run_doctests
+    run_doctests()

--- a/odl/trafos/convolution.py
+++ b/odl/trafos/convolution.py
@@ -30,8 +30,6 @@ from odl.discr.discr_ops import Resampling
 from odl.discr.lp_discr import (
     DiscreteLp, DiscreteLpVector, uniform_discr, uniform_discr_fromdiscr)
 from odl.operator.operator import Operator
-from odl.space.ntuples import Ntuples
-from odl.space.cu_ntuples import CudaNtuples
 from odl.set.sets import ComplexNumbers
 from odl.trafos.fourier import FourierTransform
 from odl.util.normalize import normalized_scalar_param_list, safe_int_conv
@@ -262,16 +260,10 @@ class FourierSpaceConvolution(Convolution):
             # Assuming uniform discretization
             min_corner = -self.domain.cell_sides * self.domain.shape / 2
             max_corner = self.domain.cell_sides * self.domain.shape / 2
-            if isinstance(self.domain.dspace, Ntuples):
-                impl = 'numpy'
-            elif isinstance(self.domain.dspace, CudaNtuples):
-                impl = 'cuda'
-            else:
-                raise RuntimeError
-
             space = uniform_discr(min_corner, max_corner, kernel.shape,
                                   self.domain.exponent, self.domain.interp,
-                                  impl, dtype=self.domain.dspace.dtype,
+                                  impl=self.domain.impl,
+                                  dtype=self.domain.dspace.dtype,
                                   order=self.domain.order,
                                   weighting=self.domain.weighting)
             return space.element(kernel)

--- a/odl/trafos/convolution.py
+++ b/odl/trafos/convolution.py
@@ -508,15 +508,14 @@ class RealSpaceConvolution(Convolution):
         self._impl = impl
 
         # Handle the `resample` input parameter
-        resample = normalized_scalar_param_list(kwargs.pop('resample', 'down'),
-                                                length=self.domain.ndim,
-                                                param_conv=str)
-        for i, r in enumerate(resample):
-            if r.lower() not in ('up', 'down'):
+        resample = kwargs.pop('resample', 'down')
+        resample, resample_in = normalized_scalar_param_list(
+            resample, length=self.domain.ndim,
+            param_conv=lambda s: str(s).lower()), resample
+        for i, (r, r_in) in enumerate(zip(resample, resample_in)):
+            if r not in ('up', 'down'):
                 raise ValueError("in axis {}: `resample` '{}' not understood"
-                                 ''.format(i, r))
-            else:
-                resample[i] = r.lower()
+                                 ''.format(i, r_in))
         self._resample = resample
 
         # Initialize resampling operators

--- a/odl/trafos/convolution.py
+++ b/odl/trafos/convolution.py
@@ -28,7 +28,7 @@ import scipy.signal as signal
 
 from odl.discr.discr_ops import Resampling
 from odl.discr.lp_discr import (
-    DiscreteLp, DiscreteLpVector, uniform_discr, uniform_discr_fromdiscr)
+    DiscreteLp, DiscreteLpElement, uniform_discr, uniform_discr_fromdiscr)
 from odl.operator.operator import Operator
 from odl.set.sets import ComplexNumbers
 from odl.trafos.fourier import FourierTransform
@@ -74,7 +74,7 @@ class FourierSpaceConvolution(Convolution):
         domain : `DiscreteLp`
             Uniformly discretized space of functions on which the
             operator can act.
-        kernel : `DiscreteLpVector`, callable or array-like
+        kernel : `DiscreteLpElement`, callable or array-like
             Fixed kernel of the convolution operator. It can be
             given in real or Fourier space (see ``kernel_mode``), and
             specified in several ways, resulting in varying
@@ -82,7 +82,7 @@ class FourierSpaceConvolution(Convolution):
             the same number of dimensions as ``domain``, but the shapes
             can be different.
 
-            `DiscreteLpVector` : If ``kernel_mode == 'real'``, the range
+            `DiscreteLpElement` : If ``kernel_mode == 'real'``, the range
             is shifted by the midpoint of the kernel domain. The extents
             of ``domain`` and the kernel domain need to match.
             If ``kernel_mode == 'fourier'``, the cell sizes in Fourier
@@ -469,14 +469,14 @@ class RealSpaceConvolution(Convolution):
         domain : `DiscreteLp`
             Uniformly discretized space of functions on which the
             operator can act.
-        kernel : `DiscreteLpVector`, callable or array-like
+        kernel : `DiscreteLpElement`, callable or array-like
             Fixed kernel of the convolution operator. It can be
             specified in several ways, resulting in varying
             `Operator.range`. In all cases, the kernel must have
             the same number of dimensions as ``domain``, but the shapes
             can be different.
 
-            `DiscreteLpVector` : The range is shifted by the midpoint
+            `DiscreteLpElement` : The range is shifted by the midpoint
             of the kernel domain.
 
             callable or `array-like` : The kernel is interpreted as a
@@ -649,12 +649,12 @@ class RealSpaceConvolution(Convolution):
 
         This helper function computes an adequate zero-centered domain
         for the kernel if necessary (i.e. if the kernel is not a
-        `DiscreteLpVector`) and calculates the operator range based
+        `DiscreteLpElement`) and calculates the operator range based
         on the operator domain and the kernel space.
 
         Parameters
         ----------
-        kernel : `DiscreteLpVector` or array-like
+        kernel : `DiscreteLpElement` or array-like
             Kernel of the convolution.
         domain : `DiscreteLp`
             Domain of the convolution operator.
@@ -664,7 +664,7 @@ class RealSpaceConvolution(Convolution):
 
         Returns
         -------
-        kernel : `DiscreteLpVector`
+        kernel : `DiscreteLpElement`
             Element in an adequate space.
         range : `DiscreteLp`
             Range of the convolution operator.

--- a/odl/trafos/convolution.py
+++ b/odl/trafos/convolution.py
@@ -58,11 +58,10 @@ class Convolution(Operator):
 
 class FourierSpaceConvolution(Convolution):
 
-    """Convolution with a kernel, implemented in Fourier space.
+    """Convolution implemented in Fourier space.
 
     This operator implements a discrete approximation to the continuous
-    convolution with a fixed kernel. It supports real-space and
-    Fourier based back-ends.
+    convolution with a fixed kernel.
     """
 
     def __init__(self, domain, kernel, **kwargs):
@@ -454,6 +453,37 @@ class RealSpaceConvolution(Convolution):
         See also
         --------
         scipy.signal.convolve : real-space convolution
+
+        Examples
+        --------
+        >>> import odl
+        >>> space = odl.uniform_discr(-5, 5, 5)
+        >>> print(space.cell_sides)
+        [ 2.]
+
+        By default, the discretized convolution is scaled such that
+        it approximates the convolution integral. This behavior can be
+        switched off with ``scale=False``:
+
+        >>> kernel = [-1, 1]
+        >>> conv = RealSpaceConvolution(space, kernel)
+        >>> conv([0, 1, 2, 0, 0])
+        uniform_discr(-5.0, 5.0, 5).element([0.0, -2.0, -2.0, 4.0, 0.0])
+        >>> conv_noscale = RealSpaceConvolution(space, kernel, scale=False)
+        >>> conv_noscale([0, 1, 2, 0, 0])
+        uniform_discr(-5.0, 5.0, 5).element([0.0, -1.0, -1.0, 2.0, 0.0])
+
+        If the kernel is given as an element of a uniformly discretized
+        function space, the convolution operator range is shifted by
+        the midpoint of the kernel domain:
+
+        >>> kernel_space = odl.uniform_discr(0, 4, 2)  # midpoint 2.0
+        >>> kernel = kernel_space.element([-1, 1])
+        >>> conv_shift = RealSpaceConvolution(space, kernel)
+        >>> conv_shift.range  # Shifted by 2.0 in positive direction
+        uniform_discr(-3.0, 7.0, 5)
+        >>> conv_shift([0, 1, 2, 0, 0])
+        uniform_discr(-3.0, 7.0, 5).element([0.0, -2.0, -2.0, 4.0, 0.0])
 
         Notes
         -----

--- a/odl/trafos/convolution.py
+++ b/odl/trafos/convolution.py
@@ -325,9 +325,9 @@ class FourierSpaceConvolution(Convolution):
 
             kernel = kernel[slc]
             # Assuming uniform discretization
-            min_corner = -self.domain.cell_sides * self.domain.shape / 2
-            max_corner = self.domain.cell_sides * self.domain.shape / 2
-            space = uniform_discr(min_corner, max_corner, kernel.shape,
+            min_pt = -self.domain.cell_sides * self.domain.shape / 2
+            max_pt = self.domain.cell_sides * self.domain.shape / 2
+            space = uniform_discr(min_pt, max_pt, kernel.shape,
                                   self.domain.exponent, self.domain.interp,
                                   impl=self.domain.impl,
                                   dtype=self.domain.dspace.dtype,
@@ -537,10 +537,11 @@ class RealSpaceConvolution(Convolution):
         switched off with ``scale=False``:
 
         >>> kernel = [-1, 1]
-        >>> conv = RealSpaceConvolution(space, kernel)
+        >>> conv = odl.trafos.RealSpaceConvolution(space, kernel)
         >>> conv([0, 1, 2, 0, 0])
         uniform_discr(-5.0, 5.0, 5).element([0.0, -2.0, -2.0, 4.0, 0.0])
-        >>> conv_noscale = RealSpaceConvolution(space, kernel, scale=False)
+        >>> conv_noscale = odl.trafos.RealSpaceConvolution(space, kernel,
+        ...                                                scale=False)
         >>> conv_noscale([0, 1, 2, 0, 0])
         uniform_discr(-5.0, 5.0, 5).element([0.0, -1.0, -1.0, 2.0, 0.0])
 
@@ -550,7 +551,7 @@ class RealSpaceConvolution(Convolution):
 
         >>> kernel_space = odl.uniform_discr(0, 4, 2)  # midpoint 2.0
         >>> kernel = kernel_space.element([-1, 1])
-        >>> conv_shift = RealSpaceConvolution(space, kernel)
+        >>> conv_shift = odl.trafos.RealSpaceConvolution(space, kernel)
         >>> conv_shift.range  # Shifted by 2.0 in positive direction
         uniform_discr(-3.0, 7.0, 5)
         >>> conv_shift([0, 1, 2, 0, 0])
@@ -674,9 +675,9 @@ class RealSpaceConvolution(Convolution):
                                  ''.format(kernel.ndim, domain.ndim))
             # Set the range equal to the domain shifted by the midpoint of
             # the kernel space.
-            kernel_shift = kernel.space.partition.midpoint
+            kernel_shift = kernel.space.partition.mid_pt
             range = uniform_discr_fromdiscr(
-                domain, min_corner=domain.min_corner + kernel_shift)
+                domain, min_pt=domain.min_pt + kernel_shift)
             return kernel, range
 
         else:
@@ -685,7 +686,7 @@ class RealSpaceConvolution(Convolution):
                 # version of the domain.
                 extent = domain.partition.extent()
                 std_kernel_space = uniform_discr_fromdiscr(
-                    domain, min_corner=-extent / 2)
+                    domain, min_pt=-extent / 2)
                 kernel = std_kernel_space.element(kernel, **kernel_kwargs)
                 range = domain
                 return kernel, range
@@ -693,11 +694,10 @@ class RealSpaceConvolution(Convolution):
                 # Make a zero-centered space with the same cell sides as
                 # domain, but shape according to the kernel.
                 kernel = np.asarray(kernel, dtype=domain.dtype)
-                nsamples = kernel.shape
-                extent = domain.cell_sides * nsamples
+                shape = kernel.shape
+                extent = domain.cell_sides * shape
                 kernel_space = uniform_discr_fromdiscr(
-                    domain, min_corner=-extent / 2, max_corner=extent / 2,
-                    nsamples=nsamples)
+                    domain, min_pt=-extent / 2, shape=shape)
                 kernel = kernel_space.element(kernel)
                 range = domain
                 return kernel, range
@@ -770,11 +770,11 @@ class RealSpaceConvolution(Convolution):
     def adjoint(self):
         """Adjoint operator defined by the reversed kernel."""
         # Make space for the adjoint kernel, -S if S is the kernel space
-        adj_min_corner = -self._kernel.space.max_corner
-        adj_max_corner = -self._kernel.space.min_corner
+        adj_min_pt = -self._kernel.space.max_pt
+        adj_max_pt = -self._kernel.space.min_pt
         adj_ker_space = uniform_discr_fromdiscr(
             self._kernel.space,
-            min_corner=adj_min_corner, max_corner=adj_max_corner)
+            min_pt=adj_min_pt, max_pt=adj_max_pt)
 
         # Adjoint kernel is k_adj(x) = k(-x), i.e. the kernel array is
         # reversed in each axis.
@@ -817,9 +817,8 @@ def zero_centered_discr_fromdiscr(discr, shape=None):
                                              param_conv=safe_int_conv)
     else:
         shape = discr.shape
-    new_min_corner = -(discr.cell_sides * shape) / 2
-    return uniform_discr_fromdiscr(discr, min_corner=new_min_corner,
-                                   nsamples=shape)
+    new_min_pt = -(discr.cell_sides * shape) / 2
+    return uniform_discr_fromdiscr(discr, min_pt=new_min_pt, shape=shape)
 
 
 if __name__ == '__main__':

--- a/odl/trafos/fourier.py
+++ b/odl/trafos/fourier.py
@@ -87,8 +87,13 @@ class DiscreteFourierTransformBase(Operator):
             Otherwise, calculate the full complex FFT. If ``dom_dtype``
             is a complex type, this option has no effect.
         impl : {'numpy', 'pyfftw'}
-            Backend for the FFT implementation. The 'pyfftw' backend
-            is faster but requires the ``pyfftw`` package.
+            Backend for the FFT implementation.
+
+            ``'numpy'`` : Use Numpy/Scipy FFT.
+
+            ``'pyfftw'`` : Use the `pyFFTW
+            <https://hgomersall.github.io/pyFFTW/>`_ backend based on FFTW.
+            It is much faster but requires the ``pyfftw`` package.
         """
         if not isinstance(domain, DiscreteLp):
             raise TypeError('`domain` {!r} is not a `DiscreteLp` instance'
@@ -170,7 +175,6 @@ class DiscreteFourierTransformBase(Operator):
         --------
         pyfftw_call : Call pyfftw backend directly
         """
-        # TODO: Implement zero padding
         if self.impl == 'numpy':
             out[:] = self._call_numpy(x.asarray())
         else:
@@ -220,7 +224,7 @@ class DiscreteFourierTransformBase(Operator):
         raise NotImplementedError('abstract method')
 
     def _call_numpy(self, x):
-        """Return ``self(x)`` using numpy.
+        """Return ``self(x)`` using the default Numpy/Scipy backend.
 
         Parameters
         ----------
@@ -413,8 +417,13 @@ class DiscreteFourierTransform(DiscreteFourierTransformBase):
             Otherwise, calculate the full complex FFT. If ``dom_dtype``
             is a complex type, this option has no effect.
         impl : {'numpy', 'pyfftw'}
-            Backend for the FFT implementation. The ``'pyfftw'`` backend
-            is faster but requires the ``pyfftw`` package.
+            Backend for the FFT implementation.
+
+            ``'numpy'`` : Use Numpy/Scipy FFT.
+
+            ``'pyfftw'`` : Use the `pyFFTW
+            <https://hgomersall.github.io/pyFFTW/>`_ backend based on FFTW.
+            It is much faster but requires the ``pyfftw`` package.
 
         Examples
         --------
@@ -444,7 +453,7 @@ class DiscreteFourierTransform(DiscreteFourierTransformBase):
                          sign=sign, halfcomplex=halfcomplex, impl=impl)
 
     def _call_numpy(self, x):
-        """Return ``self(x)`` using numpy.
+        """Return ``self(x)`` using the default Numpy/Scipy backend.
 
         See Also
         --------
@@ -467,7 +476,7 @@ class DiscreteFourierTransform(DiscreteFourierTransformBase):
 
         See Also
         --------
-        DiscreteFourierTransformBase._call_numpy
+        DiscreteFourierTransformBase._call_pyfftw
         """
         assert isinstance(x, np.ndarray)
         assert isinstance(out, np.ndarray)
@@ -562,8 +571,13 @@ class DiscreteFourierTransformInverse(DiscreteFourierTransformBase):
             Otherwise, domain and range have the same shape. If
             ``range`` is a complex space, this option has no effect.
         impl : {'numpy', 'pyfftw'}
-            Backend for the FFT implementation. The 'pyfftw' backend
-            is faster but requires the ``pyfftw`` package.
+            Backend for the FFT implementation.
+
+            ``'numpy'`` : Use Numpy/Scipy FFT.
+
+            ``'pyfftw'`` : Use the `pyFFTW
+            <https://hgomersall.github.io/pyFFTW/>`_ backend based on FFTW.
+            It is much faster but requires the ``pyfftw`` package.
 
         Examples
         --------
@@ -593,7 +607,7 @@ class DiscreteFourierTransformInverse(DiscreteFourierTransformBase):
                          sign=sign, halfcomplex=halfcomplex, impl=impl)
 
     def _call_numpy(self, x):
-        """Return ``self(x)`` using numpy.
+        """Return ``self(x)`` using the default Numpy/Scipy backend.
 
         Parameters
         ----------
@@ -730,9 +744,15 @@ class FourierTransformBase(Operator):
             exponent is chosen to be the conjugate ``p / (p - 1)``,
             which reads as 'inf' for p=1 and 1 for p='inf'.
         impl : {'numpy', 'pyfftw'}
-            Backend for the FFT implementation. The 'pyfftw' backend
-            is faster but requires the ``pyfftw`` package.
-        axes : int or sequence of ints, optional
+            Backend for the FFT implementation.
+
+            ``'numpy'`` : Use Numpy/Scipy FFT.
+
+            ``'pyfftw'`` : Use the `pyFFTW
+            <https://hgomersall.github.io/pyFFTW/>`_ backend based on FFTW.
+            It is much faster but requires the ``pyfftw`` package.
+
+        axes : int or `sequence` of ints, optional
             Dimensions along which to take the transform.
             Default: all axes
         sign : {'-', '+'}, optional
@@ -799,7 +819,9 @@ class FourierTransformBase(Operator):
                 ''.format(domain.dspace))
 
         # axes
-        axes = kwargs.pop('axes', np.arange(domain.ndim))
+        axes = kwargs.pop('axes', None)
+        if axes is None:
+            axes = np.arange(domain.ndim)
         self.__axes = normalized_axes_tuple(axes, domain.ndim)
 
         # Implementation
@@ -881,7 +903,6 @@ class FourierTransformBase(Operator):
         --------
         pyfftw_call : Call pyfftw backend directly
         """
-        # TODO: Implement zero padding
         if self.impl == 'numpy':
             out[:] = self._call_numpy(x.asarray())
         else:
@@ -889,7 +910,7 @@ class FourierTransformBase(Operator):
             out[:] = self._call_pyfftw(x.asarray(), out.asarray(), **kwargs)
 
     def _call_numpy(self, x):
-        """Return ``self(x)`` for numpy back-end.
+        """Return ``self(x)`` using the default Numpy/Scipy backend.
 
         Parameters
         ----------
@@ -1169,9 +1190,15 @@ class FourierTransform(FourierTransformBase):
             exponent is chosen to be the conjugate ``p / (p - 1)``,
             which reads as 'inf' for p=1 and 1 for p='inf'.
         impl : {'numpy', 'pyfftw'}
-            Backend for the FFT implementation. The 'pyfftw' backend
-            is faster but requires the ``pyfftw`` package.
-        axes : int or sequence of ints, optional
+            Backend for the FFT implementation.
+
+            ``'numpy'`` : Use Numpy/Scipy FFT.
+
+            ``'pyfftw'`` : Use the `pyFFTW
+            <https://hgomersall.github.io/pyFFTW/>`_ backend based on FFTW.
+            It is much faster but requires the ``pyfftw`` package.
+
+        axes : int or `sequence` of ints, optional
             Dimensions along which to take the transform.
             Default: all axes
         sign : {'-', '+'}, optional
@@ -1404,9 +1431,15 @@ class FourierTransformInverse(FourierTransformBase):
             The exponent is chosen to be the conjugate ``p / (p - 1)``,
             which reads as 'inf' for p=1 and 1 for p='inf'.
         impl : {'numpy', 'pyfftw'}
-            Backend for the FFT implementation. The 'pyfftw' backend
-            is faster but requires the ``pyfftw`` package.
-        axes : int or sequence of ints, optional
+            Backend for the FFT implementation.
+
+            ``'numpy'`` : Use Numpy/Scipy FFT.
+
+            ``'pyfftw'`` : Use the `pyFFTW
+            <https://hgomersall.github.io/pyFFTW/>`_ backend based on FFTW.
+            It is much faster but requires the ``pyfftw`` package.
+
+        axes : int or `sequence` of ints, optional
             Dimensions along which to take the transform.
             Default: all axes
         sign : {'-', '+'}, optional
@@ -1513,7 +1546,7 @@ class FourierTransformInverse(FourierTransformBase):
             x, shift=self.shifts, axes=self.axes, sign=self.sign, out=out)
 
     def _call_numpy(self, x):
-        """Return ``self(x)`` for numpy back-end.
+        """Return ``self(x)`` using the default Numpy/Scipy backend.
 
         Parameters
         ----------

--- a/test/trafos/convolution_test.py
+++ b/test/trafos/convolution_test.py
@@ -62,9 +62,6 @@ def test_real_conv_init_errors():
         nonuni_discr = odl.DiscreteLp(fspace, part, odl.rn(3))
         odl.trafos.RealSpaceConvolution(nonuni_discr, [1, 1, 1])
 
-    with pytest.raises(NotImplementedError):
-        odl.trafos.RealSpaceConvolution(discr, small_ker_arr, range=discr)
-
 
 def test_real_conv_range():
 

--- a/test/trafos/convolution_test.py
+++ b/test/trafos/convolution_test.py
@@ -15,7 +15,7 @@
 # You should have received a copy of the GNU General Public License
 # along with ODL.  If not, see <http://www.gnu.org/licenses/>.
 
-"""Unit tests for `tensor_ops`."""
+"""Unit tests for convolutions."""
 
 # Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
@@ -24,108 +24,271 @@ standard_library.install_aliases()
 
 import pytest
 import numpy as np
+from scipy.signal import convolve
 
 import odl
-from odl.discr.discr_ops import Convolution
-from odl.util.testutils import all_almost_equal_array
+from odl.util.testutils import all_almost_equal
 
 
-# ---- Convolution ---- #
+# ---- RealSpaceConvolution ---- #
 
 
-ker_array = np.zeros((8, 8))
-ker_array[4:5, 4:5] = 1
+def test_real_conv_init_errors():
+    # Test if init code runs and errors are raised properly
 
+    discr = odl.uniform_discr([-1, 0], [1, 1], [5, 10])
+    subdiscr = odl.uniform_discr_fromdiscr(discr, nsamples=[3, 3])
 
-array_in = np.zeros((8, 8))
-array_in[3, 5] = 1
+    full_ker = discr.one()
+    full_ker_arr = full_ker.asarray()
+    small_ker = subdiscr.one()
+    small_ker_arr = small_ker.asarray()
 
+    odl.trafos.RealSpaceConvolution(discr, full_ker)
+    odl.trafos.RealSpaceConvolution(discr, full_ker_arr)
+    odl.trafos.RealSpaceConvolution(discr, small_ker)
+    odl.trafos.RealSpaceConvolution(discr, small_ker_arr)
 
-def kernel(x):
-    scaled_x = [xi / (np.sqrt(2) * 0.1) for xi in x]
-    sq_sum = sum(xi ** 2 for xi in scaled_x)
-    return np.exp(-sq_sum) / (2 * np.pi * 0.1 ** 2)
+    cdiscr = odl.uniform_discr([-1, 0], [1, 1], [5, 10], dtype=complex)
+    odl.trafos.RealSpaceConvolution(cdiscr, small_ker_arr)
 
-
-def kernel_autoconv(x):
-    scaled_x = [xi / (2 * 0.1) for xi in x]
-    sq_sum = sum(xi ** 2 for xi in scaled_x)
-    return np.exp(-sq_sum) / (4 * np.pi * 0.1 ** 2)
-
-
-def test_convolution_init_properties():
-    # Checking if code runs at all
-
-    # Real
-    space = odl.uniform_discr([-1, -1], [1, 1], (8, 8))
-    ft = odl.trafos.FourierTransform(space)
-
-    Convolution(space, kernel)
-    Convolution(space, space.element(kernel))
-    Convolution(space, kernel, kernel_mode='real')
-    Convolution(space, kernel, kernel_mode='real', impl='default_ft')
-    Convolution(space, kernel, kernel_mode='real', impl='scipy_convolve')
-    Convolution(space, kernel, kernel_mode='real', impl='scipy_fftconvolve')
-    Convolution(space, kernel, kernel_mode='real', axes=(1,))
-    Convolution(space, kernel, kernel_mode='real', impl='default_ft',
-                axes=(1,))
-    Convolution(space, kernel, kernel_mode='real', impl='scipy_convolve',
-                axes=(1,))
-    Convolution(space, kernel, kernel_mode='real', impl='scipy_fftconvolve',
-                axes=(1,))
-    Convolution(space, kernel, kernel_mode='ft')
-    Convolution(space, kernel, kernel_mode='ft', axes=(1,))
-    Convolution(space, kernel, kernel_mode='ft_hc')
-    Convolution(space, kernel, kernel_mode='ft_hc', axes=(1,))
-    Convolution(space, ft.range.element(kernel), kernel_mode='ft_hc')
-
-    # Bad parameter values
-    with pytest.raises(ValueError):
-        Convolution(space, kernel, kernel_mode='fourier')
+    with pytest.raises(TypeError):
+        odl.trafos.RealSpaceConvolution(odl.Rn(5), [1, 1, 1])
 
     with pytest.raises(ValueError):
-        Convolution(space, kernel, impl='scipy')
+        fspace = odl.FunctionSpace(odl.Interval(0, 1))
+        grid = odl.TensorGrid([0, 0.4, 1])
+        part = odl.RectPartition(fspace.domain, grid)
+        nonuni_discr = odl.DiscreteLp(fspace, part, odl.Rn(3))
+        odl.trafos.RealSpaceConvolution(nonuni_discr, [1, 1, 1])
 
-    # Invalid combinations
-    with pytest.raises(ValueError):
-        Convolution(space, kernel, kernel_mode='ft', impl='scipy_convolve')
-
-    with pytest.raises(ValueError):
-        Convolution(space, kernel, kernel_mode='ft', impl='scipy_fftconvolve')
-
-    with pytest.raises(ValueError):
-        Convolution(space, kernel, kernel_mode='ft_hc', impl='scipy_convolve')
-
-    with pytest.raises(ValueError):
-        Convolution(space, kernel, kernel_mode='ft_hc',
-                    impl='scipy_fftconvolve')
-
-    # Custom range not implemented
     with pytest.raises(NotImplementedError):
-        Convolution(space, kernel, ran=space)
+        odl.trafos.RealSpaceConvolution(discr, small_ker_arr, range=discr)
 
 
-var_params = [('real', 'default_ft'), ('real', 'scipy_convolve'),
-              ('real', 'scipy_fftconvolve'), ('ft', 'default_ft'),
-              ('ft_hc', 'default_ft')]
-var_ids = ['kernel_mode = {}, impl = {}'.format(mode, impl)
-           for (mode, impl) in var_params]
+def test_real_conv_range():
+
+    # midpoint: [0.0, 0.5]
+    discr = odl.uniform_discr([-1, 0], [1, 1], [5, 10])
+    # midpoint: [0.6, 0.15]
+    subdiscr = odl.uniform_discr_fromdiscr(discr, min_corner=[0, 0],
+                                           nsamples=[3, 3])
+
+    full_ker = discr.one()
+    full_ker_arr = full_ker.asarray()
+    small_ker = subdiscr.one()
+    small_ker_arr = small_ker.asarray()
+
+    def func_ker(x):
+        return sum(x)
+
+    # arrays and callables lead to domain == range
+    conv_full_arr = odl.trafos.RealSpaceConvolution(discr, full_ker_arr)
+    assert conv_full_arr.range == conv_full_arr.domain
+    conv_small_arr = odl.trafos.RealSpaceConvolution(discr, small_ker_arr)
+    assert conv_small_arr.range == conv_small_arr.domain
+    conv_func = odl.trafos.RealSpaceConvolution(discr, func_ker)
+    assert conv_func.range == conv_func.domain
+
+    # elements of discr a subspace induce a translation
+    conv_full = odl.trafos.RealSpaceConvolution(discr, full_ker)
+    true_range = odl.uniform_discr_fromdiscr(discr, min_corner=[None, 0.5])
+    assert conv_full.range.partition.approx_equals(true_range.partition,
+                                                   atol=1e-6)
+    conv_small = odl.trafos.RealSpaceConvolution(discr, small_ker)
+    true_range = odl.uniform_discr_fromdiscr(discr, min_corner=[-0.4, 0.15])
+    assert conv_small.range.partition.approx_equals(true_range.partition,
+                                                    atol=1e-6)
 
 
-@pytest.fixture(scope="module", ids=var_ids, params=var_params)
-def variant(request):
-    return request.param
+def test_real_conv_kernel():
+
+    discr = odl.uniform_discr([-1, 0], [1, 1], [5, 10])
+    subdiscr = odl.uniform_discr_fromdiscr(discr, min_corner=[0, 0],
+                                           nsamples=[3, 3])
+    std_ker_discr = odl.uniform_discr([-1, -0.5], [1, 0.5], [5, 10])
+
+    full_ker = discr.one()
+    full_ker_arr = full_ker.asarray()
+    small_ker = subdiscr.one()
+    small_ker_arr = small_ker.asarray()
+
+    def func_ker(x):
+        return sum(x)
+
+    conv_full = odl.trafos.RealSpaceConvolution(discr, full_ker)
+    assert conv_full.kernel() == full_ker
+
+    conv_full_arr = odl.trafos.RealSpaceConvolution(discr, full_ker_arr)
+    assert np.array_equal(conv_full_arr.kernel(), full_ker_arr)
+    assert np.allclose(conv_full_arr.kernel().space.partition.midpoint, 0)
+    assert conv_full_arr.kernel().shape == discr.shape
+
+    conv_small = odl.trafos.RealSpaceConvolution(discr, small_ker)
+    assert conv_small.kernel() == small_ker
+
+    conv_small_arr = odl.trafos.RealSpaceConvolution(discr, small_ker_arr)
+    assert np.array_equal(conv_small_arr.kernel(), small_ker_arr)
+    assert np.allclose(conv_small_arr.kernel().space.partition.midpoint, 0)
+    assert conv_small_arr.kernel().shape == subdiscr.shape
+
+    conv_func = odl.trafos.RealSpaceConvolution(discr, func_ker)
+    assert conv_func.kernel().space == std_ker_discr
+    assert all_almost_equal(conv_func.kernel(),
+                            std_ker_discr.element(func_ker))
+
+    def func_ker_p(x, **kwargs):
+        p = kwargs.pop('p', 1.0)
+        return x[0] + p * x[1]
+
+    conv_func_p = odl.trafos.RealSpaceConvolution(discr, func_ker_p)
+    assert all_almost_equal(conv_func_p.kernel(),
+                            std_ker_discr.element(func_ker_p, p=1.0))
+
+    conv_func_p = odl.trafos.RealSpaceConvolution(
+        discr, func_ker_p, kernel_kwargs={'p': 0.5})
+    assert all_almost_equal(conv_func_p.kernel(),
+                            std_ker_discr.element(func_ker_p, p=0.5))
 
 
-def test_convolution_call(variant):
-    mode, impl = variant
+def test_real_conv_resampling():
 
-    space = odl.uniform_discr([-2, -2], [2, 2], (8, 8))
-    conv = Convolution(space, kernel=ker_array, kernel_mode=mode, impl=impl)
+    discr = odl.uniform_discr([-1, 0], [1, 1], [5, 10])
+    ker_discr = odl.uniform_discr([-1, -0.25], [1, 0.25], [20, 2])
+    kernel = ker_discr.one()
 
-    true_conv_img = space.element(kernel_autoconv)
-    conv_img = conv(kernel)
-    assert all_almost_equal_array(autoconv, true_autoconv, places=7)
+    cs_up = [0.1, 0.1]
+    discr_up = odl.uniform_discr_fromdiscr(discr, cell_sides=cs_up)
+    ker_discr_up = odl.uniform_discr_fromdiscr(ker_discr, cell_sides=cs_up)
+    conv_up = odl.trafos.RealSpaceConvolution(discr, kernel, resample='up')
+    assert conv_up._domain_resampling_op.domain == discr
+    assert conv_up._domain_resampling_op.range == discr_up
+    assert conv_up._kernel_resampling_op.domain == ker_discr
+    assert conv_up._kernel_resampling_op.range == ker_discr_up
+
+    cs_down = [0.4, 0.25]
+    discr_down = odl.uniform_discr_fromdiscr(discr, cell_sides=cs_down)
+    ker_discr_down = odl.uniform_discr_fromdiscr(ker_discr, cell_sides=cs_down)
+    conv_down = odl.trafos.RealSpaceConvolution(discr, kernel, resample='down')
+    assert conv_down._domain_resampling_op.domain == discr
+    assert conv_down._domain_resampling_op.range == discr_down
+    assert conv_down._kernel_resampling_op.domain == ker_discr
+    assert conv_down._kernel_resampling_op.range == ker_discr_down
+
+    cs_ud = [0.1, 0.25]
+    discr_ud = odl.uniform_discr_fromdiscr(discr, cell_sides=cs_ud)
+    ker_discr_ud = odl.uniform_discr_fromdiscr(ker_discr, cell_sides=cs_ud)
+    conv_ud = odl.trafos.RealSpaceConvolution(discr, kernel,
+                                              resample=['up', 'down'])
+    assert conv_ud._domain_resampling_op.domain == discr
+    assert conv_ud._domain_resampling_op.range == discr_ud
+    assert conv_ud._kernel_resampling_op.domain == ker_discr
+    assert conv_ud._kernel_resampling_op.range == ker_discr_ud
+
+    cs_du = [0.4, 0.1]
+    discr_du = odl.uniform_discr_fromdiscr(discr, cell_sides=cs_du)
+    ker_discr_du = odl.uniform_discr_fromdiscr(ker_discr, cell_sides=cs_du)
+    conv_du = odl.trafos.RealSpaceConvolution(discr, kernel,
+                                              resample=['down', 'up'])
+    assert conv_du._domain_resampling_op.domain == discr
+    assert conv_du._domain_resampling_op.range == discr_du
+    assert conv_du._kernel_resampling_op.domain == ker_discr
+    assert conv_du._kernel_resampling_op.range == ker_discr_du
+
+
+def test_real_conv_call_1d():
+
+    discr = odl.uniform_discr(0, 1, 5)
+    ker_array = np.ones(3)
+    conv = odl.trafos.RealSpaceConvolution(discr, ker_array)
+
+    def char(x):
+        return (x[0] >= 0) & (x[0] <= 0.5)
+
+    func = discr.element(char)
+    func_arr = func.asarray()
+    scaling = discr.cell_volume
+    assert np.allclose(conv(func),
+                       scaling * convolve(func_arr, ker_array, mode='same'))
+
+    # Switched roles
+    discr = odl.uniform_discr(0, 1, 3)
+    scaling = discr.cell_volume
+    conv = odl.trafos.RealSpaceConvolution(discr, func_arr)
+    assert np.allclose(conv(ker_array),
+                       scaling * convolve(ker_array, func_arr, mode='same'))
+
+
+def test_real_conv_call_2d():
+
+    discr = odl.uniform_discr([-1, 0], [1, 1], [5, 10])
+    ker_array = np.ones((3, 3))
+    conv = odl.trafos.RealSpaceConvolution(discr, ker_array)
+
+    def rectangle(x):
+        return (x[0] >= 0) & (x[0] <= 0.5) & (x[1] >= 0.5) & (x[1] <= 1)
+
+    func = discr.element(rectangle)
+    func_arr = func.asarray()
+    scaling = discr.cell_volume
+    assert np.allclose(conv(func),
+                       scaling * convolve(func_arr, ker_array, mode='same'))
+
+
+def test_real_conv_adjoint_1d():
+
+    discr = odl.uniform_discr(0, 1, 5)
+    ker_array = np.array([-1, 0, 1], dtype=float)
+    ker_elem = discr.element([0, -1, 0, 1, 0])
+    adj_ker_array = np.array([1, 0, -1], dtype=float)
+    adj_ker_elem = discr.element([0, 1, 0, -1, 0])
+
+    def char(x):
+        return (x[0] >= 0) & (x[0] <= 0.5)
+
+    conv_elem = odl.trafos.RealSpaceConvolution(discr, ker_elem)
+    conv_elem_adj = conv_elem.adjoint
+    dom_elem = discr.element(char)
+    ran_elem = conv_elem.range.one()
+    assert conv_elem_adj.domain == conv_elem.range
+    assert conv_elem_adj.range == conv_elem.domain
+    assert np.allclose(conv_elem_adj.kernel(), adj_ker_elem)
+    assert np.isclose(conv_elem(dom_elem).inner(ran_elem),
+                      dom_elem.inner(conv_elem_adj(ran_elem)))
+
+    conv_arr = odl.trafos.RealSpaceConvolution(discr, ker_array)
+    conv_arr_adj = conv_arr.adjoint
+    dom_elem = discr.element(char)
+    ran_elem = conv_arr.range.one()
+    assert conv_arr_adj.domain == conv_arr.range
+    assert conv_arr_adj.range == conv_arr.domain
+    assert np.allclose(conv_arr_adj.kernel(), adj_ker_array)
+    assert np.isclose(conv_arr(dom_elem).inner(ran_elem),
+                      dom_elem.inner(conv_arr_adj(ran_elem)))
+
+
+def test_real_conv_adjoint_2d():
+
+    discr = odl.uniform_discr([-1, 0], [1, 1], [5, 10])
+    ker_array = np.array([[0, 1, 0],
+                          [-1, 0, 1],
+                          [0, -1, 0]], dtype=float)
+    adj_ker_array = np.array([[0, -1, 0],
+                              [1, 0, -1],
+                              [0, 1, 0]], dtype=float)
+
+    def char(x):
+        return (x[0] > 0) & (x[0] < 0.5) & (x[1] >= 0) & (x[1] <= 0.5)
+
+    conv = odl.trafos.RealSpaceConvolution(discr, ker_array)
+    conv_adj = conv.adjoint
+    dom_elem = discr.element(char)
+    ran_elem = conv.range.one()
+    assert conv_adj.domain == conv.range
+    assert conv_adj.range == conv.domain
+    assert np.allclose(conv_adj.kernel(), adj_ker_array)
+    assert np.isclose(conv(dom_elem).inner(ran_elem),
+                      dom_elem.inner(conv_adj(ran_elem)))
 
 
 if __name__ == '__main__':

--- a/test/trafos/convolution_test.py
+++ b/test/trafos/convolution_test.py
@@ -179,7 +179,7 @@ def test_real_conv_resampling():
     discr_ud = odl.uniform_discr_fromdiscr(discr, cell_sides=cs_ud)
     ker_discr_ud = odl.uniform_discr_fromdiscr(ker_discr, cell_sides=cs_ud)
     conv_ud = odl.trafos.RealSpaceConvolution(discr, kernel,
-                                              resample=['up', 'down'])
+                                              resample=['UP', 'DOWN'])
     assert conv_ud._domain_resampling_op.domain == discr
     assert conv_ud._domain_resampling_op.range == discr_ud
     assert conv_ud._kernel_resampling_op.domain == ker_discr

--- a/test/trafos/convolution_test.py
+++ b/test/trafos/convolution_test.py
@@ -1,0 +1,132 @@
+# Copyright 2014-2016 The ODL development group
+#
+# This file is part of ODL.
+#
+# ODL is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# ODL is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with ODL.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Unit tests for `tensor_ops`."""
+
+# Imports for common Python 2/3 codebase
+from __future__ import print_function, division, absolute_import
+from future import standard_library
+standard_library.install_aliases()
+
+import pytest
+import numpy as np
+
+import odl
+from odl.discr.discr_ops import Convolution
+from odl.util.testutils import all_almost_equal_array
+
+
+# ---- Convolution ---- #
+
+
+ker_array = np.zeros((8, 8))
+ker_array[4:5, 4:5] = 1
+
+
+array_in = np.zeros((8, 8))
+array_in[3, 5] = 1
+
+
+def kernel(x):
+    scaled_x = [xi / (np.sqrt(2) * 0.1) for xi in x]
+    sq_sum = sum(xi ** 2 for xi in scaled_x)
+    return np.exp(-sq_sum) / (2 * np.pi * 0.1 ** 2)
+
+
+def kernel_autoconv(x):
+    scaled_x = [xi / (2 * 0.1) for xi in x]
+    sq_sum = sum(xi ** 2 for xi in scaled_x)
+    return np.exp(-sq_sum) / (4 * np.pi * 0.1 ** 2)
+
+
+def test_convolution_init_properties():
+    # Checking if code runs at all
+
+    # Real
+    space = odl.uniform_discr([-1, -1], [1, 1], (8, 8))
+    ft = odl.trafos.FourierTransform(space)
+
+    Convolution(space, kernel)
+    Convolution(space, space.element(kernel))
+    Convolution(space, kernel, kernel_mode='real')
+    Convolution(space, kernel, kernel_mode='real', impl='default_ft')
+    Convolution(space, kernel, kernel_mode='real', impl='scipy_convolve')
+    Convolution(space, kernel, kernel_mode='real', impl='scipy_fftconvolve')
+    Convolution(space, kernel, kernel_mode='real', axes=(1,))
+    Convolution(space, kernel, kernel_mode='real', impl='default_ft',
+                axes=(1,))
+    Convolution(space, kernel, kernel_mode='real', impl='scipy_convolve',
+                axes=(1,))
+    Convolution(space, kernel, kernel_mode='real', impl='scipy_fftconvolve',
+                axes=(1,))
+    Convolution(space, kernel, kernel_mode='ft')
+    Convolution(space, kernel, kernel_mode='ft', axes=(1,))
+    Convolution(space, kernel, kernel_mode='ft_hc')
+    Convolution(space, kernel, kernel_mode='ft_hc', axes=(1,))
+    Convolution(space, ft.range.element(kernel), kernel_mode='ft_hc')
+
+    # Bad parameter values
+    with pytest.raises(ValueError):
+        Convolution(space, kernel, kernel_mode='fourier')
+
+    with pytest.raises(ValueError):
+        Convolution(space, kernel, impl='scipy')
+
+    # Invalid combinations
+    with pytest.raises(ValueError):
+        Convolution(space, kernel, kernel_mode='ft', impl='scipy_convolve')
+
+    with pytest.raises(ValueError):
+        Convolution(space, kernel, kernel_mode='ft', impl='scipy_fftconvolve')
+
+    with pytest.raises(ValueError):
+        Convolution(space, kernel, kernel_mode='ft_hc', impl='scipy_convolve')
+
+    with pytest.raises(ValueError):
+        Convolution(space, kernel, kernel_mode='ft_hc',
+                    impl='scipy_fftconvolve')
+
+    # Custom range not implemented
+    with pytest.raises(NotImplementedError):
+        Convolution(space, kernel, ran=space)
+
+
+var_params = [('real', 'default_ft'), ('real', 'scipy_convolve'),
+              ('real', 'scipy_fftconvolve'), ('ft', 'default_ft'),
+              ('ft_hc', 'default_ft')]
+var_ids = ['kernel_mode = {}, impl = {}'.format(mode, impl)
+           for (mode, impl) in var_params]
+
+
+@pytest.fixture(scope="module", ids=var_ids, params=var_params)
+def variant(request):
+    return request.param
+
+
+def test_convolution_call(variant):
+    mode, impl = variant
+
+    space = odl.uniform_discr([-2, -2], [2, 2], (8, 8))
+    conv = Convolution(space, kernel=ker_array, kernel_mode=mode, impl=impl)
+
+    true_conv_img = space.element(kernel_autoconv)
+    conv_img = conv(kernel)
+    assert all_almost_equal_array(autoconv, true_autoconv, places=7)
+
+
+if __name__ == '__main__':
+    pytest.main(str(__file__.replace('\\', '/')) + ' -v')

--- a/test/trafos/convolution_test.py
+++ b/test/trafos/convolution_test.py
@@ -53,13 +53,13 @@ def test_real_conv_init_errors():
     odl.trafos.RealSpaceConvolution(cdiscr, small_ker_arr)
 
     with pytest.raises(TypeError):
-        odl.trafos.RealSpaceConvolution(odl.Rn(5), [1, 1, 1])
+        odl.trafos.RealSpaceConvolution(odl.rn(5), [1, 1, 1])
 
     with pytest.raises(ValueError):
         fspace = odl.FunctionSpace(odl.Interval(0, 1))
         grid = odl.TensorGrid([0, 0.4, 1])
         part = odl.RectPartition(fspace.domain, grid)
-        nonuni_discr = odl.DiscreteLp(fspace, part, odl.Rn(3))
+        nonuni_discr = odl.DiscreteLp(fspace, part, odl.rn(3))
         odl.trafos.RealSpaceConvolution(nonuni_discr, [1, 1, 1])
 
     with pytest.raises(NotImplementedError):


### PR DESCRIPTION
The real-space convolution is fully working now and could use a design review. Here's a quick summary of its behavior with respect to the different possibilities a kernel can be provided:
1. **As a `DiscreteLpVector`.** The kernel has information about its own function domain, which results in the convolution operator to map to a translated space, where the shift is the midpoint of the kernel domain. The reason for this is that mathematically, the region shifted in this way contains the main "mass" of the convolved function.
2. **As a `callable`.** In this case, a "standard" kernel space is created, which is a zero-centered version of the operator domain (same cell sizes and shape). The operator range is the same as the domain.
3. **As an array-like.** Similarly to case 2, a standard zero-centered kernel space is created, but this time with the same shape as the given array. This is actually the most useful (=efficient) case when one wants to calculate a convolution with a very small kernel.

The Fourier-based convolution is currently not functioning, ignore it for now.
