### PR TITLE
Improvements to DiscreteLp.element

### DIFF
--- a/odl/discr/discretization.py
+++ b/odl/discr/discretization.py
@@ -164,7 +164,7 @@ class DiscretizedSet(NtuplesBase):
         Parameters
         ----------
         inp : optional
-            The input data to create an element from. It needs to be
+            Input data to create an element from. It needs to be
             understood by either the `sampling` operator of this
             instance or by its ``dspace.element`` method.
         kwargs :

--- a/odl/discr/lp_discr.py
+++ b/odl/discr/lp_discr.py
@@ -234,13 +234,13 @@ class DiscreteLp(DiscretizedSpace):
         Parameters
         ----------
         inp : optional
-            The input data to create an element from.
+            Input data to create an element from.
 
             If `callable`, it needs to be understood by the ``uspace.element``
             method.
 
-            Otherwise, it has to be understandable by the
-            ``dspace.element`` method.
+            Otherwise, it has to be understood by the ``dspace.element``
+            method.
         kwargs :
             Additional arguments passed on to `sampling` when called
             on ``inp``, in the form ``sampling(inp, **kwargs)``.
@@ -249,8 +249,10 @@ class DiscreteLp(DiscretizedSpace):
         Other Parameters
         ----------------
         vectorized : `bool`
-            Can only be used if ``inp`` is `callable`, in that case, indicates
-            if ``inp`` is vectorized.
+            Can only be used if ``inp`` is `callable`, in which case it
+            indicates if ``inp`` is vectorized. If not, it will be wrapped
+            with a vectorizer.
+            Default: True
 
         Returns
         -------
@@ -274,10 +276,7 @@ class DiscreteLp(DiscretizedSpace):
         On the other hand, non-discretized objects like Python functions
         can be discretized "on the fly":
 
-        >>> def f(x):
-        ...     return x * 2
-        ...
-        >>> space.element(f)
+        >>> space.element(lambda x: x * 2)
         uniform_discr(-1.0, 1.0, 4).element([-1.5, -0.5, 0.5, 1.5])
 
         This works also with parameterized functions, however only

--- a/odl/discr/lp_discr.py
+++ b/odl/discr/lp_discr.py
@@ -234,13 +234,23 @@ class DiscreteLp(DiscretizedSpace):
         Parameters
         ----------
         inp : optional
-            The input data to create an element from. It needs to be
-            understood by either the `sampling` operator of this
-            instance or by its ``dspace.element`` method.
+            The input data to create an element from.
+
+            If `callable`, it needs to be understood by the ``uspace.element``
+            method.
+
+            Otherwise, it has to be understandable by the
+            ``dspace.element`` method.
         kwargs :
             Additional arguments passed on to `sampling` when called
             on ``inp``, in the form ``sampling(inp, **kwargs)``.
             This can be used e.g. for functions with parameters.
+
+        Other Parameters
+        ----------------
+        vectorized : `bool`
+            Can only be used if ``inp`` is `callable`, in that case, indicates
+            if ``inp`` is vectorized.
 
         Returns
         -------
@@ -293,8 +303,9 @@ class DiscreteLp(DiscretizedSpace):
         elif inp in self.dspace:
             return self.element_type(self, inp)
         elif callable(inp):
+            vectorized = kwargs.pop('vectorized', True)
             # uspace element -> discretize
-            inp_elem = self.uspace.element(inp)
+            inp_elem = self.uspace.element(inp, vectorized=vectorized)
             return self.element_type(self, self.sampling(inp_elem, **kwargs))
         else:
             # Sequence-type input

--- a/test/discr/lp_discr_test.py
+++ b/test/discr/lp_discr_test.py
@@ -277,6 +277,11 @@ def test_element_from_function_1d():
     true_elem = [-x ** 2 for x in points]
     assert all_equal(elem_lam, true_elem)
 
+    # Broadcast from constant function
+    elem_lam = space.element(lambda x: 1.0)
+    true_elem = [1.0 for x in points]
+    assert all_equal(elem_lam, true_elem)
+
     # Non vectorized
     elem_lam = space.element(lambda x: x[0], vectorized=False)
     assert all_equal(elem_lam, points)
@@ -320,6 +325,11 @@ def test_element_from_function_2d():
 
     elem_lam = space.element(lambda x: x[1])
     true_elem = [x[1] for x in points]
+    assert all_equal(elem_lam, true_elem)
+
+    # Broadcast from constant function
+    elem_lam = space.element(lambda x: 1.0)
+    true_elem = [1.0 for x in points]
     assert all_equal(elem_lam, true_elem)
 
     # Non vectorized

--- a/test/discr/lp_discr_test.py
+++ b/test/discr/lp_discr_test.py
@@ -277,6 +277,10 @@ def test_element_from_function_1d():
     true_elem = [-x ** 2 for x in points]
     assert all_equal(elem_lam, true_elem)
 
+    # Non vectorized
+    elem_lam = space.element(lambda x: x[0], vectorized=False)
+    assert all_equal(elem_lam, points)
+
 
 def test_element_from_function_2d():
 
@@ -316,6 +320,11 @@ def test_element_from_function_2d():
 
     elem_lam = space.element(lambda x: x[1])
     true_elem = [x[1] for x in points]
+    assert all_equal(elem_lam, true_elem)
+
+    # Non vectorized
+    elem_lam = space.element(lambda x: x[0] + x[1], vectorized=False)
+    true_elem = [x[0] + x[1] for x in points]
     assert all_equal(elem_lam, true_elem)
 
 


### PR DESCRIPTION
* Allow non-vectorized input by exposing the `vectorized` parameter.
* Allow scalar functions (e.g. `lambda x: 1.0`) as input to `DiscreteLp.element`.
* Also removed the old check in `DiscreteLp.element` that disallowed specifically the above (but only in 1d).
