### PR TITLE
Issue 411  padding

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -55,7 +55,8 @@ ntuples_impl_params = odl.NTUPLES_IMPLS.keys()
 ntuples_impl_ids = [" impl='{}' ".format(p) for p in ntuples_impl_params]
 
 
-@pytest.fixture(scope="module", ids=ntuples_impl_ids, params=ntuples_impl_params)
+@pytest.fixture(scope="module", ids=ntuples_impl_ids,
+                params=ntuples_impl_params)
 def ntuples_impl(request):
     return request.param
 

--- a/doc/source/math/images/resize_large.svg
+++ b/doc/source/math/images/resize_large.svg
@@ -1,0 +1,447 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="529.84656mm"
+   height="103.32518mm"
+   viewBox="0 0 1877.409 366.11284"
+   id="svg9677"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="resize_large.svg">
+  <defs
+     id="defs9679">
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker10562"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow2Mend">
+      <path
+         transform="scale(-0.6,-0.6)"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         id="path10564"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="Arrow1Mend"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path4294"
+         d="M 0,0 5,-5 -12.5,0 5,5 0,0 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow2Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="Arrow2Mend"
+       style="overflow:visible"
+       inkscape:isstock="true"
+       inkscape:collect="always">
+      <path
+         inkscape:connector-curvature="0"
+         id="path4312"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         transform="scale(-0.6,-0.6)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow2Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="Arrow2Mend-1"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         inkscape:connector-curvature="0"
+         id="path4312-27"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         transform="scale(-0.6,-0.6)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow2Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="Arrow2Mend-61"
+       style="overflow:visible"
+       inkscape:isstock="true"
+       inkscape:collect="always">
+      <path
+         inkscape:connector-curvature="0"
+         id="path4312-8"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         transform="scale(-0.6,-0.6)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow2Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="Arrow2Mend-1-7"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         inkscape:connector-curvature="0"
+         id="path4312-27-9"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         transform="scale(-0.6,-0.6)" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker9230"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow2Mend">
+      <path
+         transform="scale(-0.6,-0.6)"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         id="path9232"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow2Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker9656"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         inkscape:connector-curvature="0"
+         id="path9658"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         transform="scale(-0.6,-0.6)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow2Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="Arrow2Mend-9"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         inkscape:connector-curvature="0"
+         id="path4312-7"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         transform="scale(-0.6,-0.6)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow2Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="Arrow2Mend-6"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         inkscape:connector-curvature="0"
+         id="path4312-2"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         transform="scale(-0.6,-0.6)" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker10562-8"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow2Mend">
+      <path
+         transform="scale(-0.6,-0.6)"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         id="path10564-4"
+         inkscape:connector-curvature="0" />
+    </marker>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="0.35"
+     inkscape:cx="516.56171"
+     inkscape:cy="271.62784"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     inkscape:window-width="1855"
+     inkscape:window-height="1176"
+     inkscape:window-x="65"
+     inkscape:window-y="24"
+     inkscape:window-maximized="1"
+     fit-margin-top="10"
+     fit-margin-left="10"
+     fit-margin-right="10"
+     fit-margin-bottom="10" />
+  <metadata
+     id="metadata9682">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(570.13314,-437.8772)">
+    <g
+       transform="translate(602.14285,269.21956)"
+       id="g9620">
+      <rect
+         y="438.1647"
+         x="212.93553"
+         height="59.73151"
+         width="455.30881"
+         id="rect3336-9"
+         style="fill:#999999;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none" />
+      <rect
+         y="204.76073"
+         x="212.93553"
+         height="81.298279"
+         width="455.81387"
+         id="rect3336-6"
+         style="fill:#999999;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none" />
+      <rect
+         y="277.94821"
+         x="534.59949"
+         height="167.31277"
+         width="133.57521"
+         id="rect3336-3"
+         style="fill:#999999;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none" />
+      <rect
+         y="282.4939"
+         x="212.61334"
+         height="160.24168"
+         width="58.823921"
+         id="rect3336-3-5"
+         style="fill:#999999;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none" />
+      <rect
+         y="286.53452"
+         x="272.02945"
+         height="151.6554"
+         width="262.36966"
+         id="rect3336"
+         style="fill:#999999;stroke:#000000;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none" />
+      <rect
+         y="205.09071"
+         x="212.72852"
+         height="293.2467"
+         width="455.97156"
+         id="rect4138"
+         style="fill:none;stroke:#000000;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path4140"
+         d="m 212.85715,286.03452 455.71429,0"
+         style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:2, 2;stroke-dashoffset:0;stroke-opacity:1" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path4157-5"
+         d="m 534.95228,205.36174 0,292.70466"
+         style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:2, 2;stroke-dashoffset:0;stroke-opacity:1" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path4140-3"
+         d="m 212.85715,438.68991 455.71429,0"
+         style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:2, 2;stroke-dashoffset:0;stroke-opacity:1" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path4157"
+         d="m 271.43394,205.36174 0,292.70466"
+         style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:2, 2;stroke-dashoffset:0;stroke-opacity:1" />
+      <path
+         sodipodi:nodetypes="cc"
+         inkscape:connector-curvature="0"
+         id="path4279"
+         d="m 403.50238,393.53486 c -45.48597,45.48642 0,78.63754 0,78.63754"
+         style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:3;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#Arrow2Mend)" />
+      <path
+         sodipodi:nodetypes="cc"
+         inkscape:connector-curvature="0"
+         id="path4279-0"
+         d="m 401.59292,327.07018 c 45.2119,-48.94129 0,-84.61036 0,-84.61036"
+         style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:3;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#Arrow2Mend-1)" />
+      <path
+         sodipodi:nodetypes="cc"
+         inkscape:connector-curvature="0"
+         id="path4279-2"
+         d="m 603.6102,393.53486 c -45.48597,45.48642 0,78.63754 0,78.63754"
+         style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:3;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#Arrow2Mend-61)" />
+      <path
+         sodipodi:nodetypes="cc"
+         inkscape:connector-curvature="0"
+         id="path4279-0-0"
+         d="m 601.70074,327.07018 c 45.2119,-48.94129 0,-84.61036 0,-84.61036"
+         style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:3;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#Arrow2Mend-1-7)" />
+      <path
+         style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:3;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker9230)"
+         d="m 243.6102,393.53486 c -45.48597,45.48642 0,78.63754 0,78.63754"
+         id="path9226"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cc" />
+      <path
+         style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:3;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#Arrow2Mend-1-7)"
+         d="m 241.70074,327.07018 c 45.2119,-48.94129 0,-84.61036 0,-84.61036"
+         id="path9228"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cc" />
+    </g>
+    <g
+       transform="translate(-538.24337,469.76697)"
+       id="g9747">
+      <g
+         id="layer1-2"
+         transform="translate(-208.18521,-200.54741)">
+        <rect
+           style="fill:#999999;stroke:#000000;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none"
+           id="rect3336-37"
+           width="262.36966"
+           height="151.6554"
+           x="272.02945"
+           y="286.53452" />
+        <rect
+           style="fill:none;stroke:#000000;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none"
+           id="rect4138-5"
+           width="455.97156"
+           height="293.2467"
+           x="212.72852"
+           y="205.09071" />
+        <path
+           inkscape:connector-curvature="0"
+           style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:2, 2;stroke-dashoffset:0;stroke-opacity:1"
+           d="m 212.85715,286.03452 455.71429,0"
+           id="path4140-9" />
+        <path
+           inkscape:connector-curvature="0"
+           style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:2, 2;stroke-dashoffset:0;stroke-opacity:1"
+           d="m 534.95228,205.36174 0,292.70466"
+           id="path4157-5-2" />
+        <path
+           inkscape:connector-curvature="0"
+           style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:2, 2;stroke-dashoffset:0;stroke-opacity:1"
+           d="m 212.85715,438.68991 455.71429,0"
+           id="path4140-3-2" />
+        <path
+           inkscape:connector-curvature="0"
+           style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:2, 2;stroke-dashoffset:0;stroke-opacity:1"
+           d="m 271.43394,205.36174 0,292.70466"
+           id="path4157-8" />
+      </g>
+    </g>
+    <g
+       transform="translate(-72.142831,269.21956)"
+       id="g9792">
+      <rect
+         y="286.53452"
+         x="534.59949"
+         height="151.6554"
+         width="133.57521"
+         id="rect3336-3-3"
+         style="fill:#999999;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none" />
+      <rect
+         y="286.53452"
+         x="212.61334"
+         height="151.6554"
+         width="58.823921"
+         id="rect3336-3-5-6"
+         style="fill:#999999;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none" />
+      <rect
+         y="286.53452"
+         x="272.02945"
+         height="151.6554"
+         width="262.36966"
+         id="rect3336-1"
+         style="fill:#999999;stroke:#000000;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none" />
+      <rect
+         y="205.09071"
+         x="212.72852"
+         height="293.2467"
+         width="455.97156"
+         id="rect4138-2"
+         style="fill:none;stroke:#000000;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path4140-93"
+         d="m 212.85715,286.03452 455.71429,0"
+         style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:2, 2;stroke-dashoffset:0;stroke-opacity:1" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path4157-5-1"
+         d="m 534.95228,205.36174 0,292.70466"
+         style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:2, 2;stroke-dashoffset:0;stroke-opacity:1" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path4140-3-9"
+         d="m 212.85715,438.68991 455.71429,0"
+         style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:2, 2;stroke-dashoffset:0;stroke-opacity:1" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path4157-4"
+         d="m 271.43394,205.36174 0,292.70466"
+         style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:2, 2;stroke-dashoffset:0;stroke-opacity:1" />
+      <path
+         sodipodi:nodetypes="cc"
+         inkscape:connector-curvature="0"
+         id="path4279-7"
+         d="m 480.55065,361.68518 c 73.05644,-43.54101 126.30096,0 126.30096,0"
+         style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:3;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#Arrow2Mend-9)" />
+      <path
+         sodipodi:nodetypes="cc"
+         inkscape:connector-curvature="0"
+         id="path4279-9"
+         d="m 331.43761,361.95782 c -40.68276,-42.96835 -89.54292,0 -89.54292,0"
+         style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:3;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#Arrow2Mend-6)" />
+    </g>
+    <path
+       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:10;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker10562)"
+       d="m -46.1306,621.02971 140,0"
+       id="path9861"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:10;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker10562-8)"
+       d="m 628.15515,621.02971 140,0"
+       id="path9861-5"
+       inkscape:connector-curvature="0" />
+  </g>
+</svg>

--- a/doc/source/math/images/resize_small.svg
+++ b/doc/source/math/images/resize_small.svg
@@ -1,0 +1,421 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="529.84656mm"
+   height="103.32518mm"
+   viewBox="0 0 1877.409 366.11284"
+   id="svg9677"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="resize_small.svg">
+  <defs
+     id="defs9679">
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker10562"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow2Mend">
+      <path
+         transform="scale(-0.6,-0.6)"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         id="path10564"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="Arrow1Mend"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path4294"
+         d="M 0,0 5,-5 -12.5,0 5,5 0,0 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow2Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="Arrow2Mend-1"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         inkscape:connector-curvature="0"
+         id="path4312-27"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         transform="scale(-0.6,-0.6)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow2Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="Arrow2Mend-1-7"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         inkscape:connector-curvature="0"
+         id="path4312-27-9"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         transform="scale(-0.6,-0.6)" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker9230"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow2Mend">
+      <path
+         transform="scale(-0.6,-0.6)"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         id="path9232"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow2Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker9656"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         inkscape:connector-curvature="0"
+         id="path9658"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         transform="scale(-0.6,-0.6)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow2Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="Arrow2Mend-9"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         inkscape:connector-curvature="0"
+         id="path4312-7"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         transform="scale(-0.6,-0.6)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow2Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="Arrow2Mend-6"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         inkscape:connector-curvature="0"
+         id="path4312-2"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         transform="scale(-0.6,-0.6)" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker10562-8"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow2Mend">
+      <path
+         transform="scale(-0.6,-0.6)"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         id="path10564-4"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow2Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="Arrow2Mend-0"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         inkscape:connector-curvature="0"
+         id="path4312-3"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         transform="scale(-0.6,-0.6)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow2Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="Arrow2Mend-1-6"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         inkscape:connector-curvature="0"
+         id="path4312-27-1"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         transform="scale(-0.6,-0.6)" />
+    </marker>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="0.35"
+     inkscape:cx="516.56171"
+     inkscape:cy="271.62784"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     inkscape:window-width="1855"
+     inkscape:window-height="1176"
+     inkscape:window-x="65"
+     inkscape:window-y="24"
+     inkscape:window-maximized="1"
+     fit-margin-top="10"
+     fit-margin-left="10"
+     fit-margin-right="10"
+     fit-margin-bottom="10" />
+  <metadata
+     id="metadata9682">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(570.13314,-437.8772)">
+    <g
+       transform="translate(-538.24337,469.76697)"
+       id="g9747">
+      <g
+         id="layer1-2"
+         transform="translate(-208.18521,-200.54741)">
+        <rect
+           style="fill:#999999;stroke:#000000;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none"
+           id="rect3336-37"
+           width="262.36966"
+           height="151.6554"
+           x="272.02945"
+           y="286.53452" />
+        <rect
+           style="fill:none;stroke:#000000;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none"
+           id="rect4138-5"
+           width="455.97156"
+           height="293.2467"
+           x="212.72852"
+           y="205.09071" />
+        <path
+           inkscape:connector-curvature="0"
+           style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:2, 2;stroke-dashoffset:0;stroke-opacity:1"
+           d="m 212.85715,286.03452 455.71429,0"
+           id="path4140-9" />
+        <path
+           inkscape:connector-curvature="0"
+           style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:2, 2;stroke-dashoffset:0;stroke-opacity:1"
+           d="m 534.95228,205.36174 0,292.70466"
+           id="path4157-5-2" />
+        <path
+           inkscape:connector-curvature="0"
+           style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:2, 2;stroke-dashoffset:0;stroke-opacity:1"
+           d="m 212.85715,438.68991 455.71429,0"
+           id="path4140-3-2" />
+        <path
+           inkscape:connector-curvature="0"
+           style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:2, 2;stroke-dashoffset:0;stroke-opacity:1"
+           d="m 271.43394,205.36174 0,292.70466"
+           id="path4157-8" />
+      </g>
+    </g>
+    <g
+       transform="translate(-72.142903,269.21956)"
+       id="g9792">
+      <rect
+         y="286.53452"
+         x="534.59949"
+         height="151.6554"
+         width="133.57521"
+         id="rect3336-3-3"
+         style="fill:#999999;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none" />
+      <rect
+         y="286.53452"
+         x="212.61334"
+         height="151.6554"
+         width="58.823921"
+         id="rect3336-3-5-6"
+         style="fill:#999999;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none" />
+      <rect
+         y="286.53452"
+         x="272.02945"
+         height="151.6554"
+         width="262.36966"
+         id="rect3336-1"
+         style="fill:#999999;stroke:#000000;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none" />
+      <rect
+         y="205.09071"
+         x="212.72852"
+         height="293.2467"
+         width="455.97156"
+         id="rect4138-2"
+         style="fill:none;stroke:#000000;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path4140-93"
+         d="m 212.85715,286.03452 455.71429,0"
+         style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:2, 2;stroke-dashoffset:0;stroke-opacity:1" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path4157-5-1"
+         d="m 534.95228,205.36174 0,292.70466"
+         style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:2, 2;stroke-dashoffset:0;stroke-opacity:1" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path4140-3-9"
+         d="m 212.85715,438.68991 455.71429,0"
+         style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:2, 2;stroke-dashoffset:0;stroke-opacity:1" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path4157-4"
+         d="m 271.43394,205.36174 0,292.70466"
+         style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:2, 2;stroke-dashoffset:0;stroke-opacity:1" />
+      <path
+         sodipodi:nodetypes="cc"
+         inkscape:connector-curvature="0"
+         id="path4279-7"
+         d="m 480.55065,361.68518 c 73.05644,-43.54101 126.30096,0 126.30096,0"
+         style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:3;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#Arrow2Mend-9)" />
+      <path
+         sodipodi:nodetypes="cc"
+         inkscape:connector-curvature="0"
+         id="path4279-9"
+         d="m 331.43761,361.95782 c -40.68276,-42.96835 -89.54292,0 -89.54292,0"
+         style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:3;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#Arrow2Mend-6)" />
+    </g>
+    <path
+       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:10;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker10562)"
+       d="m -46.1306,621.02971 140,0"
+       id="path9861"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:10;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker10562-8)"
+       d="m 628.15515,621.02971 140,0"
+       id="path9861-5"
+       inkscape:connector-curvature="0" />
+    <g
+       transform="translate(602.14285,269.21956)"
+       id="g10917">
+      <rect
+         y="438.1647"
+         x="272.02945"
+         height="59.73151"
+         width="262.36966"
+         id="rect3336-9-0"
+         style="fill:#999999;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none" />
+      <rect
+         y="204.76073"
+         x="272.02945"
+         height="81.298279"
+         width="262.36966"
+         id="rect3336-6-6"
+         style="fill:#999999;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none" />
+      <rect
+         y="286.53452"
+         x="534.59949"
+         height="151.6554"
+         width="133.57521"
+         id="rect3336-3-32"
+         style="fill:#999999;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none" />
+      <rect
+         y="286.53452"
+         x="212.61334"
+         height="151.6554"
+         width="58.823921"
+         id="rect3336-3-5-0"
+         style="fill:#999999;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none" />
+      <rect
+         y="286.53452"
+         x="272.02945"
+         height="151.6554"
+         width="262.36966"
+         id="rect3336-61"
+         style="fill:#999999;stroke:#000000;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none" />
+      <rect
+         y="205.09071"
+         x="212.72852"
+         height="293.2467"
+         width="455.97156"
+         id="rect4138-55"
+         style="fill:none;stroke:#000000;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path4140-4"
+         d="m 212.85715,286.03452 455.71429,0"
+         style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:2, 2;stroke-dashoffset:0;stroke-opacity:1" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path4157-5-7"
+         d="m 534.95228,205.36174 0,292.70466"
+         style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:2, 2;stroke-dashoffset:0;stroke-opacity:1" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path4140-3-6"
+         d="m 212.85715,438.68991 455.71429,0"
+         style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:2, 2;stroke-dashoffset:0;stroke-opacity:1" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path4157-56"
+         d="m 271.43394,205.36174 0,292.70466"
+         style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:2, 2;stroke-dashoffset:0;stroke-opacity:1" />
+      <path
+         sodipodi:nodetypes="cc"
+         inkscape:connector-curvature="0"
+         id="path4279-93"
+         d="m 403.50238,393.53486 c -45.48597,45.48642 0,78.63754 0,78.63754"
+         style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:3;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#Arrow2Mend-0)" />
+      <path
+         sodipodi:nodetypes="cc"
+         inkscape:connector-curvature="0"
+         id="path4279-0-7"
+         d="m 401.59292,327.07018 c 45.2119,-48.94129 0,-84.61036 0,-84.61036"
+         style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:3;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#Arrow2Mend-1-6)" />
+    </g>
+  </g>
+</svg>

--- a/doc/source/math/math.rst
+++ b/doc/source/math/math.rst
@@ -9,5 +9,6 @@ This section explains the mathematical concepts on which ODL is built.
 
     linear_spaces
     discretization
+    resizing_ops
     trafos/index
     solvers/solvers

--- a/doc/source/math/resizing_ops.rst
+++ b/doc/source/math/resizing_ops.rst
@@ -8,14 +8,13 @@ Resizing Operators
 Introduction
 ============
 In ODL, resizing of a discretized function is understood as the operation of shrinking or enlarging its domain in such a way that the size of the partition cells do not change.
-This "constant cell size" restriction is intentional since it ensures that the underlying operation can be implemented as array resizing without resampling, thus keeping those two functionalities separate.
+This "constant cell size" restriction is intentional since it ensures that the underlying operation can be implemented as array resizing without resampling, thus keeping those two functionalities separate (see `Resampling`).
 
 
 Basic setting
 =============
-Let now :math:`\mathbb{R}^n` with :math:`n \in \mathbb{N}` be the space of one-dimensional real vectors encoding values of a function defined on an interval :math:`[a, b] \subset \mathbb{R}`.
+Let now :math:`\mathbb{R}^n` with :math:`n \in \mathbb{N}` be the space of one-dimensional real vectors encoding values of a function defined on an interval :math:`[a, b] \subset \mathbb{R}` (see :ref:`discretizations` for details).
 Since values are not manipulated, the generalization to complex-valued functions is straightforward.
-Further, since all operations completely separate with respect to different dimensions, the results can easily applied to the multi-dimensional case.
 
 
 Restriction operator
@@ -317,3 +316,26 @@ Hence, the order-1 specific operator has the adjoint
 
 with the convention of summing values for overlapping cases, i.e. if :math:`i \in \{1, 2\}`.
 In practice, the adjoint for the order 1 padding case is applied by computing the zero'th and first order moments of :math:`y` and adding them to the two outmost entries of :math:`x` according to the above rule.
+
+
+Generalization to arbitrary dimension
+=====================================
+Fortunately, all operations are completely separable with respect to (coordinate) axes, i.e. resizing in higher-dimensional spaces can be written as a series of one-dimensional resizing operations.
+One particular issue should be mentioned with the extension operators and their adjoints, though.
+When extending a small, e.g., two-dimensional array to a larger size, there is an ambiguity in how the corner blocks should be handled.
+One possibility would be use the small array size for the extension in both axes, which would leave the corner blocks untouched (initialized to 0 usually):
+
+.. image:: images/resize_small.svg
+   :width: 100%
+
+However, this is not the behavior one would often want in practice.
+Instead, it is much more reasonable to also fill the corners in the same way the "inner" parts have been extended:
+
+.. image:: images/resize_large.svg
+   :width: 100%
+
+This latter behavior is implemented in the resizing operators in ODL.
+
+The adjoint operators of these "corner-filling" resizing operator are given by reversing the unfolding pattern, i.e. by "folding in" the large array axis by axis according to the adjoint formula for the given padding mode.
+This way, the corners also contribute to the final result, which leads to the correct adjoint of the 2D resizing operator.
+Of course, the same principle can easily be generalized to arbitrary dimension.

--- a/doc/source/math/resizing_ops.rst
+++ b/doc/source/math/resizing_ops.rst
@@ -7,34 +7,27 @@ Resizing Operators
 
 Introduction
 ============
-Resizing can be described in a continuous as well as in a fully discrete setting. In the
-continuous case, resizing corresponds to changing the domain of a function space, and the restriction
-and extension operations are well-defined.
+In ODL, resizing of a discretized function is understood as the operation of shrinking or enlarging its domain in such a way that the size of the partition cells do not change.
+This "constant cell size" restriction is intentional since it ensures that the underlying operation can be implemented as array resizing without resampling, thus keeping those two functionalities separate.
 
-However, due to practical reasons, it makes sense to investigate resizing in a discretized setting,
-mainly to make it reflect the resizing of an array directly. This means, for example, that in
-uniformly discretized spaces, the side lengths of the unit cell are not changed, which implies that
-no resampling is performed. In this way, resampling and resizing can be kept separate, with the
-possibility to chain them whenever necessary.
 
-Let now :math:`\mathbb{R}^n` with :math:`n \in \mathbb{N}` be the space of one-dimensional real
-vectors encoding values of a function defined on an interval :math:`[a, b] \subset \mathbb{R}`.
+Basic setting
+=============
+Let now :math:`\mathbb{R}^n` with :math:`n \in \mathbb{N}` be the space of one-dimensional real vectors encoding values of a function defined on an interval :math:`[a, b] \subset \mathbb{R}`.
 Since values are not manipulated, the generalization to complex-valued functions is straightforward.
-Further, since all operations completely separate with respect to different dimensions, the results
-can easily applied to the multi-dimensional case.
+Further, since all operations completely separate with respect to different dimensions, the results can easily applied to the multi-dimensional case.
 
 
 Restriction operator
 ====================
-We consider the space :math:`\mathbb{R}^m` for an :math:`m < n \in \mathbb{N}` and define the
-restriction operator
+We consider the space :math:`\mathbb{R}^m` for an :math:`m < n \in \mathbb{N}` and define the restriction operator
 
 .. math::
     R : \mathbb{R}^n \to \mathbb{R}^m, \quad R(x) := (x_p, \dots, x_{p+m-1})
     :label: def_restrict_op
 
-with a given index :math:`0 \leq p \leq n - m - 1`. Its adjoint with respect to the standard inner
-product is easy to determine:
+with a given index :math:`0 \leq p \leq n - m - 1`.
+Its adjoint with respect to the standard inner product is easy to determine:
 
 .. math::
     \langle R(x), y \rangle_{\mathbb{R}^m}
@@ -53,37 +46,29 @@ with the zero-padding operator
     \end{cases}
     :label: zero_pad_as_restr_adj
 
-In practice, this means that a new zero vector of size :math:`n` is created, and the values
-:math:`y` are filled in from index :math:`p` onwards. It is also clear that the operator :math:`R`
-is right-invertible by :math:`R^*`, i.e. :math:`R R^* = \mathrm{Id}_{\mathbb{R}^m}`. In fact, any
-operator of the form :math:`R^* + P`, where :math:`P` is linear and :math:`P(x)_i = 0` for
-:math:`i \not \in \{p, \dots, p+m-1\}` acts as a right inverse for :math:`R`. On the other hand,
-:math:`R` has no left inverse since it has a non-trivial kernel
-:math:`\mathrm{ker} R = \{x \in \mathbb{R}^n\,|\,x_i = 0 \text{ for } i = p, \dots, p+m-1\}`.
+In practice, this means that a new zero vector of size :math:`n` is created, and the values :math:`y` are filled in from index :math:`p` onwards.
+It is also clear that the operator :math:`R` is right-invertible by :math:`R^*`, i.e. :math:`R R^* = \mathrm{Id}_{\mathbb{R}^m}`.
+In fact, any operator of the form :math:`R^* + P`, where :math:`P` is linear and :math:`P(x)_i = 0` for :math:`i \not \in \{p, \dots, p+m-1\}` acts as a right inverse for :math:`R`.
+On the other hand, :math:`R` has no left inverse since it has a non-trivial kernel (null space) :math:`\mathrm{ker} R = \{x \in \mathbb{R}^n\,|\,x_i = 0 \text{ for } i = p, \dots, p+m-1\}`.
 
 
 Extension operators
 ===================
-Now we study the opposite case of resizing, namely extending a vector. We thus choose :math:`m > n`
-and consider different cases of enlarging a given vector :math:`x \in \mathbb{R}^n` to a vector in
-:math:`\mathbb{R}^m`. The start index is again denoted by :math:`p` and needs to fulfill
-:math:`0 \leq p \leq m - n - 1`, such that a vector of length :math:`n` "fits into" a vector of
-length :math:`m` when starting at index :math:`p`.
+Now we study the opposite case of resizing, namely extending a vector.
+We thus choose :math:`m > n` and consider different cases of enlarging a given vector :math:`x \in \mathbb{R}^n` to a vector in :math:`\mathbb{R}^m`.
+The start index is again denoted by :math:`p` and needs to fulfill :math:`0 \leq p \leq m - n - 1`, such that a vector of length :math:`n` "fits into" a vector of length :math:`m` when starting at index :math:`p`.
 
-It should be noted that all extension operators mentioned here are of the above form
-:math:`R^* + P` with :math:`P` acting on the "outer" indices only. Hence they all act as a right
-inverses for the restriction operator. This property can also be read as the fact that all extension
-operators are left-inverted by the restriction operator :math:`R`.
+It should be noted that all extension operators mentioned here are of the above form :math:`R^* + P` with :math:`P` acting on the "outer" indices only.
+Hence they all act as a right inverses for the restriction operator.
+This property can also be read as the fact that all extension operators are left-inverted by the restriction operator :math:`R`.
 
-Moreover, the "mixed" case, i.e. the combination of restriction and extension which would occur e.g.
-for a constant index shift :math:`x \mapsto (0, \dots, 0, x_0, \dots, x_{n-p-1})`, is not considered
-here. It can be represented by a combination of the two "pure" operations.
+Moreover, the "mixed" case, i.e. the combination of restriction and extension which would occur e.g. for a constant index shift :math:`x \mapsto (0, \dots, 0, x_0, \dots, x_{n-p-1})`, is not considered here.
+It can be represented by a combination of the two "pure" operations.
 
 
 Zero padding
 ------------
-In this most basic padding variant, one fills the missing values in the target vector with zeros,
-yielding the operator
+In this most basic padding variant, one fills the missing values in the target vector with zeros, yielding the operator
 
 .. math::
     E_{\mathrm{z}} : \mathbb{R}^n \to \mathbb{R}^m, \quad E_{\mathrm{z}}(x)_j :=
@@ -99,9 +84,8 @@ Hence, its adjoint is given by the restriction, :math:`E_{\mathrm{z}}^* = R`.
 
 Constant padding
 ----------------
-In constant padding with constant :math:`c`, the extra zeros in :eq:`def_zero_pad_op` are replaced
-with :math:`c`. Hence, the operator performing constant padding can be written as
-:math:`E_{\mathrm{c}} = E_{\mathrm{z}} + P_{\mathrm{c}}`, where the second summand is given by
+In constant padding with constant :math:`c`, the extra zeros in :eq:`def_zero_pad_op` are replaced with :math:`c`.
+Hence, the operator performing constant padding can be written as :math:`E_{\mathrm{c}} = E_{\mathrm{z}} + P_{\mathrm{c}}`, where the second summand is given by
 
 .. math::
     P_{\mathrm{c}}(x) =
@@ -110,17 +94,14 @@ with :math:`c`. Hence, the operator performing constant padding can be written a
     c      , & \text{else}.
     \end{cases}
 
-Note that this operator is not linear, and its derivative is the zero operator, hence the derivative
-of the constant padding operator is :math:`E_{\mathrm{c}}' = E_{\mathrm{z}}`.
+Note that this operator is not linear, and its derivative is the zero operator, hence the derivative of the constant padding operator is :math:`E_{\mathrm{c}}' = E_{\mathrm{z}}`.
 
 
 Periodic padding
 ----------------
-This padding mode continues the original vector :math:`x` periodically in both directions. For
-reasons of practicability, at most one whole copy is allowed on both sides, which means that the
-numbers :math:`n`, :math:`m` and :math:`p` need to fulfill :math:`p \leq n` ("left" padding amount)
-and :math:`m - (p + n) \leq n` ("right" padding amount). The periodic padding operator is then
-defined as
+This padding mode continues the original vector :math:`x` periodically in both directions.
+For reasons of practicability, at most one whole copy is allowed on both sides, which means that the numbers :math:`n`, :math:`m` and :math:`p` need to fulfill :math:`p \leq n` ("left" padding amount) and :math:`m - (p + n) \leq n` ("right" padding amount).
+The periodic padding operator is then defined as
 
 .. math::
     E_{\mathrm{p}}(x)_j :=
@@ -131,8 +112,8 @@ defined as
     \end{cases}
     :label: def_per_pad_op
 
-Hence, one can at most get 3 full periods with :math:`m = 3n` and :math:`p = n`. Again, this operator
-can be written as :math:`E_{\mathrm{p}} = E_{\mathrm{z}} + P_{\mathrm{p}}` with an operator
+Hence, one can at most get 3 full periods with :math:`m = 3n` and :math:`p = n`.
+Again, this operator can be written as :math:`E_{\mathrm{p}} = E_{\mathrm{z}} + P_{\mathrm{p}}` with an operator
 
 .. math::
     P_{\mathrm{p}}(x)_j :=
@@ -168,24 +149,18 @@ and
     0,         & \text{else}.
     \end{cases}
 
-In practice, this means that that besides copying the values from the indices :math:`p, \dots, p+n-1`
-of a vector :math:`y \in \mathbb{R}^m` to a new vector :math:`x \in \mathbb{R}^n`, the values
-corresponding to the other indices are added to the vector :math:`x` as follows. The *first*
-:math:`m - n - p - 1` entries of :math:`y` (negative means 0) are added to the *last*
-:math:`m - n - p - 1` entries of :math:`x`, in the same ascending order. The *last* :math:`p` entries
-of :math:`y` are added to the *first* :math:`p` entries of :math:`x`, again keeping the order. This
-procedure can be interpreted as "folding back" the periodized structure of :math:`y` into a single
-period :math:`x` by adding the values from the two side periods.
+In practice, this means that that besides copying the values from the indices :math:`p, \dots, p+n-1` of a vector :math:`y \in \mathbb{R}^m` to a new vector :math:`x \in \mathbb{R}^n`, the values corresponding to the other indices are added to the vector :math:`x` as follows.
+The *first* :math:`m - n - p - 1` entries of :math:`y` (negative means 0) are added to the *last* :math:`m - n - p - 1` entries of :math:`x`, in the same ascending order.
+The *last* :math:`p` entries of :math:`y` are added to the *first* :math:`p` entries of :math:`x`, again keeping the order.
+This procedure can be interpreted as "folding back" the periodized structure of :math:`y` into a single period :math:`x` by adding the values from the two side periods.
 
 
 Symmetric padding
 -----------------
-In symmetric padding mode, a given vector is extended by mirroring at the outmost nodes to the
-desired extent. By convention, the outmost values are not repeated, and as in periodic mode, the
-input vector is re-used at most once on both sides. Since the outmost values are not doubled, the
-numbers :math:`n`, :math:`m` and :math:`p` need to fulfill the relations
-:math:`p \leq n - 1` ("left" padding amount) and :math:`m - (p + n) \leq n - 1` ("right" padding
-amount). Now the symmetric padding operator is defined as
+In symmetric padding mode, a given vector is extended by mirroring at the outmost nodes to the desired extent.
+By convention, the outmost values are not repeated, and as in periodic mode, the input vector is re-used at most once on both sides.
+Since the outmost values are not doubled, the numbers :math:`n`, :math:`m` and :math:`p` need to fulfill the relations :math:`p \leq n - 1` ("left" padding amount) and :math:`m - (p + n) \leq n - 1` ("right" padding amount).
+Now the symmetric padding operator is defined as
 
 .. math::
     E_{\mathrm{s}}(x)_j :=
@@ -232,18 +207,12 @@ and
     0,            & \text{else}.
     \end{cases}
 
-Note that the index condition :math:`m - (p + n) \leq n - 1` is equivalent to
-:math:`2n - 1 + p - m \geq 0`, hence the index range in the definition of
-:math:`P_{\mathrm{s},2}^*` is well-defined.
+Note that the index condition :math:`m - (p + n) \leq n - 1` is equivalent to :math:`2n - 1 + p - m \geq 0`, hence the index range in the definition of :math:`P_{\mathrm{s},2}^*` is well-defined.
 
-Practically, the evaluation of :math:`E_{\mathrm{s}}^*` consists in copying the "main" part of
-:math:`y \in \mathbb{R}^m` corresponding to the indices :math:`p, \dots, p + n - 1` to
-:math:`x \in \mathbb{R}^n` and updating the vector additively as follows. The values at indices 1 to
-:math:`p` are updated with the values of :math:`y` mirrored at the index position :math:`p`, i.e. in
-reversed order. The values at the indices :math:`2n - 1 + p - m` to :math:`n - 2` are updated with
-the values of :math:`y` mirrored at the position :math:`2n + 2 - p`, again in reversed order. This
-procedure can be interpreted as "mirroring back" the outer two parts of the vector :math:`y` at the
-indices :math:`p` and :math:`2n + 2 - p`, adding those parts to the "main" vector.
+Practically, the evaluation of :math:`E_{\mathrm{s}}^*` consists in copying the "main" part of :math:`y \in \mathbb{R}^m` corresponding to the indices :math:`p, \dots, p + n - 1` to :math:`x \in \mathbb{R}^n` and updating the vector additively as follows.
+The values at indices 1 to :math:`p` are updated with the values of :math:`y` mirrored at the index position :math:`p`, i.e. in reversed order.
+The values at the indices :math:`2n - 1 + p - m` to :math:`n - 2` are updated with the values of :math:`y` mirrored at the position :math:`2n + 2 - p`, again in reversed order.
+This procedure can be interpreted as "mirroring back" the outer two parts of the vector :math:`y` at the indices :math:`p` and :math:`2n + 2 - p`, adding those parts to the "main" vector.
 
 
 Order 0 padding
@@ -272,15 +241,15 @@ This operator is the sum of the zero-padding operator and
 We calculate the adjoint of :math:`P_{\mathrm{o0}}`:
 
 .. math::
- \langle P_{\mathrm{o0}}(x), y \rangle_{\mathbb{R}^m}
- &= \sum_{j=0}^{p-1} x_0\, y_j + \sum_{j=p+n}^{m-1} x_{n-1}\, y_j \\
- &= x_0 \sum_{j=0}^{p-1} y_j + x_{n-1} \sum_{j=p+n}^{m-1} y_j \\
- &= x_0 M_{\mathrm{l},0}(y) + x_{n-1} M_{\mathrm{r},0}(y)
+    \langle P_{\mathrm{o0}}(x), y \rangle_{\mathbb{R}^m}
+    &= \sum_{j=0}^{p-1} x_0\, y_j + \sum_{j=p+n}^{m-1} x_{n-1}\, y_j \\
+    &= x_0 \sum_{j=0}^{p-1} y_j + x_{n-1} \sum_{j=p+n}^{m-1} y_j \\
+    &= x_0 M_{\mathrm{l},0}(y) + x_{n-1} M_{\mathrm{r},0}(y)
 
 with the zero'th order moments
 
 .. math::
- M_{\mathrm{l},0}(y) := \sum_{j=0}^{p-1} y_j, \quad M_{\mathrm{r},0}(y) := \sum_{j=p+n}^{m-1} y_j.
+    M_{\mathrm{l},0}(y) := \sum_{j=0}^{p-1} y_j, \quad M_{\mathrm{r},0}(y) := \sum_{j=p+n}^{m-1} y_j.
 
 Hence, we get
 
@@ -292,11 +261,8 @@ Hence, we get
     0,                   & \text{else},
     \end{cases}
 
-with the convention that the sum of the two values is taken in the case that $n = 1$, i.e. both first
-cases are the same. Hence, after constructing the restriction :math:`x \in \mathbb{R}^n` of a vector
-:math:`y \in \mathbb{R}^m` to the main part :math:`p, \dots, p + n - 1`, the sum of the entries to
-the left are added to :math:`x_0`, and the sum of the entries to the right are added to
-:math:`x_{n-1}`.
+with the convention that the sum of the two values is taken in the case that $n = 1$, i.e. both first cases are the same.
+Hence, after constructing the restriction :math:`x \in \mathbb{R}^n` of a vector :math:`y \in \mathbb{R}^m` to the main part :math:`p, \dots, p + n - 1`, the sum of the entries to the left are added to :math:`x_0`, and the sum of the entries to the right are added to :math:`x_{n-1}`.
 
 
 Order 1 padding
@@ -312,8 +278,7 @@ In this padding mode, a given vector is continued with constant slope instead of
  \end{cases}
  :label: def_order1_pad_op
 
-We can write this operator as :math:`E_{\mathrm{o1}} = E_{\mathrm{o0}} + S_{\mathrm{o1}}` with the
-order-1 specific part
+We can write this operator as :math:`E_{\mathrm{o1}} = E_{\mathrm{o0}} + S_{\mathrm{o1}}` with the order-1 specific part
 
 .. math::
     S_{\mathrm{o1}}(x)_j :=
@@ -350,7 +315,5 @@ Hence, the order-1 specific operator has the adjoint
     0,                  & \text{else},
     \end{cases}
 
-with the convention of summing values for overlapping cases, i.e. if :math:`i \in \{1, 2\}`. In
-practice, the adjoint for the order 1 padding case is applied by computing the zero'th and first
-order moments of :math:`y` and adding them to the two outmost entries of :math:`x` according to the
-above rule.
+with the convention of summing values for overlapping cases, i.e. if :math:`i \in \{1, 2\}`.
+In practice, the adjoint for the order 1 padding case is applied by computing the zero'th and first order moments of :math:`y` and adding them to the two outmost entries of :math:`x` according to the above rule.

--- a/doc/source/math/resizing_ops.rst
+++ b/doc/source/math/resizing_ops.rst
@@ -1,0 +1,356 @@
+.. _resizing_ops:
+
+##################
+Resizing Operators
+##################
+
+
+Introduction
+============
+Resizing can be described in a continuous as well as in a fully discrete setting. In the
+continuous case, resizing corresponds to changing the domain of a function space, and the restriction
+and extension operations are well-defined.
+
+However, due to practical reasons, it makes sense to investigate resizing in a discretized setting,
+mainly to make it reflect the resizing of an array directly. This means, for example, that in
+uniformly discretized spaces, the side lengths of the unit cell are not changed, which implies that
+no resampling is performed. In this way, resampling and resizing can be kept separate, with the
+possibility to chain them whenever necessary.
+
+Let now :math:`\mathbb{R}^n` with :math:`n \in \mathbb{N}` be the space of one-dimensional real
+vectors encoding values of a function defined on an interval :math:`[a, b] \subset \mathbb{R}`.
+Since values are not manipulated, the generalization to complex-valued functions is straightforward.
+Further, since all operations completely separate with respect to different dimensions, the results
+can easily applied to the multi-dimensional case.
+
+
+Restriction operator
+====================
+We consider the space :math:`\mathbb{R}^m` for an :math:`m < n \in \mathbb{N}` and define the
+restriction operator
+
+.. math::
+    R : \mathbb{R}^n \to \mathbb{R}^m, \quad R(x) := (x_p, \dots, x_{p+m-1})
+    :label: def_restrict_op
+
+with a given index :math:`0 \leq p \leq n - m - 1`. Its adjoint with respect to the standard inner
+product is easy to determine:
+
+.. math::
+    \langle R(x), y \rangle_{\mathbb{R}^m}
+    &= \sum_{j=0}^{m-1} R(x)_j\, y_j
+    = \sum_{j=0}^{m-1} x_{p+j}\, y_j
+    = \sum_{j=p}^{p+m-1} x_j\, y_{j-p} \\
+    &= \sum_{i=0}^{n-1} x_i\, R^*(y)_i
+
+with the zero-padding operator
+
+.. math::
+    R^*(y)_i :=
+    \begin{cases}
+    y_{i-p} & \text{if } p \leq i \leq p + m - 1, \\
+    0       & \text{else.}
+    \end{cases}
+    :label: zero_pad_as_restr_adj
+
+In practice, this means that a new zero vector of size :math:`n` is created, and the values
+:math:`y` are filled in from index :math:`p` onwards. It is also clear that the operator :math:`R`
+is right-invertible by :math:`R^*`, i.e. :math:`R R^* = \mathrm{Id}_{\mathbb{R}^m}`. In fact, any
+operator of the form :math:`R^* + P`, where :math:`P` is linear and :math:`P(x)_i = 0` for
+:math:`i \not \in \{p, \dots, p+m-1\}` acts as a right inverse for :math:`R`. On the other hand,
+:math:`R` has no left inverse since it has a non-trivial kernel
+:math:`\mathrm{ker} R = \{x \in \mathbb{R}^n\,|\,x_i = 0 \text{ for } i = p, \dots, p+m-1\}`.
+
+
+Extension operators
+===================
+Now we study the opposite case of resizing, namely extending a vector. We thus choose :math:`m > n`
+and consider different cases of enlarging a given vector :math:`x \in \mathbb{R}^n` to a vector in
+:math:`\mathbb{R}^m`. The start index is again denoted by :math:`p` and needs to fulfill
+:math:`0 \leq p \leq m - n - 1`, such that a vector of length :math:`n` "fits into" a vector of
+length :math:`m` when starting at index :math:`p`.
+
+It should be noted that all extension operators mentioned here are of the above form
+:math:`R^* + P` with :math:`P` acting on the "outer" indices only. Hence they all act as a right
+inverses for the restriction operator. This property can also be read as the fact that all extension
+operators are left-inverted by the restriction operator :math:`R`.
+
+Moreover, the "mixed" case, i.e. the combination of restriction and extension which would occur e.g.
+for a constant index shift :math:`x \mapsto (0, \dots, 0, x_0, \dots, x_{n-p-1})`, is not considered
+here. It can be represented by a combination of the two "pure" operations.
+
+
+Zero padding
+------------
+In this most basic padding variant, one fills the missing values in the target vector with zeros,
+yielding the operator
+
+.. math::
+    E_{\mathrm{z}} : \mathbb{R}^n \to \mathbb{R}^m, \quad E_{\mathrm{z}}(x)_j :=
+    \begin{cases}
+    x_{j-p}, & \text{if } p \leq j \leq p + n - 1, \\
+    0      , & \text{else}.
+    \end{cases}
+    :label: def_zero_pad_op
+
+Note that this is the adjoint of the restriction operator :math:`R` defined in :eq:`def_restrict_op`.
+Hence, its adjoint is given by the restriction, :math:`E_{\mathrm{z}}^* = R`.
+
+
+Constant padding
+----------------
+In constant padding with constant :math:`c`, the extra zeros in :eq:`def_zero_pad_op` are replaced
+with :math:`c`. Hence, the operator performing constant padding can be written as
+:math:`E_{\mathrm{c}} = E_{\mathrm{z}} + P_{\mathrm{c}}`, where the second summand is given by
+
+.. math::
+    P_{\mathrm{c}}(x) =
+    \begin{cases}
+    0      , & \text{if } p \leq j \leq p + n - 1, \\
+    c      , & \text{else}.
+    \end{cases}
+
+Note that this operator is not linear, and its derivative is the zero operator, hence the derivative
+of the constant padding operator is :math:`E_{\mathrm{c}}' = E_{\mathrm{z}}`.
+
+
+Periodic padding
+----------------
+This padding mode continues the original vector :math:`x` periodically in both directions. For
+reasons of practicability, at most one whole copy is allowed on both sides, which means that the
+numbers :math:`n`, :math:`m` and :math:`p` need to fulfill :math:`p \leq n` ("left" padding amount)
+and :math:`m - (p + n) \leq n` ("right" padding amount). The periodic padding operator is then
+defined as
+
+.. math::
+    E_{\mathrm{p}}(x)_j :=
+    \begin{cases}
+    x_{j-p + n}, & \text{if } 0 \leq j \leq p - 1,     \\
+    x_{j-p},     & \text{if } p \leq j \leq p + n - 1, \\
+    x_{j-p - n}, & \text{if } p + n \leq j \leq m - 1.
+    \end{cases}
+    :label: def_per_pad_op
+
+Hence, one can at most get 3 full periods with :math:`m = 3n` and :math:`p = n`. Again, this operator
+can be written as :math:`E_{\mathrm{p}} = E_{\mathrm{z}} + P_{\mathrm{p}}` with an operator
+
+.. math::
+    P_{\mathrm{p}}(x)_j :=
+    \begin{cases}
+    x_{j-p + n}, & \text{if } 0 \leq j \leq p - 1,     \\
+    0,           & \text{if } p \leq j \leq p + n - 1, \\
+    x_{j-p - n}, & \text{if } p + n \leq j \leq m - 1.
+    \end{cases}
+
+For the adjoint of :math:`P_{\mathrm{p}}`, we calculate
+
+.. math::
+    \langle P_{\mathrm{p}}(x), y \rangle_{\mathbb{R}^m}
+    &= \sum_{j=0}^{p-1} x_{j-p+n}\, y_j + \sum_{j=p+n}^{m-1} x_{j-p-n}\, y_j \\
+    &= \sum_{i=n-p}^{n-1} x_i\, y_{i+p-n} + \sum_{i=0}^{m-n-p-1} x_i\, y_{i+p+n} \\
+    &= \sum_{i=0}^{n-1} x_i\, \big( P_{\mathrm{p},1}^*(y) + P_{\mathrm{p},2}^*(y) \big)
+
+with
+
+.. math::
+    P_{\mathrm{p},1}^*(y)_i :=
+    \begin{cases}
+    y_{i+p-n}, & \text{if } n - p \leq i \leq n - 1, \\
+    0,         & \text{else},
+    \end{cases}
+
+and
+
+.. math::
+    P_{\mathrm{p},2}^*(y)_i :=
+    \begin{cases}
+    y_{i+p+n}, & \text{if } 0 \leq i \leq m - n - p - 1, \\
+    0,         & \text{else}.
+    \end{cases}
+
+In practice, this means that that besides copying the values from the indices :math:`p, \dots, p+n-1`
+of a vector :math:`y \in \mathbb{R}^m` to a new vector :math:`x \in \mathbb{R}^n`, the values
+corresponding to the other indices are added to the vector :math:`x` as follows. The *first*
+:math:`m - n - p - 1` entries of :math:`y` (negative means 0) are added to the *last*
+:math:`m - n - p - 1` entries of :math:`x`, in the same ascending order. The *last* :math:`p` entries
+of :math:`y` are added to the *first* :math:`p` entries of :math:`x`, again keeping the order. This
+procedure can be interpreted as "folding back" the periodized structure of :math:`y` into a single
+period :math:`x` by adding the values from the two side periods.
+
+
+Symmetric padding
+-----------------
+In symmetric padding mode, a given vector is extended by mirroring at the outmost nodes to the
+desired extent. By convention, the outmost values are not repeated, and as in periodic mode, the
+input vector is re-used at most once on both sides. Since the outmost values are not doubled, the
+numbers :math:`n`, :math:`m` and :math:`p` need to fulfill the relations
+:math:`p \leq n - 1` ("left" padding amount) and :math:`m - (p + n) \leq n - 1` ("right" padding
+amount). Now the symmetric padding operator is defined as
+
+.. math::
+    E_{\mathrm{s}}(x)_j :=
+    \begin{cases}
+    x_{p-j},      & \text{if } 0 \leq j \leq p - 1,      \\
+    x_{j-p},      & \text{if } p \leq j \leq p + n - 1,  \\
+    x_{2n-2+p-j}, & \text{if } p + n \leq j \leq m - 1.
+    \end{cases}
+    :label: def_sym_pad_op
+
+This operator is the sum of the zero-padding operator :math:`E_{\mathrm{z}}` and
+
+.. math::
+    P_{\mathrm{s}}(x)_j :=
+    \begin{cases}
+    x_{p-j},      & \text{if } 0 \leq j \leq p - 1,      \\
+    0,            & \text{if } p \leq j \leq p + n - 1,  \\
+    x_{2n-2+p-j}, & \text{if } p + n \leq j \leq m - 1.
+    \end{cases}
+
+For its adjoint, we compute
+
+.. math::
+    \langle P_{\mathrm{s}}(x), y \rangle_{\mathbb{R}^m}
+    &= \sum_{j=0}^{p-1} x_{p-j}\, y_j + \sum_{j=p+n}^{m-1} x_{2n-2+p-j}\, y_j \\
+    &= \sum_{i=1}^p x_i\, y_{p-i} + \sum_{i=2n-1+p-m}^{n-2} x_i\, y_{2n-2+p-i} \\
+    &= \sum_{i=0}^{n-1} x_i\, \big( P_{\mathrm{s},1}^*(y) + P_{\mathrm{s},2}^*(y) \big)
+
+with
+
+.. math::
+    P_{\mathrm{s},1}^*(y)_i :=
+    \begin{cases}
+    y_{p-i},   & \text{if } 1 \leq i \leq p, \\
+    0,         & \text{else},
+    \end{cases}
+
+and
+
+.. math::
+    P_{\mathrm{s},2}^*(y)_i :=
+    \begin{cases}
+    y_{2n-2+p-i}, & \text{if } 2n - 1 + p - m \leq i \leq n - 2, \\
+    0,            & \text{else}.
+    \end{cases}
+
+Note that the index condition :math:`m - (p + n) \leq n - 1` is equivalent to
+:math:`2n - 1 + p - m \geq 0`, hence the index range in the definition of
+:math:`P_{\mathrm{s},2}^*` is well-defined.
+
+Practically, the evaluation of :math:`E_{\mathrm{s}}^*` consists in copying the "main" part of
+:math:`y \in \mathbb{R}^m` corresponding to the indices :math:`p, \dots, p + n - 1` to
+:math:`x \in \mathbb{R}^n` and updating the vector additively as follows. The values at indices 1 to
+:math:`p` are updated with the values of :math:`y` mirrored at the index position :math:`p`, i.e. in
+reversed order. The values at the indices :math:`2n - 1 + p - m` to :math:`n - 2` are updated with
+the values of :math:`y` mirrored at the position :math:`2n + 2 - p`, again in reversed order. This
+procedure can be interpreted as "mirroring back" the outer two parts of the vector :math:`y` at the
+indices :math:`p` and :math:`2n + 2 - p`, adding those parts to the "main" vector.
+
+
+Order 0 padding
+---------------
+Padding with order 0 consistency means continuing the vector constantly beyond its boundaries, i.e.
+
+.. math::
+    E_{\mathrm{o0}}(x)_j :=
+    \begin{cases}
+    x_0,     & \text{if } 0 \leq j \leq p - 1,      \\
+    x_{j-p}, & \text{if } p \leq j \leq p + n - 1,  \\
+    x_{n-1}, & \text{if } p + n \leq j \leq m - 1.
+    \end{cases}
+    :label: def_order0_pad_op
+
+This operator is the sum of the zero-padding operator and
+
+.. math::
+    P_{\mathrm{o0}}(x)_j :=
+    \begin{cases}
+    x_0,     & \text{if } 0 \leq j \leq p - 1,      \\
+    0,       & \text{if } p \leq j \leq p + n - 1,  \\
+    x_{n-1}, & \text{if } p + n \leq j \leq m - 1.
+    \end{cases}
+
+We calculate the adjoint of :math:`P_{\mathrm{o0}}`:
+
+.. math::
+ \langle P_{\mathrm{o0}}(x), y \rangle_{\mathbb{R}^m}
+ &= \sum_{j=0}^{p-1} x_0\, y_j + \sum_{j=p+n}^{m-1} x_{n-1}\, y_j \\
+ &= x_0 \sum_{j=0}^{p-1} y_j + x_{n-1} \sum_{j=p+n}^{m-1} y_j \\
+ &= x_0 M_{\mathrm{l},0}(y) + x_{n-1} M_{\mathrm{r},0}(y)
+
+with the zero'th order moments
+
+.. math::
+ M_{\mathrm{l},0}(y) := \sum_{j=0}^{p-1} y_j, \quad M_{\mathrm{r},0}(y) := \sum_{j=p+n}^{m-1} y_j.
+
+Hence, we get
+
+.. math::
+    P_{\mathrm{o0}}^*(y)_i :=
+    \begin{cases}
+    M_{\mathrm{l},0}(y), & \text{if } i = 0,     \\
+    M_{\mathrm{r},0}(y), & \text{if } i = n - 1, \\
+    0,                   & \text{else},
+    \end{cases}
+
+with the convention that the sum of the two values is taken in the case that $n = 1$, i.e. both first
+cases are the same. Hence, after constructing the restriction :math:`x \in \mathbb{R}^n` of a vector
+:math:`y \in \mathbb{R}^m` to the main part :math:`p, \dots, p + n - 1`, the sum of the entries to
+the left are added to :math:`x_0`, and the sum of the entries to the right are added to
+:math:`x_{n-1}`.
+
+
+Order 1 padding
+---------------
+In this padding mode, a given vector is continued with constant slope instead of constant value, i.e.
+
+.. math::
+ E_{\mathrm{o1}}(x)_j :=
+ \begin{cases}
+  x_0 + (j - p)(x_1 - x_0),                     & \text{if } 0 \leq j \leq p - 1,      \\
+  x_{j-p},                                      & \text{if } p \leq j \leq p + n - 1,  \\
+  x_{n-1} + (j - p - n + 1)(x_{n-1} - x_{n-2}), & \text{if } p + n \leq j \leq m - 1.
+ \end{cases}
+ :label: def_order1_pad_op
+
+We can write this operator as :math:`E_{\mathrm{o1}} = E_{\mathrm{o0}} + S_{\mathrm{o1}}` with the
+order-1 specific part
+
+.. math::
+    S_{\mathrm{o1}}(x)_j :=
+    \begin{cases}
+    (j - p)(x_1 - x_0),                 & \text{if } 0 \leq j \leq p - 1,      \\
+    0,                                  & \text{if } p \leq j \leq p + n - 1,  \\
+    (j - p - n + 1)(x_{n-1} - x_{n-2}), & \text{if } p + n \leq j \leq m - 1.
+    \end{cases}
+
+For its adjoint, we get
+
+.. math::
+ \langle S_{\mathrm{o1}}(x), y \rangle_{\mathbb{R}^m}
+ &= \sum_{j=0}^{p-1} (j - p)(x_1 - x_0)\, y_j +
+    \sum_{j=p+n}^{m-1} (j - p - n + 1)(x_{n-1} - x_{n-2})\, y_j \\
+ &= x_0 (-M_{\mathrm{l}}(y)) + x_1 M_{\mathrm{l}}(y) +
+    x_{n-2}(-M_{\mathrm{r}}(y)) + x_{n-1} M_{\mathrm{r}}(y)
+
+with the first order moments
+
+.. math::
+ M_{\mathrm{l},1}(y) := \sum_{j=0}^{p-1} (j - p)\, y_j, \quad
+ M_{\mathrm{r},1}(y) := \sum_{j=p+n}^{m-1} (j - p - n + 1)\, y_j.
+
+Hence, the order-1 specific operator has the adjoint
+
+.. math::
+    S_{\mathrm{o1}}^*(y)_i :=
+    \begin{cases}
+    -M_{\mathrm{l},1}(y), & \text{if } i = 0,     \\
+    M_{\mathrm{l},1}(y),  & \text{if } i = 1,     \\
+    -M_{\mathrm{r},1}(y), & \text{if } i = n - 2, \\
+    M_{\mathrm{r},1}(y),  & \text{if } i = n - 1, \\
+    0,                  & \text{else},
+    \end{cases}
+
+with the convention of summing values for overlapping cases, i.e. if :math:`i \in \{1, 2\}`. In
+practice, the adjoint for the order 1 padding case is applied by computing the zero'th and first
+order moments of :math:`y` and adding them to the two outmost entries of :math:`x` according to the
+above rule.

--- a/doc/source/release_notes.rst
+++ b/doc/source/release_notes.rst
@@ -9,6 +9,10 @@ Release Notes
 Next release
 ============
 
+New features
+------------
+- Add ``ResizingOperator`` for shrinking and extending (padding) of discretized functions, including a variety of padding methods. (:pull:`499`)
+
 Changes
 --------
 - Changed definition of ``LinearSpaceVector.multiply`` to match the definition used by numpy (:pull:`509`)

--- a/examples/trafos/fourier_trafo.py
+++ b/examples/trafos/fourier_trafo.py
@@ -17,12 +17,6 @@
 
 """Simple example on the usage of the Fourier Transform."""
 
-# Imports for common Python 2/3 codebase
-from __future__ import print_function, division, absolute_import
-from future import standard_library
-standard_library.install_aliases()
-
-# Internal
 import odl
 
 
@@ -31,20 +25,20 @@ import odl
 space = odl.uniform_discr([-1, -1], [1, 1], (512, 512), dtype='complex')
 
 # Make the Fourier transform operator on this space. The range is calculated
-# automatically. The default backend is numpy.fft
+# automatically. The default backend is numpy.fft.
 ft_op = odl.trafos.FourierTransform(space)
 
-# Create a phantom and its Fourier transfrom and display them
+# Create a phantom and its Fourier transfrom and display them.
 phantom = odl.phantom.shepp_logan(space, modified=True)
 phantom.show(title='Shepp-Logan phantom')
 phantom_ft = ft_op(phantom)
 phantom_ft.show(title='Full Fourier Transform')
 
-# Calculate the inverse transform
+# Calculate the inverse transform.
 phantom_ft_inv = ft_op.inverse(phantom_ft)
 phantom_ft_inv.show(title='Full Fourier Transform inverted')
 
-# Calculate the FT only along the first axis
+# Calculate the FT only along the first axis.
 ft_op_axis0 = odl.trafos.FourierTransform(space, axes=0)
 phantom_ft_axis0 = ft_op_axis0(phantom)
 phantom_ft_axis0.show(title='Fourier transform along axis 0')
@@ -60,7 +54,16 @@ phantom_real.show(title='Shepp-Logan phantom, real version')
 phantom_real_ft = ft_op_halfc(phantom_real)
 phantom_real_ft.show(title='Half-complex Fourier Transform')
 
-# If the space is real, the inverse also gives a real result
+# If the space is real, the inverse also gives a real result.
 phantom_real_ft_inv = ft_op_halfc.inverse(phantom_real_ft)
 phantom_real_ft_inv.show(title='Half-complex Fourier Transform inverted',
                          show=True)
+
+# The FT operator itself has no option of (zero-)padding, but it can be
+# composed with a `ResizingOperator` which does exactly that. Note that the
+# FT needs to be redefined on the enlarged space.
+padding_op = odl.ResizingOperator(space, ran_shp=(768, 768))
+ft_op = odl.trafos.FourierTransform(padding_op.range)
+padded_ft_op = ft_op * padding_op
+phantom_ft_padded = padded_ft_op(phantom)
+phantom_ft_padded.show('Padded FT of the phantom')

--- a/odl/__init__.py
+++ b/odl/__init__.py
@@ -33,19 +33,15 @@ __all__ = ('diagnostics', 'discr', 'operator', 'set', 'space', 'solvers',
 # module
 from . import diagnostics
 
-from . import discr
 from .discr import *
 __all__ += discr.__all__
 
-from . import operator
 from .operator import *
 __all__ += operator.__all__
 
-from . import set
 from .set import *
 __all__ += set.__all__
 
-from . import space
 from .space import *
 __all__ += space.__all__
 

--- a/odl/discr/discr_ops.py
+++ b/odl/discr/discr_ops.py
@@ -221,10 +221,6 @@ class ResizingOperator(Operator):
             the first derivative). This requires at least 2 values along
             each axis where padding is applied.
 
-            Note that for ``'symmetric'`` and ``'periodic'`` padding, the
-            number of added values on each side of the array cannot exceed
-            the original size.
-
         pad_const : scalar, optional
             Value to be used in the ``'constant'`` padding mode.
 
@@ -326,10 +322,21 @@ class ResizingOperator(Operator):
         if not self.is_linear:
             raise NotImplementedError('this operator is not linear and '
                                       'thus has no adjoint')
+        # TODO: this is not correct, fix it
         return ResizingOperator(domain=self.range, range=self.domain,
                                 pad_mode='constant', pad_const=0.0)
 
-    # TODO: inverse
+    @property
+    def inverse(self):
+        """(Pseudo-)Inverse of this operator.
+
+        Note that in axes where ``self`` extends, the returned operator
+        acts as left inverse, while in restriction axes, it is a
+        right inverse.
+        """
+        return ResizingOperator(domain=self.range, range=self.domain,
+                                pad_mode=self.pad_mode,
+                                pad_const=self.pad_const)
 
     @staticmethod
     def _num_left_from_spaces(dom, ran):

--- a/odl/discr/discr_ops.py
+++ b/odl/discr/discr_ops.py
@@ -23,22 +23,28 @@ from future import standard_library
 standard_library.install_aliases()
 from builtins import super
 
+import numpy as np
+
+from odl.discr import DiscreteLp, uniform_discr
 from odl.operator import Operator
+from odl.util.normalize import normalized_scalar_param_list, safe_int_conv
+from odl.util.numerics import resize_array, _SUPPORTED_PAD_MODES
 
 
-__all__ = ('Resampling',)
+__all__ = ('Resampling', 'ResizingOperator')
 
 
 class Resampling(Operator):
 
-    """An operator that resamples a vector on another grid.
+    """An operator that resamples on a different grid in the same set.
 
     The operator uses the underlying `DiscretizedSet.sampling` and
     `DiscretizedSet.interpolation` operators to achieve this.
 
     The spaces need to have the same `DiscretizedSet.uspace` in order
-    for this to work. The data space types may be different, although
-    performance may vary drastically.
+    for this to work. The data space implementations may be different,
+    although performance may suffer drastically due to translation
+    steps.
     """
 
     def __init__(self, domain, range):
@@ -46,10 +52,10 @@ class Resampling(Operator):
 
         Parameters
         ----------
-        domain : `LinearSpace`
-            Space that should be cast from.
-        range : `LinearSpace`
-            Space that should be cast to.
+        domain : `DiscretizedSet`
+            Set of elements that are to be resampled.
+        range : `DiscretizedSet`
+            Set in which the resampled elements lie.
 
         Examples
         --------
@@ -57,9 +63,13 @@ class Resampling(Operator):
         operator.
 
         >>> import odl
-        >>> X = odl.uniform_discr(0, 1, 3)
-        >>> Y = odl.uniform_discr(0, 1, 6)
-        >>> resampling = Resampling(X, Y)
+        >>> coarse_discr = odl.uniform_discr(0, 1, 3)
+        >>> fine_discr = odl.uniform_discr(0, 1, 6)
+        >>> resampling = odl.Resampling(coarse_discr, fine_discr)
+        >>> resampling.domain
+        uniform_discr(0.0, 1.0, 3)
+        >>> resampling.range
+        uniform_discr(0.0, 1.0, 6)
         """
         if domain.uspace != range.uspace:
             raise ValueError('`domain.uspace` ({}) does not match '
@@ -76,18 +86,18 @@ class Resampling(Operator):
 
         Examples
         --------
-        Create two spaces with different number of points and create resampling
-        operator. Apply operator to vector.
+        Create two spaces with different number of points and apply the
+        corresponding resampling operator to an element:
 
         >>> import odl
-        >>> X = odl.uniform_discr(0, 1, 3)
-        >>> Y = odl.uniform_discr(0, 1, 6)
-        >>> resampling = Resampling(X, Y)
+        >>> coarse_discr = odl.uniform_discr(0, 1, 3)
+        >>> fine_discr = odl.uniform_discr(0, 1, 6)
+        >>> resampling = odl.Resampling(coarse_discr, fine_discr)
         >>> print(resampling([0, 1, 0]))
         [0.0, 0.0, 1.0, 1.0, 0.0, 0.0]
 
         The result depends on the interpolation chosen for the underlying
-        spaces.
+        spaces:
 
         >>> Z = odl.uniform_discr(0, 1, 3, interp='linear')
         >>> linear_resampling = Resampling(Z, Y)
@@ -101,16 +111,14 @@ class Resampling(Operator):
 
     @property
     def inverse(self):
-        """Return an (approximate) inverse.
+        """An (approximate) inverse of this resampling operator.
 
-        Returns
-        -------
-        inverse : Resampling
-            The resampling operator defined in the inverse direction.
+        The returned operator is resampling defined in the opposite
+        direction.
 
         See Also
         --------
-        adjoint : resampling is unitary, so adjoint is inverse.
+        adjoint : resampling is unitary, so the adjoint is the inverse.
         """
         return Resampling(self.range, self.domain)
 
@@ -118,26 +126,26 @@ class Resampling(Operator):
     def adjoint(self):
         """Return an (approximate) adjoint.
 
-        The result is only exact if the interpolation and sampling operators
-        of the underlying spaces match exactly.
+        The result is only exact if the interpolation and sampling
+        operators of the underlying spaces match exactly.
 
         Returns
         -------
         adjoint : Resampling
-            The resampling operator defined in the inverse direction.
+            Resampling operator defined in the opposite direction.
 
         Examples
         --------
-        Create resampling operator and inverse
+        Create resampling operator and inverse:
 
         >>> import odl
-        >>> X = odl.uniform_discr(0, 1, 3)
-        >>> Y = odl.uniform_discr(0, 1, 6)
-        >>> resampling = Resampling(X, Y)
+        >>> coarse_discr = odl.uniform_discr(0, 1, 3)
+        >>> fine_discr = odl.uniform_discr(0, 1, 6)
+        >>> resampling = odl.Resampling(coarse_discr, fine_discr)
         >>> resampling_inv = resampling.inverse
 
         The inverse is proper left inverse if the resampling goes from a
-        lower sampling to a higher sampling
+        coarser to a finer sampling:
 
         >>> x = [0.0, 1.0, 0.0]
         >>> print(resampling_inv(resampling(x)))
@@ -150,6 +158,219 @@ class Resampling(Operator):
         [0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
         """
         return self.inverse
+
+
+class ResizingOperator(Operator):
+
+    """Operator mapping between discretized spaces of different shapes.
+
+    This operator is intended as a mapping between uniformly
+    discretized spaces with the same `DiscreteLp.cell_sides` but
+    different `DiscreteLp.shape`. The underlying operation is array
+    resizing, i.e. no resampling is performed.
+
+    By default, the `Operator.range` is a uniformly discretized space
+    with  the same properties as `Operator.domain`, except for changed
+    shape.
+
+    All resizing operator variants are linear, except constant padding
+    with constant != 0.
+    """
+
+    def __init__(self, domain, range=None, ran_shp=None, **kwargs):
+        """Initialize a new instance.
+
+        Parameters
+        ----------
+        domain : uniform `DiscreteLp`
+            Uniformly discretized space, the operator can be applied
+            to its elements.
+        range : uniform `DiscreteLp`, optional
+            Uniformly discretized space in which the result of the
+            application of this operator lies.
+            For the default ``None``, a space with the same attributes
+            as ``domain`` is used, except for its shape, which is set
+            to ``ran_shp``.
+        ran_shp : sequence of int
+            Shape of the range of this operator. This can be provided
+            instead of ``range`` and is mandatory if ``range`` is
+            ``None``.
+        num_left : int or sequence of int, optional
+            Number of cells to add to/remove from the left of
+            ``domain.partition``. By default, the difference is
+            distributed evenly, with preference for left in case of
+            ambiguity.
+            This option is can only be used together with ``ran_shp``.
+        pad_mode : str, optional
+            Method to be used to fill in missing values in an enlarged array.
+
+            ``'constant'``: Fill with ``pad_const``.
+
+            ``'symmetric'``: Reflect at the boundaries, not doubling the
+            outmost values. This requires left and right padding sizes
+            to be strictly smaller than the original array shape.
+
+            ``'periodic'``: Fill in values from the other side, keeping
+            the order. This requires left and right padding sizes to be
+            at most as large as the original array shape.
+
+            ``'order0'``: Extend constantly with the outmost values
+            (ensures continuity).
+
+            ``'order1'``: Extend with constant slope (ensures continuity of
+            the first derivative). This requires at least 2 values along
+            each axis where padding is applied.
+
+            Note that for ``'symmetric'`` and ``'periodic'`` padding, the
+            number of added values on each side of the array cannot exceed
+            the original size.
+
+        pad_const : scalar, optional
+            Value to be used in the ``'constant'`` padding mode.
+
+        discr_kwargs: dict, optional
+            Keyword arguments passed to the `uniform_discr` constructor.
+        """
+        if not isinstance(domain, DiscreteLp):
+            raise TypeError('`domain` must be a `DiscreteLp` instance, '
+                            'got {!r}'.format(domain))
+
+        if not domain.is_uniform:
+            raise ValueError('`domain` is not uniformly discretized')
+
+        num_left = kwargs.pop('num_left', None)
+        discr_kwargs = kwargs.pop('discr_kwargs', {})
+
+        if range is None:
+            if ran_shp is None:
+                raise ValueError('either `range` or `ran_shp` must be '
+                                 'given')
+
+            num_left = normalized_scalar_param_list(
+                num_left, domain.ndim, param_conv=safe_int_conv)
+            self.__num_left = tuple(num_left)
+
+            range = _resize_discr(domain, ran_shp, num_left, discr_kwargs)
+
+        elif ran_shp is None:
+            if num_left is not None:
+                raise ValueError('`num_left` can only be combined with '
+                                 '`ran_shp`')
+
+            if not np.allclose(range.cell_sides, domain.cell_sides):
+                raise ValueError(
+                    'cell sides of domain and range differ significantly '
+                    '(difference {})'
+                    ''.format(range.cell_sides - domain.cell_sides))
+
+            self.__num_left = self._num_left_from_spaces(domain, range)
+
+        else:
+            raise ValueError('cannot combine `range` with `ran_shape`')
+
+        pad_mode = kwargs.pop('pad_mode', 'constant')
+        self.__pad_mode = str(pad_mode).lower()
+        if self.pad_mode not in _SUPPORTED_PAD_MODES:
+            raise ValueError("`pad_mode` '{}' not understood".format(pad_mode))
+
+        self.__pad_const = float(kwargs.pop('pad_const', 0.0))
+
+        # padding mode 'constant' with `pad_const != 0` is not linear
+        linear = (self.pad_mode != 'constant' or self.pad_const == 0.0)
+
+        super().__init__(domain, range, linear=linear)
+
+    @property
+    def num_left(self):
+        """Number of cells added to/removed from the left."""
+        return self.__num_left
+
+    @property
+    def pad_mode(self):
+        """Padding mode used by this operator."""
+        return self.__pad_mode
+
+    @property
+    def pad_const(self):
+        """Constant used by this operator in case of constant padding."""
+        return self.__pad_const
+
+    def _call(self, x, out):
+        """Implement ``self(x, out)``."""
+        # TODO: simplify once context manager is available
+        out[:] = resize_array(x.asarray(), self.range.shape,
+                              num_left=self.num_left, pad_mode=self.pad_mode,
+                              pad_const=self.pad_const, out=out.asarray())
+
+    def derivative(self, point):
+        """Derivative of this operator.
+
+        For the particular case of constant padding with non-zero
+        constant, the derivative is the corresponding zero-padding
+        variant. In all other cases, this operator is linear, i.e.
+        the derivative is equal to ``self``.
+        """
+        if self.pad_mode == 'constant' and self.pad_const != 0:
+            return ResizingOperator(
+                domain=self.domain, range=self.range, pad_mode='constant',
+                pad_const=0.0)
+
+    @property
+    def adjoint(self):
+        """Adjoint of this operator.
+
+        In axes where ``self`` extends, the adjoint is given by the
+        corresponding restriction. In restriction axes, the adjoint
+        performs zero-padding.
+        """
+        if not self.is_linear:
+            raise NotImplementedError('this operator is not linear and '
+                                      'thus has no adjoint')
+        return ResizingOperator(domain=self.range, range=self.domain,
+                                pad_mode='constant', pad_const=0.0)
+
+    # TODO: inverse
+
+    @staticmethod
+    def _num_left_from_spaces(dom, ran):
+        """Return num_left corresponding to given spaces."""
+        diff_l = np.abs(ran.grid.min() - dom.grid.min())
+        num_left_float = diff_l / dom.cell_sides
+        num_left = np.around(num_left_float).astype(int)
+        if not np.allclose(num_left, num_left_float):
+            raise ValueError('range is shifted relative to domain by a '
+                             'non-multiple of cell_sides')
+        return tuple(num_left)
+
+
+def _resize_discr(discr, newshp, num_left, discr_kwargs):
+    """Return ``discr`` resized to ``newshp``.
+
+    Resize to ``newshp``, using ``num_left`` added/removed points to
+    the left (per axis). In axes where ``num_left`` is ``None``, the
+    points are distributed evenly.
+    """
+    new_begin, new_end = [], []
+    for b_orig, e_orig, n_orig, cs, n_new, num_l in zip(
+            discr.min_corner, discr.max_corner, discr.shape, discr.cell_sides,
+            newshp, num_left):
+
+        n_diff = n_new - n_orig
+#        print(n_diff)
+        if num_l is None:
+            num_r = n_diff // 2
+            num_l = n_diff - num_r
+        else:
+            num_r = n_diff - num_l
+
+#        print(num_l, num_r)
+
+        new_begin.append(b_orig - num_l * cs)
+        new_end.append(e_orig + num_r * cs)
+
+#    print(new_begin, new_end)
+
+    return uniform_discr(new_begin, new_end, newshp, **discr_kwargs)
 
 if __name__ == '__main__':
     # pylint: disable=wrong-import-position

--- a/odl/discr/discr_ops.py
+++ b/odl/discr/discr_ops.py
@@ -99,8 +99,8 @@ class Resampling(Operator):
         The result depends on the interpolation chosen for the underlying
         spaces:
 
-        >>> Z = odl.uniform_discr(0, 1, 3, interp='linear')
-        >>> linear_resampling = Resampling(Z, Y)
+        >>> coarse_discr = odl.uniform_discr(0, 1, 3, interp='linear')
+        >>> linear_resampling = odl.Resampling(coarse_discr, fine_discr)
         >>> print(linear_resampling([0, 1, 0]))
         [0.0, 0.25, 0.75, 0.75, 0.25, 0.0]
         """

--- a/odl/discr/discr_ops.py
+++ b/odl/discr/discr_ops.py
@@ -28,7 +28,7 @@ import numpy as np
 from odl.discr import DiscreteLp, uniform_discr
 from odl.operator import Operator
 from odl.util.normalize import normalized_scalar_param_list, safe_int_conv
-from odl.util.numerics import resize_array, _SUPPORTED_PAD_MODES
+from odl.util.numerics import resize_array, _SUPPORTED_RESIZE_PAD_MODES
 
 
 __all__ = ('Resampling', 'ResizingOperator')

--- a/odl/discr/lp_discr.py
+++ b/odl/discr/lp_discr.py
@@ -35,6 +35,7 @@ from odl.discr.partition import (
     RectPartition, uniform_partition_fromintv, uniform_partition)
 from odl.set import RealNumbers, ComplexNumbers, IntervalProd
 from odl.space import FunctionSpace, ProductSpace, FN_IMPLS
+from odl.space.weighting import WeightingBase
 from odl.util.normalize import (
     normalized_scalar_param_list, safe_int_conv, normalized_nodes_on_bdry)
 from odl.util.numerics import apply_on_boundary
@@ -908,14 +909,18 @@ def uniform_discr_frompartition(partition, exponent=2.0, interp='nearest',
     order = kwargs.pop('order', 'C')
 
     weighting = kwargs.pop('weighting', 'const')
-    weighting, weighting_in = str(weighting).lower(), weighting
-    if weighting == 'none' or float(exponent) == float('inf'):
-        weight = None
-    elif weighting == 'const':
-        weight = partition.cell_volume
+    if isinstance(weighting, WeightingBase):
+        # TODO: harmonize names, should be 'weighting' across the board
+        weight = weighting
     else:
-        raise ValueError("`weighting` '{}' not understood"
-                         "".format(weighting_in))
+        weighting, weighting_in = str(weighting).lower(), weighting
+        if weighting == 'none' or float(exponent) == float('inf'):
+            weight = None
+        elif weighting == 'const':
+            weight = partition.cell_volume
+        else:
+            raise ValueError("`weighting` '{}' not understood"
+                             "".format(weighting_in))
 
     if dtype is not None:
         dspace = ds_type(partition.size, dtype=dtype, impl=impl, weight=weight,

--- a/odl/util/normalize.py
+++ b/odl/util/normalize.py
@@ -29,7 +29,7 @@ __all__ = ('normalized_index_expression', 'normalized_scalar_param_list')
 
 
 def normalized_scalar_param_list(param, length, param_conv=None,
-                                 keep_none=True):
+                                 keep_none=True, return_nonconv=False):
     """Return a list of given length from a scalar parameter.
 
     The typical use case is when a single value or a sequence of
@@ -62,11 +62,17 @@ def normalized_scalar_param_list(param, length, param_conv=None,
         Conversion applied to each list element. None means no conversion.
     keep_none : bool, optional
         If True, None is not converted.
+    return_nonconv : bool, optional
+        If True, return also the list where no conversion has been
+        applied.
 
     Returns
     -------
     plist : list
         Input parameter turned into a list of length ``length``.
+    nonconv : list
+        The same as ``plist``, but without conversion. This is only
+        returned if ``return_nonconv == True``.
 
     Examples
     --------
@@ -113,39 +119,45 @@ def normalized_scalar_param_list(param, length, param_conv=None,
     try:
         # TODO: always use this when numpy >= 1.10 can be assumed
         param = np.array(param, dtype=object, copy=True, ndmin=1)
-        out_list = list(np.broadcast_to(param, (length,)))
+        nonconv_list = list(np.broadcast_to(param, (length,)))
     except AttributeError:
         # numpy.broadcast_to not available
         if np.isscalar(param):
             # Try this first, will work better with iterable input like '10'
-            out_list = [param] * length
+            nonconv_list = [param] * length
         else:
             try:
                 param_len = len(param)
             except TypeError:
                 # Not a sequence -> single parameter
-                out_list = [param] * length
+                nonconv_list = [param] * length
             else:
                 if param_len == 1:
-                    out_list = list(param) * length
+                    nonconv_list = list(param) * length
                 elif param_len == length:
-                    out_list = list(param)
+                    nonconv_list = list(param)
                 else:
                     raise ValueError('sequence `param` has length {}, '
                                      'expected {}'.format(param_len, length))
 
-    if len(out_list) != length:
+    if len(nonconv_list) != length:
         raise ValueError('sequence `param` has length {}, expected {}'
-                         ''.format(len(out_list), length))
+                         ''.format(len(nonconv_list), length))
 
-    if param_conv is not None:
-        for i, p in enumerate(out_list):
+    if param_conv is None:
+        out_list = nonconv_list.copy()
+    else:
+        out_list = []
+        for p in nonconv_list:
             if p is None and keep_none:
-                pass
+                out_list.append(p)
             else:
-                out_list[i] = param_conv(p)
+                out_list.append(param_conv(p))
 
-    return out_list
+    if return_nonconv:
+        return out_list, nonconv_list
+    else:
+        return out_list
 
 
 def normalized_index_expression(indices, shape, int_to_slice=False):

--- a/odl/util/normalize.py
+++ b/odl/util/normalize.py
@@ -145,7 +145,7 @@ def normalized_scalar_param_list(param, length, param_conv=None,
                          ''.format(len(nonconv_list), length))
 
     if param_conv is None:
-        out_list = nonconv_list.copy()
+        out_list = list(nonconv_list)
     else:
         out_list = []
         for p in nonconv_list:

--- a/odl/util/numerics.py
+++ b/odl/util/numerics.py
@@ -312,6 +312,10 @@ def resize_array(arr, newshp, offset=None, pad_mode='constant', pad_const=0,
     Where ``newshp < arr.shape``, the array is cropped to the new
     size.
 
+    See `the online documentation
+    <https://odl.readthedocs.io/math/resizing_ops.html>`_
+    on resizing operators for mathematical details.
+
     Parameters
     ----------
     arr : array-like

--- a/odl/util/numerics.py
+++ b/odl/util/numerics.py
@@ -304,7 +304,8 @@ def fast_1d_tensor_mult(ndarr, onedim_arrs, axes=None, out=None):
 
 
 def resize_array(arr, newshp, frac_left=None, num_left=None,
-                 pad_mode='constant', pad_const=0, out=None):
+                 pad_mode='constant', pad_const=0, direction='forward',
+                 out=None):
     """Return the resized version of ``arr`` with shape ``newshp``.
 
     In axes where ``newshp > arr.shape``, padding is applied according
@@ -356,6 +357,16 @@ def resize_array(arr, newshp, frac_left=None, num_left=None,
 
     pad_const : scalar, optional
         Value to be used in the ``'constant'`` padding mode.
+    direction : {'forward', 'adjoint'}
+        Determines which variant of the resizing is applied.
+
+        'forward' : in axes where ``out`` is larger than ``arr``,
+        apply padding. Otherwise, restrict to the smaller size.
+
+        'adjoint' : in axes where ``out`` is larger than ``arr``,
+        apply zero-padding. Otherwise, restrict to the smaller size
+        and add the outside contributions according to ``pad_mode``.
+
     out : `numpy.ndarray`, optional
         Array to write the result to. Must have shape ``newshp`` and
         be able to hold the data type of the input array.
@@ -498,7 +509,7 @@ def resize_array(arr, newshp, frac_left=None, num_left=None,
     for i, (n_orig, n_new, num_l) in enumerate(zip(arr.shape, out.shape,
                                                    num_left)):
         if n_new < n_orig:
-            # Simple case: remove according to fraction
+            # Simple case: remove according to num_left
             n_remove = n_orig - n_new
             istart = num_l
             istop = n_orig - (n_remove - istart)

--- a/odl/util/numerics.py
+++ b/odl/util/numerics.py
@@ -732,10 +732,12 @@ def _apply_padding(lhs_arr, rhs_arr, offset, pad_mode, direction):
                 lhs_slc_l[axis] = left_slc
                 lhs_slc_r[axis] = right_slc
 
-                lhs_arr[tuple(lhs_slc_l)] += np.sum(lhs_arr[tuple(rhs_slc_l)],
-                                                    axis=axis, keepdims=True)
-                lhs_arr[tuple(lhs_slc_r)] += np.sum(lhs_arr[tuple(rhs_slc_r)],
-                                                    axis=axis, keepdims=True)
+                lhs_arr[tuple(lhs_slc_l)] += np.sum(
+                    lhs_arr[tuple(rhs_slc_l)],
+                    axis=axis, keepdims=True, dtype=lhs_arr.dtype)
+                lhs_arr[tuple(lhs_slc_r)] += np.sum(
+                    lhs_arr[tuple(rhs_slc_r)],
+                    axis=axis, keepdims=True, dtype=lhs_arr.dtype)
 
         elif pad_mode == 'order1':
             # Some extra work necessary: need to compute the derivative at
@@ -783,16 +785,20 @@ def _apply_padding(lhs_arr, rhs_arr, offset, pad_mode, direction):
                     lhs_arr[tuple(bdry_slc_r)] + arange_r * slope_r)
             else:
                 # Same as in 'order0'
-                lhs_arr[tuple(bdry_slc_l)] += np.sum(lhs_arr[tuple(rhs_slc_l)],
-                                                     axis=axis, keepdims=True)
-                lhs_arr[tuple(bdry_slc_r)] += np.sum(lhs_arr[tuple(rhs_slc_r)],
-                                                     axis=axis, keepdims=True)
+                lhs_arr[tuple(bdry_slc_l)] += np.sum(
+                    lhs_arr[tuple(rhs_slc_l)],
+                    axis=axis, keepdims=True, dtype=lhs_arr.dtype)
+                lhs_arr[tuple(bdry_slc_r)] += np.sum(
+                    lhs_arr[tuple(rhs_slc_r)],
+                    axis=axis, keepdims=True, dtype=lhs_arr.dtype)
 
                 # Calculate the order 1 moments
                 moment1_l = np.sum(arange_l * lhs_arr[tuple(rhs_slc_l)],
-                                   axis=axis, keepdims=True)
+                                   axis=axis, keepdims=True,
+                                   dtype=lhs_arr.dtype)
                 moment1_r = np.sum(arange_r * lhs_arr[tuple(rhs_slc_r)],
-                                   axis=axis, keepdims=True)
+                                   axis=axis, keepdims=True,
+                                   dtype=lhs_arr.dtype)
 
                 # Add moment1 at the "width-2 boundary layers", with the sign
                 # corresponding to the sign in the derivative calculation

--- a/odl/util/numerics.py
+++ b/odl/util/numerics.py
@@ -454,7 +454,7 @@ def resize_array(arr, newshp, frac_left=None, num_left=None,
         arr = np.asarray(arr)
         out = np.empty(newshp, dtype=arr.dtype)
         if len(newshp) != arr.ndim:
-            raise ValueError('`number of axes of `arr` and `len(newshp)` do '
+            raise ValueError('number of axes of `arr` and `len(newshp)` do '
                              'not match ({} != {})'
                              ''.format(arr.ndim, len(newshp)))
 
@@ -474,7 +474,7 @@ def resize_array(arr, newshp, frac_left=None, num_left=None,
                                                      out.shape)]
         for i, (fl, fl_in) in enumerate(zip(frac_left, frac_left_in)):
             if not 0.0 <= fl <= 1.0:
-                raise ValueError('in axis {}: `frac_l` must lie between 0 '
+                raise ValueError('in axis {}: `frac_left` must lie between 0 '
                                  'and 1, got {}'.format(i, fl_in))
     else:
         num_left = normalized_scalar_param_list(
@@ -520,6 +520,11 @@ def resize_array(arr, newshp, frac_left=None, num_left=None,
             n_pad_r = len(range(istop, n_new))
 
             # Handle some error scenarios with illegal lengths
+            if pad_mode == 'order0' and n_orig == 0:
+                raise ValueError('in axis {}: need at least 1 value for '
+                                 'order 0 padding, got 0'
+                                 ''.format(i))
+
             if pad_mode == 'order1' and n_orig == 1:
                 raise ValueError('in axis {}: need at least 2 values for '
                                  'order 1 padding, got 1'

--- a/odl/util/numerics.py
+++ b/odl/util/numerics.py
@@ -304,7 +304,7 @@ def fast_1d_tensor_mult(ndarr, onedim_arrs, axes=None, out=None):
 
 
 def resize_array(arr, newshp, frac_left=None, num_left=None,
-                 pad_mode='constant', pad_const=0.0, out=None):
+                 pad_mode='constant', pad_const=0, out=None):
     """Return the resized version of ``arr`` with shape ``newshp``.
 
     In axes where ``newshp > arr.shape``, padding is applied according
@@ -485,7 +485,10 @@ def resize_array(arr, newshp, frac_left=None, num_left=None,
     if pad_mode not in _SUPPORTED_PAD_MODES:
         raise ValueError("`pad_mode` '{}' not understood".format(pad_mode_in))
 
-    if pad_mode == 'constant' and not np.can_cast(pad_const, out.dtype):
+    if (pad_mode == 'constant' and
+        not np.can_cast(pad_const, out.dtype) and
+        any(n_new > n_orig
+            for n_orig, n_new in zip(arr.shape, out.shape))):
         raise ValueError('`pad_const` {} cannot be safely cast to the data '
                          'type {} of the output array'
                          ''.format(pad_const, out.dtype))

--- a/odl/util/testutils.py
+++ b/odl/util/testutils.py
@@ -39,12 +39,36 @@ __all__ = ('almost_equal', 'all_equal', 'all_almost_equal', 'never_skip',
 
 
 def _places(a, b, default=None):
-    """Return 3 if one dtype is 'float32' or 'complex64', else 5."""
+    """Return number of expected correct digits between ``a`` and ``b``.
+
+    Returned numbers if one of ``a.dtype`` and ``b.dtype`` is as below:
+        2 -- for ``np.float16``
+
+        3 -- for ``np.float32`` or ``np.complex64``
+
+        5 -- for all other cases
+    """
     dtype1 = getattr(a, 'dtype', object)
     dtype2 = getattr(b, 'dtype', object)
-    small_dtypes = [np.float32, np.complex64]
+    return min(dtype_places(dtype1, default), dtype_places(dtype2, default))
 
-    if dtype1 in small_dtypes or dtype2 in small_dtypes:
+
+def dtype_places(dtype, default=None):
+    """Return number of correct digits expected for given dtype.
+
+    Returned numbers:
+        1 -- for ``np.float16``
+
+        3 -- for ``np.float32`` or ``np.complex64``
+
+        5 -- for all other cases
+    """
+    small_dtypes = [np.float32, np.complex64]
+    tiny_dtypes = [np.float16]
+
+    if dtype in tiny_dtypes:
+        return 1
+    elif dtype in small_dtypes:
         return 3
     else:
         return default if default is not None else 5

--- a/test/discr/discr_ops_test.py
+++ b/test/discr/discr_ops_test.py
@@ -146,7 +146,35 @@ def test_resizing_op_deriv():
     assert res_op_deriv.pad_const == 0.0
 
 
-# TODO: adjoint and inverse
+pad_modes = [('constant', 0), ('constant', 1), 'symmetric', 'periodic',
+             'order0', 'order1']
+pad_mode_ids = [' constant=0 ', ' constant=1 ', ' symmetric ', ' periodic ',
+                ' order0 ', ' order1 ']
+
+
+@pytest.fixture(scope="module", params=pad_modes, ids=pad_mode_ids)
+def pad_mode(request):
+    return request.param
+
+
+def test_resizing_op_inverse(pad_mode):
+
+    if isinstance(pad_mode, tuple):
+        pad_mode, pad_const = pad_mode
+    else:
+        pad_const = 0.0
+
+    space = odl.uniform_discr([0, -1], [1, 1], (4, 5))
+    res_space = odl.uniform_discr([0, -1.4], [1.5, 1.4], (6, 7))
+    res_op = odl.ResizingOperator(space, res_space, pad_mode=pad_mode,
+                                  pad_const=pad_const)
+
+    # Only left inverse if the operator extentds in all axes
+    x = space.element(np.arange(space.size).reshape(space.shape))
+    assert res_op.inverse(res_op(x)) == x
+
+
+# TODO: adjoint
 
 
 if __name__ == '__main__':

--- a/test/discr/discr_ops_test.py
+++ b/test/discr/discr_ops_test.py
@@ -91,11 +91,20 @@ def test_resizing_op_raise():
         odl.ResizingOperator(space, res_space, pad_mode='something')
 
 
-def test_resizing_op_properties():
+dtype_params = ['float64', 'complex64']
+dtype_ids = [' dtype = {} '.format(p) for p in dtype_params]
+
+
+@pytest.fixture(scope="module", ids=dtype_ids, params=dtype_params)
+def dtype(request):
+    return request.param
+
+
+def test_resizing_op_properties(dtype):
 
     # Explicit range, rest default
-    space = odl.uniform_discr([0, -1], [1, 1], (10, 5))
-    res_space = odl.uniform_discr([0, -3], [2, 3], (20, 15))
+    space = odl.uniform_discr([0, -1], [1, 1], (10, 5), dtype=dtype)
+    res_space = odl.uniform_discr([0, -3], [2, 3], (20, 15), dtype=dtype)
     res_op = odl.ResizingOperator(space, res_space)
 
     assert res_op.domain == space
@@ -109,6 +118,8 @@ def test_resizing_op_properties():
     res_op = odl.ResizingOperator(space, ran_shp=(20, 15), offset=[0, 5])
     assert np.allclose(res_op.range.min_corner, res_space.min_corner)
     assert np.allclose(res_op.range.max_corner, res_space.max_corner)
+    assert np.allclose(res_op.range.cell_sides, res_space.cell_sides)
+    assert res_op.range.dtype == res_space.dtype
     assert res_op.offset == (0, 5)
 
     # Different padding mode
@@ -156,15 +167,6 @@ pad_mode_ids = [' constant=0 ', ' constant=1 ', ' symmetric ', ' periodic ',
 
 @pytest.fixture(scope="module", params=pad_modes, ids=pad_mode_ids)
 def pad_mode(request):
-    return request.param
-
-
-dtype_params = ['float64', 'complex64']
-dtype_ids = [' dtype = {} '.format(p) for p in dtype_params]
-
-
-@pytest.fixture(scope="module", ids=dtype_ids, params=dtype_params)
-def dtype(request):
     return request.param
 
 

--- a/test/discr/discr_ops_test.py
+++ b/test/discr/discr_ops_test.py
@@ -27,25 +27,49 @@ import numpy as np
 
 import odl
 from odl.discr.discr_ops import _SUPPORTED_RESIZE_PAD_MODES
-from odl.util.testutils import almost_equal, example_element
+from odl.util.testutils import almost_equal, example_element, dtype_places
+from odl.util.utility import is_scalar_dtype, is_real_floating_dtype
 
 
 # --- ResizingOperator --- #
 
 
-def test_resizing_op_init():
+paddings = list(_SUPPORTED_RESIZE_PAD_MODES)
+paddings.remove('constant')
+paddings.extend([('constant', 0), ('constant', 1)])
+padding_ids = [" pad_mode = '{}' {} ".format(*p)
+               if isinstance(p, tuple)
+               else " pad_mode = '{}' ".format(p)
+               for p in paddings]
+
+
+@pytest.fixture(scope="module", ids=padding_ids, params=paddings)
+def padding(request):
+    if isinstance(request.param, tuple):
+        pad_mode, pad_const = request.param
+    else:
+        pad_mode = request.param
+        pad_const = 0
+
+    return pad_mode, pad_const
+
+
+def test_resizing_op_init(fn_impl, padding):
 
     # Test if the different init patterns run
 
-    space = odl.uniform_discr([0, -1], [1, 1], (10, 5))
-    res_space = odl.uniform_discr([0, -3], [2, 3], (20, 15))
+    pad_mode, pad_const = padding
+
+    space = odl.uniform_discr([0, -1], [1, 1], (10, 5), impl=fn_impl)
+    res_space = odl.uniform_discr([0, -3], [2, 3], (20, 15), impl=fn_impl)
 
     odl.ResizingOperator(space, res_space)
     odl.ResizingOperator(space, ran_shp=(20, 15))
     odl.ResizingOperator(space, ran_shp=(20, 15), offset=(0, 5))
-    odl.ResizingOperator(space, ran_shp=(20, 15), pad_mode='symmetric')
-    odl.ResizingOperator(space, ran_shp=(20, 15), pad_const=1.0)
-    odl.ResizingOperator(space, ran_shp=(20, 15), pad_const=1.0,
+    odl.ResizingOperator(space, ran_shp=(20, 15), pad_mode=pad_mode)
+    odl.ResizingOperator(space, ran_shp=(20, 15), pad_mode=pad_mode,
+                         pad_const=pad_const)
+    odl.ResizingOperator(space, ran_shp=(20, 15),
                          discr_kwargs={'nodes_on_bdry': True})
 
 
@@ -91,127 +115,141 @@ def test_resizing_op_raise():
         odl.ResizingOperator(space, res_space, pad_mode='something')
 
 
-dtype_params = ['float64', 'complex64']
-dtype_ids = [' dtype = {} '.format(p) for p in dtype_params]
+def test_resizing_op_properties(fn_impl, padding):
 
+    dtypes = [dt for dt in odl.FN_IMPLS[fn_impl].available_dtypes()
+              if is_scalar_dtype(dt)]
 
-@pytest.fixture(scope="module", ids=dtype_ids, params=dtype_params)
-def dtype(request):
-    return request.param
+    pad_mode, pad_const = padding
 
+    for dtype in dtypes:
+        # Explicit range
+        space = odl.uniform_discr([0, -1], [1, 1], (10, 5), dtype=dtype)
+        res_space = odl.uniform_discr([0, -3], [2, 3], (20, 15), dtype=dtype)
+        res_op = odl.ResizingOperator(space, res_space, pad_mode=pad_mode,
+                                      pad_const=pad_const)
 
-def test_resizing_op_properties(dtype):
+        assert res_op.domain == space
+        assert res_op.range == res_space
+        assert res_op.offset == (0, 5)
+        assert res_op.pad_mode == pad_mode
+        assert res_op.pad_const == pad_const
+        if pad_mode == 'constant' and pad_const != 0:
+            assert not res_op.is_linear
+        else:
+            assert res_op.is_linear
 
-    # Explicit range, rest default
-    space = odl.uniform_discr([0, -1], [1, 1], (10, 5), dtype=dtype)
-    res_space = odl.uniform_discr([0, -3], [2, 3], (20, 15), dtype=dtype)
-    res_op = odl.ResizingOperator(space, res_space)
-
-    assert res_op.domain == space
-    assert res_op.range == res_space
-    assert res_op.offset == (0, 5)
-    assert res_op.pad_mode == 'constant'
-    assert res_op.pad_const == 0.0
-    assert res_op.is_linear
-
-    # Implicit range via ran_shp and offset
-    res_op = odl.ResizingOperator(space, ran_shp=(20, 15), offset=[0, 5])
-    assert np.allclose(res_op.range.min_corner, res_space.min_corner)
-    assert np.allclose(res_op.range.max_corner, res_space.max_corner)
-    assert np.allclose(res_op.range.cell_sides, res_space.cell_sides)
-    assert res_op.range.dtype == res_space.dtype
-    assert res_op.offset == (0, 5)
-
-    # Different padding mode
-    res_op = odl.ResizingOperator(space, res_space, pad_const=1)
-    assert res_op.pad_const == 1.0
-    assert not res_op.is_linear
-
-    res_op = odl.ResizingOperator(space, res_space, pad_mode='symmetric')
-    assert res_op.pad_mode == 'symmetric'
-    assert res_op.is_linear
+        # Implicit range via ran_shp and offset
+        res_op = odl.ResizingOperator(space, ran_shp=(20, 15), offset=[0, 5],
+                                      pad_mode=pad_mode, pad_const=pad_const)
+        assert np.allclose(res_op.range.min_corner, res_space.min_corner)
+        assert np.allclose(res_op.range.max_corner, res_space.max_corner)
+        assert np.allclose(res_op.range.cell_sides, res_space.cell_sides)
+        assert res_op.range.dtype == res_space.dtype
+        assert res_op.offset == (0, 5)
+        assert res_op.pad_mode == pad_mode
+        assert res_op.pad_const == pad_const
+        if pad_mode == 'constant' and pad_const != 0:
+            assert not res_op.is_linear
+        else:
+            assert res_op.is_linear
 
 
 def test_resizing_op_call(fn_impl):
 
-    # Minimal test since this operator only wraps resize_array
+    dtypes = [dt for dt in odl.FN_IMPLS[fn_impl].available_dtypes()
+              if is_scalar_dtype(dt)]
+
+    for dtype in dtypes:
+        # Minimal test since this operator only wraps resize_array
+        space = odl.uniform_discr([0, -1], [1, 1], (4, 5), impl=fn_impl)
+        res_space = odl.uniform_discr([0, -0.6], [2, 0.2], (8, 2),
+                                      impl=fn_impl)
+        res_op = odl.ResizingOperator(space, res_space)
+        out = res_op(space.one())
+        true_res = np.zeros((8, 2))
+        true_res[:4, :] = 1
+        assert np.array_equal(out, true_res)
+
+        out = res_space.element()
+        res_op(space.one(), out=out)
+        assert np.array_equal(out, true_res)
+
+        # Test also mapping to default impl for other 'fn_impl'
+        if fn_impl != 'numpy':
+            space = odl.uniform_discr([0, -1], [1, 1], (4, 5), impl=fn_impl)
+            res_space = odl.uniform_discr([0, -0.6], [2, 0.2], (8, 2))
+            res_op = odl.ResizingOperator(space, res_space)
+            out = res_op(space.one())
+            true_res = np.zeros((8, 2))
+            true_res[:4, :] = 1
+            assert np.array_equal(out, true_res)
+
+            out = res_space.element()
+            res_op(space.one(), out=out)
+            assert np.array_equal(out, true_res)
+
+
+def test_resizing_op_deriv(padding):
+
+    pad_mode, pad_const = padding
     space = odl.uniform_discr([0, -1], [1, 1], (4, 5))
     res_space = odl.uniform_discr([0, -0.6], [2, 0.2], (8, 2))
-    res_op = odl.ResizingOperator(space, res_space)
-    out = res_op(space.one())
-    true_res = np.zeros((8, 2))
-    true_res[:4, :] = 1
-    assert np.array_equal(out, true_res)
-
-    out = res_space.element()
-    res_op(space.one(), out=out)
-    assert np.array_equal(out, true_res)
-
-
-def test_resizing_op_deriv():
-
-    # Only non-trivial case is constant padding with const != 0
-    space = odl.uniform_discr([0, -1], [1, 1], (4, 5))
-    res_space = odl.uniform_discr([0, -0.6], [2, 0.2], (8, 2))
-    res_op = odl.ResizingOperator(space, res_space, pad_const=1.0)
+    res_op = odl.ResizingOperator(space, res_space, pad_mode=pad_mode,
+                                  pad_const=pad_const)
     res_op_deriv = res_op.derivative(space.one())
-    assert res_op_deriv.pad_mode == 'constant'
-    assert res_op_deriv.pad_const == 0.0
 
-
-pad_modes = [('constant', 0), ('constant', 1), 'symmetric', 'periodic',
-             'order0', 'order1']
-pad_mode_ids = [' constant=0 ', ' constant=1 ', ' symmetric ', ' periodic ',
-                ' order0 ', ' order1 ']
-
-
-@pytest.fixture(scope="module", params=pad_modes, ids=pad_mode_ids)
-def pad_mode(request):
-    return request.param
-
-
-def test_resizing_op_inverse(pad_mode, dtype, fn_impl):
-
-    if isinstance(pad_mode, tuple):
-        pad_mode, pad_const = pad_mode
+    if pad_mode == 'constant' and pad_const != 0:
+        # Only non-trivial case is constant padding with const != 0
+        assert res_op_deriv.pad_mode == 'constant'
+        assert res_op_deriv.pad_const == 0.0
     else:
-        pad_const = 0.0
+        assert res_op_deriv is res_op
 
-    space = odl.uniform_discr([0, -1], [1, 1], (4, 5), dtype=dtype,
-                              impl=fn_impl)
-    res_space = odl.uniform_discr([0, -1.4], [1.5, 1.4], (6, 7), dtype=dtype,
+
+def test_resizing_op_inverse(padding, fn_impl):
+
+    pad_mode, pad_const = padding
+    dtypes = [dt for dt in odl.FN_IMPLS[fn_impl].available_dtypes()
+              if is_scalar_dtype(dt)]
+
+    for dtype in dtypes:
+        space = odl.uniform_discr([0, -1], [1, 1], (4, 5), dtype=dtype,
                                   impl=fn_impl)
-    res_op = odl.ResizingOperator(space, res_space, pad_mode=pad_mode,
-                                  pad_const=pad_const)
+        res_space = odl.uniform_discr([0, -1.4], [1.5, 1.4], (6, 7),
+                                      dtype=dtype, impl=fn_impl)
+        res_op = odl.ResizingOperator(space, res_space, pad_mode=pad_mode,
+                                      pad_const=pad_const)
 
-    # Only left inverse if the operator extentds in all axes
-    x = space.element(np.arange(space.size).reshape(space.shape))
-    assert res_op.inverse(res_op(x)) == x
+        # Only left inverse if the operator extentds in all axes
+        x = example_element(space)
+        assert res_op.inverse(res_op(x)) == x
 
 
-def test_resizing_op_adjoint(pad_mode, dtype, fn_impl):
+def test_resizing_op_adjoint(padding, fn_impl):
 
-    if isinstance(pad_mode, tuple):
-        pad_mode, pad_const = pad_mode
-    else:
-        pad_const = 0.0
+    pad_mode, pad_const = padding
+    dtypes = [dt for dt in odl.FN_IMPLS[fn_impl].available_dtypes()
+              if is_real_floating_dtype(dt)]
 
-    space = odl.uniform_discr([0, -1], [1, 1], (4, 5), dtype=dtype,
-                              impl=fn_impl)
-    res_space = odl.uniform_discr([0, -1.4], [1.5, 1.4], (6, 7), dtype=dtype,
+    for dtype in dtypes:
+        space = odl.uniform_discr([0, -1], [1, 1], (4, 5), dtype=dtype,
                                   impl=fn_impl)
-    res_op = odl.ResizingOperator(space, res_space, pad_mode=pad_mode,
-                                  pad_const=pad_const)
+        res_space = odl.uniform_discr([0, -1.4], [1.5, 1.4], (6, 7),
+                                      dtype=dtype, impl=fn_impl)
+        res_op = odl.ResizingOperator(space, res_space, pad_mode=pad_mode,
+                                      pad_const=pad_const)
 
-    if pad_const != 0.0:
-        with pytest.raises(NotImplementedError):
-            res_op.adjoint
-        return
+        if pad_const != 0.0:
+            with pytest.raises(NotImplementedError):
+                res_op.adjoint
+            return
 
-    elem = example_element(space)
-    res_elem = example_element(res_space)
-    assert almost_equal(res_op(elem).inner(res_elem),
-                        elem.inner(res_op.adjoint(res_elem)))
+        elem = example_element(space)
+        res_elem = example_element(res_space)
+        inner1 = res_op(elem).inner(res_elem)
+        inner2 = elem.inner(res_op.adjoint(res_elem))
+        assert almost_equal(inner1, inner2, places=dtype_places(dtype))
 
 
 if __name__ == '__main__':

--- a/test/discr/discr_ops_test.py
+++ b/test/discr/discr_ops_test.py
@@ -1,0 +1,153 @@
+# Copyright 2014-2016 The ODL development group
+#
+# This file is part of ODL.
+#
+# ODL is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# ODL is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with ODL.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Unit tests for `discr_ops`."""
+
+# Imports for common Python 2/3 codebase
+from __future__ import print_function, division, absolute_import
+from future import standard_library
+standard_library.install_aliases()
+
+import pytest
+import numpy as np
+
+import odl
+from odl.discr.discr_ops import _SUPPORTED_PAD_MODES
+
+
+# --- ResizingOperator --- #
+
+
+def test_resizing_op_init():
+
+    # Test if the different init patterns run
+
+    space = odl.uniform_discr([0, -1], [1, 1], (10, 5))
+    res_space = odl.uniform_discr([0, -3], [2, 3], (20, 15))
+
+    odl.ResizingOperator(space, res_space)
+    odl.ResizingOperator(space, ran_shp=(20, 15))
+    odl.ResizingOperator(space, ran_shp=(20, 15), num_left=(0, 5))
+    odl.ResizingOperator(space, ran_shp=(20, 15), pad_mode='symmetric')
+    odl.ResizingOperator(space, ran_shp=(20, 15), pad_const=1.0)
+    odl.ResizingOperator(space, ran_shp=(20, 15), pad_const=1.0,
+                         discr_kwargs={'nodes_on_bdry': True})
+
+
+def test_resizing_op_raise():
+
+    # domain not a uniformely discretized Lp
+    with pytest.raises(TypeError):
+        odl.ResizingOperator(odl.rn(5), ran_shp=(10,))
+
+    grid = odl.TensorGrid([0, 2, 3])
+    part = odl.RectPartition(odl.IntervalProd(0, 3), grid)
+    fspace = odl.FunctionSpace(odl.IntervalProd(0, 3))
+    dspace = odl.rn(3)
+    space = odl.DiscreteLp(fspace, part, dspace)
+    with pytest.raises(ValueError):
+        odl.ResizingOperator(space, ran_shp=(10,))
+
+    # different cell sides in domain and range
+    space = odl.uniform_discr(0, 1, 10)
+    res_space = odl.uniform_discr(0, 1, 15)
+    with pytest.raises(ValueError):
+        odl.ResizingOperator(space, res_space)
+
+    # non-integer multiple of cell sides used as shift (grid of the
+    # resized space shifted)
+    space = odl.uniform_discr(0, 1, 5)
+    res_space = odl.uniform_discr(-0.5, 1.5, 10)
+    with pytest.raises(ValueError):
+        odl.ResizingOperator(space, res_space)
+
+    # need either range or ran_shp
+    with pytest.raises(ValueError):
+        odl.ResizingOperator(space)
+
+    # num_left cannot be combined with range
+    space = odl.uniform_discr([0, -1], [1, 1], (10, 5))
+    res_space = odl.uniform_discr([0, -3], [2, 3], (20, 15))
+    with pytest.raises(ValueError):
+        odl.ResizingOperator(space, res_space, num_left=(0, 0))
+
+    # bad pad_mode
+    with pytest.raises(ValueError):
+        odl.ResizingOperator(space, res_space, pad_mode='something')
+
+
+def test_resizing_op_properties():
+
+    # Explicit range, rest default
+    space = odl.uniform_discr([0, -1], [1, 1], (10, 5))
+    res_space = odl.uniform_discr([0, -3], [2, 3], (20, 15))
+    res_op = odl.ResizingOperator(space, res_space)
+
+    assert res_op.domain == space
+    assert res_op.range == res_space
+    assert res_op.num_left == (0, 5)
+    assert res_op.pad_mode == 'constant'
+    assert res_op.pad_const == 0.0
+    assert res_op.is_linear
+
+    # Implicit range via ran_shp and num_left
+    res_op = odl.ResizingOperator(space, ran_shp=(20, 15), num_left=[0, 5])
+    assert res_op.range == res_space
+    assert res_op.num_left == (0, 5)
+
+    # Different padding mode
+    res_op = odl.ResizingOperator(space, res_space, pad_const=1)
+    assert res_op.pad_const == 1.0
+    assert not res_op.is_linear
+
+    res_op = odl.ResizingOperator(space, res_space, pad_mode='symmetric')
+    assert res_op.pad_mode == 'symmetric'
+    assert res_op.is_linear
+
+
+def test_resizing_op_call(fn_impl):
+
+    # Minimal test since this operator only wraps resize_array
+    space = odl.uniform_discr([0, -1], [1, 1], (4, 5))
+    res_space = odl.uniform_discr([0, -0.6], [2, 0.2], (8, 2))
+    res_op = odl.ResizingOperator(space, res_space)
+    out = res_op(space.one())
+    true_res = np.zeros((8, 2))
+    true_res[:4, :] = 1
+    assert np.array_equal(out, true_res)
+
+    out = res_space.element()
+    res_op(space.one(), out=out)
+    assert np.array_equal(out, true_res)
+
+
+def test_resizing_op_deriv():
+
+    # Only non-trivial case is constant padding with const != 0
+    space = odl.uniform_discr([0, -1], [1, 1], (4, 5))
+    res_space = odl.uniform_discr([0, -0.6], [2, 0.2], (8, 2))
+    res_op = odl.ResizingOperator(space, res_space, pad_const=1.0)
+    res_op_deriv = res_op.derivative(space.one())
+    assert res_op_deriv.pad_mode == 'constant'
+    assert res_op_deriv.pad_const == 0.0
+
+
+# TODO: adjoint and inverse
+
+
+if __name__ == '__main__':
+    pytest.main(str(__file__.replace('\\', '/')) + ' -v')

--- a/test/discr/discr_ops_test.py
+++ b/test/discr/discr_ops_test.py
@@ -107,7 +107,8 @@ def test_resizing_op_properties():
 
     # Implicit range via ran_shp and offset
     res_op = odl.ResizingOperator(space, ran_shp=(20, 15), offset=[0, 5])
-    assert res_op.range == res_space
+    assert np.allclose(res_op.range.min_corner, res_space.min_corner)
+    assert np.allclose(res_op.range.max_corner, res_space.max_corner)
     assert res_op.offset == (0, 5)
 
     # Different padding mode

--- a/test/util/numerics_test.py
+++ b/test/util/numerics_test.py
@@ -257,7 +257,6 @@ def resize_setup(request):
                 [5, 6, 7, 8],
                 [9, 10, 11, 12]]
 
-    print(request.param)
     pad_mode, variant = request.param
     pad_const = 0
 
@@ -382,13 +381,6 @@ def test_resize_array_adj(resize_setup, dtype):
     resized_adj = resize_array(other_arr, array.shape, offset, pad_mode,
                                pad_const, direction='adjoint')
 
-    print(resized)
-    print(other_arr)
-    print(np.vdot(resized.ravel(), other_arr.ravel()))
-
-    print(resized_adj)
-    print(array)
-    print(np.vdot(resized_adj.ravel(), array.ravel()))
     assert almost_equal(np.vdot(resized.ravel(), other_arr.ravel()),
                         np.vdot(array.ravel(), resized_adj.ravel()))
 

--- a/test/util/numerics_test.py
+++ b/test/util/numerics_test.py
@@ -21,14 +21,13 @@ from __future__ import print_function, division, absolute_import
 from future import standard_library
 standard_library.install_aliases()
 
-# External
-import pytest
+from itertools import product
 import numpy as np
+import pytest
 
-# Internal
 from odl.util import apply_on_boundary, fast_1d_tensor_mult, resize_array
 from odl.util.numerics import _SUPPORTED_RESIZE_PAD_MODES
-from odl.util.testutils import all_equal
+from odl.util.testutils import all_equal, almost_equal
 
 
 # --- apply_on_boundary --- #
@@ -235,7 +234,9 @@ def dtype(request):
     return request.param
 
 
-pad_mode_params = _SUPPORTED_RESIZE_PAD_MODES
+pad_mode_params = list(_SUPPORTED_RESIZE_PAD_MODES)
+pad_mode_params.remove('constant')
+pad_mode_params.extend(['constant 0', 'constant 1'])
 pad_mode_ids = [" pad_mode = '{}' ".format(p) for p in pad_mode_params]
 
 
@@ -244,9 +245,161 @@ def pad_mode(request):
     return request.param
 
 
+variants = ['extend', 'restrict', 'mixed']
+setup_params = list(product(pad_mode_params, variants))
+setup_ids = [" pad_mode = '{}', variant = '{}' ".format(*p)
+             for p in setup_params]
+
+
+@pytest.fixture(scope="module", ids=setup_ids, params=setup_params)
+def resize_setup(request):
+    array_in = [[1, 2, 3, 4],
+                [5, 6, 7, 8],
+                [9, 10, 11, 12]]
+
+    print(request.param)
+    pad_mode, variant = request.param
+    pad_const = 0
+
+    if variant == 'extend':
+        newshp = (4, 7)
+        offset = (1, 2)
+
+        if pad_mode == 'constant 0':
+            pad_mode = 'constant'
+            true_out = [[0, 0, 0, 0, 0, 0, 0],
+                        [0, 0, 1, 2, 3, 4, 0],
+                        [0, 0, 5, 6, 7, 8, 0],
+                        [0, 0, 9, 10, 11, 12, 0]]
+        elif pad_mode == 'constant 1':
+            pad_mode = 'constant'
+            pad_const = 1
+            true_out = [[1, 1, 1, 1, 1, 1, 1],
+                        [1, 1, 1, 2, 3, 4, 1],
+                        [1, 1, 5, 6, 7, 8, 1],
+                        [1, 1, 9, 10, 11, 12, 1]]
+        elif pad_mode == 'periodic':
+            true_out = [[11, 12, 9, 10, 11, 12, 9],
+                        [3, 4, 1, 2, 3, 4, 1],
+                        [7, 8, 5, 6, 7, 8, 5],
+                        [11, 12, 9, 10, 11, 12, 9]]
+        elif pad_mode == 'symmetric':
+            true_out = [[7, 6, 5, 6, 7, 8, 7],
+                        [3, 2, 1, 2, 3, 4, 3],
+                        [7, 6, 5, 6, 7, 8, 7],
+                        [11, 10, 9, 10, 11, 12, 11]]
+        elif pad_mode == 'order0':
+            true_out = [[1, 1, 1, 2, 3, 4, 4],
+                        [1, 1, 1, 2, 3, 4, 4],
+                        [5, 5, 5, 6, 7, 8, 8],
+                        [9, 9, 9, 10, 11, 12, 12]]
+        elif pad_mode == 'order1':
+            true_out = [[-5, -4, -3, -2, -1, 0, 1],
+                        [-1, 0, 1, 2, 3, 4, 5],
+                        [3, 4, 5, 6, 7, 8, 9],
+                        [7, 8, 9, 10, 11, 12, 13]]
+
+    elif variant == 'restrict':
+        newshp = (2, 1)
+        offset = (1, 2)
+
+        true_out = [[7],
+                    [11]]
+
+        if pad_mode == 'constant 0':
+            pad_mode = 'constant'
+        elif pad_mode == 'constant 1':
+            pad_mode = 'constant'
+            pad_const = 1
+
+    elif variant == 'mixed':
+        newshp = (2, 7)
+        offset = (1, 2)
+
+        if pad_mode == 'constant 0':
+            pad_mode = 'constant'
+            true_out = [[0, 0, 5, 6, 7, 8, 0],
+                        [0, 0, 9, 10, 11, 12, 0]]
+        elif pad_mode == 'constant 1':
+            pad_mode = 'constant'
+            pad_const = 1
+            true_out = [[1, 1, 5, 6, 7, 8, 1],
+                        [1, 1, 9, 10, 11, 12, 1]]
+        elif pad_mode == 'periodic':
+            true_out = [[7, 8, 5, 6, 7, 8, 5],
+                        [11, 12, 9, 10, 11, 12, 9]]
+        elif pad_mode == 'symmetric':
+            true_out = [[7, 6, 5, 6, 7, 8, 7],
+                        [11, 10, 9, 10, 11, 12, 11]]
+        elif pad_mode == 'order0':
+            true_out = [[5, 5, 5, 6, 7, 8, 8],
+                        [9, 9, 9, 10, 11, 12, 12]]
+        elif pad_mode == 'order1':
+            true_out = [[3, 4, 5, 6, 7, 8, 9],
+                        [7, 8, 9, 10, 11, 12, 13]]
+        else:
+            raise ValueError('unknown param')
+
+    else:
+        raise ValueError('unknown variant')
+
+    return pad_mode, pad_const, newshp, offset, array_in, true_out
+
+
+def test_resize_array_fwd(resize_setup, dtype):
+    pad_mode, pad_const, newshp, offset, array_in, true_out = resize_setup
+    array_in = np.array(array_in, dtype=dtype)
+    true_out = np.array(true_out, dtype=dtype)
+
+    resized = resize_array(array_in, newshp, offset, pad_mode, pad_const,
+                           direction='forward')
+    out = np.empty(newshp, dtype=dtype)
+    resize_array(array_in, newshp, offset, pad_mode, pad_const,
+                 direction='forward', out=out)
+
+    assert np.array_equal(resized, true_out)
+    assert np.array_equal(out, true_out)
+
+
+def test_resize_array_adj(resize_setup, dtype):
+    pad_mode, pad_const, newshp, offset, array, _ = resize_setup
+
+    if pad_const != 0:
+        # Not well-defined
+        return
+
+    array = np.array(array, dtype=dtype)
+    if dtype == 'int64':
+        other_arr = np.random.randint(-10, 10, size=newshp)
+    elif dtype == 'float64':
+        other_arr = np.random.uniform(-10, 10, size=newshp)
+    else:
+        other_arr = (np.random.uniform(-10, 10, size=newshp) +
+                     1j * np.random.uniform(-10, 10, size=newshp))
+
+    resized = resize_array(array, newshp, offset, pad_mode, pad_const,
+                           direction='forward')
+    resized_adj = resize_array(other_arr, array.shape, offset, pad_mode,
+                               pad_const, direction='adjoint')
+
+    print(resized)
+    print(other_arr)
+    print(np.vdot(resized.ravel(), other_arr.ravel()))
+
+    print(resized_adj)
+    print(array)
+    print(np.vdot(resized_adj.ravel(), array.ravel()))
+    assert almost_equal(np.vdot(resized.ravel(), other_arr.ravel()),
+                        np.vdot(array.ravel(), resized_adj.ravel()))
+
+
 def test_resize_array_corner_cases(dtype, pad_mode):
     # Test extreme cases of resizing that are still valid for several
     # `pad_mode`s
+
+    if pad_mode.startswith('constant'):
+        pad_mode, pad_const = pad_mode.split()
+        pad_const = int(pad_const)
 
     # Test array
     arr = np.arange(12, dtype=dtype).reshape((3, 4))
@@ -258,22 +411,18 @@ def test_resize_array_corner_cases(dtype, pad_mode):
     squashed_arr = resize_array(arr, (0, 0), pad_mode=pad_mode)
     assert squashed_arr.size == 0
 
-    if pad_mode == 'const':
-        true_blownup_arr_0 = np.zeros_like(arr)
-        true_blownup_arr_1 = np.ones_like(arr)
+    if pad_mode == 'constant':
+        # Blowing up from size 0 only works with constant padding
+        true_blownup_arr = np.empty_like(arr)
+        true_blownup_arr.fill(pad_const)
+
         blownup_arr = resize_array(np.ones((3, 0), dtype=dtype), (3, 4),
-                                   pad_mode=pad_mode, pad_const=0)
-        assert np.array_equal(blownup_arr, true_blownup_arr_0)
-        blownup_arr = resize_array(-np.ones((3, 0), dtype=dtype), (3, 4),
-                                   pad_mode=pad_mode, pad_const=1)
-        assert np.array_equal(blownup_arr, true_blownup_arr_1)
+                                   pad_mode=pad_mode, pad_const=pad_const)
+        assert np.array_equal(blownup_arr, true_blownup_arr)
 
         blownup_arr = resize_array(np.ones((0, 0), dtype=dtype), (3, 4),
-                                   pad_mode=pad_mode, pad_const=0)
-        assert np.array_equal(blownup_arr, true_blownup_arr_0)
-        blownup_arr = resize_array(-np.ones((0, 0), dtype=dtype), (3, 4),
-                                   pad_mode=pad_mode, pad_const=1)
-        assert np.array_equal(blownup_arr, true_blownup_arr_1)
+                                   pad_mode=pad_mode, pad_const=pad_const)
+        assert np.array_equal(blownup_arr, true_blownup_arr)
 
     # Resize from 0 axes to 0 axes
     zero_axes_arr = resize_array(np.array(0, dtype=dtype), (),


### PR DESCRIPTION
Implements the resizing of a multi-dimensional array as an operator wrapping a helper function `resize_array` which will be very helpful in itself.

Basically, resizing means keeping the cell sizes and changing the number of cells per axis, plus a shift by a multiple of the cell size.

The extension (padding) is supported in 5 different versions: constant (i.e. fill with a constant), periodic, symmetric, order 0 (continue constantly) and order 1 (continue with constant slope). Not sure we need all of those, but was not too hard to add once the infrastructure was there.

~~What's missing currently is the adjoint. It's not super simple and needs some thought to get it right. I'd suggest we deal with it in a separate issue.~~

TODO:
- [x] Refactor code so forward and adjoint use as much common code as possible (basically the slice calculations)
- [x] More tests, especially corner cases and adjoint
- [x] Doc improvements
- [x] Decision on how to specify start position / distribution of cropped stuff between the left and right sides of the array. I went for `offset` ~~Currently implemented:~~
  * ~~`num_left` -- how many cells added/removed on the left side~~
  * ~~`frac_left` -- same as above, but as fraction. Less reliable due to rounding. Will be removed.~~
  
   ~~Questions: Do we need a `num_right` counterpart? Do we need another option to specify the amount?~~

Edit: last point updated.