### PR TITLE
BUG: fix bug with odl.test()

### DIFF
--- a/odl/util/testutils.py
+++ b/odl/util/testutils.py
@@ -461,7 +461,7 @@ def test(arguments=''):
     import pytest
     this_dir = os.path.dirname(__file__)
     odl_root = os.path.abspath(os.path.join(this_dir, os.pardir, os.pardir))
-    base_args = '-x {odl_root}/odl {odl_root}/test '.format(odl_root=odl_root)
+    base_args = '-x {root}/odl {root}/test '.format(root=repr(odl_root))
     pytest.main(base_args + arguments)
 
 


### PR DESCRIPTION
Running

```bash
$ python -c "import odl; odl.test()"
```

gave an error, `ERROR: file not found: D:GitHubODL/odl` on windows. This commit should fix that. Could someone (@kohr-h) test if it also works as expected on Linux?