### PR TITLE
Forward backward primal dual

### DIFF
--- a/examples/solvers/forward_backward_primal_dual_denoising.py
+++ b/examples/solvers/forward_backward_primal_dual_denoising.py
@@ -1,0 +1,69 @@
+# Copyright 2014-2016 The ODL development group
+#
+# This file is part of ODL.
+#
+# ODL is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# ODL is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with ODL.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Total variation denoising using the Forward-backward solver.
+
+Solves the optimization problem
+
+    min_{0 <= x <= 255}  1/2 ||x - g||_2^2 + lam || |grad(x)| ||_1
+
+where ``grad`` is the spatial gradient and ``g`` the given noisy data.
+"""
+
+import numpy as np
+import scipy.misc
+import odl
+import odl.solvers as odlsol
+
+# Parameters
+n = 256
+
+# Create a space
+space = odl.uniform_discr([0, 0], [n, n], [n, n])
+
+# Load image and noise
+data = space.element(np.rot90(scipy.misc.ascent()[::2, ::2], 3))
+noise = odl.phantom.white_noise(space) * 10.0
+
+# Create noisy data
+noisy_data = data + noise
+data.show('Original data')
+noisy_data.show('Noisy convolved data')
+
+
+# Gradient for TV regularization
+gradient = odl.Gradient(space)
+
+# Assemble all operators
+lin_ops = [gradient]
+
+# Create proximals as needed
+prox_cc_g = [odlsol.proximal_cconj_l1(gradient.range, lam=1e1,
+                                      isotropic=False)]
+prox_f = odlsol.proximal_box_constraint(space, 0, 255)
+
+# Create gradient needed. This is the derivative of the 2-norm squared
+grad_h = odl.ResidualOperator(odl.IdentityOperator(space), noisy_data)
+
+# Solve
+x = noisy_data.copy()
+
+callback = (odl.solvers.CallbackShow(display_step=20, clim=[0, 255]) &
+            odl.solvers.CallbackPrintIteration())
+
+odlsol.forward_backward_pd(x, prox_f, prox_cc_g, lin_ops, grad_h, tau=1.0,
+                           sigma=[0.01], niter=1000, callback=callback)

--- a/examples/solvers/forward_backward_primal_dual_denoising.py
+++ b/examples/solvers/forward_backward_primal_dual_denoising.py
@@ -32,8 +32,7 @@ import odl
 image = np.rot90(scipy.misc.ascent()[::2, ::2], 3)
 
 # Reading the size
-n = image.shape[0]
-m = image.shape[1]
+n, m = image.shape
 
 # Create a space
 space = odl.uniform_discr([0, 0], [n, m], [n, m])

--- a/odl/solvers/advanced/__init__.py
+++ b/odl/solvers/advanced/__init__.py
@@ -27,3 +27,6 @@ __all__ += chambolle_pock.__all__
 
 from .douglas_rachford import *
 __all__ += douglas_rachford.__all__
+
+from .forward_backward import *
+__all__ += forward_backward.__all__

--- a/odl/solvers/advanced/forward_backward.py
+++ b/odl/solvers/advanced/forward_backward.py
@@ -1,0 +1,165 @@
+# Copyright 2014-2016 The ODL development group
+#
+# This file is part of ODL.
+#
+# ODL is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# ODL is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with ODL.  If not, see <http://www.gnu.org/licenses/>.
+
+""" Implementation of the Forward-Backward splitting algorithm """
+
+
+# Imports for common Python 2/3 codebase
+from __future__ import print_function, division, absolute_import
+from future import standard_library
+standard_library.install_aliases()
+
+from odl.operator import Operator
+
+
+__all__ = ('forward_backward_pd',)
+
+
+def forward_backward_pd(x, prox_f, prox_cc_g, L, grad_h, tau, sigma, niter,
+                        callback=None, **kwargs):
+    """ The forward-backward primal-dual splitting algorithm
+
+    Minimizes the sum of several convex functions composed with linear
+    operators
+
+        ``min_x f(x) + sum_i g_i(L_i x) + h(x)``
+
+    Where f, g_i, h are convex functions, L_i are linear `Operator`'s, and h is
+    also differentiable.
+
+    Can also be used to solve the more general problem
+
+        ``min_x f(x) + sum_i (g_i @ l_i)(L_i x)``
+
+    where l_i are convex functions and @ is the infimal convolution:
+
+        ``(f @ g)(x) = inf_y { f(x-y) + g(y) }``
+
+    Parameters
+    ----------
+    x : `Vector`
+        Initial point
+    prox_f : `callable`
+        Funciton returning an `Operator` when called with `tau`.
+        The Operator should be the proximal of `tau * f`.
+    prox_cc_g : `sequence` of `callable`'s
+        Sequence of functions returning an operator when called with stepsize
+        `sigma`.
+        The Operator should be the proximal of `sigma_i * g_i^*`.
+    grad_h : `Operator`
+        Operators representing the gradient of  `h`.
+    L : `sequence` of `Operator`'s
+        A sequence with as many elements as ``prox__cc_gs`` of operators
+        ``L_i``
+    tau : `float`
+        Stepsize of ``f``
+    sigma : `sequence` of  `float`
+        Stepsize of the ``g_i``'s
+    niter : `int`
+        Number of iterations
+    callback : `Callback`, optional
+        Show partial results
+
+    Other Parameters
+    ----------------
+    grad_cc_l : `sequence` of `Operator`'s, optional
+        Sequence of operators representing the gradient of  `l_i^*`.
+        If omitted, the simpler problem will be considered, which corresponds
+        to the convex conjugate functionals of the l_i:s being zero functionals
+        and hence the gradient being the zero-operator.
+
+    Notes
+    -----
+    Strictly, we have the following conditions on the functions involved: f and
+    g_i are proper, convex and lower semicontinuous, and h is convex and
+    differentialbe with :math:`\\eta`-Lipschitz continuous gradient.
+
+    For the optional input l_i we need it to be proper, convex, lower
+    semicontinuous, and :math:`\\nu_i^{-1}`-strongly convex. The fact that l_i
+    is :math:`\\nu_i^{-1}`-strongly convex implies that the convex conjugate
+    functional of l_i is differentiable with :math:`\\nu_i`-Lipschitz
+    continuous gradient.
+
+    To guarantee convergence, the parameters ``tau``, ``sigma`` and
+    ``L`` need to satisfy
+
+    .. math::
+
+       2 * \min \{ \\frac{1}{\\tau}, \\frac{1}{\sigma_1}, \\ldots,
+       \\frac{1}{\sigma_m} \} * \min\{ \\eta, \\nu_1, \\ldots, \\nu_m  \} *
+       \\sqrt{1 - \\tau \\sum_{i=1}^n \\sigma_i ||L_i||^2} > 1
+
+    where, if the simpler problem is considered, all :math:`\\nu_i` can be
+    considered to be :math:`\\infty`.
+
+    For references on the Forward-Backward algorithm, see [BC2015]_.
+
+    For more on convex analysis including convex conjugates and
+    resolvent operators see [Roc1970]_.
+
+    For more on proximal operators and algorithms see [PB2014]_.
+    """
+
+    # Problem size
+    m = len(L)
+
+    # Validate input
+    if not all(isinstance(op, Operator) for op in L):
+        raise ValueError('`L` not a sequence of operators')
+    if not all(op.is_linear for op in L):
+        raise ValueError('not all operators in `L` are linear')
+    if not all(x in op.domain for op in L):
+        raise ValueError('`x` not in the domain of all operators')
+    if len(sigma) != m:
+        raise ValueError('len(sigma) != len(L)')
+    if len(prox_cc_g) != m:
+        raise ValueError('len(prox_cc_g) != len(L)')
+
+    # Get parameters from kwargs
+    grad_cc_l = kwargs.pop('prox_cc_l', None)
+    if grad_cc_l is not None and len(grad_cc_l) != m:
+        raise ValueError('`grad_cc_l` not same length as `L`')
+
+    # Check for unused parameters
+    if kwargs:
+        raise TypeError('unexpected keyword argument: {}'.format(kwargs))
+
+    # Pre-allocate values
+    v = [Li.range.zero() for Li in L]
+    y = x.space.zero()
+
+    # Iteratively solve
+    for k in range(niter):
+        x_old = x
+
+        tmp_1 = grad_h(x) + sum(Li.adjoint(vi) for Li, vi in zip(L, v))
+        prox_f(tau)(x - tau * tmp_1, out=x)
+        y.lincomb(2.0, x, -1, x_old)
+
+        for i in range(m):
+            # In this case gradients were given
+            if grad_cc_l is not None:
+                tmp_2 = sigma[i] * (L[i](y) + grad_cc_l[i](v[i]))
+
+            # In this case there were not. "Applying" zero-operator
+            else:
+                tmp_2 = sigma[i] * L[i](y)
+
+            v[i] = prox_cc_g[i](sigma[i])(v[i] + tmp_2)
+
+        if callback is not None:
+            callback(x)

--- a/odl/solvers/advanced/forward_backward.py
+++ b/odl/solvers/advanced/forward_backward.py
@@ -50,7 +50,7 @@ def forward_backward_pd(x, prox_f, prox_cc_g, L, grad_h, tau, sigma, niter,
 
         ``(g @ l)(x) = inf_y { g(y) + l(x-y) }``.
 
-    Note that the strong convetiy of ``l_i`` makes the convex conjugate
+    Note that the strong convexity of ``l_i`` makes the convex conjugate
     ``l_i^*`` differentialbe; see the Notes section for more information on
     this.
 
@@ -61,13 +61,13 @@ def forward_backward_pd(x, prox_f, prox_cc_g, L, grad_h, tau, sigma, niter,
     prox_f : `callable`
         `Proximal factory` for the functional ``f``.
     prox_cc_g : `sequence` of `callable`'s
-        Sequence of `proximal factories` for the convex conjuates of the
+        Sequence of `proximal factorie`'s for the convex conjuates of the
         functionals ``g_i``.
     grad_h : `Operator`
         Operator representing the gradient of  ``h``.
     L : `sequence` of `Operator`
-        Sequence with as many elements as ``prox_cc_gs`` of linear operators
-        ``L_i``.
+        Sequence of linear operators ``L_i``, with as many elements as
+        ``prox_cc_gs``.
     tau : `float`
         Step size-like parameter for ``prox_f``.
     sigma : `sequence` of  `float`
@@ -100,7 +100,7 @@ def forward_backward_pd(x, prox_f, prox_cc_g, L, grad_h, tau, sigma, niter,
 
     The exact conditions on the involved functionals are as follows: :math:`f`
     and :math:`g_i` are proper, convex and lower semicontinuous, and :math:`h`
-    is convex and differentialbe with :math:`\\eta^{-1}`-Lipschitz continuous
+    is convex and differentiable with :math:`\\eta^{-1}`-Lipschitz continuous
     gradient, :math:`\\eta > 0`.
 
     The optional operators :math:`\\nabla l_i^*` need to be

--- a/odl/solvers/advanced/forward_backward.py
+++ b/odl/solvers/advanced/forward_backward.py
@@ -43,11 +43,16 @@ def forward_backward_pd(x, prox_f, prox_cc_g, L, grad_h, tau, sigma, niter,
 
     The method can also be used to solve the more general problem
 
-        ``min_x f(x) + sum_i (g_i @ l_i)(L_i x)``,
+        ``min_x f(x) + sum_i (g_i @ l_i)(L_i x) + h(x)``,
 
-    where ``l_i`` are convex functionals and @ is the infimal convolution:
+    where ``l_i`` are strongly convex functionals and @ is the infimal
+    convolution:
 
-        ``(f @ g)(x) = inf_y { f(y) + g(x-y) }``.
+        ``(g @ l)(x) = inf_y { g(y) + l(x-y) }``.
+
+    Note that the strong convetiy of ``l_i`` makes the convex conjugate
+    ``l_i^*`` differentialbe; see the Notes section for more information on
+    this.
 
     Parameters
     ----------
@@ -61,7 +66,7 @@ def forward_backward_pd(x, prox_f, prox_cc_g, L, grad_h, tau, sigma, niter,
     grad_h : `Operator`
         Operator representing the gradient of  ``h``.
     L : `sequence` of `Operator`
-        A sequence with as many elements as ``prox__cc_gs`` of linear operators
+        Sequence with as many elements as ``prox_cc_gs`` of linear operators
         ``L_i``.
     tau : `float`
         Step size-like parameter for ``prox_f``.
@@ -69,8 +74,8 @@ def forward_backward_pd(x, prox_f, prox_cc_g, L, grad_h, tau, sigma, niter,
         Sequence of step size-like parameters for the sequence ``prox_cc_g``.
     niter : `int`
         Number of iterations.
-    callback : `Callback`, optional
-        Show partial results.
+    callback : `callable`, optional
+        Function called with the current iterate after each iteration.
 
     Other Parameters
     ----------------
@@ -80,23 +85,36 @@ def forward_backward_pd(x, prox_f, prox_cc_g, L, grad_h, tau, sigma, niter,
 
     Notes
     -----
+    The mathematical problem to solve is
+
+     .. math::
+
+        \min_x f(x) + \sum_{i=0}^n (g_i \Box l_i)(L_i x) + h(x),
+
+     where :math:`L_i` are linear functionals and the infimal convolution
+     :math:`g \Box l` is defined by
+
+     .. math::
+
+        (g \Box l)(x) = \inf_y g(y) + l(x - y).
+
     The exact conditions on the involved functionals are as follows: :math:`f`
     and :math:`g_i` are proper, convex and lower semicontinuous, and :math:`h`
     is convex and differentialbe with :math:`\\eta^{-1}`-Lipschitz continuous
     gradient, :math:`\\eta > 0`.
 
     The optional operators :math:`\\nabla l_i^*` need to be
-    :math:`\\nu_i^{-1}`-Lipschitz continuous. Note that in the reference
+    :math:`\\nu_i`-Lipschitz continuous. Note that in the reference
     [BC2015]_, the condition is formulated as :math:`l_i` being proper, lower
     semicontinuous, and :math:`\\nu_i^{-1}`-strongly convex, which implies that
     :math:`l_i^*` have :math:`\\nu_i`-Lipschitz continuous gradients.
 
     If the optional operators :math:`\\nabla l_i^*` are omitted, the simpler
-    problem without :mat:`l_i` will be considered. Mathematically, this is done
-    by taking :math:`l_i` to be the functionals that are zero only in the zero
-    element and :math:`\\infty` otherwise. This gives that :math:`l_i^*` are
-    the zero functionals, and hence the corresponding gradients are the zero
-    operators.
+    problem without :math:`l_i` will be considered. Mathematically, this is
+    done by taking :math:`l_i` to be the functionals that are zero only in the
+    zero element and :math:`\\infty` otherwise. This gives that :math:`l_i^*`
+    are the zero functionals, and hence the corresponding gradients are the
+    zero operators.
 
     To guarantee convergence, the parameters ``tau``, ``sigma`` and
     ``L`` need to satisfy
@@ -109,13 +127,6 @@ def forward_backward_pd(x, prox_f, prox_cc_g, L, grad_h, tau, sigma, niter,
 
     where, if the simpler problem is considered, all :math:`\\nu_i` can be
     considered to be :math:`\\infty`.
-
-
-
-    Note here that if the functional
-    :math:`h` is taken as the zero functional, its gradient will be the zero
-    operator and thus :math:`\\eta = 0`. Hence the algorithm CANNOT be
-    guaranteed to converge in this case.
 
     For reference on the forward-backward primal-dual algorithm, see [BC2015]_.
 

--- a/odl/solvers/advanced/forward_backward.py
+++ b/odl/solvers/advanced/forward_backward.py
@@ -15,9 +15,7 @@
 # You should have received a copy of the GNU General Public License
 # along with ODL.  If not, see <http://www.gnu.org/licenses/>.
 
-""" Implementation of the forward-backward primal-dual splitting algorithm for
-optimization.
-"""
+"""Optimization methods based on a forward-backward splitting scheme."""
 
 
 # Imports for common Python 2/3 codebase
@@ -33,7 +31,7 @@ __all__ = ('forward_backward_pd',)
 
 def forward_backward_pd(x, prox_f, prox_cc_g, L, grad_h, tau, sigma, niter,
                         callback=None, **kwargs):
-    """ The forward-backward primal-dual splitting algorithm.
+    """The forward-backward primal-dual splitting algorithm.
 
     The algorithm minimizes the sum of several convex functionals composed with
     linear operators,
@@ -41,7 +39,7 @@ def forward_backward_pd(x, prox_f, prox_cc_g, L, grad_h, tau, sigma, niter,
         ``min_x f(x) + sum_i g_i(L_i x) + h(x)``,
 
     where ``f``, ``g_i`` are convex functionals, ``L_i`` are linear
-    `Operator`'s, and ``h`` is a convex and differentiable functional.
+    operator's, and ``h`` is a convex and differentiable functional.
 
     The method can also be used to solve the more general problem
 
@@ -49,7 +47,7 @@ def forward_backward_pd(x, prox_f, prox_cc_g, L, grad_h, tau, sigma, niter,
 
     where ``l_i`` are convex functionals and @ is the infimal convolution:
 
-        ``(f @ g)(x) = inf_y { f(x-y) + g(y) }``
+        ``(f @ g)(x) = inf_y { f(y) + g(x-y) }``.
 
     Parameters
     ----------
@@ -61,43 +59,44 @@ def forward_backward_pd(x, prox_f, prox_cc_g, L, grad_h, tau, sigma, niter,
         Sequence of `proximal factories` for the convex conjuates of the
         functionals ``g_i``.
     grad_h : `Operator`
-        Operators representing the gradient of  `h`.
-    L : `sequence` of `Operator`'s
-        A sequence with as many elements as ``prox__cc_gs`` of operators
-        ``L_i``
+        Operator representing the gradient of  ``h``.
+    L : `sequence` of `Operator`
+        A sequence with as many elements as ``prox__cc_gs`` of linear operators
+        ``L_i``.
     tau : `float`
-        Step size-like parameter for ``prox_f``
+        Step size-like parameter for ``prox_f``.
     sigma : `sequence` of  `float`
-        Sequence of step size-like parameter for the sequence ``prox_cc_g``
+        Sequence of step size-like parameters for the sequence ``prox_cc_g``.
     niter : `int`
-        Number of iterations
+        Number of iterations.
     callback : `Callback`, optional
-        Show partial results
+        Show partial results.
 
     Other Parameters
     ----------------
-    grad_cc_l : `sequence` of `Operator`'s, optional
-        Sequence of operators representing the gradient of  `l_i^*`.
-        If omitted, the simpler problem will be considered.
+    grad_cc_l : `sequence` of `Operator`, optional
+        Sequence of operators representing the gradients of  ``l_i^*``.
+        If omitted, the simpler problem without ``l_i``  will be considered.
 
     Notes
     -----
     The exact conditions on the involved functionals are as follows: :math:`f`
     and :math:`g_i` are proper, convex and lower semicontinuous, and :math:`h`
-    is convex and differentialbe with :math:`\\eta`-Lipschitz continuous
-    gradient.
+    is convex and differentialbe with :math:`\\eta^{-1}`-Lipschitz continuous
+    gradient, :math:`\\eta > 0`.
 
-    The optional input :math:`\\nabla l_i^*` need to be :math:`\\nu_i`
-    -Lipschitz continuous. Note that in the reference [BC2015]_, the condition
-    is formulated as :math:`l_i` being proper, lower semicontinuous, and
-    :math:`\\nu_i^{-1}`-strongly convex, which implies that :math:`l_i^*` have
-    :math:`\\nu_i`-Lipschitz continuous gradient.
+    The optional operators :math:`\\nabla l_i^*` need to be
+    :math:`\\nu_i^{-1}`-Lipschitz continuous. Note that in the reference
+    [BC2015]_, the condition is formulated as :math:`l_i` being proper, lower
+    semicontinuous, and :math:`\\nu_i^{-1}`-strongly convex, which implies that
+    :math:`l_i^*` have :math:`\\nu_i`-Lipschitz continuous gradients.
 
-    If the optional input :math:`\\nabla l_i^*` is omitted, the simpler problem
-    will be considered. Mathematically, this is done by taking :math:`l_i` to
-    be the functional that is zero only in the zero element and :math:`\\infty`
-    otherwise. This gives that :math:`l_i^*` is the zero functional, and hence
-    the corresponding gradient is the zero operator.
+    If the optional operators :math:`\\nabla l_i^*` are omitted, the simpler
+    problem without :mat:`l_i` will be considered. Mathematically, this is done
+    by taking :math:`l_i` to be the functionals that are zero only in the zero
+    element and :math:`\\infty` otherwise. This gives that :math:`l_i^*` are
+    the zero functionals, and hence the corresponding gradients are the zero
+    operators.
 
     To guarantee convergence, the parameters ``tau``, ``sigma`` and
     ``L`` need to satisfy
@@ -110,6 +109,13 @@ def forward_backward_pd(x, prox_f, prox_cc_g, L, grad_h, tau, sigma, niter,
 
     where, if the simpler problem is considered, all :math:`\\nu_i` can be
     considered to be :math:`\\infty`.
+
+
+
+    Note here that if the functional
+    :math:`h` is taken as the zero functional, its gradient will be the zero
+    operator and thus :math:`\\eta = 0`. Hence the algorithm CANNOT be
+    guaranteed to converge in this case.
 
     For reference on the forward-backward primal-dual algorithm, see [BC2015]_.
 
@@ -128,7 +134,7 @@ def forward_backward_pd(x, prox_f, prox_cc_g, L, grad_h, tau, sigma, niter,
     if not all(op.is_linear for op in L):
         raise ValueError('not all operators in `L` are linear')
     if not all(x in op.domain for op in L):
-        raise ValueError('`x` not in the domain of all operators')
+        raise ValueError('`x` not in the domain of all operators in `L`')
     if len(sigma) != m:
         raise ValueError('len(sigma) != len(L)')
     if len(prox_cc_g) != m:
@@ -145,7 +151,6 @@ def forward_backward_pd(x, prox_f, prox_cc_g, L, grad_h, tau, sigma, niter,
     v = [Li.range.zero() for Li in L]
     y = x.space.zero()
 
-    # Iteratively solve
     for k in range(niter):
         x_old = x
 
@@ -156,7 +161,7 @@ def forward_backward_pd(x, prox_f, prox_cc_g, L, grad_h, tau, sigma, niter,
         for i in range(m):
             if grad_cc_l is not None:
                 # In this case gradients were given.
-                tmp_2 = sigma[i] * (L[i](y) + grad_cc_l[i](v[i]))
+                tmp_2 = sigma[i] * (L[i](y) - grad_cc_l[i](v[i]))
             else:
                 # In this case gradients were not given. Therefore the gradient
                 # step is omitted. For more details, see the documentation.

--- a/test/solvers/advanced/forward_backward_test.py
+++ b/test/solvers/advanced/forward_backward_test.py
@@ -214,8 +214,8 @@ def test_forward_backward_with_li_and_h():
     forward_backward_pd(x, prox_f, prox_cc_g, lin_ops, grad_h, tau=0.5,
                         sigma=[1.0], niter=20, grad_cc_l=grad_cc_ls)
 
-    expected_result = space.element(-0.5)
-    assert almost_equal(x.data, expected_result.data, places=LOW_ACCURACY)
+    expected_result = -0.5
+    assert almost_equal(x[0], expected_result, places=LOW_ACCURACY)
 
 
 if __name__ == '__main__':

--- a/test/solvers/advanced/forward_backward_test.py
+++ b/test/solvers/advanced/forward_backward_test.py
@@ -1,0 +1,125 @@
+# Copyright 2014-2016 The ODL development group
+#
+# This file is part of ODL.
+#
+# ODL is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# ODL is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with ODL.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Test for the forward-backward solver."""
+
+# Imports for common Python 2/3 codebase
+from __future__ import print_function, division, absolute_import
+from future import standard_library
+standard_library.install_aliases()
+
+# External
+import pytest
+import numpy as np
+
+# Internal
+import odl
+from odl.solvers import forward_backward_pd
+from odl.util.testutils import all_almost_equal, example_element
+
+# Places for the accepted error when comparing results
+PLACES = 8
+
+
+def test_forward_backward_inpit_handeling():
+    """Test to see that input is handled correctly.
+    """
+
+    # Create spaces
+    space1 = odl.uniform_discr(0, 1, 10)
+
+    # Create "correct" set of operators
+    lin_ops = [odl.ZeroOperator(space1), odl.ZeroOperator(space1)]
+    prox_cc_g = [odl.solvers.proximal_zero(space1),  # Identity operator
+                 odl.solvers.proximal_zero(space1)]  # Identity operator
+    prox_f = odl.solvers.proximal_zero(space1)  # Identity operator
+    grad_h = odl.ZeroOperator(space1)
+
+    # Check that the algorithm runs. With the above operators the algorithm
+    # is the identity operator in each iteration
+    x0 = example_element(space1)
+    x = x0.copy()
+    niter = np.random.randint(low=3, high=20)
+
+    forward_backward_pd(x, prox_f, prox_cc_g, lin_ops, grad_h, tau=1.0,
+                        sigma=[1.0, 1.0], niter=niter)
+
+    assert x == x0
+
+    # Testing that sizes needs to agree:
+    # To few sigma_i:s
+    with pytest.raises(ValueError):
+        forward_backward_pd(x, prox_f, prox_cc_g, lin_ops, grad_h, tau=1.0,
+                            sigma=[1.0], niter=niter)
+
+    # To many sigma_i:s
+    with pytest.raises(ValueError):
+        forward_backward_pd(x, prox_f, prox_cc_g, lin_ops, grad_h, tau=1.0,
+                            sigma=[1.0, 1.0, 1.0], niter=niter)
+
+    # To few operators
+    prox_cc_g_to_few = [odl.solvers.proximal_zero(space1)]
+    with pytest.raises(ValueError):
+        forward_backward_pd(x, prox_f, prox_cc_g_to_few, lin_ops, grad_h,
+                            tau=1.0, sigma=[1.0, 1.0], niter=niter)
+
+    # To many operators
+    prox_cc_g_to_many = [odl.solvers.proximal_zero(space1),
+                         odl.solvers.proximal_zero(space1),
+                         odl.solvers.proximal_zero(space1)]
+    with pytest.raises(ValueError):
+        forward_backward_pd(x, prox_f, prox_cc_g_to_many, lin_ops, grad_h,
+                            tau=1.0, sigma=[1.0, 1.0], niter=niter)
+
+    # Test for correct space
+    space2 = odl.uniform_discr(1, 2, 10)
+    x = example_element(space2)
+    with pytest.raises(ValueError):
+        forward_backward_pd(x, prox_f, prox_cc_g, lin_ops, grad_h, tau=1.0,
+                            sigma=[1.0, 1.0], niter=niter)
+
+
+def test_forward_backward():
+    """Test for the forward-backward solver by minimizing ||x||_2^2. The
+    general problem is of the form
+
+        ``min_x f(x) + sum_i g_i(L_i x) + h(x)``
+
+    and here we take f(x) = g(x) = 0, h(x) = ||x||_2^2 and L is the
+    zero-operator.
+    """
+
+    # Create spaces
+    space = odl.rn(10)
+
+    # Create "correct" set of operators
+    lin_ops = [odl.ZeroOperator(space)]
+    prox_cc_g = [odl.solvers.proximal_cconj(odl.solvers.proximal_zero(space))]
+    prox_f = odl.solvers.proximal_zero(space)
+    grad_h = 2.0 * odl.IdentityOperator(space)  # Gradient of two-norm square
+
+    x = example_element(space)
+    x_global_min = space.zero()
+
+    forward_backward_pd(x, prox_f, prox_cc_g, lin_ops, grad_h, tau=0.5,
+                        sigma=[1.0], niter=10)
+
+    assert all_almost_equal(x, x_global_min, places=PLACES)
+
+
+if __name__ == '__main__':
+    pytest.main(str(__file__.replace('\\', '/') + ' -v'))


### PR DESCRIPTION
Adds the forward-backward primal-dual solver. Reference article is found [here](http://www.mat.univie.ac.at/~rabot/publications/jour15-01.pdf) (algorithm is found in Theorem 2).