### PR TITLE
Discr space to space

### DIFF
--- a/examples/solvers/denoising_with_entropy_type_regularization.py
+++ b/examples/solvers/denoising_with_entropy_type_regularization.py
@@ -47,19 +47,19 @@ image *= 100 / image.max()
 noisy_image = np.random.poisson(1 + image)
 
 # Discretized spaces and vectors
-discr_space = odl.uniform_discr([0, 0], shape, shape)
-orig = discr_space.element(image)
-noisy = discr_space.element(noisy_image)
+space = odl.uniform_discr([0, 0], shape, shape)
+orig = space.element(image)
+noisy = space.element(noisy_image)
 
 
 # --- Set up the inverse problem --- #
 
 
 # Gradient operator
-gradient = odl.Gradient(discr_space, method='forward')
+gradient = odl.Gradient(space, method='forward')
 
 # Matrix of operators
-op = odl.BroadcastOperator(odl.IdentityOperator(discr_space), gradient)
+op = odl.BroadcastOperator(odl.IdentityOperator(space), gradient)
 
 
 # Proximal operator related to the primal variable
@@ -70,7 +70,7 @@ proximal_primal = odl.solvers.proximal_nonnegativity(op.domain)
 # Proximal operators related to the dual variable
 
 # l2-data matching
-prox_convconj_kl = odl.solvers.proximal_cconj_kl(discr_space, lam=1.0, g=noisy)
+prox_convconj_kl = odl.solvers.proximal_cconj_kl(space, lam=1.0, g=noisy)
 
 # Isotropic TV-regularization: l1-norm of grad(x)
 prox_convconj_l1 = odl.solvers.proximal_cconj_l1(gradient.range, lam=0.1,
@@ -90,8 +90,6 @@ callback = (odl.solvers.CallbackPrintIteration() &
 
 # Estimated operator norm, add 10 percent to ensure ||K||_2^2 * sigma * tau < 1
 op_norm = 1.1 * odl.power_method_opnorm(op, 100)
-
-niter = 100  # Number of iterations
 tau = 10.0 / op_norm  # Step size for the primal variable
 sigma = 0.1 / op_norm  # Step size for the dual variable
 
@@ -101,7 +99,7 @@ x = op.domain.zero()
 # Run algorithms (and display intermediates)
 odl.solvers.chambolle_pock_solver(
     op, x, tau=tau, sigma=sigma, proximal_primal=proximal_primal,
-    proximal_dual=proximal_dual, niter=niter, callback=callback)
+    proximal_dual=proximal_dual, niter=100, callback=callback)
 
 # Display images
 orig.show(title='original image')

--- a/examples/trafos/fourier_trafo.py
+++ b/examples/trafos/fourier_trafo.py
@@ -28,30 +28,39 @@ import odl
 
 # Discretized space: discretized functions on the rectangle [-1, 1] x [-1, 1]
 # with 512 samples per dimension and complex data type (for full FT).
-discr_space = odl.uniform_discr([-1, -1], [1, 1], (512, 512), dtype='complex')
+space = odl.uniform_discr([-1, -1], [1, 1], (512, 512), dtype='complex')
 
 # Make the Fourier transform operator on this space. The range is calculated
 # automatically. The default backend is numpy.fft
-ft_op = odl.trafos.FourierTransform(discr_space)
+ft_op = odl.trafos.FourierTransform(space)
 
 # Create a phantom and its Fourier transfrom and display them
-phantom = odl.phantom.shepp_logan(discr_space, modified=True)
-phantom.show(title='Shepp-Logan phantom', show=True)
+phantom = odl.phantom.shepp_logan(space, modified=True)
+phantom.show(title='Shepp-Logan phantom')
 phantom_ft = ft_op(phantom)
-phantom_ft.show(title='Full Fourier Transform', show=True)
+phantom_ft.show(title='Full Fourier Transform')
+
+# Calculate the inverse transform
+phantom_ft_inv = ft_op.inverse(phantom_ft)
+phantom_ft_inv.show(title='Full Fourier Transform inverted')
 
 # Calculate the FT only along the first axis
-ft_op_axis0 = odl.trafos.FourierTransform(discr_space, axes=(0,))
+ft_op_axis0 = odl.trafos.FourierTransform(space, axes=0)
 phantom_ft_axis0 = ft_op_axis0(phantom)
-phantom_ft_axis0.show(title='Fourier transform along axis 0', show=True)
+phantom_ft_axis0.show(title='Fourier transform along axis 0')
 
 # If a real space is used, the Fourier transform can be calculated in the
 # "half-complex" mode. This means that along the last axis of the transform,
 # only the negative half of the spectrum is stored since the other half is
 # its complex conjugate. This is faster and more memory efficient.
-discr_space_real = odl.uniform_discr([-1, -1], [1, 1], (512, 512))
-ft_op_halfc = odl.trafos.FourierTransform(discr_space_real, halfcomplex=True)
-phantom_real = odl.phantom.shepp_logan(discr_space_real, modified=True)
-phantom_real.show(title='Shepp-Logan phantom, real version', show=True)
+real_space = space.real_space
+ft_op_halfc = odl.trafos.FourierTransform(real_space, halfcomplex=True)
+phantom_real = odl.phantom.shepp_logan(real_space, modified=True)
+phantom_real.show(title='Shepp-Logan phantom, real version')
 phantom_real_ft = ft_op_halfc(phantom_real)
-phantom_real_ft.show(title='Half-complex Fourier Transform', show=True)
+phantom_real_ft.show(title='Half-complex Fourier Transform')
+
+# If the space is real, the inverse also gives a real result
+phantom_real_ft_inv = ft_op_halfc.inverse(phantom_real_ft)
+phantom_real_ft_inv.show(title='Half-complex Fourier Transform inverted',
+                         show=True)

--- a/odl/phantom/geometric.py
+++ b/odl/phantom/geometric.py
@@ -27,24 +27,24 @@ import numpy as np
 __all__ = ('cuboid', 'indicate_proj_axis')
 
 
-def cuboid(discr_space, begin=None, end=None):
+def cuboid(space, begin=None, end=None):
     """Rectangular cuboid.
 
     Parameters
     ----------
-    discr_space : `DiscretizedSpace`
+    space : `DiscretizedSpace`
         Discretized space in which the phantom is supposed to be created.
-    begin : array-like of length ``discr_space.ndim``
+    begin : array-like of length ``space.ndim``
         The lower left corner of the cuboid within the space.
         Default: A quarter of the volume from the minimum corner
-    end : array-like of length ``discr_space.ndim``
+    end : array-like of length ``space.ndim``
         The upper right corner of the cuboid within the space.
         Default: A quarter of the volume from the maximum corner
 
     Returns
     -------
     phantom : `LinearSpaceVector`
-        Returns an element in ``discr_space``
+        Returns an element in ``space``
 
     Examples
     --------
@@ -59,8 +59,8 @@ def cuboid(discr_space, begin=None, end=None):
      [1.0, 1.0, 1.0, 0.0, 0.0, 0.0],
      [0.0, 0.0, 0.0, 0.0, 0.0, 0.0]]
     """
-    minp = np.asarray(discr_space.domain.min())
-    maxp = np.asarray(discr_space.domain.max())
+    minp = np.asarray(space.domain.min())
+    maxp = np.asarray(space.domain.max())
 
     if begin is None:
         begin = minp * 0.75 + maxp * 0.25
@@ -70,8 +70,8 @@ def cuboid(discr_space, begin=None, end=None):
     begin = np.atleast_1d(begin)
     end = np.atleast_1d(end)
 
-    assert begin.size == discr_space.ndim
-    assert end.size == discr_space.ndim
+    assert begin.size == space.ndim
+    assert end.size == space.ndim
 
     def phan(x):
         result = True
@@ -81,10 +81,10 @@ def cuboid(discr_space, begin=None, end=None):
                       np.less_equal(minv, xp) & np.less_equal(xp, maxv))
         return result
 
-    return discr_space.element(phan)
+    return space.element(phan)
 
 
-def indicate_proj_axis(discr_space, scale_structures=0.5):
+def indicate_proj_axis(space, scale_structures=0.5):
     """Phantom indicating along which axis it is projected.
 
     The number (n) of rectangles in a parallel-beam projection along a main
@@ -93,7 +93,7 @@ def indicate_proj_axis(discr_space, scale_structures=0.5):
 
     Parameters
     ----------
-    discr_space : `DiscretizedSpace`
+    space : `DiscretizedSpace`
         Discretized space in which the phantom is supposed to be created
     scale_structures : positive `float` in (0, 1]
         Scales objects (cube, cuboids)
@@ -101,7 +101,7 @@ def indicate_proj_axis(discr_space, scale_structures=0.5):
     Returns
     -------
     phantom : `LinearSpaceVector`
-        Returns an element in ``discr_space``
+        Returns an element in ``space``
 
     Examples
     --------
@@ -140,9 +140,9 @@ def indicate_proj_axis(discr_space, scale_structures=0.5):
         raise ValueError('`scale_structures` ({}) is not in (0, 1]'
                          ''.format(scale_structures))
 
-    assert discr_space.ndim == 3
+    assert space.ndim == 3
 
-    shape = discr_space.shape
+    shape = space.shape
     phan = np.zeros(shape)
     shape = np.array(shape) - 1
     cen = np.round(0.5 * shape)
@@ -169,7 +169,7 @@ def indicate_proj_axis(discr_space, scale_structures=0.5):
     z = (cen - dx)[2]
     phan[x0:x1, y:y1, z:-z] = 1
 
-    return discr_space.element(phan)
+    return space.element(phan)
 
 if __name__ == '__main__':
     # Show the phantoms

--- a/test/discr/diff_ops_test.py
+++ b/test/discr/diff_ops_test.py
@@ -291,12 +291,11 @@ def test_gradient(method, fn_impl, padding):
         padding_method, padding_value = padding, None
 
     # DiscreteLp Vector
-    discr_space = odl.uniform_discr([0, 0], [1, 1], DATA_2D.shape,
-                                    impl=fn_impl)
-    dom_vec = discr_space.element(DATA_2D)
+    space = odl.uniform_discr([0, 0], [1, 1], DATA_2D.shape, impl=fn_impl)
+    dom_vec = space.element(DATA_2D)
 
     # computation of gradient components with helper function
-    dx0, dx1 = discr_space.cell_sides
+    dx0, dx1 = space.cell_sides
     diff_0 = finite_diff(DATA_2D, axis=0, dx=dx0, method=method,
                          padding_method=padding_method,
                          padding_value=padding_value)
@@ -305,7 +304,7 @@ def test_gradient(method, fn_impl, padding):
                          padding_value=padding_value)
 
     # gradient
-    grad = Gradient(discr_space, method=method,
+    grad = Gradient(space, method=method,
                     padding_method=padding_method,
                     padding_value=padding_value)
     grad_vec = grad(dom_vec)

--- a/test/solvers/advanced/chambolle_pock_test.py
+++ b/test/solvers/advanced/chambolle_pock_test.py
@@ -47,10 +47,10 @@ def test_chambolle_pock_solver_simple_space():
     """Test for the Chambolle-Pock algorithm."""
 
     # Create a discretized image space
-    discr_space = odl.uniform_discr(0, 1, DATA.size)
+    space = odl.uniform_discr(0, 1, DATA.size)
 
     # Operator
-    op = odl.IdentityOperator(discr_space)
+    op = odl.IdentityOperator(space)
 
     # Starting point (image)
     discr_vec = op.domain.element(DATA)
@@ -62,7 +62,7 @@ def test_chambolle_pock_solver_simple_space():
     discr_dual = op.range.zero()
 
     # Proximal operator, use same the factory function for F^* and G
-    prox = proximal_zero(discr_space)
+    prox = proximal_zero(space)
 
     # Run the algorithm
     chambolle_pock_solver(op, discr_vec, tau=TAU, sigma=SIGMA,
@@ -134,10 +134,10 @@ def test_chambolle_pock_solver_produce_space():
     """Test the Chambolle-Pock algorithm using a product space operator."""
 
     # Create a discretized image space
-    discr_space = odl.uniform_discr(0, 1, DATA.size)
+    space = odl.uniform_discr(0, 1, DATA.size)
 
     # Operator
-    identity = odl.IdentityOperator(discr_space)
+    identity = odl.IdentityOperator(space)
 
     # Create broadcasting operator
     prod_op = odl.BroadcastOperator(identity, -2 * identity)

--- a/test/solvers/advanced/douglas_rachford_test.py
+++ b/test/solvers/advanced/douglas_rachford_test.py
@@ -141,8 +141,8 @@ def test_primal_dual_with_li():
     douglas_rachford_pd(x, prox_f, prox_cc_g, lin_ops, tau=0.5,
                         sigma=[1.0], niter=20, prox_cc_l=prox_cc_ls)
 
-    assert lower_lim - 10**-LOW_ACCURACY <= x[0]
-    assert x[0] <= upper_lim + 10**-LOW_ACCURACY
+    assert lower_lim - 10 ** -LOW_ACCURACY <= x[0]
+    assert x[0] <= upper_lim + 10 ** -LOW_ACCURACY
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Fixed the remaining pesky `discr_space` where there is no real continuous space to talk about in the example.

Also updated the Fourier example to do inverses.