### PR TITLE
MAINT: harmonize names for padding parameters

### DIFF
--- a/doc/source/release_notes.rst
+++ b/doc/source/release_notes.rst
@@ -12,6 +12,8 @@ Next release
 Changes
 --------
 - Changed definition of ``LinearSpaceVector.multiply`` to match the definition used by numpy (:pull:`509`)
+- The parameters ``padding_method`` in ``diff_ops.py`` and ``mode`` in ``wavelet.py`` have been renamed to ``pad_mode``.
+  The parameter ``padding_value`` is now called ``pad_const``.
 
 Bugfixes
 --------

--- a/odl/deform/linearized.py
+++ b/odl/deform/linearized.py
@@ -213,7 +213,7 @@ class LinDeformFixedTempl(Operator):
 
         # TODO: allow users to select what method to use here.
         grad = Gradient(domain=self.range, method='central',
-                        padding_method='symmetric')
+                        pad_mode='symmetric')
         grad_templ = grad(self.template)
         def_grad = self.domain.element(
             [_linear_deform(gf, displacement) for gf in grad_templ])
@@ -353,7 +353,7 @@ class LinDeformFixedDisp(Operator):
         """
         # TODO allow users to select what method to use here.
         div_op = Divergence(domain=self.displacement.space, method='forward',
-                            padding_method='symmetric')
+                            pad_mode='symmetric')
         jacobian_det = self.domain.element(
             np.exp(-div_op(self.displacement)))
 


### PR DESCRIPTION
Simple pull to harmonize the names of the padding-related parameters as used in differential operators and the wavelet transform.