### PR TITLE
Add option to run examples with pytest

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -38,6 +38,9 @@ def pytest_addoption(parser):
     parser.addoption('--benchmark', action='store_true',
                      help='Run benchmarks')
 
+    parser.addoption('--examples', action='store_true',
+                     help='Run examples')
+
 
 # reusable fixtures
 fn_impl_params = odl.FN_IMPLS.keys()

--- a/examples/diagnostics/diagonstics_space.py
+++ b/examples/diagnostics/diagonstics_space.py
@@ -29,20 +29,20 @@ print('\n\n TESTING FOR Lp SPACE \n\n')
 discr = odl.uniform_discr(0, 1, 10)
 odl.diagnostics.SpaceTest(discr).run_tests()
 
-print('\n\n TESTING FOR Rn SPACE \n\n')
+print('\n\n TESTING FOR rn SPACE \n\n')
 
 spc = odl.rn(10)
 odl.diagnostics.SpaceTest(spc).run_tests()
 
 
-print('\n\n TESTING FOR Cn SPACE \n\n')
+print('\n\n TESTING FOR cn SPACE \n\n')
 
 spc = odl.cn(10)
 odl.diagnostics.SpaceTest(spc).run_tests()
 
 
 if 'cuda' in odl.FN_IMPLS:
-    print('\n\n TESTING FOR CUDA Rn SPACE \n\n')
+    print('\n\n TESTING FOR CUDA rn SPACE \n\n')
 
     spc = odl.rn(10, impl='cuda')
     odl.diagnostics.SpaceTest(spc, eps=0.0001).run_tests()

--- a/examples/operator/simple_operator.py
+++ b/examples/operator/simple_operator.py
@@ -15,7 +15,7 @@
 # You should have received a copy of the GNU General Public License
 # along with ODL.  If not, see <http://www.gnu.org/licenses/>.
 
-"""An example of a very simple operator on Rn."""
+"""An example of a very simple operator on rn."""
 
 # Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
@@ -29,14 +29,14 @@ import odl
 
 class AddOp(odl.Operator):
     def __init__(self, size, add_this):
-        super().__init__(domain=odl.Rn(size), range=odl.Rn(size))
+        super().__init__(domain=odl.rn(size), range=odl.rn(size))
         self.value = add_this
 
     def _call(self, x, out):
         out[:] = x.data + self.value
 
 size = 3
-rn = odl.Rn(size)
+rn = odl.rn(size)
 x = rn.element([1, 2, 3])
 
 op = AddOp(size, add_this=10)

--- a/examples/solvers/chambolle_pock_deconvolve.py
+++ b/examples/solvers/chambolle_pock_deconvolve.py
@@ -92,7 +92,7 @@ proximal_dual = odl.solvers.combine_proximals(prox_convconj_l2,
 
 
 # Estimated operator norm, add 10 percent to ensure ||K||_2^2 * sigma * tau < 1
-op_norm = 1.1 * odl.power_method_opnorm(op, 5)
+op_norm = 1.1 * odl.power_method_opnorm(op, 6)
 
 niter = 500  # Number of iterations
 tau = 1.0 / op_norm  # Step size for the primal variable

--- a/examples/solvers/chambolle_pock_tomography.py
+++ b/examples/solvers/chambolle_pock_tomography.py
@@ -102,7 +102,7 @@ proximal_dual = odl.solvers.combine_proximals(prox_convconj_l2,
 
 
 # Estimated operator norm, add 10 percent to ensure ||K||_2^2 * sigma * tau < 1
-op_norm = 1.1 * odl.power_method_opnorm(op, 5)
+op_norm = 1.1 * odl.power_method_opnorm(op, 6)
 
 niter = 400  # Number of iterations
 tau = 1.0 / op_norm  # Step size for the primal variable

--- a/examples/solvers/conjugate_gradient_tomography.py
+++ b/examples/solvers/conjugate_gradient_tomography.py
@@ -68,16 +68,16 @@ discr_phantom = odl.phantom.shepp_logan(reco_space, modified=True)
 data = ray_trafo(discr_phantom)
 data += odl.phantom.white_noise(ray_trafo.range) * np.mean(data) * 0.1
 
-# Optionally pass partial to the solver to display intermediate results
-partial = (odl.solvers.PrintIterationPartial() &
-           odl.solvers.ShowPartial())
+# Optionally pass callback to the solver to display intermediate results
+callback = (odl.solvers.CallbackPrintIteration() &
+            odl.solvers.CallbackShow())
 
 # Choose a starting point
 x = ray_trafo.domain.zero()
 
 # Run the algorithm
 odl.solvers.conjugate_gradient_normal(
-    ray_trafo, x, data, niter=20, partial=partial)
+    ray_trafo, x, data, niter=20, callback=callback)
 
 # Display images
 discr_phantom.show(title='original image')

--- a/examples/space/simple_rn.py
+++ b/examples/space/simple_rn.py
@@ -15,7 +15,7 @@
 # You should have received a copy of the GNU General Public License
 # along with ODL.  If not, see <http://www.gnu.org/licenses/>.
 
-"""An example of a very simple space, the space Rn.
+"""An example of a very simple space, the space rn.
 
 Including some benchmarks with an optimized version.
 """
@@ -94,7 +94,7 @@ r5 = SimpleRn(5)
 n = 10**7
 iterations = 10
 
-# Perform some benchmarks with Rn adn CudaRn
+# Perform some benchmarks with rn
 opt_spc = odl.rn(n)
 simple_spc = SimpleRn(n)
 

--- a/examples/visualization/show_ntuple.py
+++ b/examples/visualization/show_ntuple.py
@@ -19,7 +19,7 @@
 
 import odl
 
-spc = odl.Rn(5)
+spc = odl.rn(5)
 vec = spc.element([1, 2, 3, 4, 5])
 
 vec.show(show=True)

--- a/odl/operator/oputils.py
+++ b/odl/operator/oputils.py
@@ -159,7 +159,8 @@ def power_method_opnorm(op, niter, xstart=None):
                 ValueError('a starting element must be defined in case the '
                            'operator domain has no `one()`'), exc)
     else:
-        x = op.domain.element(xstart)
+        # copy to ensure xstart is not modified
+        x = op.domain.element(xstart).copy()
 
     x_norm = x.norm()
     if x_norm == 0:

--- a/test/test_examples.py
+++ b/test/test_examples.py
@@ -40,10 +40,11 @@ matplotlib.use('Agg')  # To avoid the backend freezing
 import matplotlib.pyplot as plt
 
 
-# Simply modify exp_params to modify the fixture
+# Make a fixture for all examples
+this_file_path = os.path.dirname(os.path.abspath(__file__))
 example_ids = []
 example_params = []
-for dirpath, dirnames, filenames in os.walk("../examples/"):
+for dirpath, dirnames, filenames in os.walk(this_file_path + "/../examples/"):
     for filename in [f for f in filenames if f.endswith(".py") and
                      not f.startswith('__init__')]:
         example_params.append(os.path.join(dirpath, filename))
@@ -58,7 +59,6 @@ def example(request):
 @pytest.mark.skipif("not pytest.config.getoption('--examples')",
                     reason='Need --examples option to run')
 def test_example(example):
-    print(example)
     imp.load_source('tmp', example)
     plt.close("all")
 

--- a/test/test_examples.py
+++ b/test/test_examples.py
@@ -1,0 +1,67 @@
+# Copyright 2014-2016 The ODL development group
+#
+# This file is part of ODL.
+#
+# ODL is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# ODL is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with ODL.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Tests that all examples run at all.
+
+Running this file causes all examples to be run, and any exception will give
+a FAILED result. All other results are considered PASSED.
+
+Plots are displayed while the examples are run, but are closed after each
+example. A user can, if he/she wants inspect the plots to further see if the
+examples are OK.
+
+This package assumes that all dependencies are installed.
+"""
+
+# Imports for common Python 2/3 codebase
+from __future__ import print_function, division, absolute_import
+from future import standard_library
+standard_library.install_aliases()
+
+import os
+import imp
+import pytest
+import matplotlib
+matplotlib.use('Agg')  # To avoid the backend freezing
+import matplotlib.pyplot as plt
+
+
+# Simply modify exp_params to modify the fixture
+example_ids = []
+example_params = []
+for dirpath, dirnames, filenames in os.walk("../examples/"):
+    for filename in [f for f in filenames if f.endswith(".py") and
+                     not f.startswith('__init__')]:
+        example_params.append(os.path.join(dirpath, filename))
+        example_ids.append(filename[:-3])  # skip .py
+
+
+@pytest.fixture(scope="module", ids=example_ids, params=example_params)
+def example(request):
+    return request.param
+
+
+@pytest.mark.skipif("not pytest.config.getoption('--examples')",
+                    reason='Need --examples option to run')
+def test_example(example):
+    print(example)
+    imp.load_source('tmp', example)
+    plt.close("all")
+
+
+if __name__ == '__main__':
+    pytest.main(str(__file__.replace('\\', '/')) + ' -v --examples')


### PR DESCRIPTION
Adds the flag `--examples` to pytest, invoked as:

```
py.test --examples
```

this causes all examples in ODL to be run as part of the test suite, thus allowing easy tests that the examples at least do not crash.

Using this I also fixed several failing examples.