### PR TITLE
ENH: simplify _call assignment in Operator.__new__

### DIFF
--- a/odl/operator/operator.py
+++ b/odl/operator/operator.py
@@ -31,7 +31,6 @@ import sys
 from odl.set.space import (
     LinearSpace, LinearSpaceVector, UniversalSpace)
 from odl.set.sets import Set, UniversalSet, Field
-from odl.util.utility import preload_first_arg
 
 
 __all__ = ('Operator', 'OperatorComp', 'OperatorSum',
@@ -425,27 +424,22 @@ class Operator(object):
 
     def __new__(cls, *args, **kwargs):
         """Create a new instance."""
-        instance = object.__new__(cls)
-
         call_has_out, call_out_optional, _ = _dispatch_call_args(cls)
-        instance._call_has_out = call_has_out
-        instance._call_out_optional = call_out_optional
+        cls._call_has_out = call_has_out
+        cls._call_out_optional = call_out_optional
         if not call_has_out:
             # Out-of-place _call
-            instance._call_in_place = preload_first_arg(
-                instance, 'in-place')(_default_call_in_place)
-            instance._call_out_of_place = instance._call
+            cls._call_in_place = _default_call_in_place
+            cls._call_out_of_place = cls._call
         elif call_out_optional:
             # Dual-use _call
-            instance._call_in_place = instance._call
-            instance._call_out_of_place = instance._call
+            cls._call_in_place = cls._call_out_of_place = cls._call
         else:
             # In-place only _call
-            instance._call_in_place = instance._call
-            instance._call_out_of_place = preload_first_arg(
-                instance, 'out-of-place')(_default_call_out_of_place)
+            cls._call_in_place = cls._call
+            cls._call_out_of_place = _default_call_out_of_place
 
-        return instance
+        return object.__new__(cls)
 
     def __init__(self, domain, range, linear=False):
         """Initialize a new instance.

--- a/odl/space/fspace.py
+++ b/odl/space/fspace.py
@@ -216,7 +216,7 @@ class FunctionSetVector(Operator):
 
     """Representation of a `FunctionSet` element."""
 
-    def __init__(self, fset, fcall, out_dtype=None):
+    def __init__(self, fset, fcall):
         """Initialize a new instance.
 
         Parameters
@@ -227,7 +227,6 @@ class FunctionSetVector(Operator):
             The actual instruction for out-of-place evaluation.
             It must return an `FunctionSet.range` element or a
             `numpy.ndarray` of such (vectorized call).
-        out_d
         """
         self.__space = fset
         super().__init__(self.space.domain, self.space.range, linear=False)
@@ -271,8 +270,6 @@ class FunctionSetVector(Operator):
         else:
             # In-place only
             self._call_in_place = fcall
-            # The default out-of-place method needs to guess the data
-            # type, so we need a separate decorator to help it.
             self._call_out_of_place = preload_first_arg(self, 'out-of-place')(
                 _default_out_of_place)
 


### PR DESCRIPTION
Small improvement I realized during review of PR #471. The old problem that the `self` argument was not filled in had to do with internal Python things. Basically it boils down to this: If a function is assigned as an attribute of a *class*, `self` is filled in magically. If it is assigned as an *instance* attribute, no `self`.