### PR TITLE
Documentation review, closes #408 (for now)

### DIFF
--- a/odl/deform/linearized.py
+++ b/odl/deform/linearized.py
@@ -195,7 +195,7 @@ class LinDeformFixedTempl(Operator):
 
         Parameters
         ----------
-        displacement : `domain` element-like
+        displacement : `domain` `element-like`
             Point at which the derivative is computed.
 
         Returns

--- a/odl/deform/linearized.py
+++ b/odl/deform/linearized.py
@@ -44,8 +44,8 @@ def _linear_deform(template, displacement, out=None):
     ----------
     template : `DiscreteLpVector`
         Template to be deformed by a displacement field.
-    displacement : element of power space of `DiscreteLp`
-        The vector field (displacement field) used to deform the
+    displacement : element of power space of ``template.space``
+        Vector field (displacement field) used to deform the
         template.
     out : `numpy.ndarray`, optional
         Array to which the function values of the deformed template

--- a/odl/diagnostics/operator.py
+++ b/odl/diagnostics/operator.py
@@ -86,7 +86,7 @@ class OperatorTest(object):
 
         Returns
         -------
-        norm : `float`
+        norm : float
             Estimate of operator norm
 
         References

--- a/odl/discr/diff_ops.py
+++ b/odl/discr/diff_ops.py
@@ -65,7 +65,7 @@ class PartialDerivative(PointwiseTensorFieldOperator):
         method : {'central', 'forward', 'backward'}, optional
             Finite difference method which is used in the interior of the
             domain of ``f``.
-        pad_mode : {'constant', 'symmetric', 'periodic', None}, optional
+        pad_mode : {'constant', 'symmetric', 'periodic', ``None``}, optional
 
             'constant' : Pads values outside the domain of ``f`` with a
             constant value given by ``pad_const``.
@@ -75,16 +75,15 @@ class PartialDerivative(PointwiseTensorFieldOperator):
 
             'periodic' : Pads with the values from the other side of the array.
 
-            If None is given, one-sided forward or backward differences
-            are used at the boundary.
+            ``None`` : Use one-sided forward or backward differences at
+            the boundary.
 
         pad_const : float, optional
             For ``pad_mode == 'constant'``, ``f`` assumes
             ``pad_const`` for indices outside the domain of ``f``
         edge_order : {1, 2}, optional
-            Edge-order accuracy at the boundaries if no padding is used. If
-            None the edge-order accuracy at endpoints corresponds to the
-            accuracy in the interior.
+            Edge-order accuracy at the boundaries if no padding is used.
+            Default: Same order as in the interior.
         """
         if not isinstance(space, DiscreteLp):
             raise TypeError('`space` {!r} is not a DiscreteLp instance'
@@ -686,7 +685,7 @@ def finite_diff(f, axis=0, dx=1.0, method='forward', out=None, **kwargs):
 
     Parameters
     ----------
-    f : array-like
+    f : `array-like`
          An N-dimensional array.
     axis : int, optional
         The axis along which the partial derivative is evaluated.
@@ -695,7 +694,11 @@ def finite_diff(f, axis=0, dx=1.0, method='forward', out=None, **kwargs):
     method : {'central', 'forward', 'backward'}, optional
         Finite difference method which is used in the interior of the domain
          of ``f``.
-    pad_mode : {'constant', 'symmetric', 'periodic', None}, optional
+    out : `numpy.ndarray`, optional
+         An N-dimensional array to which the output is written. Has to have
+         the same shape as the input array ``f``.
+
+    pad_mode : {'constant', 'symmetric', 'periodic', ``None``}, optional
 
         'constant' : Pads values outside the domain of ``f`` with a constant
         value given by ``pad_const``.
@@ -705,24 +708,20 @@ def finite_diff(f, axis=0, dx=1.0, method='forward', out=None, **kwargs):
 
         'periodic' : Pads with the values from the other side of the array.
 
-        If None is given, one-sided forward or backward differences
-        are used at the boundary.
+        ``None`` : Use one-sided forward or backward differences at
+        the boundary.
 
     pad_const : float, optional
-        For ``pad_mode == 'constant'``, ``f`` assumes
-        ``pad_const`` for indices outside the domain of ``f``
+        For ``pad_mode == 'constant'``, ``f`` assumes ``pad_const`` for
+        indices outside the domain of ``f``
 
     edge_order : {1, 2}, optional
-        Edge-order accuracy at the boundaries if no padding is used. If
-        None the edge-order accuracy at endpoints corresponds to the
-        accuracy in the interior. Default: None
-    out : numpy.ndarray, optional
-         An N-dimensional array to which the output is written. Has to have
-         the same shape as the input array ``f``. Default: None
+        Edge-order accuracy at the boundaries if no padding is used.
+        Default: Same order as in the interior.
 
     Returns
     -------
-    out : numpy.ndarray
+    out : `numpy.ndarray`
         N-dimensional array of the same shape as ``f``. If ``out`` is
         provided, the returned object is a reference to it.
 

--- a/odl/discr/diff_ops.py
+++ b/odl/discr/diff_ops.py
@@ -104,15 +104,15 @@ class PartialDerivative(PointwiseTensorFieldOperator):
 
         Parameters
         ----------
-        x : ``domain`` element
-            Input vector to which the operator is applied to
-        out : ``range`` element, optional
-            Output vector to which the result is written
+        x : `domain` element
+            Input vector to which the operator is applied.
+        out : `range` element, optional
+            Output vector to which the result is written.
 
         Returns
         -------
-        out : ``range`` element
-            Result of the evaluation. If ``out`` is provided, the
+        out : `range` element
+            Result of the evaluation. If ``out`` was provided, the
             returned object is a reference to it.
 
         Examples
@@ -151,7 +151,7 @@ class PartialDerivative(PointwiseTensorFieldOperator):
 
         Parameters
         ----------
-        point : ``domain`` element, optional
+        point : `domain` `element-like`, optional
             The point to take the derivative in. Does not change the result
             since the operator is affine.
         """
@@ -259,15 +259,15 @@ class Gradient(PointwiseTensorFieldOperator):
 
         Parameters
         ----------
-        x : ``domain`` element
-            Input vector to which the `Gradient` operator is applied
-        out : ``range`` element, optional
-            Output vector to which the result is written
+        x : `domain` element
+            Input vector to which the `Gradient` operator is applied.
+        out : `range` element, optional
+            Output vector to which the result is written.
 
         Returns
         -------
-        out : ``range`` element
-            Result of the evaluation. If ``out`` is provided, the returned
+        out : `range` element
+            Result of the evaluation. If ``out`` was provided, the returned
             object is a reference to it.
 
         Examples
@@ -324,7 +324,7 @@ class Gradient(PointwiseTensorFieldOperator):
 
         Parameters
         ----------
-        point : ``domain`` element, optional
+        point : `domain` element, optional
             The point to take the derivative in. Does not change the result
             since the operator is affine.
         """
@@ -440,16 +440,16 @@ class Divergence(PointwiseTensorFieldOperator):
 
         Parameters
         ----------
-        x : ``domain`` element
+        x : `domain` element
             `ProductSpaceVector` to which the divergence operator
-            is applied
-        out : ``range`` element, optional
-            Output vector to which the result is written
+            is applied.
+        out : `range` element, optional
+            Output vector to which the result is written.
 
         Returns
         -------
-        out : ``range`` element
-            Result of the evaluation. If ``out`` is provided, the returned
+        out : `range` element
+            Result of the evaluation. If ``out`` was provided, the returned
             object is a reference to it.
 
         Examples
@@ -505,7 +505,7 @@ class Divergence(PointwiseTensorFieldOperator):
 
         Parameters
         ----------
-        point : ``domain`` element, optional
+        point : `domain` element, optional
             The point to take the derivative in. Does not change the result
             since the operator is affine.
         """
@@ -576,16 +576,16 @@ class Laplacian(PointwiseTensorFieldOperator):
 
         Parameters
         ----------
-        x : ``domain`` element
+        x : `domain` element
             Input vector to which the `Laplacian` operator is
             applied
-        out : ``range`` element, optional
+        out : `range` element, optional
             Output vector to which the result is written
 
         Returns
         -------
-        out : ``range`` element
-            Result of the evaluation. If ``out`` is provided, the returned
+        out : `range` element
+            Result of the evaluation. If ``out`` was provided, the returned
             object is a reference to it.
 
         Examples
@@ -722,7 +722,7 @@ def finite_diff(f, axis=0, dx=1.0, method='forward', out=None, **kwargs):
     Returns
     -------
     out : `numpy.ndarray`
-        N-dimensional array of the same shape as ``f``. If ``out`` is
+        N-dimensional array of the same shape as ``f``. If ``out`` was
         provided, the returned object is a reference to it.
 
     Notes

--- a/odl/discr/diff_ops.py
+++ b/odl/discr/diff_ops.py
@@ -60,7 +60,7 @@ class PartialDerivative(PointwiseTensorFieldOperator):
         ----------
         space : `DiscreteLp`
             Space of elements which the operator is acting on.
-        axis : `int`, optional
+        axis : int, optional
             Axis along which the partial derivative is evaluated.
         method : {'central', 'forward', 'backward'}, optional
             Finite difference method which is used in the interior of the
@@ -75,15 +75,15 @@ class PartialDerivative(PointwiseTensorFieldOperator):
 
             'periodic' : Pads with the values from the other side of the array.
 
-            If `None` is given, one-sided forward or backward differences
+            If None is given, one-sided forward or backward differences
             are used at the boundary.
 
-        pad_const : `float`, optional
-            If ``pad_mode`` is 'constant', ``f`` assumes
+        pad_const : float, optional
+            For ``pad_mode == 'constant'``, ``f`` assumes
             ``pad_const`` for indices outside the domain of ``f``
         edge_order : {1, 2}, optional
             Edge-order accuracy at the boundaries if no padding is used. If
-            `None` the edge-order accuracy at endpoints corresponds to the
+            None the edge-order accuracy at endpoints corresponds to the
             accuracy in the interior.
         """
         if not isinstance(space, DiscreteLp):
@@ -105,14 +105,14 @@ class PartialDerivative(PointwiseTensorFieldOperator):
 
         Parameters
         ----------
-        x : ``domain`` `element`
+        x : ``domain`` element
             Input vector to which the operator is applied to
         out : ``range`` element, optional
             Output vector to which the result is written
 
         Returns
         -------
-        out : ``range`` `element`
+        out : ``range`` element
             Result of the evaluation. If ``out`` is provided, the
             returned object is a reference to it.
 
@@ -213,9 +213,9 @@ class Gradient(PointwiseTensorFieldOperator):
 
             'periodic' : Pads with the values from the other side of the array.
 
-        pad_const : `float`, optional
-            If ``pad_mode`` is 'constant', ``f`` assumes
-            ``pad_const`` for indices outside the domain of ``f``.
+        pad_const : float, optional
+            For ``pad_mode == 'constant'``, ``f`` assumes
+            ``pad_const`` for indices outside the domain of ``f``
 
         Examples
         --------
@@ -260,14 +260,14 @@ class Gradient(PointwiseTensorFieldOperator):
 
         Parameters
         ----------
-        x : ``domain`` `element`
+        x : ``domain`` element
             Input vector to which the `Gradient` operator is applied
-        out : ``range`` `element`, optional
+        out : ``range`` element, optional
             Output vector to which the result is written
 
         Returns
         -------
-        out : ``range`` `element`
+        out : ``range`` element
             Result of the evaluation. If ``out`` is provided, the returned
             object is a reference to it.
 
@@ -394,9 +394,9 @@ class Divergence(PointwiseTensorFieldOperator):
 
             'periodic' : Pads with the values from the other side of the array.
 
-        pad_const : `float`, optional
-            If ``pad_mode`` is 'constant', ``f`` assumes
-            ``pad_const`` for indices outside the domain of ``f``.
+        pad_const : float, optional
+            For ``pad_mode == 'constant'``, ``f`` assumes
+            ``pad_const`` for indices outside the domain of ``f``
 
         Examples
         --------
@@ -441,15 +441,15 @@ class Divergence(PointwiseTensorFieldOperator):
 
         Parameters
         ----------
-        x : ``domain`` `element`
+        x : ``domain`` element
             `ProductSpaceVector` to which the divergence operator
             is applied
-        out : ``range`` `element`, optional
+        out : ``range`` element, optional
             Output vector to which the result is written
 
         Returns
         -------
-        out : ``range`` `element`
+        out : ``range`` element
             Result of the evaluation. If ``out`` is provided, the returned
             object is a reference to it.
 
@@ -561,9 +561,9 @@ class Laplacian(PointwiseTensorFieldOperator):
 
             'periodic' : Pads with the values from the other side of the array.
 
-        pad_const : `float`, optional
-            If ``pad_mode`` is 'constant', ``f`` assumes
-            ``pad_const`` for indices outside the domain of ``f``.
+        pad_const : float, optional
+            For ``pad_mode == 'constant'``, ``f`` assumes
+            ``pad_const`` for indices outside the domain of ``f``
         """
         if not isinstance(space, DiscreteLp):
             raise TypeError('`space` {!r} is not a DiscreteLp instance'
@@ -577,15 +577,15 @@ class Laplacian(PointwiseTensorFieldOperator):
 
         Parameters
         ----------
-        x : ``domain`` `element`
+        x : ``domain`` element
             Input vector to which the `Laplacian` operator is
             applied
-        out : ``range`` `element`, optional
+        out : ``range`` element, optional
             Output vector to which the result is written
 
         Returns
         -------
-        out : ``range`` `element`
+        out : ``range`` element
             Result of the evaluation. If ``out`` is provided, the returned
             object is a reference to it.
 
@@ -686,11 +686,11 @@ def finite_diff(f, axis=0, dx=1.0, method='forward', out=None, **kwargs):
 
     Parameters
     ----------
-    f : `array-like`
+    f : array-like
          An N-dimensional array.
-    axis : `int`, optional
+    axis : int, optional
         The axis along which the partial derivative is evaluated.
-    dx : `float`, optional
+    dx : float, optional
         Scalar specifying the distance between sampling points along ``axis``.
     method : {'central', 'forward', 'backward'}, optional
         Finite difference method which is used in the interior of the domain
@@ -705,23 +705,24 @@ def finite_diff(f, axis=0, dx=1.0, method='forward', out=None, **kwargs):
 
         'periodic' : Pads with the values from the other side of the array.
 
-        If `None` is given, one-sided forward or backward differences
+        If None is given, one-sided forward or backward differences
         are used at the boundary.
 
-    pad_const : `float`, optional
-        If ``pad_mode`` is 'constant', ``f`` assumes ``pad_const``
-        for indices outside the domain of ``f``.
+    pad_const : float, optional
+        For ``pad_mode == 'constant'``, ``f`` assumes
+        ``pad_const`` for indices outside the domain of ``f``
+
     edge_order : {1, 2}, optional
         Edge-order accuracy at the boundaries if no padding is used. If
-        `None` the edge-order accuracy at endpoints corresponds to the
-        accuracy in the interior. Default: `None`
-    out : `numpy.ndarray`, optional
+        None the edge-order accuracy at endpoints corresponds to the
+        accuracy in the interior. Default: None
+    out : numpy.ndarray, optional
          An N-dimensional array to which the output is written. Has to have
-         the same shape as the input array ``f``. Default: `None`
+         the same shape as the input array ``f``. Default: None
 
     Returns
     -------
-    out : `numpy.ndarray`
+    out : numpy.ndarray
         N-dimensional array of the same shape as ``f``. If ``out`` is
         provided, the returned object is a reference to it.
 

--- a/odl/discr/discr_mappings.py
+++ b/odl/discr/discr_mappings.py
@@ -68,7 +68,7 @@ class FunctionSetMapping(Operator):
             discretized object. Its `NtuplesBase.size` must be equal
             to the total number of grid points.
         linear : bool
-            Create a linear operator if `True`, otherwise a non-linear
+            Create a linear operator if True, otherwise a non-linear
             operator.
         order : {'C', 'F'}, optional
             Ordering of the axes in the data storage. 'C' means the
@@ -563,11 +563,11 @@ class PerAxisInterpolation(FunctionSetMapping):
             discretized object. Its `NtuplesBase.size` must be equal
             to the total number of grid points, and its `FnBase.field`
             must be the same as that of the function space.
-        schemes : `str` or `sequence` of `str`
+        schemes : string or sequence of string
             Indicates which interpolation scheme to use for which axis.
             A single string is interpreted as a global scheme for all
             axes.
-        nn_variants : `str` or `sequence` of `str`, optional
+        nn_variants : string or sequence of string, optional
             Which variant ('left' or 'right') to use in nearest neighbor
             interpolation for which axis. A single string is interpreted
             as a global variant for all axes.
@@ -709,9 +709,9 @@ scipy.interpolate.RegularGridInterpolator.html>`_ class.
     def __init__(self, coord_vecs, values, input_type):
         """Initialize a new instance.
 
-        coord_vecs : `sequence` of `numpy.ndarray`
+        coord_vecs : sequence of numpy.ndarray
             Coordinate vectors defining the interpolation grid
-        values : `array-like`
+        values : array-like
             Grid values to use for interpolation
         input_type : {'array', 'meshgrid'}
             Type of expected input values in ``__call__``
@@ -744,15 +744,15 @@ scipy.interpolate.RegularGridInterpolator.html>`_ class.
 
         Parameters
         ----------
-        x : meshgrid or `numpy.ndarray`
+        x : meshgrid or numpy.ndarray
             Evaluation points of the interpolator
-        out : `numpy.ndarray`, optional
+        out : numpy.ndarray, optional
             Array to which the results are written. Needs to have
             correct shape according to input ``x``.
 
         Returns
         -------
-        out : `numpy.ndarray`
+        out : numpy.ndarray
             Interpolated values. If ``out`` was given, the returned
             object is a reference to it.
         """
@@ -827,9 +827,9 @@ scipy.interpolate.RegularGridInterpolator.html>`_ class.
     def __init__(self, coord_vecs, values, input_type, variant):
         """Initialize a new instance.
 
-        coord_vecs : `sequence` of `numpy.ndarray`
+        coord_vecs : sequence of numpy.ndarray
             Coordinate vectors defining the interpolation grid
-        values : `array-like`
+        values : array-like
             Grid values to use for interpolation
         input_type : {'array', 'meshgrid'}
             Type of expected input values in ``__call__``
@@ -956,15 +956,15 @@ class _PerAxisInterpolator(_Interpolator):
     def __init__(self, coord_vecs, values, input_type, schemes, nn_variants):
         """Initialize a new instance.
 
-        coord_vecs : `sequence` of `numpy.ndarray`
+        coord_vecs : sequence of numpy.ndarray
             Coordinate vectors defining the interpolation grid
-        values : `array-like`
+        values : array-like
             Grid values to use for interpolation
         input_type : {'array', 'meshgrid'}
             Type of expected input values in ``__call__``
-        schemes : `sequence` of `str`
+        schemes : sequence of string
             Indicates which interpolation scheme to use for which axis
-        nn_variants : `sequence` of `str`
+        nn_variants : sequence of string
             Which variant ('left' or 'right') to use in nearest neighbor
             interpolation for which axis.
             This option has no effect for schemes other than nearest
@@ -1024,9 +1024,9 @@ class _LinearInterpolator(_PerAxisInterpolator):
     def __init__(self, coord_vecs, values, input_type):
         """Initialize a new instance.
 
-        coord_vecs : `sequence` of `numpy.ndarray`
+        coord_vecs : sequence of numpy.ndarray
             Coordinate vectors defining the interpolation grid
-        values : `array-like`
+        values : array-like
             Grid values to use for interpolation
         input_type : {'array', 'meshgrid'}
             Type of expected input values in ``__call__``

--- a/odl/discr/discr_mappings.py
+++ b/odl/discr/discr_mappings.py
@@ -68,7 +68,7 @@ class FunctionSetMapping(Operator):
             discretized object. Its `NtuplesBase.size` must be equal
             to the total number of grid points.
         linear : bool
-            Create a linear operator if True, otherwise a non-linear
+            Create a linear operator if ``True``, otherwise a non-linear
             operator.
         order : {'C', 'F'}, optional
             Ordering of the axes in the data storage. 'C' means the
@@ -563,11 +563,11 @@ class PerAxisInterpolation(FunctionSetMapping):
             discretized object. Its `NtuplesBase.size` must be equal
             to the total number of grid points, and its `FnBase.field`
             must be the same as that of the function space.
-        schemes : string or sequence of string
+        schemes : string or `sequence` of strings
             Indicates which interpolation scheme to use for which axis.
             A single string is interpreted as a global scheme for all
             axes.
-        nn_variants : string or sequence of string, optional
+        nn_variants : string or `sequence` of strings, optional
             Which variant ('left' or 'right') to use in nearest neighbor
             interpolation for which axis. A single string is interpreted
             as a global variant for all axes.
@@ -709,9 +709,9 @@ scipy.interpolate.RegularGridInterpolator.html>`_ class.
     def __init__(self, coord_vecs, values, input_type):
         """Initialize a new instance.
 
-        coord_vecs : sequence of numpy.ndarray
+        coord_vecs : `sequence` of `numpy.ndarray`'s
             Coordinate vectors defining the interpolation grid
-        values : array-like
+        values : `array-like`
             Grid values to use for interpolation
         input_type : {'array', 'meshgrid'}
             Type of expected input values in ``__call__``
@@ -744,15 +744,15 @@ scipy.interpolate.RegularGridInterpolator.html>`_ class.
 
         Parameters
         ----------
-        x : meshgrid or numpy.ndarray
+        x : `meshgrid` or `numpy.ndarray`
             Evaluation points of the interpolator
-        out : numpy.ndarray, optional
+        out : `numpy.ndarray`, optional
             Array to which the results are written. Needs to have
             correct shape according to input ``x``.
 
         Returns
         -------
-        out : numpy.ndarray
+        out : `numpy.ndarray`
             Interpolated values. If ``out`` was given, the returned
             object is a reference to it.
         """
@@ -827,9 +827,9 @@ scipy.interpolate.RegularGridInterpolator.html>`_ class.
     def __init__(self, coord_vecs, values, input_type, variant):
         """Initialize a new instance.
 
-        coord_vecs : sequence of numpy.ndarray
+        coord_vecs : `sequence` of `numpy.ndarray`'s
             Coordinate vectors defining the interpolation grid
-        values : array-like
+        values : `array-like`
             Grid values to use for interpolation
         input_type : {'array', 'meshgrid'}
             Type of expected input values in ``__call__``
@@ -956,15 +956,15 @@ class _PerAxisInterpolator(_Interpolator):
     def __init__(self, coord_vecs, values, input_type, schemes, nn_variants):
         """Initialize a new instance.
 
-        coord_vecs : sequence of numpy.ndarray
+        coord_vecs : `sequence` of `numpy.ndarray`'s
             Coordinate vectors defining the interpolation grid
-        values : array-like
+        values : `array-like`
             Grid values to use for interpolation
         input_type : {'array', 'meshgrid'}
             Type of expected input values in ``__call__``
-        schemes : sequence of string
+        schemes : `sequence` of strings
             Indicates which interpolation scheme to use for which axis
-        nn_variants : sequence of string
+        nn_variants : `sequence` of strings
             Which variant ('left' or 'right') to use in nearest neighbor
             interpolation for which axis.
             This option has no effect for schemes other than nearest
@@ -1024,9 +1024,9 @@ class _LinearInterpolator(_PerAxisInterpolator):
     def __init__(self, coord_vecs, values, input_type):
         """Initialize a new instance.
 
-        coord_vecs : sequence of numpy.ndarray
+        coord_vecs : `sequence` of `numpy.ndarray`'s
             Coordinate vectors defining the interpolation grid
-        values : array-like
+        values : `array-like`
             Grid values to use for interpolation
         input_type : {'array', 'meshgrid'}
             Type of expected input values in ``__call__``

--- a/odl/discr/discr_ops.py
+++ b/odl/discr/discr_ops.py
@@ -182,17 +182,17 @@ class ResizingOperatorBase(Operator):
             For the default ``None``, a space with the same attributes
             as ``domain`` is used, except for its shape, which is set
             to ``ran_shp``.
-        ran_shp : sequence of int, optional
+        ran_shp : `sequence` of ints, optional
             Shape of the range of this operator. This can be provided
             instead of ``range`` and is mandatory if ``range`` is
             ``None``.
-        offset : int or sequence of int, optional
+        offset : int or `sequence` of ints, optional
             Number of cells to add to/remove from the left of
             ``domain.partition``. By default, the difference is
             distributed evenly, with preference for left in case of
             ambiguity.
             This option is can only be used together with ``ran_shp``.
-        pad_mode : str, optional
+        pad_mode : string, optional
             Method to be used to fill in missing values in an enlarged array.
 
             ``'constant'``: Fill with ``pad_const``.

--- a/odl/discr/discretization.py
+++ b/odl/discr/discretization.py
@@ -563,7 +563,7 @@ def dspace_type(space, impl, dtype=None):
         consistent with it.
     impl : string
         Implementation backend for the data space
-    dtype : type, optional
+    dtype : `numpy.dtype`, optional
         Data type which the space is supposed to use. If ``None``, the
         space type is purely determined from ``space`` and
         ``impl``. If given, it must be compatible with the

--- a/odl/discr/discretization.py
+++ b/odl/discr/discretization.py
@@ -206,10 +206,11 @@ class DiscretizedSet(NtuplesBase):
         Returns
         -------
         equals : bool
-            True if ``other`` is a `DiscretizedSet`
+            ``True`` if ``other`` is a `DiscretizedSet`
             instance and all attributes `uspace`, `dspace`,
             `DiscretizedSet.sampling` and `DiscretizedSet.interpolation`
-            of ``other`` and this discretization are equal, False otherwise.
+            of ``other`` and this discretization are equal, ``False``
+            otherwise.
         """
         if other is self:
             return True
@@ -281,7 +282,7 @@ class DiscretizedSetVector(NtuplesBaseVector):
 
         Parameters
         ----------
-        out : numpy.ndarray, optional
+        out : `numpy.ndarray`, optional
             Array in which the result should be written in-place.
             Has to be contiguous and of the correct dtype.
         """
@@ -293,8 +294,8 @@ class DiscretizedSetVector(NtuplesBaseVector):
         Returns
         -------
         equals : bool
-            True if all entries of ``other`` are equal to this
-            vector's entries, False otherwise.
+            ``True`` if all entries of ``other`` are equal to this
+            vector's entries, ``False`` otherwise.
         """
         return (other in self.space and
                 self.ntuple == other.ntuple)
@@ -304,7 +305,7 @@ class DiscretizedSetVector(NtuplesBaseVector):
 
         Parameters
         ----------
-        indices : int or slice
+        indices : int or `slice`
             The position(s) that should be accessed
 
         Returns
@@ -319,9 +320,9 @@ class DiscretizedSetVector(NtuplesBaseVector):
 
         Parameters
         ----------
-        indices : int or slice
+        indices : int or `slice`
             The position(s) that should be set
-        values : scalar, array-like or `NtuplesBaseVector`
+        values : scalar, `array-like` or `NtuplesBaseVector`
             The value(s) that are to be assigned.
 
             If ``index`` is an int, ``value`` must be single value.
@@ -488,7 +489,7 @@ class DiscretizedSpace(DiscretizedSet, FnBase):
 
     @property
     def is_weighted(self):
-        """Return True if the ``dspace`` is weighted."""
+        """``True`` if the ``dspace`` is weighted."""
         return getattr(self.dspace, 'is_weighted', False)
 
     def _lincomb(self, a, x1, b, x2, out):
@@ -560,10 +561,10 @@ def dspace_type(space, impl, dtype=None):
         Template space from which to infer an adequate data space. If
         it has a `LinearSpace.field` attribute, ``dtype`` must be
         consistent with it.
-    impl : `str`
+    impl : string
         Implementation backend for the data space
-    dtype : `type`, optional
-        Data type which the space is supposed to use. If None, the
+    dtype : type, optional
+        Data type which the space is supposed to use. If ``None``, the
         space type is purely determined from ``space`` and
         ``impl``. If given, it must be compatible with the
         field of ``space``.

--- a/odl/discr/discretization.py
+++ b/odl/discr/discretization.py
@@ -205,11 +205,11 @@ class DiscretizedSet(NtuplesBase):
 
         Returns
         -------
-        equals : `bool`
-            `True` if ``other`` is a `DiscretizedSet`
+        equals : bool
+            True if ``other`` is a `DiscretizedSet`
             instance and all attributes `uspace`, `dspace`,
             `DiscretizedSet.sampling` and `DiscretizedSet.interpolation`
-            of ``other`` and this discretization are equal, `False` otherwise.
+            of ``other`` and this discretization are equal, False otherwise.
         """
         if other is self:
             return True
@@ -281,7 +281,7 @@ class DiscretizedSetVector(NtuplesBaseVector):
 
         Parameters
         ----------
-        out : `numpy.ndarray`, optional
+        out : numpy.ndarray, optional
             Array in which the result should be written in-place.
             Has to be contiguous and of the correct dtype.
         """
@@ -292,9 +292,9 @@ class DiscretizedSetVector(NtuplesBaseVector):
 
         Returns
         -------
-        equals : `bool`
-            `True` if all entries of ``other`` are equal to this
-            vector's entries, `False` otherwise.
+        equals : bool
+            True if all entries of ``other`` are equal to this
+            vector's entries, False otherwise.
         """
         return (other in self.space and
                 self.ntuple == other.ntuple)
@@ -304,7 +304,7 @@ class DiscretizedSetVector(NtuplesBaseVector):
 
         Parameters
         ----------
-        indices : `int` or `slice`
+        indices : int or slice
             The position(s) that should be accessed
 
         Returns
@@ -319,14 +319,14 @@ class DiscretizedSetVector(NtuplesBaseVector):
 
         Parameters
         ----------
-        indices : `int` or `slice`
+        indices : int or slice
             The position(s) that should be set
-        values : scalar, `array-like` or `NtuplesBaseVector`
+        values : scalar, array-like or `NtuplesBaseVector`
             The value(s) that are to be assigned.
 
-            If ``index`` is an `int`, ``value`` must be single value.
+            If ``index`` is an int, ``value`` must be single value.
 
-            If ``index`` is a `slice`, ``value`` must be broadcastable
+            If ``index`` is a slice, ``value`` must be broadcastable
             to the size of the slice (same size, shape (1,)
             or single value).
         """
@@ -488,7 +488,7 @@ class DiscretizedSpace(DiscretizedSet, FnBase):
 
     @property
     def is_weighted(self):
-        """Return `True` if the ``dspace`` is weighted."""
+        """Return True if the ``dspace`` is weighted."""
         return getattr(self.dspace, 'is_weighted', False)
 
     def _lincomb(self, a, x1, b, x2, out):
@@ -563,7 +563,7 @@ def dspace_type(space, impl, dtype=None):
     impl : `str`
         Implementation backend for the data space
     dtype : `type`, optional
-        Data type which the space is supposed to use. If `None`, the
+        Data type which the space is supposed to use. If None, the
         space type is purely determined from ``space`` and
         ``impl``. If given, it must be compatible with the
         field of ``space``.

--- a/odl/discr/grid.py
+++ b/odl/discr/grid.py
@@ -43,12 +43,12 @@ def sparse_meshgrid(*x):
 
     Parameters
     ----------
-    x1,...,xN : `array-like`
+    x1,...,xN : array-like
         Input arrays to turn into sparse meshgrid vectors
 
     Returns
     -------
-    meshgrid : `tuple` of `numpy.ndarray`
+    meshgrid : tuple of numpy.ndarray
         Sparse coordinate vectors representing an N-dimensional grid
 
     See also
@@ -108,7 +108,7 @@ class TensorGrid(Set):
 
         Parameters
         ----------
-        vec1,...,vecN : `array-like`
+        vec1,...,vecN : array-like
             The coordinate vectors defining the grid points. They must
             be sorted in ascending order and may not contain
             duplicates. Empty vectors are not allowed.
@@ -182,7 +182,7 @@ class TensorGrid(Set):
 
         Returns
         -------
-        coord_vectors : tuple of `numpy.ndarray`'s
+        coord_vectors : tuple of numpy.ndarray's
 
         Examples
         --------
@@ -371,18 +371,18 @@ class TensorGrid(Set):
 
         Parameters
         ----------
-        other : `object`
+        other :
             Object to be tested
-        atol : `float`
+        atol : float
             Allow deviations up to this number in absolute value
             per vector entry.
 
         Returns
         -------
-        equals : `bool`
-            `True` if ``other`` is a `TensorGrid` instance with all
+        equals : bool
+            True if ``other`` is a `TensorGrid` instance with all
             coordinate vectors equal (up to the given tolerance), to
-            the ones of this grid, otherwise `False`.
+            the ones of this grid, False otherwise.
 
         Examples
         --------
@@ -421,9 +421,9 @@ class TensorGrid(Set):
 
         Parameters
         ----------
-        other : `array-like` or `float`
+        other : array-like or float
             The object to test for membership in this grid
-        atol : `float`
+        atol : float
             Allow deviations up to this number in absolute value
             per vector entry.
 
@@ -460,7 +460,7 @@ class TensorGrid(Set):
         ----------
         other :  `TensorGrid`
             The other grid which is supposed to contain this grid
-        atol : `float`
+        atol : float
             Allow deviations up to this number in absolute value
             per coordinate vector entry.
 
@@ -506,7 +506,7 @@ class TensorGrid(Set):
 
         Parameters
         ----------
-        index : `int`
+        index : int
             The index of the dimension before which ``other`` is to
             be inserted. Negative indices count backwards from
             ``self.ndim``.
@@ -589,7 +589,7 @@ class TensorGrid(Set):
 
         Returns
         -------
-        points : `numpy.ndarray`
+        points : numpy.ndarray
             The shape of the array is ``size x ndim``, i.e. the points
             are stored as rows.
 
@@ -662,7 +662,7 @@ class TensorGrid(Set):
 
         Returns
         -------
-        corners : `numpy.ndarray`
+        corners : numpy.ndarray
             The size of the array is 2^m x ndim, where m is the number
             of non-degenerate axes, i.e. the corners are stored as rows.
 
@@ -688,7 +688,7 @@ class TensorGrid(Set):
 
         Returns
         -------
-        meshgrid : `tuple` of `numpy.ndarray`
+        meshgrid : tuple of numpy.ndarray
             Function evaluation grid with ``ndim`` axes
 
         See also
@@ -727,7 +727,7 @@ class TensorGrid(Set):
         ----------
         indices : index expression
             Object determining which parts of the grid to extract.
-            `None` (new axis) and empty axes are not supported.
+            None (new axis) and empty axes are not supported.
 
         Examples
         --------
@@ -780,7 +780,7 @@ class TensorGrid(Set):
         Parameters
         ----------
         dtype : `numpy.dtype`
-            The numpy dtype of the result array. Default: `float`
+            The numpy dtype of the result array. Default: float
 
         Examples
         --------
@@ -832,13 +832,13 @@ class RegularGrid(TensorGrid):
 
         Parameters
         ----------
-        min_pt : `array-like` or `float`
+        min_pt : array-like or float
             Grid point with minimum coordinates, can be a single float
             for 1D grids
-        max_pt : `array-like` or `float`
+        max_pt : array-like or float
             Grid point with maximum coordinates, can be a single float
             for 1D grids
-        shape : `array-like` or `int`
+        shape : array-like or int
             The number of grid points per axis, can be an integer for
             1D grids
 
@@ -929,7 +929,7 @@ class RegularGrid(TensorGrid):
         ----------
         other :
             Check if this object is a subgrid
-        atol : `float`
+        atol : float
             Allow deviations up to this number in absolute value
             per coordinate vector entry.
 
@@ -993,7 +993,7 @@ class RegularGrid(TensorGrid):
 
         Parameters
         ----------
-        index : `int`
+        index : int
             Index of the dimension before which ``other`` is to
             be inserted. Negative indices count backwards from
             ``self.ndim``.
@@ -1070,7 +1070,7 @@ class RegularGrid(TensorGrid):
         ----------
         indices : index expression
             Object determining which parts of the grid to extract.
-            `None` (new axis) and empty axes are not supported.
+            None (new axis) and empty axes are not supported.
 
         Examples
         --------
@@ -1158,16 +1158,16 @@ def uniform_sampling_fromintv(intv_prod, num_nodes, nodes_on_bdry=True):
     ----------
     intv_prod : `IntervalProd`
         Set to be sampled
-    num_nodes : `int` or `tuple` of `int`
-        Number of nodes per axis. For dimension >= 2, a `tuple`
+    num_nodes : int or tuple of int
+        Number of nodes per axis. For dimension >= 2, a tuple
         is required. All entries must be positive. Entries
         corresponding to degenerate axes must be equal to 1.
-    nodes_on_bdry : `bool` or `sequence`, optional
+    nodes_on_bdry : bool or sequence, optional
         If a sequence is provided, it determines per axis whether to
         place the last grid point on the boundary (True) or shift it
         by half a cell size into the interior (False). In each axis,
-        an entry may consist in a single `bool` or a 2-tuple of
-        `bool`. In the latter case, the first tuple entry decides for
+        an entry may consist in a single bool or a 2-tuple of
+        bool. In the latter case, the first tuple entry decides for
         the left, the second for the right boundary. The length of the
         sequence must be ``array.ndim``.
 
@@ -1276,20 +1276,20 @@ def uniform_sampling(begin, end, num_nodes, nodes_on_bdry=True):
 
     Parameters
     ----------
-    begin : `array-like` or `float`
+    begin : array-like or float
         The lower ends of the intervals in the product
-    end : `array-like` or `float`
+    end : array-like or float
         The upper ends of the intervals in the product
-    num_nodes : `int` or `tuple` of `int`
-        Number of nodes per axis. For dimension >= 2, a `tuple`
+    num_nodes : int or tuple of int
+        Number of nodes per axis. For dimension >= 2, a tuple
         is required. All entries must be positive. Entries
         corresponding to degenerate axes must be equal to 1.
-    nodes_on_bdry : `bool` or `sequence`, optional
+    nodes_on_bdry : bool or sequence, optional
         If a sequence is provided, it determines per axis whether to
         place the last grid point on the boundary (True) or shift it
         by half a cell size into the interior (False). In each axis,
-        an entry may consist in a single `bool` or a 2-tuple of
-        `bool`. In the latter case, the first tuple entry decides for
+        an entry may consist in a single bool or a 2-tuple of
+        bool. In the latter case, the first tuple entry decides for
         the left, the second for the right boundary. The length of the
         sequence must be ``array.ndim``.
 

--- a/odl/discr/grid.py
+++ b/odl/discr/grid.py
@@ -43,12 +43,12 @@ def sparse_meshgrid(*x):
 
     Parameters
     ----------
-    x1,...,xN : array-like
+    x1,...,xN : `array-like`
         Input arrays to turn into sparse meshgrid vectors
 
     Returns
     -------
-    meshgrid : tuple of numpy.ndarray
+    meshgrid : tuple of `numpy.ndarray`'s
         Sparse coordinate vectors representing an N-dimensional grid
 
     See also
@@ -108,7 +108,7 @@ class TensorGrid(Set):
 
         Parameters
         ----------
-        vec1,...,vecN : array-like
+        vec1,...,vecN : `array-like`
             The coordinate vectors defining the grid points. They must
             be sorted in ascending order and may not contain
             duplicates. Empty vectors are not allowed.
@@ -182,7 +182,7 @@ class TensorGrid(Set):
 
         Returns
         -------
-        coord_vectors : tuple of numpy.ndarray's
+        coord_vectors : tuple of `numpy.ndarray`'s
 
         Examples
         --------
@@ -380,9 +380,9 @@ class TensorGrid(Set):
         Returns
         -------
         equals : bool
-            True if ``other`` is a `TensorGrid` instance with all
+            ``True`` if ``other`` is a `TensorGrid` instance with all
             coordinate vectors equal (up to the given tolerance), to
-            the ones of this grid, False otherwise.
+            the ones of this grid, ``False`` otherwise.
 
         Examples
         --------
@@ -421,7 +421,7 @@ class TensorGrid(Set):
 
         Parameters
         ----------
-        other : array-like or float
+        other : `array-like` or float
             The object to test for membership in this grid
         atol : float
             Allow deviations up to this number in absolute value
@@ -589,7 +589,7 @@ class TensorGrid(Set):
 
         Returns
         -------
-        points : numpy.ndarray
+        points : `numpy.ndarray`
             The shape of the array is ``size x ndim``, i.e. the points
             are stored as rows.
 
@@ -662,7 +662,7 @@ class TensorGrid(Set):
 
         Returns
         -------
-        corners : numpy.ndarray
+        corners : `numpy.ndarray`
             The size of the array is 2^m x ndim, where m is the number
             of non-degenerate axes, i.e. the corners are stored as rows.
 
@@ -688,7 +688,7 @@ class TensorGrid(Set):
 
         Returns
         -------
-        meshgrid : tuple of numpy.ndarray
+        meshgrid : tuple of `numpy.ndarray`'s
             Function evaluation grid with ``ndim`` axes
 
         See also
@@ -717,7 +717,7 @@ class TensorGrid(Set):
 
     @property
     def is_uniform(self):
-        """Return `True` if this is a `RegularGrid`."""
+        """Return ``True`` if this grid is a `RegularGrid`."""
         return isinstance(self, RegularGrid)
 
     def __getitem__(self, indices):
@@ -727,7 +727,7 @@ class TensorGrid(Set):
         ----------
         indices : index expression
             Object determining which parts of the grid to extract.
-            None (new axis) and empty axes are not supported.
+            ``None`` (new axis) and empty axes are not supported.
 
         Examples
         --------
@@ -832,13 +832,13 @@ class RegularGrid(TensorGrid):
 
         Parameters
         ----------
-        min_pt : array-like or float
+        min_pt : `array-like` or float
             Grid point with minimum coordinates, can be a single float
             for 1D grids
-        max_pt : array-like or float
+        max_pt : `array-like` or float
             Grid point with maximum coordinates, can be a single float
             for 1D grids
-        shape : array-like or int
+        shape : `array-like` or int
             The number of grid points per axis, can be an integer for
             1D grids
 
@@ -1070,7 +1070,7 @@ class RegularGrid(TensorGrid):
         ----------
         indices : index expression
             Object determining which parts of the grid to extract.
-            None (new axis) and empty axes are not supported.
+            ``None`` (new axis) and empty axes are not supported.
 
         Examples
         --------
@@ -1158,14 +1158,14 @@ def uniform_sampling_fromintv(intv_prod, num_nodes, nodes_on_bdry=True):
     ----------
     intv_prod : `IntervalProd`
         Set to be sampled
-    num_nodes : int or tuple of int
+    num_nodes : int or `sequence` of ints
         Number of nodes per axis. For dimension >= 2, a tuple
         is required. All entries must be positive. Entries
         corresponding to degenerate axes must be equal to 1.
-    nodes_on_bdry : bool or sequence, optional
+    nodes_on_bdry : bool or `sequence`, optional
         If a sequence is provided, it determines per axis whether to
-        place the last grid point on the boundary (True) or shift it
-        by half a cell size into the interior (False). In each axis,
+        place the last grid point on the boundary (``True``) or shift it
+        by half a cell size into the interior (``False``). In each axis,
         an entry may consist in a single bool or a 2-tuple of
         bool. In the latter case, the first tuple entry decides for
         the left, the second for the right boundary. The length of the
@@ -1194,7 +1194,7 @@ def uniform_sampling_fromintv(intv_prod, num_nodes, nodes_on_bdry=True):
     >>> grid.coord_vectors
     (array([-1.5, -1. , -0.5]), array([ 2. ,  2.5,  3. ]))
 
-    To have the nodes in the "middle", use nodes_on_bdry=False
+    To have the nodes in the "middle", use ``nodes_on_bdry=False``:
 
     >>> grid = uniform_sampling_fromintv(rbox, (2, 2), nodes_on_bdry=False)
     >>> grid.coord_vectors
@@ -1276,18 +1276,18 @@ def uniform_sampling(begin, end, num_nodes, nodes_on_bdry=True):
 
     Parameters
     ----------
-    begin : array-like or float
+    begin : `array-like` or float
         The lower ends of the intervals in the product
-    end : array-like or float
+    end : `array-like` or float
         The upper ends of the intervals in the product
-    num_nodes : int or tuple of int
+    num_nodes : int or `sequence` of ints
         Number of nodes per axis. For dimension >= 2, a tuple
         is required. All entries must be positive. Entries
         corresponding to degenerate axes must be equal to 1.
-    nodes_on_bdry : bool or sequence, optional
+    nodes_on_bdry : bool or `sequence`, optional
         If a sequence is provided, it determines per axis whether to
-        place the last grid point on the boundary (True) or shift it
-        by half a cell size into the interior (False). In each axis,
+        place the last grid point on the boundary (``True``) or shift it
+        by half a cell size into the interior (``False``). In each axis,
         an entry may consist in a single bool or a 2-tuple of
         bool. In the latter case, the first tuple entry decides for
         the left, the second for the right boundary. The length of the
@@ -1310,7 +1310,7 @@ def uniform_sampling(begin, end, num_nodes, nodes_on_bdry=True):
     >>> grid.coord_vectors
     (array([-1.5, -1. , -0.5]), array([ 2. ,  2.5,  3. ]))
 
-    To have the nodes in the "middle", use nodes_on_bdry=False
+    To have the nodes in the "middle", use ``nodes_on_bdry=False``:
 
     >>> grid = uniform_sampling([-1.5, 2], [-0.5, 3], (2, 2),
     ...                         nodes_on_bdry=False)

--- a/odl/discr/lp_discr.py
+++ b/odl/discr/lp_discr.py
@@ -266,7 +266,7 @@ class DiscreteLp(DiscretizedSpace):
 
         Returns
         -------
-        element : `DiscretizedSetVector`
+        element : `DiscreteLpVector`
             The discretized element, calculated as ``sampling(inp)`` or
             ``dspace.element(inp)``, tried in this order.
 

--- a/odl/discr/lp_discr.py
+++ b/odl/discr/lp_discr.py
@@ -73,7 +73,7 @@ class DiscreteLp(DiscretizedSpace):
             The parameter :math:`p` in :math:`L^p`. If the exponent is
             not equal to the default 2.0, the space has no inner
             product.
-        interp : string or sequence of string, optional
+        interp : string or `sequence` of strings, optional
             The interpolation type to be used for discretization.
             A sequence is interpreted as interpolation scheme per
             axis.
@@ -186,7 +186,7 @@ class DiscreteLp(DiscretizedSpace):
 
     @property
     def is_uniform(self):
-        """Return `True` if ``self.partition`` is uniform."""
+        """``True`` if ``self.partition`` is uniform."""
         return self.partition.is_uniform
 
     @property
@@ -246,8 +246,8 @@ class DiscreteLp(DiscretizedSpace):
         inp : optional
             Input data to create an element from.
 
-            If `callable`, it needs to be understood by the ``uspace.element``
-            method.
+            If ``inp`` is `callable`, it needs to be understood by the
+            ``uspace.element`` method.
 
             Otherwise, it has to be understood by the ``dspace.element``
             method.
@@ -258,8 +258,8 @@ class DiscreteLp(DiscretizedSpace):
 
         Other Parameters
         ----------------
-        vectorized : `bool`
-            Can only be used if ``inp`` is `callable`, in which case it
+        vectorized : bool
+            Can only be used if ``inp`` is callable, in which case it
             indicates if ``inp`` is vectorized. If not, it will be wrapped
             with a vectorizer.
             Default: True
@@ -491,7 +491,7 @@ class DiscreteLpVector(DiscretizedSpaceVector):
 
         Parameters
         ----------
-        out : numpy.ndarray, optional
+        out : `numpy.ndarray`, optional
             Array in which the result should be written in-place.
             Has to be contiguous and of the correct dtype and
             shape.
@@ -622,7 +622,7 @@ class DiscreteLpVector(DiscretizedSpaceVector):
 
         Parameters
         ----------
-        indices : int or slice
+        indices : int or `slice`
             The position(s) that should be set
         values : scalar or `array-like`
             Value(s) to be assigned.
@@ -721,13 +721,13 @@ class DiscreteLpVector(DiscretizedSpaceVector):
             'scatter' : cloud of scattered 3d points
             (3rd axis <-> value)
 
-        coords : array-like, optional
-            Display a slice of the array instead of the full array. The values
-            are shown accordinging to the given values, None represent all
-            values along that dimension. For example [None, None, 0.5] shows
-            all values in the first two dimensions, with third coordinate equal
-            to 0.5.
-            This option is mutually exclusive to indices.
+        coords : `array-like`, optional
+            Display a slice of the array instead of the full array.
+            The values are shown accordinging to the given values,
+            where ``None`` means all values along that dimension. For
+            example, ``[None, None, 0.5]`` shows all values in the first
+            two dimensions, with the third coordinate equal to 0.5.
+            This option is mutually exclusive to ``indices``.
 
         indices : index expression, optional
             Display a slice of the array instead of the full array. The
@@ -737,19 +737,20 @@ class DiscreteLpVector(DiscretizedSpaceVector):
             For data with 3 or more dimensions, the 2d slice in the first
             two axes at the "middle" along the remaining axes is shown
             (semantically ``[:, :, shape[2:] // 2]``).
-            This option is mutually exclusive to coords.
+            This option is mutually exclusive to ``coords``.
 
         show : bool, optional
-            If the plot should be showed now or deferred until later.
+            If ``True``, show the plot now. Otherwise, display is deferred
+            deferred until later.
 
         fig : `matplotlib.figure.Figure`
             The figure to show in. Expected to be of same "style", as
             the figure given by this function. The most common use case
-            is that ``fig`` is the return value from an earlier call to
+            is that ``fig`` is the return value of an earlier call to
             this function.
 
         kwargs : {'figsize', 'saveto', 'clim', ...}
-            Extra keyword arguments passed on to display method
+            Extra keyword arguments passed on to the display method.
             See the Matplotlib functions for documentation of extra
             options.
 
@@ -841,7 +842,7 @@ def uniform_discr_frompartition(partition, exponent=2.0, interp='nearest',
     exponent : positive float, optional
         The parameter ``p`` in ``L^p``. If the exponent is not
         equal to the default 2.0, the space has no inner product.
-    interp : string or sequence of string, optional
+    interp : string or `sequence` of strings, optional
         Interpolation type to be used for discretization.
         A sequence is interpreted as interpolation scheme per axis.
 
@@ -849,7 +850,7 @@ def uniform_discr_frompartition(partition, exponent=2.0, interp='nearest',
 
             'linear' : use linear interpolation
 
-    impl : `str`, optional
+    impl : string, optional
         Implementation of the data storage arrays
 
     Other Parameters
@@ -941,13 +942,13 @@ def uniform_discr_fromspace(fspace, nsamples, exponent=2.0, interp='nearest',
     fspace : `FunctionSpace`
         Continuous function space. Its domain must be an
         `IntervalProd` instance.
-    nsamples : int or tuple of int
+    nsamples : int or `sequence` of ints
         Number of samples per axis. For dimension >= 2, a tuple is
         required.
     exponent : positive float, optional
         The parameter ``p`` in ``L^p``. If the exponent is not
         equal to the default 2.0, the space has no inner product.
-    interp : string or sequence of string, optional
+    interp : string or `sequence` of strings, optional
         Interpolation type to be used for discretization.
         A sequence is interpreted as interpolation scheme per axis.
 
@@ -955,19 +956,19 @@ def uniform_discr_fromspace(fspace, nsamples, exponent=2.0, interp='nearest',
 
             'linear' : use linear interpolation
 
-    impl : `str`, optional
+    impl : string, optional
         Implementation of the data storage arrays
 
     Other Parameters
     ----------------
-    nodes_on_bdry : bool or boolean array-like, optional
-        If True, place the outermost grid points at the boundary. For
-        False, they are shifted by half a cell size to the 'inner'.
-        If an array-like is given, it must have shape ``(ndim, 2)``,
+    nodes_on_bdry : bool or boolean `array-like`, optional
+        If ``True``, place the outermost grid points at the boundary. For
+        ``False``, they are shifted by half a cell size to the 'inner'.
+        If an array-like object is given, it must have shape ``(ndim, 2)``,
         where ``ndim`` is the number of dimensions. It defines per axis
         whether the leftmost (first column) and rightmost (second column)
         nodes node lie on the boundary.
-        Default: False
+        Default: ``False``
     order : {'C', 'F'}, optional
         Axis ordering in the data storage. Default: 'C'
     dtype : dtype, optional
@@ -1049,13 +1050,13 @@ def uniform_discr_fromintv(interval, nsamples, exponent=2.0, interp='nearest',
     ----------
     interval : `IntervalProd`
         The domain of the uniformly discretized space.
-    nsamples : int or tuple of int
+    nsamples : int or `sequence` of ints
         Number of samples per axis. For dimension >= 2, a tuple is
         required.
     exponent : positive float, optional
         The parameter :math:`p` in :math:`L^p`. If the exponent is not
         equal to the default 2.0, the space has no inner product.
-    interp : string or sequence of string, optional
+    interp : string or `sequence` of strings, optional
         Interpolation type to be used for discretization.
         A sequence is interpreted as interpolation scheme per axis.
 
@@ -1065,10 +1066,10 @@ def uniform_discr_fromintv(interval, nsamples, exponent=2.0, interp='nearest',
 
     impl : str, optional
         Implementation of the data storage arrays.
-    nodes_on_bdry : bool or sequence, optional
+    nodes_on_bdry : bool or `sequence`, optional
         If a sequence is provided, it determines per axis whether to
-        place the last grid point on the boundary (True) or shift it
-        by half a cell size into the interior (False). In each axis,
+        place the last grid point on the boundary (``True``) or shift it
+        by half a cell size into the interior (``False``). In each axis,
         an entry may consist in a single bool or a 2-tuple of
         bool. In the latter case, the first tuple entry decides for
         the left, the second for the right boundary. The length of the
@@ -1076,7 +1077,7 @@ def uniform_discr_fromintv(interval, nsamples, exponent=2.0, interp='nearest',
 
         A single boolean is interpreted as a global choice for all
         boundaries.
-        Default: False
+        Default: ``False``
 
     dtype : dtype, optional
         Data type for the discretized space
@@ -1132,16 +1133,16 @@ def uniform_discr(min_corner, max_corner, nsamples,
 
     Parameters
     ----------
-    min_corner, max_corner : float or tuple of float
+    min_corner, max_corner : float or `sequence` of floats
         Minimum/maximum corners of the domain of the resulting space.
         For dimension >= 2, sequences are required.
-    nsamples : int or tuple of int
+    nsamples : int or `sequence` of ints
         Number of samples per axis. For dimension >= 2, a sequence is
         required.
     exponent : positive float, optional
         The parameter :math:`p` in :math:`L^p`. If the exponent is not
         equal to the default 2.0, the space has no inner product.
-    interp : string or sequence of string, optional
+    interp : string or `sequence` of strings, optional
         Interpolation type to be used for discretization.
         A sequence is interpreted as interpolation scheme per axis.
 
@@ -1149,12 +1150,12 @@ def uniform_discr(min_corner, max_corner, nsamples,
 
             'linear' : use linear interpolation
 
-    impl : `str`, optional
+    impl : string, optional
         Implementation of the data storage arrays
-    nodes_on_bdry : bool or sequence, optional
+    nodes_on_bdry : bool or `sequence`, optional
         If a sequence is provided, it determines per axis whether to
-        place the last grid point on the boundary (True) or shift it
-        by half a cell size into the interior (False). In each axis,
+        place the last grid point on the boundary (``True``) or shift it
+        by half a cell size into the interior (``False``). In each axis,
         an entry may consist in a single bool or a 2-tuple of
         bool. In the latter case, the first tuple entry decides for
         the left, the second for the right boundary. The length of the
@@ -1162,7 +1163,7 @@ def uniform_discr(min_corner, max_corner, nsamples,
 
         A single boolean is interpreted as a global choice for all
         boundaries.
-        Default: False
+        Default: ``False``
 
     dtype : dtype, optional
         Data type for the discretized space
@@ -1223,13 +1224,13 @@ def discr_sequence_space(shape, exponent=2.0, impl='numpy', **kwargs):
 
     Parameters
     ----------
-    shape : sequence of int
+    shape : `sequence` of ints
         Multi-dimensional size of the elements in this space
     exponent : positive float, optional
         The parameter ``p`` in ```L^p``. If the exponent is
         not equal to the default 2.0, the space has no inner
         product.
-    impl : `str`, optional
+    impl : string, optional
         Implementation of the data storage arrays
     dtype : dtype, optional
         Data type for the discretized space
@@ -1279,16 +1280,16 @@ def uniform_discr_fromdiscr(discr, min_corner=None, max_corner=None,
     ----------
     discr : `DiscreteLp`
         Uniformly discretized space used as a template.
-    min_corner : float or sequence of float
+    min_corner : float or `sequence` of floats
         Minimum corner of the resulting spatial domain.
-    max_corner : float or sequence of float
+    max_corner : float or `sequence` of floats
         Maximum corner of the resulting spatial domain.
-    nsamples : int or sequence of int
+    nsamples : int or `sequence` of ints
         Number of samples per axis.
     exponent : positive float, optional
         The parameter :math:`p` in :math:`L^p`. If the exponent is not
         equal to the default 2.0, the space has no inner product.
-    interp : str or sequence of str, optional
+    interp : string or `sequence` of strings, optional
         Interpolation type to be used for discretization.
         A sequence is interpreted as interpolation scheme per axis.
 
@@ -1296,15 +1297,15 @@ def uniform_discr_fromdiscr(discr, min_corner=None, max_corner=None,
 
             'linear' : use linear interpolation
 
-    impl : `str`
+    impl : string
         Implementation of the data storage arrays. See
-    nodes_on_bdry : bool or sequence, optional
+    nodes_on_bdry : bool or `sequence`, optional
         Specifies whether to put the outmost grid nodes on the
         boundary of the domain.
 
         If a sequence is provided, it determines per axis whether to
-        place the last grid point on the boundary (True) or shift it
-        by half a cell size into the interior (False). In each axis,
+        place the last grid point on the boundary (``True``) or shift it
+        by half a cell size into the interior (``False``). In each axis,
         an entry may consist in a single boolean or a 2-tuple of
         bool. In the latter case, the first tuple entry decides for
         the left, the second for the right boundary. The length of the
@@ -1312,7 +1313,7 @@ def uniform_discr_fromdiscr(discr, min_corner=None, max_corner=None,
 
         A single boolean is interpreted as a global choice for all
         boundaries.
-        Default: `False`
+        Default: ``False``
 
     dtype : optional
         Data type for the discretized space.

--- a/odl/discr/lp_discr.py
+++ b/odl/discr/lp_discr.py
@@ -69,11 +69,11 @@ class DiscreteLp(DiscretizedSpace):
         dspace : `FnBase`
             Space of elements used for data storage. It must have the
             same `FnBase.field` as ``fspace``
-        exponent : positive `float`, optional
+        exponent : positive float, optional
             The parameter :math:`p` in :math:`L^p`. If the exponent is
             not equal to the default 2.0, the space has no inner
             product.
-        interp : `str` or `sequence` of `str`, optional
+        interp : string or sequence of string, optional
             The interpolation type to be used for discretization.
             A sequence is interpreted as interpolation scheme per
             axis.
@@ -491,7 +491,7 @@ class DiscreteLpVector(DiscretizedSpaceVector):
 
         Parameters
         ----------
-        out : `numpy.ndarray`, optional
+        out : numpy.ndarray, optional
             Array in which the result should be written in-place.
             Has to be contiguous and of the correct dtype and
             shape.
@@ -622,16 +622,16 @@ class DiscreteLpVector(DiscretizedSpaceVector):
 
         Parameters
         ----------
-        indices : `int` or `slice`
+        indices : int or slice
             The position(s) that should be set
         values : scalar or `array-like`
-            The value(s) that are to be assigned.
-            If ``indices`` is an `int`, ``values`` must be a single
+            Value(s) to be assigned.
+            If ``indices`` is an integer, ``values`` must be a scalar
             value.
-            If ``indices`` is a `slice`, ``values`` must be
+            If ``indices`` is a slice, ``values`` must be
             broadcastable to the size of the slice (same size,
-            shape ``(1,)`` or single value).
-            For ``indices=slice(None)``, i.e. in the call
+            shape ``(1,)`` or scalar).
+            For ``indices == slice(None)``, i.e. in the call
             ``vec[:] = values``, a multi-dimensional array of correct
             shape is allowed as ``values``.
         """
@@ -702,10 +702,10 @@ class DiscreteLpVector(DiscretizedSpaceVector):
 
         Parameters
         ----------
-        title : `str`, optional
+        title : string, optional
             Set the title of the figure
 
-        method : `str`, optional
+        method : string, optional
             1d methods:
 
             'plot' : graph plot
@@ -723,7 +723,7 @@ class DiscreteLpVector(DiscretizedSpaceVector):
 
         coords : array-like, optional
             Display a slice of the array instead of the full array. The values
-            are shown accordinging to the given values, `None` represent all
+            are shown accordinging to the given values, None represent all
             values along that dimension. For example [None, None, 0.5] shows
             all values in the first two dimensions, with third coordinate equal
             to 0.5.
@@ -739,7 +739,7 @@ class DiscreteLpVector(DiscretizedSpaceVector):
             (semantically ``[:, :, shape[2:] // 2]``).
             This option is mutually exclusive to coords.
 
-        show : `bool`, optional
+        show : bool, optional
             If the plot should be showed now or deferred until later.
 
         fig : `matplotlib.figure.Figure`
@@ -838,10 +838,10 @@ def uniform_discr_frompartition(partition, exponent=2.0, interp='nearest',
     ----------
     partition : `RectPartition`
         Regular (uniform) partition to be used for discretization
-    exponent : positive `float`, optional
+    exponent : positive float, optional
         The parameter ``p`` in ``L^p``. If the exponent is not
         equal to the default 2.0, the space has no inner product.
-    interp : `str` or `sequence` of `str`, optional
+    interp : string or sequence of string, optional
         Interpolation type to be used for discretization.
         A sequence is interpreted as interpolation scheme per axis.
 
@@ -941,13 +941,13 @@ def uniform_discr_fromspace(fspace, nsamples, exponent=2.0, interp='nearest',
     fspace : `FunctionSpace`
         Continuous function space. Its domain must be an
         `IntervalProd` instance.
-    nsamples : `int` or `tuple` of `int`
+    nsamples : int or tuple of int
         Number of samples per axis. For dimension >= 2, a tuple is
         required.
-    exponent : positive `float`, optional
+    exponent : positive float, optional
         The parameter ``p`` in ``L^p``. If the exponent is not
         equal to the default 2.0, the space has no inner product.
-    interp : `str` or `sequence` of `str`, optional
+    interp : string or sequence of string, optional
         Interpolation type to be used for discretization.
         A sequence is interpreted as interpolation scheme per axis.
 
@@ -960,14 +960,14 @@ def uniform_discr_fromspace(fspace, nsamples, exponent=2.0, interp='nearest',
 
     Other Parameters
     ----------------
-    nodes_on_bdry : `bool` or boolean `array-like`, optional
-        If `True`, place the outermost grid points at the boundary. For
-        `False`, they are shifted by half a cell size to the 'inner'.
+    nodes_on_bdry : bool or boolean array-like, optional
+        If True, place the outermost grid points at the boundary. For
+        False, they are shifted by half a cell size to the 'inner'.
         If an array-like is given, it must have shape ``(ndim, 2)``,
         where ``ndim`` is the number of dimensions. It defines per axis
         whether the leftmost (first column) and rightmost (second column)
         nodes node lie on the boundary.
-        Default: `False`
+        Default: False
     order : {'C', 'F'}, optional
         Axis ordering in the data storage. Default: 'C'
     dtype : dtype, optional
@@ -1049,13 +1049,13 @@ def uniform_discr_fromintv(interval, nsamples, exponent=2.0, interp='nearest',
     ----------
     interval : `IntervalProd`
         The domain of the uniformly discretized space.
-    nsamples : `int` or `tuple` of `int`
+    nsamples : int or tuple of int
         Number of samples per axis. For dimension >= 2, a tuple is
         required.
-    exponent : positive `float`, optional
+    exponent : positive float, optional
         The parameter :math:`p` in :math:`L^p`. If the exponent is not
         equal to the default 2.0, the space has no inner product.
-    interp : `str` or `sequence` of `str`, optional
+    interp : string or sequence of string, optional
         Interpolation type to be used for discretization.
         A sequence is interpreted as interpolation scheme per axis.
 
@@ -1063,20 +1063,20 @@ def uniform_discr_fromintv(interval, nsamples, exponent=2.0, interp='nearest',
 
             'linear' : use linear interpolation
 
-    impl : `str`, optional
+    impl : str, optional
         Implementation of the data storage arrays.
-    nodes_on_bdry : `bool` or `sequence`, optional
+    nodes_on_bdry : bool or sequence, optional
         If a sequence is provided, it determines per axis whether to
         place the last grid point on the boundary (True) or shift it
         by half a cell size into the interior (False). In each axis,
-        an entry may consist in a single `bool` or a 2-tuple of
-        `bool`. In the latter case, the first tuple entry decides for
+        an entry may consist in a single bool or a 2-tuple of
+        bool. In the latter case, the first tuple entry decides for
         the left, the second for the right boundary. The length of the
         sequence must be ``array.ndim``.
 
         A single boolean is interpreted as a global choice for all
         boundaries.
-        Default: `False`
+        Default: False
 
     dtype : dtype, optional
         Data type for the discretized space
@@ -1132,17 +1132,16 @@ def uniform_discr(min_corner, max_corner, nsamples,
 
     Parameters
     ----------
-    min_corner : `float` or `tuple` of `float`
-        Minimum corner of the result.
-    max_corner : `float` or `tuple` of `float`
-        Minimum corner of the result.
-    nsamples : `int` or `tuple` of `int`
-        Number of samples per axis. For dimension >= 2, a tuple is
+    min_corner, max_corner : float or tuple of float
+        Minimum/maximum corners of the domain of the resulting space.
+        For dimension >= 2, sequences are required.
+    nsamples : int or tuple of int
+        Number of samples per axis. For dimension >= 2, a sequence is
         required.
-    exponent : positive `float`, optional
+    exponent : positive float, optional
         The parameter :math:`p` in :math:`L^p`. If the exponent is not
         equal to the default 2.0, the space has no inner product.
-    interp : `str` or `sequence` of `str`, optional
+    interp : string or sequence of string, optional
         Interpolation type to be used for discretization.
         A sequence is interpreted as interpolation scheme per axis.
 
@@ -1152,18 +1151,18 @@ def uniform_discr(min_corner, max_corner, nsamples,
 
     impl : `str`, optional
         Implementation of the data storage arrays
-    nodes_on_bdry : `bool` or `sequence`, optional
+    nodes_on_bdry : bool or sequence, optional
         If a sequence is provided, it determines per axis whether to
         place the last grid point on the boundary (True) or shift it
         by half a cell size into the interior (False). In each axis,
-        an entry may consist in a single `bool` or a 2-tuple of
-        `bool`. In the latter case, the first tuple entry decides for
+        an entry may consist in a single bool or a 2-tuple of
+        bool. In the latter case, the first tuple entry decides for
         the left, the second for the right boundary. The length of the
         sequence must be ``array.ndim``.
 
         A single boolean is interpreted as a global choice for all
         boundaries.
-        Default: `False`
+        Default: False
 
     dtype : dtype, optional
         Data type for the discretized space
@@ -1224,9 +1223,9 @@ def discr_sequence_space(shape, exponent=2.0, impl='numpy', **kwargs):
 
     Parameters
     ----------
-    shape : `sequence` of `int`
+    shape : sequence of int
         Multi-dimensional size of the elements in this space
-    exponent : positive `float`, optional
+    exponent : positive float, optional
         The parameter ``p`` in ```L^p``. If the exponent is
         not equal to the default 2.0, the space has no inner
         product.

--- a/odl/discr/partition.py
+++ b/odl/discr/partition.py
@@ -160,7 +160,7 @@ class RectPartition(object):
     # TensorGrid related pass-through methods and derived properties
     @property
     def is_uniform(self):
-        """True if ``self.grid`` is a `RegularGrid`."""
+        """``True`` if ``self.grid`` is a `RegularGrid`."""
         return isinstance(self.grid, RegularGrid)
 
     @property
@@ -225,7 +225,7 @@ class RectPartition(object):
 
         Returns
         -------
-        on_bdry : tuple of 2-tuple of float
+        on_bdry : tuple of 2-tuples of floats
             Each 2-tuple contains the fraction of the leftmost
             (first entry) and rightmost (second entry) cell in the
             partitioned set in the corresponding dimension.
@@ -274,7 +274,7 @@ class RectPartition(object):
 
         Returns
         -------
-        csizes : tuple of numpy.ndarray
+        csizes : tuple of `numpy.ndarray`'s
             The cell sizes per axis. The length of the vectors is the
             same as the corresponding ``grid.coord_vectors``.
             For axes with 1 grid point, cell size is set to 0.0.
@@ -360,14 +360,14 @@ class RectPartition(object):
         return float(np.prod(self.cell_sides))
 
     def approx_equals(self, other, atol):
-        """Return True in case of approximate equality.
+        """Return ``True`` in case of approximate equality.
 
         Returns
         -------
         approx_eq : bool
-            True if ``other`` is a `RectPartition` instance with
+            ``True`` if ``other`` is a `RectPartition` instance with
             ``self.set == other.set`` up to ``atol`` and
-            ``self.grid == other.other`` up to ``atol``.
+            ``self.grid == other.other`` up to ``atol``, ``False`` otherwise.
         """
         if other is self:
             return True
@@ -389,7 +389,7 @@ class RectPartition(object):
         ----------
         indices : index expression
             Object determining which parts of the partition to extract.
-            None (new axis) and empty axes are not supported.
+            ``None`` (new axis) and empty axes are not supported.
 
         Examples
         --------
@@ -565,13 +565,13 @@ def uniform_partition_fromintv(intv_prod, num_nodes, nodes_on_bdry=False):
     ----------
     intv_prod : `IntervalProd`
         Interval product to be partitioned
-    num_nodes : int or sequence of int
+    num_nodes : int or `sequence` of ints
         Number of nodes per axis. For 1d intervals, a single integer
         can be specified.
-    nodes_on_bdry : bool or sequence, optional
+    nodes_on_bdry : bool or `sequence`, optional
         If a sequence is provided, it determines per axis whether to
-        place the last grid point on the boundary (True) or shift it
-        by half a cell size into the interior (False). In each axis,
+        place the last grid point on the boundary (``True``) or shift it
+        by half a cell size into the interior (``False``). In each axis,
         an entry may consist in a single bool or a 2-tuple of
         bool. In the latter case, the first tuple entry decides for
         the left, the second for the right boundary. The length of the
@@ -638,7 +638,7 @@ def uniform_partition_fromgrid(grid, begin=None, end=None):
     ----------
     grid : `TensorGrid`
         Grid on which the partition is based
-    begin, end : array-like or dict
+    begin, end : `array-like` or dict
         Spatial points defining the begin and end of an interval
         product to be partitioned. The points can be specified in
         two ways:
@@ -657,7 +657,7 @@ def uniform_partition_fromgrid(grid, begin=None, end=None):
 
         In general, ``begin`` may not be larger than ``grid.min_pt``,
         and ``end`` not smaller than ``grid.max_pt`` in any component.
-        None is equivalent to an empty dictionary, i.e. the values
+        ``None`` is equivalent to an empty dictionary, i.e. the values
         are calculated in each dimension.
 
     See also
@@ -742,21 +742,21 @@ def uniform_partition(begin=None, end=None, num_nodes=None,
 
     Parameters
     ----------
-    begin, end : float or array-like, optional
+    begin, end : float or `array-like`, optional
         Vectors defining the begin end end points of an `IntervalProd`
         (a rectangular box). For one-dimensional partitions, single
         floats can be provided. ``None`` entries mean "compute the value".
-    num_nodes : int or sequence of int, optional
+    num_nodes : int or `sequence` of ints, optional
         Number of nodes per axis. For 1d intervals, a single integer
         can be specified. ``None`` entries mean "compute the value".
-    cell_sides : float or array-like, optional
+    cell_sides : float or `array-like`, optional
         Side length of the partition cells per axis. For 1d intervals,
         a single integer can be specified. ``None`` entries mean
         "compute the value".
-    nodes_on_bdry : bool or sequence, optional
+    nodes_on_bdry : bool or `sequence`, optional
         If a sequence is provided, it determines per axis whether to
-        place the last grid point on the boundary (True) or shift it
-        by half a cell size into the interior (False). In each axis,
+        place the last grid point on the boundary (``True``) or shift it
+        by half a cell size into the interior (``False``). In each axis,
         an entry may consist in a single bool or a 2-tuple of
         bool. In the latter case, the first tuple entry decides for
         the left, the second for the right boundary. The length of the
@@ -795,7 +795,7 @@ def uniform_partition(begin=None, end=None, num_nodes=None,
     (array([ 0. ,  0.5,  1. ,  1.5,  2. ]),)
 
     In higher dimensions, the parameters can be given differently in
-    each axis. Where None is given, the value will be computed:
+    each axis. Where ``None`` is given, the value will be computed:
 
     >>> part = uniform_partition(begin=[0, 0], end=[1, 2],
     ...                          num_nodes=[4, 2])

--- a/odl/discr/partition.py
+++ b/odl/discr/partition.py
@@ -160,7 +160,7 @@ class RectPartition(object):
     # TensorGrid related pass-through methods and derived properties
     @property
     def is_uniform(self):
-        """Return `True` if ``self.grid`` is a `RegularGrid`."""
+        """True if ``self.grid`` is a `RegularGrid`."""
         return isinstance(self.grid, RegularGrid)
 
     @property
@@ -225,7 +225,7 @@ class RectPartition(object):
 
         Returns
         -------
-        on_bdry : `tuple` of 2-tuple of `float`
+        on_bdry : tuple of 2-tuple of float
             Each 2-tuple contains the fraction of the leftmost
             (first entry) and rightmost (second entry) cell in the
             partitioned set in the corresponding dimension.
@@ -274,7 +274,7 @@ class RectPartition(object):
 
         Returns
         -------
-        csizes : `tuple` of `numpy.ndarray`
+        csizes : tuple of numpy.ndarray
             The cell sizes per axis. The length of the vectors is the
             same as the corresponding ``grid.coord_vectors``.
             For axes with 1 grid point, cell size is set to 0.0.
@@ -360,12 +360,12 @@ class RectPartition(object):
         return float(np.prod(self.cell_sides))
 
     def approx_equals(self, other, atol):
-        """Return `True` in case of approximate equality.
+        """Return True in case of approximate equality.
 
         Returns
         -------
-        approx_eq : `bool`
-            `True` if ``other`` is a `RectPartition` instance with
+        approx_eq : bool
+            True if ``other`` is a `RectPartition` instance with
             ``self.set == other.set`` up to ``atol`` and
             ``self.grid == other.other`` up to ``atol``.
         """
@@ -389,7 +389,7 @@ class RectPartition(object):
         ----------
         indices : index expression
             Object determining which parts of the partition to extract.
-            `None` (new axis) and empty axes are not supported.
+            None (new axis) and empty axes are not supported.
 
         Examples
         --------
@@ -458,7 +458,7 @@ class RectPartition(object):
 
         Parameters
         ----------
-        index : `int`
+        index : int
             Index of the dimension before which ``other`` is to
             be inserted. Negative indices count backwards from
             ``self.ndim``.
@@ -565,15 +565,15 @@ def uniform_partition_fromintv(intv_prod, num_nodes, nodes_on_bdry=False):
     ----------
     intv_prod : `IntervalProd`
         Interval product to be partitioned
-    num_nodes : `int` or `sequence` of `int`
+    num_nodes : int or sequence of int
         Number of nodes per axis. For 1d intervals, a single integer
         can be specified.
-    nodes_on_bdry : `bool` or `sequence`, optional
+    nodes_on_bdry : bool or sequence, optional
         If a sequence is provided, it determines per axis whether to
         place the last grid point on the boundary (True) or shift it
         by half a cell size into the interior (False). In each axis,
-        an entry may consist in a single `bool` or a 2-tuple of
-        `bool`. In the latter case, the first tuple entry decides for
+        an entry may consist in a single bool or a 2-tuple of
+        bool. In the latter case, the first tuple entry decides for
         the left, the second for the right boundary. The length of the
         sequence must be ``array.ndim``.
 
@@ -638,14 +638,14 @@ def uniform_partition_fromgrid(grid, begin=None, end=None):
     ----------
     grid : `TensorGrid`
         Grid on which the partition is based
-    begin, end : `array-like` or `dictionary`
+    begin, end : array-like or dict
         Spatial points defining the begin and end of an interval
         product to be partitioned. The points can be specified in
         two ways:
 
         array-like: These values are used directly as begin and/or end.
 
-        dictionary: Index-value pairs specifying an axis and a spatial
+        dict: Index-value pairs specifying an axis and a spatial
         coordinate to be used in that axis. In axes which are not a key
         in the dictionary, the coordinate for the vector is calculated
         as::
@@ -657,7 +657,7 @@ def uniform_partition_fromgrid(grid, begin=None, end=None):
 
         In general, ``begin`` may not be larger than ``grid.min_pt``,
         and ``end`` not smaller than ``grid.max_pt`` in any component.
-        `None` is equivalent to an empty dictionary, i.e. the values
+        None is equivalent to an empty dictionary, i.e. the values
         are calculated in each dimension.
 
     See also
@@ -753,12 +753,12 @@ def uniform_partition(begin=None, end=None, num_nodes=None,
         Side length of the partition cells per axis. For 1d intervals,
         a single integer can be specified. ``None`` entries mean
         "compute the value".
-    nodes_on_bdry : `bool` or `sequence`, optional
+    nodes_on_bdry : bool or sequence, optional
         If a sequence is provided, it determines per axis whether to
         place the last grid point on the boundary (True) or shift it
         by half a cell size into the interior (False). In each axis,
-        an entry may consist in a single `bool` or a 2-tuple of
-        `bool`. In the latter case, the first tuple entry decides for
+        an entry may consist in a single bool or a 2-tuple of
+        bool. In the latter case, the first tuple entry decides for
         the left, the second for the right boundary. The length of the
         sequence must be ``array.ndim``.
 

--- a/odl/discr/tensor_ops.py
+++ b/odl/discr/tensor_ops.py
@@ -333,13 +333,13 @@ class PointwiseNorm(PointwiseTensorFieldOperator):
 
         Parameters
         ----------
-        vf : domain `element-like`
-            Vector field ``F`` at which to evaluate the derivative
+        vf : `domain` `element-like`
+            Vector field ``F`` at which to evaluate the derivative.
 
         Returns
         -------
         deriv : `PointwiseInner`
-            Derivative operator at the given point ``vf``
+            Derivative operator at the given point ``vf``.
 
         Raises
         ------
@@ -390,7 +390,7 @@ class PointwiseInnerBase(PointwiseTensorFieldOperator):
             Space of vector fields on which the operator acts.
             It has to be a product space of identical spaces, i.e. a
             power space.
-        vecfield : domain `element-like`
+        vecfield : ``vfspace`` `element-like`
             Vector field with which to calculate the point-wise inner
             product of an input vector field
         weight : `array-like` or float, optional
@@ -492,7 +492,7 @@ class PointwiseInner(PointwiseInnerBase):
             Space of vector fields on which the operator acts.
             It has to be a product space of identical spaces, i.e. a
             power space.
-        vecfield : domain `element-like`
+        vecfield : ``vfspace`` `element-like`
             Vector field with which to calculate the point-wise inner
             product of an input vector field
         weight : `array-like` or float, optional
@@ -609,7 +609,7 @@ class PointwiseInnerAdjoint(PointwiseInnerBase):
         ----------
         sspace : `LinearSpace`
             "Scalar" space on which the operator acts
-        vecfield : domain `element-like`
+        vecfield : `range` `element-like`
             Vector field of the point-wise inner product operator
         vfspace : `ProductSpace`, optional
             Space of vector fields to which the operator maps. It must

--- a/odl/discr/tensor_ops.py
+++ b/odl/discr/tensor_ops.py
@@ -67,8 +67,8 @@ class PointwiseTensorFieldOperator(Operator):
             They have to be either power spaces of the same base space
             ``X`` or the base space itself (only one of them).
             Empty product spaces are not allowed.
-        linear : `bool`, optional
-            If `True`, assume that the operator is linear.
+        linear : bool, optional
+            If True, assume that the operator is linear.
         """
         if isinstance(domain, ProductSpace):
             if not domain.is_power_space:
@@ -142,12 +142,12 @@ class PointwiseNorm(PointwiseTensorFieldOperator):
             Space of vector fields on which the operator acts.
             It has to be a product space of identical spaces, i.e. a
             power space.
-        exponent : non-zero `float`, optional
+        exponent : non-zero float, optional
             Exponent of the norm in each point. Values between
             0 and 1 are currently not supported due to numerical
             instability.
             Default: ``vfspace.exponent``
-        weight : `array-like` or `float`, optional
+        weight : array-like or float, optional
             Weighting array or constant for the norm. If an array is
             given, its length must be equal to ``domain.size``, and
             all entries must be positive. A provided constant must be
@@ -243,7 +243,7 @@ class PointwiseNorm(PointwiseTensorFieldOperator):
 
     @property
     def is_weighted(self):
-        """`True` if weighting is not 1 or all ones."""
+        """True if weighting is not 1 or all ones."""
         return self._is_weighted
 
     def _call(self, f, out):
@@ -494,7 +494,7 @@ class PointwiseInner(PointwiseInnerBase):
         vecfield : domain `element-like`
             Vector field with which to calculate the point-wise inner
             product of an input vector field
-        weight : `array-like` or `float`, optional
+        weight : array-like or float, optional
             Weighting array or constant for the norm. If an array is
             given, its length must be equal to ``domain.size``, and
             all entries must be positive. A provided constant must be
@@ -540,7 +540,7 @@ class PointwiseInner(PointwiseInnerBase):
 
     @property
     def is_weighted(self):
-        """`True` if weighting is not 1 or all ones."""
+        """True if weighting is not 1 or all ones."""
         return self._is_weighted
 
     def _call(self, vf, out):
@@ -616,7 +616,7 @@ class PointwiseInnerAdjoint(PointwiseInnerBase):
             This option is intended to enforce an operator range
             with a certain weighting.
             Default: ``ProductSpace(space, len(vecfield), weight=weight)``
-        weight : `array-like` or `float`, optional
+        weight : array-like or float, optional
             Weighting array or constant of the inner product operator.
             If an array is given, its length must be equal to
             ``len(vecfield)``, and all entries must be positive. A

--- a/odl/discr/tensor_ops.py
+++ b/odl/discr/tensor_ops.py
@@ -68,7 +68,7 @@ class PointwiseTensorFieldOperator(Operator):
             ``X`` or the base space itself (only one of them).
             Empty product spaces are not allowed.
         linear : bool, optional
-            If True, assume that the operator is linear.
+            If ``True``, assume that the operator is linear.
         """
         if isinstance(domain, ProductSpace):
             if not domain.is_power_space:
@@ -147,7 +147,7 @@ class PointwiseNorm(PointwiseTensorFieldOperator):
             0 and 1 are currently not supported due to numerical
             instability.
             Default: ``vfspace.exponent``
-        weight : array-like or float, optional
+        weight : `array-like` or float, optional
             Weighting array or constant for the norm. If an array is
             given, its length must be equal to ``domain.size``, and
             all entries must be positive. A provided constant must be
@@ -243,7 +243,7 @@ class PointwiseNorm(PointwiseTensorFieldOperator):
 
     @property
     def is_weighted(self):
-        """True if weighting is not 1 or all ones."""
+        """``True`` if weighting is not 1 or all ones."""
         return self._is_weighted
 
     def _call(self, f, out):
@@ -383,8 +383,9 @@ class PointwiseInnerBase(PointwiseTensorFieldOperator):
 
         Parameters
         ----------
-        adjoint : `bool`
-            True if the operator should be the adjoint, False else.
+        adjoint : bool
+            ``True`` if the operator should be the adjoint, ``False``
+            otherwise.
         vfspace : `ProductSpace`
             Space of vector fields on which the operator acts.
             It has to be a product space of identical spaces, i.e. a
@@ -392,7 +393,7 @@ class PointwiseInnerBase(PointwiseTensorFieldOperator):
         vecfield : domain `element-like`
             Vector field with which to calculate the point-wise inner
             product of an input vector field
-        weight : `array-like` or `float`, optional
+        weight : `array-like` or float, optional
             Weighting array or constant for the norm. If an array is
             given, its length must be equal to ``domain.size``, and
             all entries must be positive. A provided constant must be
@@ -456,7 +457,7 @@ class PointwiseInnerBase(PointwiseTensorFieldOperator):
 
     @property
     def is_weighted(self):
-        """`True` if weighting is not 1 or all ones."""
+        """``True`` if weighting is not 1 or all ones."""
         return self._is_weighted
 
     @property
@@ -494,7 +495,7 @@ class PointwiseInner(PointwiseInnerBase):
         vecfield : domain `element-like`
             Vector field with which to calculate the point-wise inner
             product of an input vector field
-        weight : array-like or float, optional
+        weight : `array-like` or float, optional
             Weighting array or constant for the norm. If an array is
             given, its length must be equal to ``domain.size``, and
             all entries must be positive. A provided constant must be
@@ -540,7 +541,7 @@ class PointwiseInner(PointwiseInnerBase):
 
     @property
     def is_weighted(self):
-        """True if weighting is not 1 or all ones."""
+        """``True`` if weighting is not 1 or all ones."""
         return self._is_weighted
 
     def _call(self, vf, out):
@@ -616,7 +617,7 @@ class PointwiseInnerAdjoint(PointwiseInnerBase):
             This option is intended to enforce an operator range
             with a certain weighting.
             Default: ``ProductSpace(space, len(vecfield), weight=weight)``
-        weight : array-like or float, optional
+        weight : `array-like` or float, optional
             Weighting array or constant of the inner product operator.
             If an array is given, its length must be equal to
             ``len(vecfield)``, and all entries must be positive. A

--- a/odl/operator/default_ops.py
+++ b/odl/operator/default_ops.py
@@ -44,10 +44,9 @@ class ScalingOperator(Operator):
         Parameters
         ----------
         space : `LinearSpace`
-            Space of elements which the operator is acting on
-        scalar : `LinearSpace.field` `element`
-            An element of the field of the space which vectors are
-            scaled with
+            Space of elements on which this operator acts.
+        scalar : `LinearSpace.field` `element-like`
+            Fixed scaling factor of this operator.
         """
         if not isinstance(space, LinearSpace):
             raise TypeError('`space` {!r} not a LinearSpace instance'
@@ -58,7 +57,7 @@ class ScalingOperator(Operator):
 
     @property
     def scalar(self):
-        """The scalar to scale by."""
+        """Fixed scaling factor of this operator."""
         return self.__scalar
 
     def _call(self, x, out=None):
@@ -66,14 +65,14 @@ class ScalingOperator(Operator):
 
         Parameters
         ----------
-        x : ``domain`` `element`
+        x : ``domain`` element
             input vector to be scaled
-        out : ``range`` `element`, optional
+        out : ``range`` element, optional
             Output vector to which the result is written
 
         Returns
         -------
-        out : ``range`` `element`
+        out : ``range`` element
             Result of the scaling. If ``out`` was provided, the
             returned object is a reference to it.
 
@@ -216,15 +215,15 @@ class LinCombOperator(Operator):
 
         Parameters
         ----------
-        x : ``domain`` `element`
+        x : ``domain`` element
             An element of the operator domain (2-tuple of space
             elements) whose linear combination is calculated
-        out : ```range`` `element`
+        out : ```range`` element
             Vector to which the result is written
 
         Returns
         -------
-        out : ``range`` `element`
+        out : ``range`` element
             Result of the linear combination. If ``out`` was provided,
             the returned object is a reference to it.
 
@@ -302,15 +301,15 @@ class MultiplyOperator(Operator):
 
         Parameters
         ----------
-        x : ``domain`` `element`
+        x : ``domain`` element
             An element in the operator domain whose elementwise product is
             calculated.
-        out : ``range`` `element`, optional
+        out : ``range`` element, optional
             Vector to which the result is written
 
         Returns
         -------
-        out : ``range`` `element`
+        out : ``range`` element
             Result of the multiplication. If ``out`` was provided, the
             returned object is a reference to it.
 
@@ -429,15 +428,15 @@ class PowerOperator(Operator):
 
         Parameters
         ----------
-        x : ``domain`` `element`
+        x : ``domain`` element
             An element in the operator domain (2-tuple of space
             elements) whose elementwise product is calculated
-        out : ``range`` `element`, optional
+        out : ``range`` element, optional
             Vector to which the result is written
 
         Returns
         -------
-        out : ``range`` `element`
+        out : ``range`` element
             Result of the multiplication. If ``out`` was provided, the
             returned object is a reference to it.
 
@@ -471,7 +470,7 @@ class PowerOperator(Operator):
 
         Parameters
         ----------
-        point : ``domain`` `element`
+        point : ``domain`` element
             The point in which to take the derivative
 
         Returns
@@ -545,12 +544,12 @@ class InnerProductOperator(Operator):
 
         Parameters
         ----------
-        x : ``vector.space`` `element`
+        x : ``vector.space`` element
             An element in the space of the vector
 
         Returns
         -------
-        out : ``field`` `element`
+        out : ``field`` element
             Result of the inner product calculation
 
         Examples
@@ -859,7 +858,7 @@ class ConstantOperator(Operator):
 
         Parameters
         ----------
-        x : ``domain`` `element`
+        x : ``domain`` element
             An element of the domain
         out : ``range`` element
             Vector that gets assigned to the constant vector
@@ -957,14 +956,14 @@ class ResidualOperator(Operator):
 
         Parameters
         ----------
-        x : ``domain`` `element`
+        x : ``domain`` element
             Any element of the domain
-        out : ``range`` `element`
+        out : ``range`` element
             Vector that gets assigned to the constant vector
 
         Returns
         -------
-        out : ``range`` `element`
+        out : ``range`` element
             Result of the evaluation. If ``out`` was provided, the
             returned object is a reference to it.
 
@@ -996,7 +995,7 @@ class ResidualOperator(Operator):
 
         Parameters
         ----------
-        x : ``domain`` `element`
+        x : ``domain`` element
             Any element in the domain where the derivative should be taken
 
         Examples

--- a/odl/operator/default_ops.py
+++ b/odl/operator/default_ops.py
@@ -647,7 +647,7 @@ class NormOperator(Operator):
 
         Returns
         -------
-        norm : `float`
+        norm : float
             Norm of ``x``.
 
         Examples
@@ -749,7 +749,7 @@ class DistOperator(Operator):
 
         Returns
         -------
-        out : `float`
+        out : float
             Distance from of ``x`` to ``self.vector``.
 
         Examples

--- a/odl/operator/default_ops.py
+++ b/odl/operator/default_ops.py
@@ -45,7 +45,7 @@ class ScalingOperator(Operator):
         ----------
         space : `LinearSpace`
             Space of elements on which this operator acts.
-        scalar : `LinearSpace.field` `element-like`
+        scalar : ``space.field`` element
             Fixed scaling factor of this operator.
         """
         if not isinstance(space, LinearSpace):
@@ -65,14 +65,14 @@ class ScalingOperator(Operator):
 
         Parameters
         ----------
-        x : ``domain`` element
+        x : `domain` element
             input vector to be scaled
-        out : ``range`` element, optional
+        out : `range` element, optional
             Output vector to which the result is written
 
         Returns
         -------
-        out : ``range`` element
+        out : `range` element
             Result of the scaling. If ``out`` was provided, the
             returned object is a reference to it.
 
@@ -202,7 +202,7 @@ class LinCombOperator(Operator):
         ----------
         space : `LinearSpace`
             Space of elements which the operator is acting on.
-        a, b : scalar
+        a, b : ``space.field`` elements
             Scalars to multiply ``x[0]`` and ``x[1]`` with, respectively.
         """
         domain = ProductSpace(space, space)
@@ -215,15 +215,15 @@ class LinCombOperator(Operator):
 
         Parameters
         ----------
-        x : ``domain`` element
+        x : `domain` element
             An element of the operator domain (2-tuple of space
             elements) whose linear combination is calculated
-        out : ```range`` element
+        out : `range` element
             Vector to which the result is written
 
         Returns
         -------
-        out : ``range`` element
+        out : `range` element
             Result of the linear combination. If ``out`` was provided,
             the returned object is a reference to it.
 
@@ -276,9 +276,10 @@ class MultiplyOperator(Operator):
         multiplicand : `LinearSpaceVector` or `Number`
             Value to multiply by.
         domain : `LinearSpace` or `Field`, optional
-            Set to take values in. Default: ``x.space``.
+            Set to which the operator can be applied.
+            Default: ``multiplicand.space``.
         range : `LinearSpace` or `Field`, optional
-            Set to map to. Default: ``x.space``.
+            Set to which the operator maps. Default: ``multiplicand.space``.
         """
         if domain is None:
             domain = multiplicand.space
@@ -301,15 +302,15 @@ class MultiplyOperator(Operator):
 
         Parameters
         ----------
-        x : ``domain`` element
+        x : `domain` element
             An element in the operator domain whose elementwise product is
             calculated.
-        out : ``range`` element, optional
+        out : `range` element, optional
             Vector to which the result is written
 
         Returns
         -------
-        out : ``range`` element
+        out : `range` element
             Result of the multiplication. If ``out`` was provided, the
             returned object is a reference to it.
 
@@ -428,15 +429,15 @@ class PowerOperator(Operator):
 
         Parameters
         ----------
-        x : ``domain`` element
+        x : `domain` element
             An element in the operator domain (2-tuple of space
             elements) whose elementwise product is calculated
-        out : ``range`` element, optional
+        out : `range` element, optional
             Vector to which the result is written
 
         Returns
         -------
-        out : ``range`` element
+        out : `range` element
             Result of the multiplication. If ``out`` was provided, the
             returned object is a reference to it.
 
@@ -470,7 +471,7 @@ class PowerOperator(Operator):
 
         Parameters
         ----------
-        point : ``domain`` element
+        point : `domain` element
             The point in which to take the derivative
 
         Returns
@@ -544,12 +545,12 @@ class InnerProductOperator(Operator):
 
         Parameters
         ----------
-        x : ``vector.space`` element
+        x : `domain` element
             An element in the space of the vector
 
         Returns
         -------
-        out : ``field`` element
+        out : `field` element
             Result of the inner product calculation
 
         Examples
@@ -667,7 +668,7 @@ class NormOperator(Operator):
 
         Parameters
         ----------
-        x : `domain` `element-like`
+        point : `domain` `element-like`
             Point in which to take the derivative.
 
         Returns
@@ -835,8 +836,8 @@ class ConstantOperator(Operator):
         vector : `LinearSpaceVector`
             The vector constant to be returned
 
-        domain : `LinearSpace`, default : vector.space
-            The domain of the operator.
+        domain : `LinearSpace`, optional
+            Domain of the operator. Default : ``vector.space``.
         """
         if not isinstance(vector, LinearSpaceVector):
             raise TypeError('`vector` {!r} not a LinearSpaceVector instance'
@@ -858,14 +859,14 @@ class ConstantOperator(Operator):
 
         Parameters
         ----------
-        x : ``domain`` element
+        x : `domain` element
             An element of the domain
-        out : ``range`` element
+        out : `range` element
             Vector that gets assigned to the constant vector
 
         Returns
         -------
-        out : ``range`` element
+        out : `range` element
             Result of the assignment. If ``out`` was provided, the
             returned object is a reference to it.
 
@@ -926,7 +927,7 @@ class ResidualOperator(Operator):
         operator : `Operator`
             Operator to be used in the residual expression. Its
             `Operator.range` must be a `LinearSpace`.
-        vector : `Operator.range` `element-like`
+        vector : ``operator.range`` `element-like`
             Vector to be subtracted from the operator result.
         """
         if not isinstance(operator, Operator):
@@ -956,14 +957,14 @@ class ResidualOperator(Operator):
 
         Parameters
         ----------
-        x : ``domain`` element
+        x : `domain` element
             Any element of the domain
-        out : ``range`` element
+        out : `range` element
             Vector that gets assigned to the constant vector
 
         Returns
         -------
-        out : ``range`` element
+        out : `range` element
             Result of the evaluation. If ``out`` was provided, the
             returned object is a reference to it.
 
@@ -995,7 +996,7 @@ class ResidualOperator(Operator):
 
         Parameters
         ----------
-        x : ``domain`` element
+        point : `domain` element
             Any element in the domain where the derivative should be taken
 
         Examples

--- a/odl/operator/operator.py
+++ b/odl/operator/operator.py
@@ -46,13 +46,13 @@ def _default_call_out_of_place(op, x, **kwargs):
 
     Parameters
     ----------
-    x : ``domain`` element
+    x : `domain` element
         An object in the operator domain. The operator is applied
         to it.
 
     Returns
     -------
-    out : ``range`` element
+    out : `range` element
         An object in the operator range. The result of an operator
         evaluation.
     """
@@ -66,11 +66,11 @@ def _default_call_in_place(op, x, out, **kwargs):
 
     Parameters
     ----------
-    x : ``domain`` element
+    x : `domain` element
         An object in the operator domain. The operator is applied
         to it.
 
-    out : ``range`` element
+    out : `range` element
         An object in the operator range. The result of an operator
         evaluation.
 
@@ -543,14 +543,14 @@ class Operator(object):
 
         Parameters
         ----------
-        x : `Operator.domain` `element-like`
+        x : `domain` `element-like`
             Element to which the operator is applied
-        out : `Operator.range` element, optional
+        out : `range` element, optional
             Element to which the result is written
 
         Returns
         -------
-        out : `Operator.range` `element-like`
+        out : `range` `element-like`
             Result of the evaluation. If ``out`` was provided, the
             returned object is a reference to it.
         """
@@ -628,21 +628,21 @@ class Operator(object):
 
         Parameters
         ----------
-        x : `Operator.domain` `element-like`
+        x : `domain` `element-like`
             An object which can be converted into an element of this
             operator's domain with the ``self.domain.element`` method.
             The operator is applied to this object, which is treated
             as immutable, hence it is not modified during evaluation.
-        out : `Operator.range` element, optional
+        out : `range` element, optional
             An object in the operator range to which the result of the
             operator evaluation is written. The result is independent
             of the initial state of this object.
-        kwargs : Further arguments to the function, optional
-            Passed on to the underlying implementation in `_call`
+        kwargs :
+            Passed on to the underlying implementation in `_call`.
 
         Returns
         -------
-        out : `Operator.range` element
+        out : `range` element
             Result of the operator evaluation. If ``out`` was provided,
             the returned object is a reference to it.
 
@@ -734,7 +734,7 @@ class Operator(object):
 
         Parameters
         ----------
-        other : {`Operator`, `LinearSpaceVector`, scalar}
+        other : `Operator`, `LinearSpaceVector` or scalar
             `Operator`:
                 The `Operator.domain` of ``other`` must match this
                 operator's `Operator.range`.
@@ -1093,7 +1093,7 @@ class OperatorSum(Operator):
 
         Parameters
         ----------
-        x : `Operator.domain` `element-like`
+        x : `domain` `element-like`
             Evaluation point of the derivative
         """
         return OperatorSum(self.left.derivative(x), self.right.derivative(x),
@@ -1218,7 +1218,7 @@ class OperatorComp(Operator):
 
         Parameters
         ----------
-        x : `Operator.domain` `element-like`
+        x : `domain` `element-like`
             Evaluation point of the derivative. Needs to be usable as
             input for the ``right`` operator.
         """
@@ -1341,9 +1341,9 @@ class OperatorLeftScalarMult(Operator):
         Parameters
         ----------
         operator : `Operator`
-            The range of ``op`` must be a `LinearSpace`
-            or `Field`.
-        scalar : ``op.range.field`` element
+            Operator in the scalar multiplication. Its `range` must be
+            a `LinearSpace` or `Field`.
+        scalar : ``operator.range.field`` element
             A real or complex number, depending on the field of
             the range.
         """
@@ -1437,7 +1437,7 @@ class OperatorLeftScalarMult(Operator):
 
         Parameters
         ----------
-        x : `Operator.domain` `element-like`
+        x : `domain` `element-like`
             Evaluation point of the derivative
 
         Returns
@@ -1516,12 +1516,12 @@ class OperatorRightScalarMult(Operator):
         Parameters
         ----------
         operator : `Operator`
-            The domain of ``op`` must be a `LinearSpace` or
-            `Field`.
-        scalar : ``op.range.field`` element
+            Operator in the scalar multiplication. Its `domain` must
+            be a `LinearSpace` or `Field`.
+        scalar : ``operator.range.field`` element
             A real or complex number, depending on the field of
             the operator domain.
-        tmp : domain element, optional
+        tmp : `domain` element, optional
             Used to avoid the creation of a temporary when applying the
             operator.
         """
@@ -1625,8 +1625,8 @@ class OperatorRightScalarMult(Operator):
 
         Parameters
         ----------
-        x : `Operator.domain` `element-like`
-            Evaluation point of the derivative
+        x : `domain` `element-like`
+            Evaluation point of the derivative.
 
         Examples
         --------
@@ -1699,10 +1699,11 @@ class FunctionalLeftVectorMult(Operator):
         Parameters
         ----------
         functional : `Operator`
-            The range of ``functional`` must be a `Field`.
-        vector : ``operator`` range `element-like`
+            Functional in the vector multiplication. Its `range` must
+            be a `Field`.
+        vector : ``functional.range`` `element-like`
             The vector to multiply by. Its space's `LinearSpace.field` must be
-            the same as ``op.range``
+            the same as ``functional.range``
         """
         if not isinstance(vector, LinearSpaceVector):
             raise TypeError('`vector` {!r} not is not a LinearSpaceVector'

--- a/odl/operator/operator.py
+++ b/odl/operator/operator.py
@@ -46,13 +46,13 @@ def _default_call_out_of_place(op, x, **kwargs):
 
     Parameters
     ----------
-    x : ``domain`` `element`
+    x : ``domain`` element
         An object in the operator domain. The operator is applied
         to it.
 
     Returns
     -------
-    out : ``range`` `element`
+    out : ``range`` element
         An object in the operator range. The result of an operator
         evaluation.
     """
@@ -66,17 +66,17 @@ def _default_call_in_place(op, x, out, **kwargs):
 
     Parameters
     ----------
-    x : ``domain`` `element`
+    x : ``domain`` element
         An object in the operator domain. The operator is applied
         to it.
 
-    out : ``range`` `element`
+    out : ``range`` element
         An object in the operator range. The result of an operator
         evaluation.
 
     Returns
     -------
-    `None`
+    None
     """
     out.assign(op.range.element(op._call_out_of_place(x, **kwargs)))
 
@@ -91,7 +91,7 @@ def _signature_from_spec(func):
 
     Returns
     -------
-    sig : `str`
+    sig : string
         Signature of the function
     """
     py3 = (sys.version_info.major > 2)
@@ -159,7 +159,7 @@ def _dispatch_call_args(cls=None, bound_call=None, unbound_call=None,
         - ``_call(self, out, x)`` -- ``out`` as second argument
         - ``_call(self, *x)`` -- Variable arguments
         - ``_call(self, x, y, out=None)`` -- more positional arguments
-        - ``_call(self, x, out=False)`` -- default other than `None` for
+        - ``_call(self, x, out=False)`` -- default other than None for
           ``out``
 
     In particular, static or class methods are not allowed.
@@ -169,18 +169,18 @@ def _dispatch_call_args(cls=None, bound_call=None, unbound_call=None,
     cls : `class`, optional
         The ``_call()`` method of this class is checked. If omitted,
         provide ``unbound_call`` instead to check directly.
-    bound_call: `callable`, optional
+    bound_call: callable, optional
         Check this bound method instead of ``cls``
-    unbound_call: `callable`, optional
+    unbound_call: callable, optional
         Check this unbound function instead of ``cls``
-    attr : `string`, optional
+    attr : string, optional
         Check this attribute instead of ``_call``, e.g. ``__call__``
 
     Returns
     -------
-    has_out : `bool`
+    has_out : bool
         Whether the call has an ``out`` argument
-    out_is_optional : `bool`
+    out_is_optional : bool
         Whether the ``out`` argument is optional
     spec : `inspect.ArgSpec` or `inspect.FullArgSpec`
         Argument specification of the checked call function
@@ -291,7 +291,7 @@ def _dispatch_call_args(cls=None, bound_call=None, unbound_call=None,
             if pos_defaults and pos_defaults[-1] is not None:
                 raise ValueError("bad signature '{}': `out` can only "
                                  "default to `None`, got '{}'"
-                                 " ".format(signature, pos_defaults[-1]) +
+                                 "".format(signature, pos_defaults[-1]) +
                                  spec_msg)
 
     else:  # Too many positional args
@@ -355,17 +355,17 @@ class Operator(object):
 
     **Parameters:**
 
-    x : `Operator.domain` `element`
+    x : `Operator.domain` element
         An object in the operator domain to which the operator is
         applied
 
-    out : `Operator.range` `element`
+    out : `Operator.range` element
         An object in the operator range to which the result of the
         operator evaluation is written.
 
     **Returns:**
 
-    `None` (return value is ignored)
+    None (return value is ignored)
 
 
     **Out-of-place-only evaluation:** ``_call(self, x[, **kwargs])``
@@ -378,7 +378,7 @@ class Operator(object):
 
     **Parameters:**
 
-    x : `Operator.domain` `element`
+    x : `Operator.domain` element
         An object in the operator domain to which the operator is
         applied
 
@@ -395,17 +395,17 @@ class Operator(object):
 
     **Parameters:**
 
-    x : `Operator.domain` `element`
+    x : `Operator.domain` element
         An object in the operator domain to which the operator is
         applied
 
-    out : `Operator.range` `element`, optional
+    out : `Operator.range` element, optional
         An object in the operator range to which the result of the
         operator evaluation is written
 
     **Returns:**
 
-    `None` (return value is ignored)
+    None (return value is ignored)
 
 
     Notes
@@ -451,8 +451,8 @@ class Operator(object):
         range : `Set`
             The range of this operator, i.e., the set this operator
             maps to
-        linear : `bool`
-            If `True`, the operator is considered as linear. In this
+        linear : bool
+            If True, the operator is considered as linear. In this
             case, ``domain`` and ``range`` have to be instances of
             `LinearSpace`, or `Field`.
         """
@@ -545,7 +545,7 @@ class Operator(object):
         ----------
         x : `Operator.domain` `element-like`
             Element to which the operator is applied
-        out : `Operator.range` `element`, optional
+        out : `Operator.range` element, optional
             Element to which the result is written
 
         Returns
@@ -571,12 +571,12 @@ class Operator(object):
 
     @property
     def is_linear(self):
-        """`True` if this operator is linear."""
+        """True if this operator is linear."""
         return self.__is_linear
 
     @property
     def is_functional(self):
-        """`True` if the this operator's range is a `Field`."""
+        """True if this operator's range is a `Field`."""
         return self.__is_functional
 
     @property
@@ -633,7 +633,7 @@ class Operator(object):
             operator's domain with the ``self.domain.element`` method.
             The operator is applied to this object, which is treated
             as immutable, hence it is not modified during evaluation.
-        out : `Operator.range` `element`, optional
+        out : `Operator.range` element, optional
             An object in the operator range to which the result of the
             operator evaluation is written. The result is independent
             of the initial state of this object.
@@ -642,7 +642,7 @@ class Operator(object):
 
         Returns
         -------
-        out : `Operator.range` `element`
+        out : `Operator.range` element
             Result of the operator evaluation. If ``out`` was provided,
             the returned object is a reference to it.
 
@@ -889,7 +889,7 @@ class Operator(object):
 
         Parameters
         ----------
-        n : positive `int`
+        n : positive int
             The power the operator should be taken to.
 
         Returns
@@ -983,7 +983,7 @@ class Operator(object):
     def __str__(self):
         """Return ``str(self)``.
 
-        The default `str` implementation. Should be overridden by
+        The default string implementation. Should be overridden by
         subclasses.
         """
         return self.__class__.__name__
@@ -1018,10 +1018,10 @@ class OperatorSum(Operator):
         right : `Operator`
             Second summand. Must have the same `Operator.domain` and
             `Operator.range` as ``left``.
-        tmp_ran : `Operator.range` `element`, optional
+        tmp_ran : `Operator.range` element, optional
             Used to avoid the creation of a temporary when applying the
             operator.
-        tmp_dom : `Operator.domain` `element`, optional
+        tmp_dom : `Operator.domain` element, optional
             Used to avoid the creation of a temporary when applying the
             operator adjoint.
         """
@@ -1154,7 +1154,7 @@ class OperatorComp(Operator):
         right : `Operator`
             The right ("inner") operator. Its range must coincide with the
             domain of ``left``.
-        tmp : `element` of the range of ``right``, optional
+        tmp : element of the range of ``right``, optional
             Used to avoid the creation of a temporary when applying the
             operator.
         """
@@ -1343,7 +1343,7 @@ class OperatorLeftScalarMult(Operator):
         operator : `Operator`
             The range of ``op`` must be a `LinearSpace`
             or `Field`.
-        scalar : ``op.range.field`` `element`
+        scalar : ``op.range.field`` element
             A real or complex number, depending on the field of
             the range.
         """
@@ -1518,10 +1518,10 @@ class OperatorRightScalarMult(Operator):
         operator : `Operator`
             The domain of ``op`` must be a `LinearSpace` or
             `Field`.
-        scalar : ``op.range.field`` `element`
+        scalar : ``op.range.field`` element
             A real or complex number, depending on the field of
             the operator domain.
-        tmp : domain `element`, optional
+        tmp : domain element, optional
             Used to avoid the creation of a temporary when applying the
             operator.
         """
@@ -2067,7 +2067,7 @@ def simple_operator(call=None, inv=None, deriv=None, domain=None, range=None,
 
     Parameters
     ----------
-    call : `callable`
+    call : callable
         Function with valid call signature, see `Operator`
     inv : `Operator`, optional
         The operator inverse
@@ -2079,9 +2079,9 @@ def simple_operator(call=None, inv=None, deriv=None, domain=None, range=None,
     range : `Set`, optional
         The range of the operator
         Default: `UniversalSpace` if linear, else `UniversalSet`
-    linear : `bool`, optional
-        `True` if the operator is linear
-        Default: `False`
+    linear : bool, optional
+        True if the operator is linear
+        Default: False
 
     Returns
     -------

--- a/odl/operator/operator.py
+++ b/odl/operator/operator.py
@@ -169,9 +169,9 @@ def _dispatch_call_args(cls=None, bound_call=None, unbound_call=None,
     cls : `class`, optional
         The ``_call()`` method of this class is checked. If omitted,
         provide ``unbound_call`` instead to check directly.
-    bound_call: callable, optional
+    bound_call: `callable`, optional
         Check this bound method instead of ``cls``
-    unbound_call: callable, optional
+    unbound_call: `callable`, optional
         Check this unbound function instead of ``cls``
     attr : string, optional
         Check this attribute instead of ``_call``, e.g. ``__call__``
@@ -452,7 +452,7 @@ class Operator(object):
             The range of this operator, i.e., the set this operator
             maps to
         linear : bool
-            If True, the operator is considered as linear. In this
+            If ``True``, the operator is considered as linear. In this
             case, ``domain`` and ``range`` have to be instances of
             `LinearSpace`, or `Field`.
         """
@@ -571,12 +571,12 @@ class Operator(object):
 
     @property
     def is_linear(self):
-        """True if this operator is linear."""
+        """``True`` if this operator is linear."""
         return self.__is_linear
 
     @property
     def is_functional(self):
-        """True if this operator's range is a `Field`."""
+        """``True`` if this operator's range is a `Field`."""
         return self.__is_functional
 
     @property
@@ -2067,7 +2067,7 @@ def simple_operator(call=None, inv=None, deriv=None, domain=None, range=None,
 
     Parameters
     ----------
-    call : callable
+    call : `callable`
         Function with valid call signature, see `Operator`
     inv : `Operator`, optional
         The operator inverse
@@ -2080,8 +2080,7 @@ def simple_operator(call=None, inv=None, deriv=None, domain=None, range=None,
         The range of the operator
         Default: `UniversalSpace` if linear, else `UniversalSet`
     linear : bool, optional
-        True if the operator is linear
-        Default: False
+        If ``True``, the operator is considered to be linear.
 
     Returns
     -------

--- a/odl/operator/oputils.py
+++ b/odl/operator/oputils.py
@@ -42,7 +42,7 @@ def matrix_representation(op):
 
     Returns
     ----------
-    matrix : numpy.ndarray
+    matrix : `numpy.ndarray`
         The matrix representation of the operator.
 
     Notes
@@ -134,8 +134,8 @@ def power_method_opnorm(op, xstart=None, maxiter=100, rtol=1e-05, atol=1e-08,
         element of the `Operator.domain` is used.
     maxiter : positive int, optional
         Number of iterations to perform. If the domain and range of ``op``
-        do not match, it needs to be an even number. If None is given, iterate
-        until convergence.
+        do not match, it needs to be an even number. If ``None`` is given,
+        iterate until convergence.
     rtol : float, optional
         Relative tolerance parameter (see Notes).
     atol : float, optional

--- a/odl/operator/oputils.py
+++ b/odl/operator/oputils.py
@@ -42,7 +42,7 @@ def matrix_representation(op):
 
     Returns
     ----------
-    matrix : `numpy.ndarray`
+    matrix : numpy.ndarray
         The matrix representation of the operator.
 
     Notes
@@ -132,20 +132,20 @@ def power_method_opnorm(op, xstart=None, maxiter=100, rtol=1e-05, atol=1e-08,
     xstart : `Operator.domain` `element`, optional
         Starting point of the iteration. By default, the ``one``
         element of the `Operator.domain` is used.
-    maxiter : positive `int`, optional
+    maxiter : positive int, optional
         Number of iterations to perform. If the domain and range of ``op``
         do not match, it needs to be an even number. If None is given, iterate
         until convergence.
-    rtol : `float`, optional
+    rtol : float, optional
         Relative tolerance parameter (see Notes).
-    atol : `float`, optional
+    atol : float, optional
         Absolute tolerance parameter (see Notes).
     callback : `callable`, optional
         Function called with the current iterate in each iteration.
 
     Returns
     -------
-    est_opnorm : `float`
+    est_opnorm : float
         The estimated operator norm of ``op``.
 
     Examples
@@ -177,7 +177,7 @@ def power_method_opnorm(op, xstart=None, maxiter=100, rtol=1e-05, atol=1e-08,
     The operator is evaluated until ``maxiter`` operator calls or until the
     relative error is small enough. The error measure is given by
 
-        abs(a - b) <= (atol + rtol * abs(b))
+        ``abs(a - b) <= (atol + rtol * abs(b))``,
 
     where ``a`` and ``b`` are consecutive iterates.
     """

--- a/odl/operator/oputils.py
+++ b/odl/operator/oputils.py
@@ -129,7 +129,7 @@ def power_method_opnorm(op, xstart=None, maxiter=100, rtol=1e-05, atol=1e-08,
         range does not coincide with its `Operator.domain`, an
         `Operator.adjoint` must be defined (which implies that the
         operator must be linear).
-    xstart : `Operator.domain` `element`, optional
+    xstart : ``op.domain`` `element-like`, optional
         Starting point of the iteration. By default, the ``one``
         element of the `Operator.domain` is used.
     maxiter : positive int, optional

--- a/odl/operator/pspace_ops.py
+++ b/odl/operator/pspace_ops.py
@@ -210,14 +210,14 @@ class ProductSpaceOperator(Operator):
 
         Parameters
         ----------
-        x : domain element
+        x : `domain` element
             Input vector to be evaluated.
-        out : range element, optional
+        out : `range` element, optional
             Output vector to write the result to.
 
         Returns
         -------
-        out : range element
+        out : `range` element
             Result of the evaluation. If ``out`` was provided, the
             returned object is a reference to it.
 
@@ -284,7 +284,7 @@ class ProductSpaceOperator(Operator):
 
         Parameters
         ----------
-        x : domain element
+        x : `domain` element
             The point to take the derivative in
 
         Returns
@@ -458,14 +458,14 @@ class ComponentProjection(Operator):
 
         Parameters
         ----------
-        x : domain element
+        x : `domain` element
             Input vector to be projected.
-        out : range element, optional
+        out : `range` element, optional
             Output vector to write the result to.
 
         Returns
         -------
-        out : range element
+        out : `range` element
             Projection of ``x`` onto the subspace. If ``out`` was provided,
             the returned object is a reference to it.
 
@@ -569,14 +569,14 @@ class ComponentProjectionAdjoint(Operator):
 
         Parameters
         ----------
-        x : domain element
+        x : `domain` element
             Input vector to be extended.
-        out : range element, optional
+        out : `range` element, optional
             Output vector to write the result to.
 
         Returns
         -------
-        out : range element
+        out : `range` element
             Extension of ``x`` to the superspace. If ``out`` was provided,
             the returned object is a reference to it.
 
@@ -713,14 +713,14 @@ class BroadcastOperator(Operator):
 
         Parameters
         ----------
-        x : domain element
+        x : `domain` element
             Input vector to be evaluated by operators.
-        out : range element, optional
+        out : `range` element, optional
             Output vector to write the result to.
 
         Returns
         -------
-        out : range element
+        out : `range` element
             Values of operators evaluated in point
         """
         wrapped_x = self.prod_op.domain.element([x], cast=False)
@@ -731,7 +731,7 @@ class BroadcastOperator(Operator):
 
         Parameters
         ----------
-        x : domain element
+        x : `domain` element
             The point to take the derivative in
 
         Returns
@@ -873,14 +873,14 @@ class ReductionOperator(Operator):
 
         Parameters
         ----------
-        x : domain element
+        x : `domain` element
             Input vector to be evaluated by operators.
-        out : range element, optional
+        out : `range` element, optional
             Output vector to write the result to.
 
         Returns
         -------
-        out : range element
+        out : `range` element
             Sum of operators evaluated in ``x``.
         """
         if out is None:

--- a/odl/operator/pspace_ops.py
+++ b/odl/operator/pspace_ops.py
@@ -102,7 +102,7 @@ class ProductSpaceOperator(Operator):
 
         Parameters
         ----------
-        operators : array-like
+        operators : `array-like`
             An array of `Operator`'s
         domain : `ProductSpace`, optional
             Domain of the operator. If not provided, it is tried to be
@@ -120,15 +120,16 @@ class ProductSpaceOperator(Operator):
         >>> X = odl.ProductSpace(r3, r3)
         >>> I = odl.IdentityOperator(r3)
 
-        Sum of elements
+        Sum of elements as product space operator:
 
         >>> prod_op = ProductSpaceOperator([I, I])
 
-        Diagonal operator, 0 or None means ignore, or the implicit zero op.
+        Diagonal operator -- 0 or ``None`` means ignore, or the implicit
+        zero operator:
 
         >>> prod_op = ProductSpaceOperator([[I, 0], [None, I]])
 
-        Complicated combinations also possible
+        Complicated combinations also possible:
 
         >>> prod_op = ProductSpaceOperator([[I, I], [I, 0]])
         """
@@ -236,7 +237,7 @@ class ProductSpaceOperator(Operator):
             [5.0, 7.0, 9.0]
         ])
 
-        Diagonal operator -- 0 or None means ignore, or the implicit
+        Diagonal operator -- 0 or ``None`` means ignore, or the implicit
         zero operator:
 
         >>> prod_op = ProductSpaceOperator([[I, 0], [0, I]])
@@ -700,7 +701,7 @@ class BroadcastOperator(Operator):
 
     @property
     def operators(self):
-        """A tuple of sub-operators."""
+        """Tuple of sub-operators that comprise ``self``."""
         return self.__operators
 
     def __getitem__(self, index):
@@ -852,7 +853,7 @@ class ReductionOperator(Operator):
 
     @property
     def operators(self):
-        """`tuple` of sub-operators."""
+        """Tuple of sub-operators that comprise ``self``."""
         return self.__operators
 
     def __getitem__(self, index):
@@ -959,8 +960,8 @@ class ReductionOperator(Operator):
 class DiagonalOperator(ProductSpaceOperator):
     """Diagonal 'matrix' of operators.
 
-    For example, if A and B are operators the DiagonalOperator can be seen as a
-    matrix of operators::
+    For example, if ``A`` and ``B`` are operators, the diagonal operator
+    can be seen as a matrix of operators::
 
         [[A, 0],
          [0, B]]
@@ -971,7 +972,7 @@ class DiagonalOperator(ProductSpaceOperator):
 
     See Also
     --------
-    ProductSpaceOperator : Case when the 'matrix' is full.
+    ProductSpaceOperator : Case when the 'matrix' is dense.
     BroadcastOperator : Case when a single argument is used by several ops.
     ReductionOperator : Calculates sum of operator results.
     """
@@ -981,9 +982,9 @@ class DiagonalOperator(ProductSpaceOperator):
 
         Parameters
         ----------
-        operator1,...,operatorN : `Operator` or `int`
+        operator1,...,operatorN : `Operator` or int
             The individual operators in the diagonal.
-            Can also be given as ``operator, n`` with ``n`` integer,
+            Can be specified as ``operator, n`` with ``n`` integer,
             in which case the diagonal operator with ``n`` multiples of
             ``operator`` is created.
         kwargs :
@@ -1030,7 +1031,7 @@ class DiagonalOperator(ProductSpaceOperator):
 
     @property
     def operators(self):
-        """A tuple of sub-operators."""
+        """Tuple of sub-operators that comprise ``self``."""
         return self.__operators
 
     def __getitem__(self, index):

--- a/odl/operator/pspace_ops.py
+++ b/odl/operator/pspace_ops.py
@@ -102,7 +102,7 @@ class ProductSpaceOperator(Operator):
 
         Parameters
         ----------
-        operators : `array-like`
+        operators : array-like
             An array of `Operator`'s
         domain : `ProductSpace`, optional
             Domain of the operator. If not provided, it is tried to be
@@ -209,14 +209,14 @@ class ProductSpaceOperator(Operator):
 
         Parameters
         ----------
-        x : domain `element`
+        x : domain element
             Input vector to be evaluated.
-        out : range `element`, optional
+        out : range element, optional
             Output vector to write the result to.
 
         Returns
         -------
-        out : range `element`
+        out : range element
             Result of the evaluation. If ``out`` was provided, the
             returned object is a reference to it.
 
@@ -236,7 +236,7 @@ class ProductSpaceOperator(Operator):
             [5.0, 7.0, 9.0]
         ])
 
-        Diagonal operator -- 0 or `None` means ignore, or the implicit
+        Diagonal operator -- 0 or None means ignore, or the implicit
         zero operator:
 
         >>> prod_op = ProductSpaceOperator([[I, 0], [0, I]])
@@ -420,10 +420,9 @@ class ComponentProjection(Operator):
         ----------
         space : `ProductSpace`
             Space to project from.
-        index : `int`, `slice`, or `iterable` [int]
-            Indices defining the subspace. If ``index`` is not
-            and `int`, the `Operator.range` of this
-            operator is also a `ProductSpace`.
+        index : int, slice, or iterable
+            Indices defining the subspace. If ``index`` is not an integer,
+            the `Operator.range` of this operator is also a `ProductSpace`.
 
         Examples
         --------
@@ -458,16 +457,16 @@ class ComponentProjection(Operator):
 
         Parameters
         ----------
-        x : domain `element`
+        x : domain element
             Input vector to be projected.
-        out : range `element`, optional
+        out : range element, optional
             Output vector to write the result to.
 
         Returns
         -------
-        out : range `element`
-            Projection of x onto subspace. If ``out`` was provided, the
-            returned object is a reference to it.
+        out : range element
+            Projection of ``x`` onto the subspace. If ``out`` was provided,
+            the returned object is a reference to it.
 
         Examples
         --------
@@ -533,7 +532,7 @@ class ComponentProjectionAdjoint(Operator):
         ----------
         space : `ProductSpace`
             Space to project to.
-        index : `int`, `slice`, or `iterable` [int]
+        index : int, slice, or iterable
             Indexes to project from.
 
         Examples
@@ -569,16 +568,16 @@ class ComponentProjectionAdjoint(Operator):
 
         Parameters
         ----------
-        x : domain `element`
+        x : domain element
             Input vector to be extended.
-        out : range `element`, optional
+        out : range element, optional
             Output vector to write the result to.
 
         Returns
         -------
-        out : range `element`
-            Extension of x to superspace. If ``out`` was provided, the
-            returned object is a reference to it.
+        out : range element
+            Extension of ``x`` to the superspace. If ``out`` was provided,
+            the returned object is a reference to it.
 
         Examples
         --------

--- a/odl/phantom/geometric.py
+++ b/odl/phantom/geometric.py
@@ -34,10 +34,10 @@ def cuboid(space, begin=None, end=None):
     ----------
     space : `DiscretizedSpace`
         Discretized space in which the phantom is supposed to be created.
-    begin : array-like of length ``space.ndim``
+    begin : `array-like` of length ``space.ndim``
         The lower left corner of the cuboid within the space.
         Default: A quarter of the volume from the minimum corner
-    end : array-like of length ``space.ndim``
+    end : `array-like` of length ``space.ndim``
         The upper right corner of the cuboid within the space.
         Default: A quarter of the volume from the maximum corner
 
@@ -95,7 +95,7 @@ def indicate_proj_axis(space, scale_structures=0.5):
     ----------
     space : `DiscretizedSpace`
         Discretized space in which the phantom is supposed to be created
-    scale_structures : positive `float` in (0, 1]
+    scale_structures : positive float in (0, 1]
         Scales objects (cube, cuboids)
 
     Returns
@@ -419,7 +419,7 @@ def ellipse_phantom(space, ellipses):
     ----------
     space : `DiscreteLp`
         Space in which the phantom is created, must be 2- or 3-dimensional.
-    ellipses : `sequence` of `sequence`
+    ellipses : `sequence` of `sequence`'s
         If ``space`` is 2-dimensional each row should contain:
 
         'value', 'axis_1', 'axis_2', 'center_x', 'center_y', 'rotation'

--- a/odl/phantom/geometric.py
+++ b/odl/phantom/geometric.py
@@ -43,8 +43,8 @@ def cuboid(space, begin=None, end=None):
 
     Returns
     -------
-    phantom : `LinearSpaceVector`
-        Returns an element in ``space``
+    phantom : ``space`` element
+        Cuboid phantom in ``space``.
 
     Examples
     --------
@@ -100,8 +100,8 @@ def indicate_proj_axis(space, scale_structures=0.5):
 
     Returns
     -------
-    phantom : `LinearSpaceVector`
-        Returns an element in ``space``
+    phantom : ``space`` element
+        Projection helper phantom in ``space``.
 
     Examples
     --------
@@ -199,8 +199,8 @@ def _ellipse_phantom_2d(space, ellipses):
 
     Returns
     -------
-    phantom : `DiscreteLpVector`
-        The phantom
+    phantom : ``space`` element
+        2D ellipse phantom in ``space``.
 
     See Also
     --------
@@ -313,8 +313,8 @@ def _ellipse_phantom_3d(space, ellipses):
 
     Returns
     -------
-    phantom : `DiscreteLpVector`
-        The phantom
+    phantom : ``space`` element
+        3D ellipse phantom in ``space``.
 
     See Also
     --------

--- a/odl/phantom/misc_phantoms.py
+++ b/odl/phantom/misc_phantoms.py
@@ -35,10 +35,10 @@ def submarine(space, smooth=True, taper=20.0):
     ----------
     space : `DiscreteLp`
         Discretized space in which the phantom is supposed to be created.
-    smooth : `bool`, optional
-        If `True`, the boundaries are smoothed out. Otherwise, the
+    smooth : bool, optional
+        If ``True``, the boundaries are smoothed out. Otherwise, the
         function steps from 0 to 1 at the boundaries.
-    taper : `float`, optional
+    taper : float, optional
         Tapering parameter for the boundary smoothing. Larger values
         mean faster taper, i.e. sharper boundaries.
 

--- a/odl/phantom/misc_phantoms.py
+++ b/odl/phantom/misc_phantoms.py
@@ -44,7 +44,8 @@ def submarine(space, smooth=True, taper=20.0):
 
     Returns
     -------
-    phantom : ``discr`` element
+    phantom : ``space`` element
+        The submarine phantom in ``space``.
     """
     if space.ndim == 2:
         if smooth:

--- a/odl/phantom/transmission.py
+++ b/odl/phantom/transmission.py
@@ -86,7 +86,7 @@ def shepp_logan_ellipses(ndim, modified=False):
     ----------
     ndim : {2, 3}
         Dimension of the space the ellipses should be in.
-    modified : `bool`, optional
+    modified : bool, optional
         True if the modified Shepp-Logan phantom should be given.
         The modified phantom has greatly amplified contrast to aid
         visualization.

--- a/odl/set/__init__.py
+++ b/odl/set/__init__.py
@@ -15,9 +15,7 @@
 # You should have received a copy of the GNU General Public License
 # along with ODL.  If not, see <http://www.gnu.org/licenses/>.
 
-"""Core Spaces and set support."""
-
-# TODO: write an introduction
+"""Core sets and spaces."""
 
 from __future__ import absolute_import
 

--- a/odl/set/domain.py
+++ b/odl/set/domain.py
@@ -52,9 +52,9 @@ class IntervalProd(Set):
 
         Parameters
         ----------
-        begin : `array-like` or `float`
+        begin : array-like or float
             The lower ends of the intervals in the product
-        end : `array-like` or `float`
+        end : array-like or float
             The upper ends of the intervals in the product
 
         Examples
@@ -163,7 +163,7 @@ class IntervalProd(Set):
 
         Parameters
         ----------
-        inp : `float` or array-like, optional
+        inp : float or array-like, optional
             Point to be cast to an element in self
 
         Returns
@@ -198,10 +198,10 @@ class IntervalProd(Set):
 
         Parameters
         ----------
-        other : `object`
-            The object to be tested
-        atol : `float`
-            The maximum allowed difference in 'inf'-norm between the
+        other :
+            Object to be tested.
+        atol : float
+            Maximum allowed difference in inf-norm between the
             interval endpoints.
 
         Examples
@@ -231,13 +231,12 @@ class IntervalProd(Set):
 
         Parameters
         ----------
-        point : `array-like` or `float`
-            The point to be tested. Its length must be equal
-            to the set's dimension. In the 1d case, 'point'
-            can be given as a `float`.
-        atol : `float`
-            The maximum allowed distance in 'inf'-norm between the
-            point and the set.
+        point : array-like or float
+            Point to be tested. Its length must be equal to the set's
+            dimension. In the 1d case, it can be given as a float.
+        atol : float
+            Maximum allowed distance in inf-norm between the point and
+            ``self``.
             Default: 0.0
 
         Examples
@@ -272,7 +271,7 @@ class IntervalProd(Set):
 
         Returns
         -------
-        containts : `bool`
+        containts : bool
             True if other is inside self.
 
         Examples
@@ -302,8 +301,8 @@ class IntervalProd(Set):
         ----------
         other : `Set`
             Set to be tested. It must implement a ``min()`` and a
-            ``max()`` method, otherwise a `TypeError` is raised.
-        atol : `float`, optional
+            ``max()`` method, otherwise a ``TypeError`` is raised.
+        atol : float, optional
             The maximum allowed distance in 'inf'-norm between the
             other set and this interval product.
 
@@ -343,8 +342,8 @@ class IntervalProd(Set):
 
         Returns
         -------
-        contains : `bool`
-            `True` if all points are contained, `False` otherwise
+        contains : bool
+            True if all points are contained, False otherwise
 
         Examples
         --------
@@ -415,7 +414,7 @@ class IntervalProd(Set):
 
         Parameters
         ----------
-        ndim : `int`, optional
+        ndim : int, optional
               The dimension of the measure to apply.
               Default: `true_ndim`
 
@@ -452,15 +451,15 @@ class IntervalProd(Set):
 
         Parameters
         ----------
-        point : `array-like` or `float`
+        point : array-like or float
                 The point. Its length must be equal to the set's
-                dimension. Can be a `float` in the 1d case.
-        exponent : non-zero `float` or ``float('inf')``, optional
+                dimension. Can be a float in the 1d case.
+        exponent : non-zero float or ``float('inf')``, optional
               The order of the norm (see `numpy.linalg.norm`)
 
         Returns
         -------
-        dist : `float`
+        dist : float
             Distance to the interior of the IntervalProd.
             Points strictly inside have distance ``0.0``, points with
             ``NaN`` have distance ``infinity``.
@@ -504,9 +503,9 @@ class IntervalProd(Set):
 
         Parameters
         ----------
-        indices : `int` or `tuple` of `int`
+        indices : int or tuple of int
             The indices of the dimensions along which to collapse
-        values : `array-like` or `float`
+        values : array-like or float
             The values to which to collapse. Must have the same
             length as ``indices``. Values must lie within the interval
             boundaries.
@@ -589,7 +588,7 @@ class IntervalProd(Set):
 
         Parameters
         ----------
-        index : `int`
+        index : int
             Index of the dimension before which ``other`` is to
             be inserted. Must fulfill ``-ndim <= index <= ndim``.
             Negative indices count backwards from ``self.ndim``.
@@ -638,9 +637,9 @@ class IntervalProd(Set):
 
         Parameters
         ----------
-        other : `IntervalProd`, `float` or array-like
-            Set to be inserted. A `float` or array a is
-            treated as an ``IntervalProd(a, a)``.
+        other : `IntervalProd`, float or array-like
+            Set to be inserted. A float or array ``a`` is  treated as
+            ``IntervalProd(a, a)``.
 
         Examples
         --------
@@ -660,14 +659,14 @@ class IntervalProd(Set):
         Parameters
         ----------
         order : {'C', 'F'}
-            The ordering of the axes in which the corners appear in
+            Ordering of the axes in which the corners appear in
             the output. 'C' means that the first axis varies slowest
             and the last one fastest, vice versa in 'F' ordering.
 
         Returns
         -------
-        corners : `numpy.ndarray`
-            The size of the array is ``2^m * ndim``, where ``m``
+        corners : numpy.ndarray
+            Size of the array is ``2^m * ndim``, where ``m``
             is the number of non-degenerate axes, i.e. the corners are
             stored as rows.
 
@@ -842,9 +841,9 @@ def Interval(begin, end):
 
     Parameters
     ----------
-    begin : `array-like`, shape ``(1,)``, or `float`
+    begin : array-like, shape ``(1,)``, or float
         The lower ends of the intervals in the product
-    end : `array-like`, shape ``(1,)``, or `float`
+    end : array-like, shape ``(1,)``, or float
         The upper ends of the intervals in the product
 
     """
@@ -860,9 +859,9 @@ def Rectangle(begin, end):
 
     Parameters
     ----------
-    begin : `array-like`, shape ``(2,)``
+    begin : array-like, shape ``(2,)``
         The lower ends of the intervals in the product
-    end : `array-like`, shape ``(2,)``
+    end : array-like, shape ``(2,)``
         The upper ends of the intervals in the product
     """
     rectangle = IntervalProd(begin, end)
@@ -877,9 +876,9 @@ def Cuboid(begin, end):
 
     Parameters
     ----------
-    begin : `array-like`, shape ``(3,)``
+    begin : array-like, shape ``(3,)``
         The lower ends of the intervals in the product
-    end : `array-like`, shape ``(3,)``
+    end : array-like, shape ``(3,)``
         The upper ends of the intervals in the product
     """
     cuboid = IntervalProd(begin, end)

--- a/odl/set/domain.py
+++ b/odl/set/domain.py
@@ -41,10 +41,10 @@ class IntervalProd(Set):
 
     An interval product is a Cartesian product of n intervals, i.e. an
     n-dimensional rectangular box aligned with the coordinate axes
-    as a subset of :math:`R^n`.
+    as a subset of the n-dimensional Euclidean space.
 
-    `IntervalProd` objects are immutable, all methods involving them return
-    a new `IntervalProd`.
+    `IntervalProd` objects are immutable, hence all manipulation methods
+    return a new instance.
     """
 
     def __init__(self, begin, end):
@@ -53,9 +53,11 @@ class IntervalProd(Set):
         Parameters
         ----------
         begin : array-like or float
-            The lower ends of the intervals in the product
+            The lower ends of the intervals. A float can be used in
+            one dimension.
         end : array-like or float
-            The upper ends of the intervals in the product
+            The upper ends of the intervals. A float can be used in
+            one dimension.
 
         Examples
         --------
@@ -68,28 +70,24 @@ class IntervalProd(Set):
         self.__end = np.atleast_1d(end).astype('float64')
 
         if self.begin.ndim > 1:
-            raise ValueError('`begin` {} is {}- instead of 1-dimensional'
-                             ''.format(begin, self.begin.ndim))
+            raise ValueError('`begin` must be 1-dimensional, got an array '
+                             'with {} axes'.format(self.begin.ndim))
         if self.end.ndim > 1:
-            raise ValueError('`end` {} is {}- instead of 1-dimensional'
-                             ''.format(end, self.end.ndim))
+            raise ValueError('`end` must be 1-dimensional, got an array '
+                             'with {} axes'.format(self.begin.ndim))
         if len(self.begin) != len(self.end):
-            raise ValueError('`begin` {} and end {} have different '
-                             'lengths ({} != {})'
-                             ''.format(begin, end,
-                                       len(self.begin), len(self.end)))
-        if not np.all(self.begin <= self.end):
-            i_wrong = np.where(self.begin > self.end)
-            raise ValueError('entries at indices {} of begin exceed '
-                             'those of end ({} > {})'
-                             ''.format(i_wrong, list(self.begin[i_wrong]),
-                                       list(self.end[i_wrong])))
+            raise ValueError('`begin` and `end` have different lengths '
+                             '({} != {})'
+                             ''.format(len(self.begin), len(self.end)))
+        for i, (beg, end) in enumerate(zip(self.begin, self.end)):
+            if beg > end:
+                raise ValueError('in axis {}: `begin` is larger than `end` '
+                                 '({} > {})'.format(i, beg, end))
 
         self.__ideg = np.where(self.begin == self.end)[0]
         self.__inondeg = np.where(self.begin != self.end)[0]
         super().__init__()
 
-    # Basic properties
     @property
     def begin(self):
         """Left interval boundary/boundaries."""
@@ -107,31 +105,31 @@ class IntervalProd(Set):
 
     @property
     def true_ndim(self):
-        """Number of non-degenerate (zero-length) intervals."""
+        """Number of non-degenerate (positive-length) intervals."""
         return len(self.inondeg)
 
     @property
     def volume(self):
-        """'dim'-dimensional volume of this interval product."""
+        """`ndim`-dimensional volume of this interval product."""
         return self.measure(ndim=self.ndim)
 
     @property
     def length(self):
-        """Length of this interval."""
+        """Length of this interval (valid for ``ndim == 1``)."""
         if self.ndim != 1:
-            raise NotImplementedError('`length` not defined if ndim != 1')
+            raise NotImplementedError('length not defined if `ndim` != 1')
         return self.volume
 
     @property
     def area(self):
-        """Area of this rectangle."""
+        """Area of this rectangle (valid if ``ndim == 2``)."""
         if self.ndim != 2:
-            raise NotImplementedError('`area` not defined if ndim != 2')
+            raise NotImplementedError('area not defined if `ndim` != 2')
         return self.volume
 
     @property
     def midpoint(self):
-        """Midpoint of the interval product."""
+        """Midpoint of this interval product."""
         midp = (self.end + self.begin) / 2.
         midp[self.ideg] = self.begin[self.ideg]
         return midp
@@ -147,34 +145,30 @@ class IntervalProd(Set):
         return self.__inondeg
 
     def min(self):
-        """Minimum value in this interval product."""
+        """Return the minimum point of this interval product."""
         return self.begin
 
     def max(self):
-        """Maximum value in this interval product."""
+        """Return the maximum point of this interval product."""
         return self.end
 
     def extent(self):
-        """Interval length per axis."""
+        """Return the vector of interval lengths per axis."""
         return self.max() - self.min()
 
     def element(self, inp=None):
-        """Create element in this set.
+        """Return an element of this interval product.
 
         Parameters
         ----------
         inp : float or array-like, optional
-            Point to be cast to an element in self
+            Point to be cast to an element.
 
         Returns
         -------
-        element
-            Returns ``inp`` if given, else ``self.midpoint``
-
-        Raises
-        ------
-        TypeError
-            If ``inp`` is not a valid element.
+        element : numpy.ndarray or float
+            Array (ndim > 1) or float version of ``inp`` if provided,
+            otherwise ``self.midpoint``.
 
         Examples
         --------
@@ -190,18 +184,18 @@ class IntervalProd(Set):
             else:
                 return np.asarray(inp)
         else:
-            raise TypeError('`inp` {!r} not a valid element in {!r}'
+            raise TypeError('`inp` {!r} is not a valid element of {!r}'
                             ''.format(inp, self))
 
     def approx_equals(self, other, atol):
-        """Test if ``other`` is equal to this set up to ``atol``.
+        """Return ``True`` if ``other`` is equal to this set up to ``atol``.
 
         Parameters
         ----------
         other :
             Object to be tested.
         atol : float
-            Maximum allowed difference in inf-norm between the
+            Maximum allowed difference in maximum norm between the
             interval endpoints.
 
         Examples
@@ -209,7 +203,7 @@ class IntervalProd(Set):
         >>> from math import sqrt
         >>> rbox1 = IntervalProd(0, 0.5)
         >>> rbox2 = IntervalProd(0, sqrt(0.5)**2)
-        >>> rbox1.approx_equals(rbox2, atol=0)  # Num error
+        >>> rbox1.approx_equals(rbox2, atol=0)  # Numerical error
         False
         >>> rbox1.approx_equals(rbox2, atol=1e-15)
         True
@@ -227,17 +221,16 @@ class IntervalProd(Set):
         return self.approx_equals(other, atol=0.0)
 
     def approx_contains(self, point, atol):
-        """Test if a point is contained.
+        """Return ``True`` if ``point`` is "almost" contained in this set.
 
         Parameters
         ----------
         point : array-like or float
-            Point to be tested. Its length must be equal to the set's
-            dimension. In the 1d case, it can be given as a float.
+            Point to be tested. Its length must be equal to `ndim`.
+            In the 1d case, ``point`` can be given as a float.
         atol : float
-            Maximum allowed distance in inf-norm between the point and
-            ``self``.
-            Default: 0.0
+            Maximum allowed distance in maximum norm from ``point``
+            to ``self``.
 
         Examples
         --------
@@ -264,16 +257,6 @@ class IntervalProd(Set):
     def __contains__(self, other):
         """Return ``other in self``.
 
-        Parameters
-        ----------
-        other
-            Arbitrary object to be tested.
-
-        Returns
-        -------
-        containts : bool
-            True if other is inside self.
-
         Examples
         --------
         >>> interv = IntervalProd(0, 1)
@@ -295,16 +278,20 @@ class IntervalProd(Set):
         return (self.begin <= point).all() and (point <= self.end).all()
 
     def contains_set(self, other, atol=0.0):
-        """Test if another set is contained.
+        """Return ``True`` if ``other`` is (almost) contained in this set.
 
         Parameters
         ----------
         other : `Set`
-            Set to be tested. It must implement a ``min()`` and a
-            ``max()`` method, otherwise a ``TypeError`` is raised.
+            Set to be tested.
         atol : float, optional
-            The maximum allowed distance in 'inf'-norm between the
-            other set and this interval product.
+            Maximum allowed distance in maximum norm from ``other``
+            to ``self``.
+
+        Raises
+        ------
+        AttributeError
+            if ``other`` does not have both ``min`` and ``max`` methods.
 
         Examples
         --------
@@ -325,17 +312,18 @@ class IntervalProd(Set):
                     self.approx_contains(other.max(), atol))
         except AttributeError as err:
             raise_from(
-                AttributeError('cannot test {!r} without `min()` and `max()`'
+                AttributeError('cannot test {!r} without `min` and `max` '
                                'methods'.format(other)), err)
 
     def contains_all(self, other, atol=0.0):
-        """Test if all points defined by ``other`` are contained.
+        """Return ``True`` if all points defined by ``other`` are contained.
 
         Parameters
         ----------
         other :
-            Can be a single point, a ``(d, N)`` array where ``d`` is the
-            number of dimensions or a length-``d`` meshgrid tuple
+            Collection of points to be tested. Can be given as a single
+            point, a ``(d, N)`` array-like where ``d`` is the
+            number of dimensions, or a length-``d`` `meshgrid` tuple.
         atol : `float`, optional
             The maximum allowed distance in 'inf'-norm between the
             other set and this interval product.
@@ -343,7 +331,7 @@ class IntervalProd(Set):
         Returns
         -------
         contains : bool
-            True if all points are contained, False otherwise
+            True if all points are contained, False otherwise.
 
         Examples
         --------
@@ -351,14 +339,14 @@ class IntervalProd(Set):
         >>> b, e = [-1, 0, 2], [-0.5, 0, 3]
         >>> rbox = IntervalProd(b, e)
 
-        rrays are expected in (ndim, npoints) shape
+        Arrays are expected in (ndim, npoints) shape:
 
         >>> arr = np.array([[-1, 0, 2],   # defining one point at a time
         ...                 [-0.5, 0, 2]])
         >>> rbox.contains_all(arr.T)
         True
 
-        Implicit meshgrids defined by coordinate vectors
+        Implicit meshgrids defined by coordinate vectors:
 
         >>> from odl.discr.grid import sparse_meshgrid
         >>> vec1 = (-1, -0.9, -0.7)
@@ -368,14 +356,14 @@ class IntervalProd(Set):
         >>> rbox.contains_all(mg)
         True
 
-        Also works with any iterable
+        Works also with an arbitrary iterable:
 
         >>> rbox.contains_all([[-1, -0.5], # define points by axis
         ...                    [0, 0],
         ...                    [2, 2]])
         True
 
-        And with grids
+        And with grids:
 
         >>> agrid = odl.uniform_sampling(rbox.begin, rbox.end, [3, 1, 3])
         >>> rbox.contains_all(agrid)
@@ -408,19 +396,18 @@ class IntervalProd(Set):
         else:
             return False
 
-    # Additional property-like methods
     def measure(self, ndim=None):
-        """(Lebesgue) measure of this interval product.
+        """Return the Lebesgue measure of this interval product.
 
         Parameters
         ----------
         ndim : int, optional
-              The dimension of the measure to apply.
-              Default: `true_ndim`
+            Dimension of the measure to apply. None is interpreted
+            as `true_ndim`, which always results in a finite and
+            positive result (unless the set is a single point).
 
         Examples
         --------
-
         >>> b, e = [-1, 2.5, 0], [-0.5, 10, 0]
         >>> rbox = IntervalProd(b, e)
         >>> rbox.measure()
@@ -447,26 +434,29 @@ class IntervalProd(Set):
             return np.prod((self.end - self.begin)[self.inondeg])
 
     def dist(self, point, exponent=2.0):
-        """Calculate the distance to a point.
+        """Return the distance of ``point`` to this set.
 
         Parameters
         ----------
         point : array-like or float
-                The point. Its length must be equal to the set's
-                dimension. Can be a float in the 1d case.
+            Point whose distance to calculate. Its length must be equal
+            to the set's dimension. Can be a float in the 1d case.
         exponent : non-zero float or ``float('inf')``, optional
-              The order of the norm (see `numpy.linalg.norm`)
+            Exponent of the norm used in the distance calculation.
 
         Returns
         -------
         dist : float
             Distance to the interior of the IntervalProd.
             Points strictly inside have distance ``0.0``, points with
-            ``NaN`` have distance ``infinity``.
+            ``NaN`` have distance ``float('inf')``.
+
+        See also
+        --------
+        numpy.linalg.norm : norm used to compute the distance
 
         Examples
         --------
-
         >>> b, e = [-1, 0, 2], [-0.5, 0, 3]
         >>> rbox = IntervalProd(b, e)
         >>> rbox.dist([-5, 3, 2])
@@ -476,17 +466,16 @@ class IntervalProd(Set):
         """
         point = np.atleast_1d(point)
         if len(point) != self.ndim:
-            raise ValueError('length {} of point {} does not match '
-                             'the dimension {} of the set {}'
-                             ''.format(len(point), point, self.ndim, self))
+            raise ValueError('`point` must have length {}, got {}'
+                             ''.format(self.ndim, len(point)))
 
         if np.any(np.isnan(point)):
-            return np.inf
+            return float('inf')
 
         i_larger = np.where(point > self.end)
         i_smaller = np.where(point < self.begin)
 
-        # Access [0] since np.where returns tuple.
+        # Access [0] since np.where returns a tuple.
         if len(i_larger[0]) == 0 and len(i_smaller[0]) == 0:
             return 0.0
         else:
@@ -495,7 +484,6 @@ class IntervalProd(Set):
                                      self.begin[i_smaller]))
             return np.linalg.norm(proj - border, ord=exponent)
 
-    # Manipulation
     def collapse(self, indices, values):
         """Partly collapse the interval product to single values.
 
@@ -504,7 +492,7 @@ class IntervalProd(Set):
         Parameters
         ----------
         indices : int or tuple of int
-            The indices of the dimensions along which to collapse
+            The indices of the dimensions along which to collapse.
         values : array-like or float
             The values to which to collapse. Must have the same
             length as ``indices``. Values must lie within the interval
@@ -513,11 +501,10 @@ class IntervalProd(Set):
         Returns
         -------
         collapsed : `IntervalProd`
-            The collapsed set
+            The collapsed set.
 
         Examples
         --------
-
         >>> b, e = [-1, 0, 2], [-0.5, 1, 3]
         >>> rbox = IntervalProd(b, e)
         >>> rbox.collapse(1, 0)
@@ -533,9 +520,10 @@ class IntervalProd(Set):
                              ''.format(indices, values,
                                        len(indices), len(values)))
 
-        if np.any(indices < 0) or np.any(indices >= self.ndim):
-            raise IndexError('indices {} out of range 0 --> {}'
-                             ''.format(list(indices), self.ndim))
+        for axis, index in enumerate(indices):
+            if not 0 <= index <= self.ndim:
+                raise IndexError('in axis {}: index {} out of range 0 --> {}'
+                                 ''.format(axis, index, self.ndim - 1))
 
         if np.any(values < self.begin[indices]):
             raise ValueError('values {} not above the lower interval '
@@ -562,7 +550,7 @@ class IntervalProd(Set):
         Returns
         -------
         squeezed : `IntervalProd`
-            Squeezed set
+            Squeezed set.
 
         Examples
         --------
@@ -580,11 +568,13 @@ class IntervalProd(Set):
         return IntervalProd(b_new, e_new)
 
     def insert(self, index, other):
-        """Return a copy with ``other`` inserted before ``index``.
+        """Insert ``other`` before ``index``.
 
         The given interval product (``ndim=m``) is inserted into the
         current one (``ndim=n``) before the given index, resulting in a
         new interval product with ``n+m`` dimensions.
+
+        Note that no changes are made in-place.
 
         Parameters
         ----------
@@ -593,16 +583,15 @@ class IntervalProd(Set):
             be inserted. Must fulfill ``-ndim <= index <= ndim``.
             Negative indices count backwards from ``self.ndim``.
         other : `IntervalProd`
-            Interval product to be inserted
+            Interval product to be inserted.
 
         Returns
         -------
         newintvp : `IntervalProd`
-            Interval product with ``other`` inserted
+            Interval product with ``other`` inserted.
 
         Examples
         --------
-
         >>> rbox = IntervalProd([-1, 2], [-0.5, 3])
         >>> rbox2 = IntervalProd([0, 0], [1, 0])
         >>> rbox.insert(1, rbox2)
@@ -610,14 +599,13 @@ class IntervalProd(Set):
         >>> rbox.insert(-1, rbox2)
         IntervalProd([-1.0, 0.0, 0.0, 2.0], [-0.5, 1.0, 0.0, 3.0])
         """
-        if index < 0:
-            index = int(index) + self.ndim
-        else:
-            index = int(index)
+        index, index_in = int(index), index
 
-        if not 0 <= index <= self.ndim:
-            raise IndexError('index {} outside the valid range 0 ... {}'
-                             ''.format(index, self.ndim))
+        if not -self.ndim <= index <= self.ndim:
+            raise IndexError('index {0} outside the valid range -{1} --> {1}'
+                             ''.format(index_in, self.ndim))
+        if index < 0:
+            index += self.ndim
 
         new_beg = np.empty(self.ndim + other.ndim)
         new_end = np.empty(self.ndim + other.ndim)
@@ -637,9 +625,13 @@ class IntervalProd(Set):
 
         Parameters
         ----------
-        other : `IntervalProd`, float or array-like
-            Set to be inserted. A float or array ``a`` is  treated as
-            ``IntervalProd(a, a)``.
+        other : `IntervalProd`
+            Set to be appended.
+
+        Returns
+        -------
+        newintvp : `IntervalProd`
+            Interval product with ``other`` appended.
 
         Examples
         --------
@@ -654,21 +646,21 @@ class IntervalProd(Set):
         return self.insert(self.ndim, other)
 
     def corners(self, order='C'):
-        """Corner points in a single array.
+        """Return the corner points as a single array.
 
         Parameters
         ----------
-        order : {'C', 'F'}
+        order : {'C', 'F'}, optional
             Ordering of the axes in which the corners appear in
-            the output. 'C' means that the first axis varies slowest
-            and the last one fastest, vice versa in 'F' ordering.
+            the output. ``'C'`` means that the first axis varies slowest
+            and the last one fastest, vice versa in ``'F'`` ordering.
 
         Returns
         -------
         corners : numpy.ndarray
-            Size of the array is ``2^m * ndim``, where ``m``
-            is the number of non-degenerate axes, i.e. the corners are
-            stored as rows.
+            Array containing the corner coordinates. The size of the
+            array is ``2^m x ndim``, where ``m`` is the number of
+            non-degenerate axes, i.e. the corners are stored as rows.
 
         Examples
         --------
@@ -703,7 +695,6 @@ class IntervalProd(Set):
         minmax_grid = TensorGrid(*minmax_vecs)
         return minmax_grid.points(order=order)
 
-    # Magic methods
     def __len__(self):
         """Return ``len(self)``."""
         return self.ndim
@@ -713,34 +704,35 @@ class IntervalProd(Set):
 
         Parameters
         ----------
-        indices : numpy style index
-            Any of: int, slice, list of ints
+        indices : index expression
+            Object determining which parts of the interval product
+            to extract.
 
         Returns
         -------
         subinterval : `IntervalProd`
-            Interval given by the indices
+            Interval product corresponding to the indices.
 
         Examples
         --------
         >>> rbox = IntervalProd([-1, 2, 0], [-0.5, 3, 0.5])
 
-        By integer
+        Indexing by integer selects single axes:
 
         >>> rbox[0]
         Interval(-1.0, -0.5)
 
-        By slice
+        With slices, multiple axes can be selected:
 
         >>> rbox[:]
         Cuboid([-1.0, 2.0, 0.0], [-0.5, 3.0, 0.5])
         >>> rbox[::2]
         Rectangle([-1.0, 0.0], [-0.5, 0.5])
 
-        By list of ints
+        A list of integers can be used for free combinations of axes:
 
-        >>> rbox[[0, 1]]
-        Rectangle([-1.0, 2.0], [-0.5, 3.0])
+        >>> rbox[[0, 1, 0]]
+        Cuboid([-1.0, 2.0, -1.0], [-0.5, 3.0, -0.5])
         """
         return IntervalProd(self.begin[indices], self.end[indices])
 
@@ -773,8 +765,8 @@ class IntervalProd(Set):
         """Return ``self * other``."""
         if isinstance(other, IntervalProd):
             if self.ndim != other.ndim:
-                raise ValueError('multiplication not possible for {!r} and'
-                                 '{!r}: dimension mismatch ({} != {})'
+                raise ValueError('multiplication not possible for {} and'
+                                 '{}: dimension mismatch ({} != {})'
                                  ''.format(self, other, self.ndim, other.ndim))
 
             comp_mat = np.empty([self.ndim, 4])
@@ -801,12 +793,10 @@ class IntervalProd(Set):
     def __rdiv__(self, other):
         """Return ``other / self``."""
         if np.isscalar(other):
-            contains_zero = np.any(np.logical_and(self.begin <= 0,
-                                                  self.end >= 0))
-            if contains_zero:
-                raise ValueError('division by other {!r} not possible:'
-                                 'Interval contains 0'
-                                 ''.format(other))
+            for axis, (b, e) in enumerate(zip(self.begin, self.end)):
+                if b <= 0 and e >= 0:
+                    raise ValueError('division not possible: interval product'
+                                     'contains 0 in axis {}'.format(axis))
 
             vec1 = other / self.begin
             vec2 = other / self.end
@@ -827,8 +817,9 @@ class IntervalProd(Set):
             return 'Cuboid({!r}, {!r})'.format(list(self.begin),
                                                list(self.end))
         else:
-            return 'IntervalProd({}, {})'.format(array1d_repr(self.begin),
-                                                 array1d_repr(self.end))
+            return '{}({}, {})'.format(self.__class__.__name__,
+                                       array1d_repr(self.begin),
+                                       array1d_repr(self.end))
 
     def __str__(self):
         """Return ``str(self)``."""
@@ -841,10 +832,10 @@ def Interval(begin, end):
 
     Parameters
     ----------
-    begin : array-like, shape ``(1,)``, or float
-        The lower ends of the intervals in the product
-    end : array-like, shape ``(1,)``, or float
-        The upper ends of the intervals in the product
+    begin : array-like with shape ``(1,)`` or float
+        Lower end of the interval.
+    end : array-like with shape ``(1,)`` or float
+        Upper end of the interval.
 
     """
     interval = IntervalProd(begin, end)
@@ -859,10 +850,10 @@ def Rectangle(begin, end):
 
     Parameters
     ----------
-    begin : array-like, shape ``(2,)``
-        The lower ends of the intervals in the product
-    end : array-like, shape ``(2,)``
-        The upper ends of the intervals in the product
+    begin : array-like with shape ``(2,)``
+        Lower ends of the intervals in the product.
+    end : array-like with shape ``(2,)``
+        Upper ends of the intervals in the product.
     """
     rectangle = IntervalProd(begin, end)
     if rectangle.ndim != 2:
@@ -876,10 +867,10 @@ def Cuboid(begin, end):
 
     Parameters
     ----------
-    begin : array-like, shape ``(3,)``
-        The lower ends of the intervals in the product
-    end : array-like, shape ``(3,)``
-        The upper ends of the intervals in the product
+    begin : array-like with shape ``(3,)``
+        Lower ends of the intervals in the product.
+    end : array-like with shape ``(3,)``
+        Upper ends of the intervals in the product.
     """
     cuboid = IntervalProd(begin, end)
     if cuboid.ndim != 3:

--- a/odl/set/domain.py
+++ b/odl/set/domain.py
@@ -52,10 +52,10 @@ class IntervalProd(Set):
 
         Parameters
         ----------
-        begin : array-like or float
+        begin : `array-like` or float
             The lower ends of the intervals. A float can be used in
             one dimension.
-        end : array-like or float
+        end : `array-like` or float
             The upper ends of the intervals. A float can be used in
             one dimension.
 
@@ -161,12 +161,12 @@ class IntervalProd(Set):
 
         Parameters
         ----------
-        inp : float or array-like, optional
+        inp : float or `array-like`, optional
             Point to be cast to an element.
 
         Returns
         -------
-        element : numpy.ndarray or float
+        element : `numpy.ndarray` or float
             Array (ndim > 1) or float version of ``inp`` if provided,
             otherwise ``self.midpoint``.
 
@@ -225,7 +225,7 @@ class IntervalProd(Set):
 
         Parameters
         ----------
-        point : array-like or float
+        point : `array-like` or float
             Point to be tested. Its length must be equal to `ndim`.
             In the 1d case, ``point`` can be given as a float.
         atol : float
@@ -324,14 +324,14 @@ class IntervalProd(Set):
             Collection of points to be tested. Can be given as a single
             point, a ``(d, N)`` array-like where ``d`` is the
             number of dimensions, or a length-``d`` `meshgrid` tuple.
-        atol : `float`, optional
+        atol : float, optional
             The maximum allowed distance in 'inf'-norm between the
             other set and this interval product.
 
         Returns
         -------
         contains : bool
-            True if all points are contained, False otherwise.
+            ``True`` if all points are contained, ``False`` otherwise.
 
         Examples
         --------
@@ -402,7 +402,7 @@ class IntervalProd(Set):
         Parameters
         ----------
         ndim : int, optional
-            Dimension of the measure to apply. None is interpreted
+            Dimension of the measure to apply. ``None`` is interpreted
             as `true_ndim`, which always results in a finite and
             positive result (unless the set is a single point).
 
@@ -438,7 +438,7 @@ class IntervalProd(Set):
 
         Parameters
         ----------
-        point : array-like or float
+        point : `array-like` or float
             Point whose distance to calculate. Its length must be equal
             to the set's dimension. Can be a float in the 1d case.
         exponent : non-zero float or ``float('inf')``, optional
@@ -491,9 +491,9 @@ class IntervalProd(Set):
 
         Parameters
         ----------
-        indices : int or tuple of int
+        indices : int or `sequence` of ints
             The indices of the dimensions along which to collapse.
-        values : array-like or float
+        values : `array-like` or float
             The values to which to collapse. Must have the same
             length as ``indices``. Values must lie within the interval
             boundaries.
@@ -657,7 +657,7 @@ class IntervalProd(Set):
 
         Returns
         -------
-        corners : numpy.ndarray
+        corners : `numpy.ndarray`
             Array containing the corner coordinates. The size of the
             array is ``2^m x ndim``, where ``m`` is the number of
             non-degenerate axes, i.e. the corners are stored as rows.
@@ -832,9 +832,9 @@ def Interval(begin, end):
 
     Parameters
     ----------
-    begin : array-like with shape ``(1,)`` or float
+    begin : `array-like` with shape ``(1,)`` or float
         Lower end of the interval.
-    end : array-like with shape ``(1,)`` or float
+    end : `array-like` with shape ``(1,)`` or float
         Upper end of the interval.
 
     """
@@ -850,9 +850,9 @@ def Rectangle(begin, end):
 
     Parameters
     ----------
-    begin : array-like with shape ``(2,)``
+    begin : `array-like` with shape ``(2,)``
         Lower ends of the intervals in the product.
-    end : array-like with shape ``(2,)``
+    end : `array-like` with shape ``(2,)``
         Upper ends of the intervals in the product.
     """
     rectangle = IntervalProd(begin, end)
@@ -867,9 +867,9 @@ def Cuboid(begin, end):
 
     Parameters
     ----------
-    begin : array-like with shape ``(3,)``
+    begin : `array-like` with shape ``(3,)``
         Lower ends of the intervals in the product.
-    end : array-like with shape ``(3,)``
+    end : `array-like` with shape ``(3,)``
         Upper ends of the intervals in the product.
     """
     cuboid = IntervalProd(begin, end)

--- a/odl/set/sets.py
+++ b/odl/set/sets.py
@@ -57,7 +57,7 @@ class Set(with_metaclass(ABCMeta, object)):
 
     **Returns:**
         contains : bool
-            True if ``other`` is a member of this set, False
+            ``True`` if ``other`` is a member of this set, ``False``
             otherwise.
 
 
@@ -73,8 +73,8 @@ class Set(with_metaclass(ABCMeta, object)):
 
     **Returns:**
         equals : bool
-            True if both sets are of the same type and contain the
-            same elements, False otherwise.
+            ``True`` if both sets are of the same type and contain the
+            same elements, ``False`` otherwise.
 
     A default implementation of the operator overload for ``!=`` via
     ``__ne__(self, other)`` is provided as ``not self.__eq__(other)``.
@@ -107,7 +107,8 @@ class Set(with_metaclass(ABCMeta, object)):
         Returns
         -------
         set_contained : bool
-            True if ``other`` is contained in this set, False otherwise
+            ``True`` if ``other`` is contained in this set, ``False``
+            otherwise.
         """
         return self == other
 
@@ -121,8 +122,8 @@ class Set(with_metaclass(ABCMeta, object)):
         Returns
         -------
         all_contained : bool
-            True if all elements of ``other`` are contained in this
-            set, False otherwise
+            ``True`` if all elements of ``other`` are contained in this
+            set, ``False`` otherwise
         """
         return all(x in self for x in other)
 
@@ -165,18 +166,18 @@ class Set(with_metaclass(ABCMeta, object)):
 
 class EmptySet(Set):
 
-    """Set with no member elements (except `None`).
+    """Set with no member elements (except ``None``).
 
-    None is considered as "no element", i.e. ``None in EmptySet()``
-    is the only test that evaluates to True.
+    ``None`` is considered as "no element", i.e. ``None in EmptySet()``
+    is the only test that evaluates to ``True``.
     """
 
     def __contains__(self, other):
-        """Return ``other in self``."""
+        """Return ``other in self``, always ``False`` except for ``None``."""
         return other is None
 
     def contains_set(self, other):
-        """Return True for the empty set, False otherwise."""
+        """Return ``True`` for the empty set, ``False`` otherwise."""
         return isinstance(other, EmptySet)
 
     def __eq__(self, other):
@@ -196,11 +197,11 @@ class UniversalSet(Set):
     """
 
     def __contains__(self, other):
-        """Return ``other in self``."""
+        """Return ``other in self``, always ``True``."""
         return True
 
     def contains_set(self, other):
-        """Return True for any set."""
+        """Return ``True`` for any set."""
         return isinstance(other, Set)
 
     def __eq__(self, other):
@@ -315,7 +316,7 @@ class ComplexNumbers(Field):
         return isinstance(other, Complex)
 
     def contains_set(self, other):
-        """Return True if ``other`` is a subset of the complex numbers.
+        """Return ``True`` if ``other`` is a subset of the complex numbers.
 
         Returns
         -------
@@ -337,7 +338,7 @@ class ComplexNumbers(Field):
                 isinstance(other, Integers))
 
     def contains_all(self, other):
-        """Return True if ``other`` is a sequence complex numbers."""
+        """Return ``True`` if ``other`` is a sequence of complex numbers."""
         dtype = getattr(other, 'dtype', None)
         if dtype is None:
             dtype = np.result_type(*other)
@@ -373,12 +374,12 @@ class RealNumbers(Field):
         return isinstance(other, Real)
 
     def contains_set(self, other):
-        """Return True if ``other`` is a subset of the real numbers.
+        """Return ``True`` if ``other`` is a subset of the real numbers.
 
         Returns
         -------
         contained : bool
-            True if other is an instance of `RealNumbers` or
+            ``True`` if other is an instance of `RealNumbers` or
             `Integers` False otherwise.
 
         Examples
@@ -457,7 +458,7 @@ class Integers(Set):
         return isinstance(other, Integers)
 
     def contains_all(self, other):
-        """Test if ``other`` is a sequence of integers."""
+        """Return ``True`` if ``other`` is a sequence of integers."""
         dtype = getattr(other, 'dtype', None)
         if dtype is None:
             dtype = np.result_type(*other)
@@ -509,9 +510,9 @@ class CartesianProduct(Set):
         Returns
         -------
         contains : bool
-            True if ``other`` is a sequence with same length as this
+            ``True`` if ``other`` is a sequence with same length as this
             Cartesian product, and each entry is contained in the set with
-            corresponding index, False otherwise.
+            corresponding index, ``False`` otherwise.
         """
         try:
             len(other)
@@ -526,9 +527,9 @@ class CartesianProduct(Set):
         Returns
         -------
         equals : bool
-            True if ``other`` is a `CartesianProduct` instance,
+            ``True`` if ``other`` is a `CartesianProduct` instance,
             has the same length as this Cartesian product and all sets
-            with the same index are equal, False otherwise.
+            with the same index are equal, ``False`` otherwise.
         """
         return (isinstance(other, CartesianProduct) and
                 len(other) == len(self) and

--- a/odl/set/sets.py
+++ b/odl/set/sets.py
@@ -52,12 +52,12 @@ class Set(with_metaclass(ABCMeta, object)):
     the operator overload for `in`.
 
     **Parameters:**
-        other : `object`
+        other :
             The object to be tested for membership
 
     **Returns:**
-        contains : `bool`
-            `True` if ``other`` is a member of this set, `False`
+        contains : bool
+            True if ``other`` is a member of this set, False
             otherwise.
 
 
@@ -68,13 +68,13 @@ class Set(with_metaclass(ABCMeta, object)):
     provides the operator overload for ``==``.
 
     **Parameters:**
-        other : `object`
+        other :
             The object to be tested for equality.
 
     **Returns:**
-        equals : `bool`
-            `True` if both sets are of the same type and contain the
-            same elements, `False` otherwise.
+        equals : bool
+            True if both sets are of the same type and contain the
+            same elements, False otherwise.
 
     A default implementation of the operator overload for ``!=`` via
     ``__ne__(self, other)`` is provided as ``not self.__eq__(other)``.
@@ -85,12 +85,12 @@ class Set(with_metaclass(ABCMeta, object)):
     input parameter.
 
     **Parameters:**
-        inp : `object`, optional
+        inp : optional
             The object from which to create the new element
 
     **Returns:**
         element : member of this set
-            If ``inp`` is `None`, return an arbitrary element.
+            If ``inp`` is None, return an arbitrary element.
             Otherwise, return the element created from ``inp``.
     """
 
@@ -144,16 +144,16 @@ class EmptySet(Set):
 
     """Set with no member elements (except `None`).
 
-    `None` is considered as "no element", i.e.
-    ``None in EmptySet()`` is `True`
+    None is considered as "no element", i.e.
+    ``None in EmptySet()`` is True
     """
 
     def __contains__(self, other):
-        """Test if ``other`` is `None`."""
+        """Test if ``other`` is None."""
         return other is None
 
     def contains_set(self, other):
-        """Return `True` for the empty set, otherwise `False`."""
+        """Return True for the empty set, False otherwise."""
         return isinstance(other, EmptySet)
 
     def __eq__(self, other):
@@ -161,7 +161,7 @@ class EmptySet(Set):
         return isinstance(other, EmptySet)
 
     def element(self, inp=None):
-        """Return `None`."""
+        """Return None."""
         return None
 
     def __str__(self):
@@ -181,11 +181,11 @@ class UniversalSet(Set):
     """
 
     def __contains__(self, other):
-        """Return `True`."""
+        """Return True."""
         return True
 
     def contains_set(self, other):
-        """Return `True` for any set."""
+        """Return True for any set."""
         return isinstance(other, Set)
 
     def __eq__(self, other):
@@ -214,7 +214,7 @@ class Strings(Set):
 
         Parameters
         ----------
-        length : `int`
+        length : int
             The fixed length of the strings in this set. Must be
             positive.
         """
@@ -232,8 +232,8 @@ class Strings(Set):
     def __contains__(self, other):
         """Return ``other in self``.
 
-        `True` if ``other`` is a string of at max `length`
-        characters, `False` otherwise."""
+        True if ``other`` is a string of at max `length`
+        characters, False otherwise."""
         return isinstance(other, basestring) and len(other) == self.length
 
     def contains_all(self, array):
@@ -304,9 +304,9 @@ class ComplexNumbers(Field):
 
         Returns
         -------
-        contained : `bool`
-            `True` if other is `ComplexNumbers`,
-            `RealNumbers` or `Integers`, `False` else.
+        contained : bool
+            True if  other is `ComplexNumbers`, `RealNumbers` or `Integers`,
+            else False.
 
         Examples
         --------
@@ -370,9 +370,9 @@ class RealNumbers(Field):
 
         Returns
         -------
-        contained : `bool`
-            `True` if other is `RealNumbers` or
-            `Integers` `False` else.
+        contained : bool
+            True if other is `RealNumbers` or
+            `Integers` False else.
 
         Examples
         --------
@@ -442,8 +442,8 @@ class Integers(Set):
 
         Returns
         -------
-        contained : `bool`
-            `True` if other is `Integers`, `False` otherwise.
+        contained : bool
+            True if  other is `Integers`, else False.
 
         Examples
         --------
@@ -504,7 +504,7 @@ class CartesianProduct(Set):
 
     @property
     def sets(self):
-        """Factors (sets) as a `tuple`."""
+        """Factors (sets) as a tuple."""
         return self.__sets
 
     def __contains__(self, other):
@@ -512,10 +512,10 @@ class CartesianProduct(Set):
 
         Returns
         -------
-        contains : `bool`
-            `True` if ``other`` has the same length as this Cartesian
+        contains : bool
+            True if ``other`` has the same length as this Cartesian
             product and each entry is contained in the set with
-            corresponding index, `False` otherwise.
+            corresponding index, False otherwise.
         """
         try:
             iter(other)
@@ -529,10 +529,10 @@ class CartesianProduct(Set):
 
         Returns
         -------
-        equals : `bool`
-            `True` if ``other`` is a `CartesianProduct` instance,
+        equals : bool
+            True if ``other`` is a `CartesianProduct` instance,
             has the same length as this Cartesian product and all sets
-            with the same index are equal, `False` otherwise.
+            with the same index are equal, False otherwise.
         """
         return (isinstance(other, CartesianProduct) and
                 len(other) == len(self) and
@@ -550,7 +550,7 @@ class CartesianProduct(Set):
 
         Returns
         -------
-        element : `tuple`
+        element : tuple
             A tuple of the given input
         """
         if inp is None:

--- a/odl/set/sets.py
+++ b/odl/set/sets.py
@@ -49,11 +49,11 @@ class Set(with_metaclass(ABCMeta, object)):
     **Membership test:** ``__contains__(self, other)``
 
     Test if ``other`` is a member of this set. This function provides
-    the operator overload for `in`.
+    the operator overload for ``in``.
 
     **Parameters:**
         other :
-            The object to be tested for membership
+            Object to be tested for membership
 
     **Returns:**
         contains : bool
@@ -69,7 +69,7 @@ class Set(with_metaclass(ABCMeta, object)):
 
     **Parameters:**
         other :
-            The object to be tested for equality.
+            Object to be tested for equality.
 
     **Returns:**
         equals : bool
@@ -86,7 +86,7 @@ class Set(with_metaclass(ABCMeta, object)):
 
     **Parameters:**
         inp : optional
-            The object from which to create the new element
+            Object from which to create the new element
 
     **Returns:**
         element : member of this set
@@ -101,15 +101,28 @@ class Set(with_metaclass(ABCMeta, object)):
     def contains_set(self, other):
         """Test if ``other`` is a subset of this set.
 
-        Implementing this method is optional. Default it tests for equality.
+        This is a default implementation that simply tests for equality.
+        It should be overridden by subclasses.
+
+        Returns
+        -------
+        set_contained : bool
+            True if ``other`` is contained in this set, False otherwise
         """
         return self == other
 
     def contains_all(self, other):
-        """Test if all points in ``other`` are contained in this set.
+        """Test if all elements in ``other`` are contained in this set.
 
-        This is a default implementation and should be overridden by
-        subclasses.
+        This is a default implementation that assumes ``other`` to be
+        a sequence and tests each elment of ``other`` sequentially.
+        This method should be overridden by subclasses.
+
+        Returns
+        -------
+        all_contained : bool
+            True if all elements of ``other`` are contained in this
+            set, False otherwise
         """
         return all(x in self for x in other)
 
@@ -124,32 +137,42 @@ class Set(with_metaclass(ABCMeta, object)):
     def element(self, inp=None):
         """Return an element from ``inp`` or from scratch.
 
-        Implementing this method is optional.
+        This method should be overridden by subclasses.
         """
         raise NotImplementedError('`element` method not implemented')
 
     @property
     def examples(self):
-        """Return a `generator` with elements in the set as name-value pairs.
+        """Generator creating name-value pairs of set elements.
 
-        Can return a finite set of examples or an infinite set.
+        This method is mainly intended for diagnostics and yields elements,
+        either a finite number of times or indefinitely.
 
-        Optional to implement, intended to be used for diagnostics.
-        By default, the generator yields ``('element()', self.element())``.
+        This default implementation returns
+        ``('element()', self.element())`` and should be overridden by
+        subclasses.
         """
         yield ('element()', self.element())
+
+    def __repr__(self):
+        """Return ``repr(self)``."""
+        return '{}()'.format(self.__class__.__name__)
+
+    def __str__(self):
+        """Return ``str(self)``."""
+        return '{}'.format(self.__class__.__name__)
 
 
 class EmptySet(Set):
 
     """Set with no member elements (except `None`).
 
-    None is considered as "no element", i.e.
-    ``None in EmptySet()`` is True
+    None is considered as "no element", i.e. ``None in EmptySet()``
+    is the only test that evaluates to True.
     """
 
     def __contains__(self, other):
-        """Test if ``other`` is None."""
+        """Return ``other in self``."""
         return other is None
 
     def contains_set(self, other):
@@ -164,14 +187,6 @@ class EmptySet(Set):
         """Return None."""
         return None
 
-    def __str__(self):
-        """Return ``str(self)``."""
-        return "EmptySet"
-
-    def __repr__(self):
-        """Return ``repr(self)``."""
-        return "EmptySet()"
-
 
 class UniversalSet(Set):
 
@@ -181,7 +196,7 @@ class UniversalSet(Set):
     """
 
     def __contains__(self, other):
-        """Return True."""
+        """Return ``other in self``."""
         return True
 
     def contains_set(self, other):
@@ -196,14 +211,6 @@ class UniversalSet(Set):
         """Return ``inp`` in any case."""
         return inp
 
-    def __str__(self):
-        """Return ``str(self)``."""
-        return "UniversalSet"
-
-    def __repr__(self):
-        """Return ``repr(self)``."""
-        return "UniversalSet()"
-
 
 class Strings(Set):
 
@@ -214,33 +221,36 @@ class Strings(Set):
 
         Parameters
         ----------
-        length : int
-            The fixed length of the strings in this set. Must be
-            positive.
+        length : positive int
+            Fixed length of the strings in this set.
         """
-        length_ = int(length)
-        if length_ <= 0:
+        length, length_in = int(length), length
+        if length <= 0:
             raise ValueError('`length` must be positive, got {}'
-                             ''.format(length))
-        self.__length = length_
+                             ''.format(length_in))
+        self.__length = length
 
     @property
     def length(self):
-        """Length of the strings."""
+        """Fixed length of the strings in this set."""
         return self.__length
 
     def __contains__(self, other):
         """Return ``other in self``.
 
-        True if ``other`` is a string of at max `length`
-        characters, False otherwise."""
+        Returns
+        -------
+        contained : bool
+            ``True`` if ``other`` is a string of exactly `length`
+            characters, ``False`` otherwise.
+        """
         return isinstance(other, basestring) and len(other) == self.length
 
-    def contains_all(self, array):
-        """Test if `array` is an array of strings with correct length."""
-        dtype = getattr(array, 'dtype', None)
+    def contains_all(self, other):
+        """Return ``True`` if all strings in ``other`` have size `length`."""
+        dtype = getattr(other, 'dtype', None)
         if dtype is None:
-            dtype = np.result_type(*array)
+            dtype = np.result_type(*other)
         dtype_str = np.dtype('S{}'.format(self.length))
         dtype_uni = np.dtype('<U{}'.format(self.length))
         return dtype in (dtype_str, dtype_uni)
@@ -250,7 +260,7 @@ class Strings(Set):
         return isinstance(other, Strings) and other.length == self.length
 
     def element(self, inp=None):
-        """Return a string from ``inp`` or from scratch."""
+        """Return an element from ``inp`` or from scratch."""
         if inp is not None:
             s = str(inp)[:self.length]
             s += ' ' * (self.length - len(s))
@@ -260,12 +270,12 @@ class Strings(Set):
 
     @property
     def examples(self):
-        """Return example strings 'hello', 'world'."""
-        return [('hello', 'hello'), ('world', 'world')]
-
-    def __str__(self):
-        """Return ``str(self)``."""
-        return 'Strings({})'.format(self.length)
+        """Return example strings 'hello', 'world' (size adapted)."""
+        hello_str = 'hello'[:self.length]
+        hello_str += ' ' * (self.length - len(hello_str))
+        world_str = 'world'[:self.length]
+        world_str += ' ' * (self.length - len(world_str))
+        return [('hello', hello_str), ('world', world_str)]
 
     def __repr__(self):
         """Return ``repr(self)``."""
@@ -273,10 +283,15 @@ class Strings(Set):
 
 
 class Field(Set):
-    """Any set that satisfies the field axioms
 
-    For example `RealNumbers`, `ComplexNumbers` or
+    """A set that satisfies the field axioms.
+
+    Examples: `RealNumbers`, `ComplexNumbers` or
     the finite field :math:`F_2`.
+
+    See `the Wikipedia entry on fields
+    <https://en.wikipedia.org/wiki/Field_%28mathematics%29>`_ for
+    further information.
     """
 
     @property
@@ -285,8 +300,8 @@ class Field(Set):
 
         Notes
         -----
-        This is a hack for this to work with duck-typing
-        with `LinearSpace`'s.
+        This is a hack to make fields to work via duck-typing with
+        `LinearSpace`'s.
         """
         return self
 
@@ -296,22 +311,22 @@ class ComplexNumbers(Field):
     """Set of complex numbers."""
 
     def __contains__(self, other):
-        """Test if ``other`` is a complex number."""
+        """Return ``other in self``."""
         return isinstance(other, Complex)
 
     def contains_set(self, other):
-        """Test if ``other`` is a subset of the complex numbers
+        """Return True if ``other`` is a subset of the complex numbers.
 
         Returns
         -------
         contained : bool
-            True if  other is `ComplexNumbers`, `RealNumbers` or `Integers`,
-            else False.
+            ``True`` if  ``other`` is an instance of `ComplexNumbers`,
+            `RealNumbers` or `Integers`, ``False`` otherwise.
 
         Examples
         --------
-        >>> C = ComplexNumbers()
-        >>> C.contains_set(RealNumbers())
+        >>> complex_numbers = ComplexNumbers()
+        >>> complex_numbers.contains_set(RealNumbers())
         True
         """
         if other is self:
@@ -321,11 +336,11 @@ class ComplexNumbers(Field):
                 isinstance(other, RealNumbers) or
                 isinstance(other, Integers))
 
-    def contains_all(self, array):
-        """Test if `array` is an array of real or complex numbers."""
-        dtype = getattr(array, 'dtype', None)
+    def contains_all(self, other):
+        """Return True if ``other`` is a sequence complex numbers."""
+        dtype = getattr(other, 'dtype', None)
         if dtype is None:
-            dtype = np.result_type(*array)
+            dtype = np.result_type(*other)
         return is_scalar_dtype(dtype)
 
     def __eq__(self, other):
@@ -348,36 +363,28 @@ class ComplexNumbers(Field):
         numbers = [-1.0, 0.5, 0.0 + 2.0j, 0.0, 0.01, 1.0 + 1.0j, 1.0j, 1.0]
         return [(str(x), x) for x in numbers]
 
-    def __str__(self):
-        """Return ``str(self)``."""
-        return "ComplexNumbers"
-
-    def __repr__(self):
-        """Return ``repr(self)``."""
-        return "ComplexNumbers()"
-
 
 class RealNumbers(Field):
 
     """Set of real numbers."""
 
     def __contains__(self, other):
-        """Test if ``other`` is a real number."""
+        """Return ``other in self``."""
         return isinstance(other, Real)
 
     def contains_set(self, other):
-        """Test if ``other`` is a subset of the real numbers
+        """Return True if ``other`` is a subset of the real numbers.
 
         Returns
         -------
         contained : bool
-            True if other is `RealNumbers` or
-            `Integers` False else.
+            True if other is an instance of `RealNumbers` or
+            `Integers` False otherwise.
 
         Examples
         --------
-        >>> R = RealNumbers()
-        >>> R.contains_set(RealNumbers())
+        >>> real_numbers = RealNumbers()
+        >>> real_numbers.contains_set(RealNumbers())
         True
         """
         if other is self:
@@ -413,14 +420,6 @@ class RealNumbers(Field):
         numbers = [-1.0, 0.5, 0.0, 0.01, 1.0]
         return [(str(x), x) for x in numbers]
 
-    def __str__(self):
-        """Return ``str(self)``."""
-        return "RealNumbers"
-
-    def __repr__(self):
-        """Return ``repr(self)``."""
-        return "RealNumbers()"
-
 
 class Integers(Set):
 
@@ -434,21 +433,22 @@ class Integers(Set):
         return isinstance(other, Integers)
 
     def __contains__(self, other):
-        """Test if ``other`` is an integer."""
+        """Return ``other in self``."""
         return isinstance(other, Integral)
 
     def contains_set(self, other):
-        """Test if ``other`` is a subset of the real numbers
+        """Test if ``other`` is a subset of the integers.
 
         Returns
         -------
         contained : bool
-            True if  other is `Integers`, else False.
+            ``True`` if  other is an instance of `Integers`,
+            ``False`` otherwise.
 
         Examples
         --------
-        >>> Z = Integers()
-        >>> Z.contains_set(RealNumbers())
+        >>> integers = Integers()
+        >>> integers.contains_set(RealNumbers())
         False
         """
         if other is self:
@@ -456,11 +456,11 @@ class Integers(Set):
 
         return isinstance(other, Integers)
 
-    def contains_all(self, array):
-        """Test if `array` is an array of integers."""
-        dtype = getattr(array, 'dtype', None)
+    def contains_all(self, other):
+        """Test if ``other`` is a sequence of integers."""
+        dtype = getattr(other, 'dtype', None)
         if dtype is None:
-            dtype = np.result_type(*array)
+            dtype = np.result_type(*other)
         return is_int_dtype(dtype)
 
     def element(self, inp=None):
@@ -476,29 +476,20 @@ class Integers(Set):
         numbers = [-1, 0, 1]
         return [(str(x), x) for x in numbers]
 
-    def __str__(self):
-        """Return ``str(self)``."""
-        return "Integers"
-
-    def __repr__(self):
-        """Return ``repr(self)``."""
-        return "Integers()"
-
 
 class CartesianProduct(Set):
 
-    """Cartesian product of ``n`` sets.
+    """Cartesian product of a finite number of sets.
 
-    The elements of this set are ``n``-tuples where the i-th entry
+    The elements of this set are tuples where the i-th entry
     is an element of the i-th set.
     """
 
     def __init__(self, *sets):
         """Initialize a new instance."""
-        if not all(isinstance(set_, Set) for set_ in sets):
-            wrong = [set_ for set_ in sets
-                     if not isinstance(set_, Set)]
-            raise TypeError('{!r} not Set instance(s)'.format(wrong))
+        for set_ in sets:
+            if not isinstance(set_, Set):
+                raise TypeError('{!r} is not a Set instance.'.format(set_))
 
         self.__sets = tuple(sets)
 
@@ -508,17 +499,22 @@ class CartesianProduct(Set):
         return self.__sets
 
     def __contains__(self, other):
-        """Test if ``other`` is contained in this set.
+        """Return ``other in self``.
+
+        Parameters
+        ----------
+        other :
+            Object to be tested for membership
 
         Returns
         -------
         contains : bool
-            True if ``other`` has the same length as this Cartesian
-            product and each entry is contained in the set with
+            True if ``other`` is a sequence with same length as this
+            Cartesian product, and each entry is contained in the set with
             corresponding index, False otherwise.
         """
         try:
-            iter(other)
+            len(other)
         except TypeError:
             return False
         return (len(other) == len(self) and
@@ -543,7 +539,7 @@ class CartesianProduct(Set):
 
         Parameters
         ----------
-        inp : `iterable`, optional
+        inp : iterable, optional
             Collection of input values for the
             `LinearSpace.element` methods
             of all sets in the Cartesian product.
@@ -569,8 +565,8 @@ class CartesianProduct(Set):
         """Return ``len(self)``."""
         return len(self.sets)
 
-    def __getitem__(self, indcs):
-        """Return ``self[indcs]``.
+    def __getitem__(self, indices):
+        """Return ``self[indices]``.
 
         Examples
         --------
@@ -581,26 +577,19 @@ class CartesianProduct(Set):
         >>> prod[2:4]
         CartesianProduct(UniversalSet(), EmptySet())
         """
-        if isinstance(indcs, slice):
-            return CartesianProduct(*self.sets[indcs])
+        if isinstance(indices, slice):
+            return CartesianProduct(*self.sets[indices])
         else:
-            return self.sets[indcs]
+            return self.sets[indices]
 
     def __str__(self):
         """Return ``str(self)``."""
         return ' x '.join(str(set_) for set_ in self.sets)
 
     def __repr__(self):
-        """Return ``repr(self)``.
-
-        Examples
-        --------
-        >>> emp, univ = EmptySet(), UniversalSet()
-        >>> CartesianProduct(emp, univ)
-        CartesianProduct(EmptySet(), UniversalSet())
-        """
+        """Return ``repr(self)``."""
         sets_str = ', '.join(repr(set_) for set_ in self.sets)
-        return 'CartesianProduct({})'.format(sets_str)
+        return '{}({})'.format(self.__class__.__name__, sets_str)
 
 
 if __name__ == '__main__':

--- a/odl/set/space.py
+++ b/odl/set/space.py
@@ -159,8 +159,8 @@ class LinearSpace(Set):
         Returns
         -------
         contains : bool
-            True if ``other`` is a `LinearSpaceVector` instance and
-            ``other.space`` is equal to this space, False otherwise.
+            ``True`` if ``other`` is a `LinearSpaceVector` instance and
+            ``other.space`` is equal to this space, ``False`` otherwise.
 
         Notes
         -----
@@ -644,7 +644,7 @@ class LinearSpaceVector(object):
         Returns
         -------
         equals : bool
-            True if the vectors are equal, else False.
+            ``True`` if the vectors are equal ``False`` otherwise.
 
         See also
         --------
@@ -864,14 +864,14 @@ class UniversalSpace(LinearSpace):
     def __eq__(self, other):
         """Return ``self == other``.
 
-        Dummy check, True for any `LinearSpace`.
+        Dummy check, ``True`` for any `LinearSpace`.
         """
         return isinstance(other, LinearSpace)
 
     def __contains__(self, other):
         """Return ``other in self``.
 
-        Dummy membership check, True for any `LinearSpaceVector`.
+        Dummy membership check, ``True`` for any `LinearSpaceVector`.
         """
         return isinstance(other, LinearSpaceVector)
 

--- a/odl/set/space.py
+++ b/odl/set/space.py
@@ -377,12 +377,13 @@ class LinearSpace(Set):
 
     @property
     def element_type(self):
-        """Type of elements of this space."""
+        """Type of elements of this space (`LinearSpaceVector`)."""
         return LinearSpaceVector
 
 
 class LinearSpaceVector(object):
-    """Abstract `LinearSpace` element.
+
+    """Abstract class for `LinearSpace` elements.
 
     Do not use this class directly -- to create an element of a vector
     space, call the space's `LinearSpace.element` method instead.

--- a/odl/set/space.py
+++ b/odl/set/space.py
@@ -181,9 +181,9 @@ class LinearSpace(Set):
 
         Returns
         -------
-        contains : `bool`
-            `True` if ``other`` is a `LinearSpaceVector` instance and
-            ``other.space`` is equal to this space, `False` otherwise.
+        contains : bool
+            True if ``other`` is a `LinearSpaceVector` instance and
+            ``other.space`` is equal to this space, False otherwise.
 
         Notes
         -----
@@ -281,7 +281,7 @@ class LinearSpace(Set):
 
         Returns
         -------
-        dist : `float`
+        dist : float
                Distance between vectors
         """
         if x1 not in self:
@@ -303,7 +303,7 @@ class LinearSpace(Set):
 
         Returns
         -------
-        out : `float`
+        out : float
             Norm of the vector
         """
         if x not in self:
@@ -659,7 +659,7 @@ class LinearSpaceVector(object):
 
         Returns
         -------
-        equals : `bool`
+        equals : bool
             True if the vectors are equal, else false.
 
         Notes
@@ -870,14 +870,14 @@ class UniversalSpace(LinearSpace):
     def __eq__(self, other):
         """Return ``self == other``.
 
-        Dummy check, `True` for any `LinearSpace`.
+        Dummy check, True for any `LinearSpace`.
         """
         return isinstance(other, LinearSpace)
 
     def __contains__(self, other):
         """Return ``other in self``.
 
-        Dummy membership check, `True` for any `LinearSpaceVector`.
+        Dummy membership check, True for any `LinearSpaceVector`.
         """
         return isinstance(other, LinearSpaceVector)
 

--- a/odl/set/space.py
+++ b/odl/set/space.py
@@ -24,9 +24,9 @@ from future import standard_library
 standard_library.install_aliases()
 
 from abc import abstractmethod
-import math as m
+import numpy as np
 
-from odl.set.sets import Set, UniversalSet
+from odl.set.sets import Field, Set, UniversalSet
 
 
 __all__ = ('LinearSpace', 'LinearSpaceVector', 'UniversalSpace',
@@ -36,35 +36,28 @@ __all__ = ('LinearSpace', 'LinearSpaceVector', 'UniversalSpace',
 class LinearSpace(Set):
     """Abstract linear vector space.
 
-    Its elements are represented as instances of the inner
+    Its elements are represented as instances of the
     `LinearSpaceVector` class.
     """
 
     def __init__(self, field):
         """Initialize a new instance.
 
-        This method should be called by all inheriting methods so that the
-        field property of the space is set properly.
+        This method should be called by all inheriting methods so that
+        the `field` property of the space is properly set.
 
         Parameters
         ----------
         field : `Field`
-            Underlying scalar field of the space
+            Scalar field of numbers for this space.
         """
+        if not isinstance(field, Field):
+            raise TypeError('`field` {!r} is not a `Field` instance')
         self.__field = field
 
     @property
     def field(self):
-        """`Field` of this vector space.
-
-        The field is the set of scalars of the space, that is numbers that
-        the vectors in the space can be multiplied with.
-
-        Returns
-        -------
-        field : `Field`
-            Underlying field.
-        """
+        """Scalar field of numbers for this vector space."""
         return self.__field
 
     @abstractmethod
@@ -80,19 +73,19 @@ class LinearSpace(Set):
         Parameters
         ----------
         inp : optional
-            Input data from which to create the element
+            Input data from which to create the element.
         kwargs :
-            Optional further arguments
+            Optional further arguments.
 
         Returns
         -------
         element : `LinearSpaceVector`
-            A vector in this space
+            A vector in this space.
         """
 
     @property
     def examples(self):
-        """Return the two default examples, `zero` and `one` (if available)."""
+        """Example elements `zero` and `one` (if available)."""
         # All spaces should yield the zero element
         yield ('Zero', self.zero())
 
@@ -103,34 +96,34 @@ class LinearSpace(Set):
 
     @abstractmethod
     def _lincomb(self, a, x1, b, x2, out):
-        """Calculate ``out = a*x1 + b*x2``.
+        """Implement ``out[:] = a * x1 + b * x2``.
 
-        This method is intended to be private, public callers should
+        This method is intended to be private. Public callers should
         resort to `lincomb` which is type-checked.
         """
 
     def _dist(self, x1, x2):
-        """Calculate the distance between x1 and x2.
+        """Return the distance between ``x1`` and ``x2``.
 
-        This method is intended to be private, public callers should
+        This method is intended to be private. Public callers should
         resort to `dist` which is type-checked.
         """
         # default implementation
         return self.norm(x1 - x2)
 
     def _norm(self, x):
-        """Calculate the norm of x.
+        """Return the norm of ``x``.
 
-        This method is intended to be private, public callers should
+        This method is intended to be private. Public callers should
         resort to `norm` which is type-checked.
         """
         # default implementation
-        return m.sqrt(self.inner(x, x).real)
+        return float(np.sqrt(self.inner(x, x).real))
 
     def _inner(self, x1, x2):
-        """Calculate the inner product of x1 and x2.
+        """Return the inner product of ``x1`` and ``x2``.
 
-        This method is intended to be private, public callers should
+        This method is intended to be private. Public callers should
         resort to `inner` which is type-checked.
         """
         # No default implementation possible
@@ -138,9 +131,9 @@ class LinearSpace(Set):
             'inner product not implemented in space {!r}'.format(self))
 
     def _multiply(self, x1, x2, out):
-        """Calculate the pointwise multiplication out = x1 * x2.
+        """Implement the pointwise multiplication ``out[:] = x1 * x2``.
 
-        This method is intended to be private, public callers should
+        This method is intended to be private. Public callers should
         resort to `multiply` which is type-checked.
         """
         # No default implementation possible
@@ -148,32 +141,16 @@ class LinearSpace(Set):
             'multiplication not implemented in space {!r}'.format(self))
 
     def one(self):
-        """A one vector in this space.
-
-        The one vector is defined as the multiplicative unit of a space.
-
-        Returns
-        -------
-        v : `LinearSpaceVector`
-            The one vector of this space
-        """
+        """Return the one (multiplicative unit) element of this space."""
         raise LinearSpaceNotImplementedError(
             '`one` element not implemented in space {!r}'.format(self))
 
     # Default methods
     def zero(self):
-        """A zero vector in this space.
-
-        The zero vector is defined as the additive unit of a space.
-
-        Returns
-        -------
-        v : `LinearSpaceVector`
-            The zero vector of this space
-        """
+        """Return the zero (additive unit) element of this space."""
         # Default implementation using lincomb
         tmp = self.element()
-        self._lincomb(tmp, 0, tmp, 0, tmp)
+        self.lincomb(tmp, 0, tmp, 0, tmp)
         return tmp
 
     def __contains__(self, other):
@@ -194,30 +171,31 @@ class LinearSpace(Set):
 
     # Error checking variant of methods
     def lincomb(self, a, x1, b=None, x2=None, out=None):
-        """Linear combination of vectors.
+        """Implement ``out[:] = a * x1 + b * x2``.
 
-        Calculates
+        This function implements
 
-        ``out = a * x1``
+            ``out[:] = a * x1``
 
-        or, if b and y are given,
+        or, if ``b`` and ``y`` are given,
 
-        ``out = a*x1 + b*x2``
+            ``out = a * x1 + b * x2``
 
         with error checking of types.
 
         Parameters
         ----------
-        a : Scalar in the field of this space
+        a : `field` element
             Scalar to multiply ``x1`` with.
         x1 : `LinearSpaceVector`
-            First of the summands.
-        b : Scalar, optional
-            Scalar to multiply ``x2`` with.
+            First vector in the linear combination.
+        b : `field` element, optional
+            Scalar to multiply ``x2`` with. Required if ``x2`` is
+            provided.
         x2 : `LinearSpaceVector`, optional
-            Second of the summands.
+            Second vector in the linear combination.
         out : `LinearSpaceVector`, optional
-            The Vector that the result should be written to.
+            Element to which the result is written.
 
         Returns
         -------
@@ -229,198 +207,192 @@ class LinearSpace(Set):
         -----
         The vectors ``out``, ``x1`` and ``x2`` may be aligned, thus a call
 
-        ``space.lincomb(x, 2, x, 3.14, out=x)``
+            ``space.lincomb(x, 2, x, 3.14, out=x)``
 
         is (mathematically) equivalent to
 
-        ``x = x * (1 + 2 + 3.14)``
+            ``x = x * (1 + 2 + 3.14)``.
         """
         if out is None:
             out = self.element()
-        elif out not in self:
-            raise LinearSpaceTypeError('`out` {!r} not in space {!r}'
+
+        if out not in self:
+            raise LinearSpaceTypeError('`out` {!r} is not an element of {!r}'
                                        ''.format(out, self))
-
         if a not in self.field:
-            raise LinearSpaceTypeError('`a` {!r} not in the field '
-                                       '{!r} of the space {!r}'
+            raise LinearSpaceTypeError('`a` {!r} not an element of the field '
+                                       '{!r} of {!r}'
                                        ''.format(a, self.field, self))
-
         if x1 not in self:
-            raise LinearSpaceTypeError('`x1` {!r} not in space {!r}'
+            raise LinearSpaceTypeError('`x1` {!r} is not an element of {!r}'
                                        ''.format(x1, self))
 
-        if b is None:  # Single argument
+        if b is None:  # Single vector
             if x2 is not None:
-                raise ValueError('`x2` provided but no `b`')
+                raise ValueError('`x2` provided but not `b`')
             self._lincomb(a, x1, 0, x1, out)
             return out
 
-        else:  # Two arguments
+        else:  # Two vectors
             if b not in self.field:
-                raise LinearSpaceTypeError('`b` {!r} not in the '
-                                           'field {!r} of the space {!r}'
+                raise LinearSpaceTypeError('`b` {!r} not an element of the '
+                                           'field {!r} of {!r}'
                                            ''.format(b, self.field, self))
-
             if x2 not in self:
-                raise LinearSpaceTypeError('`x2` {!r} not in space {!r}'
-                                           ''.format(x2, self))
+                raise LinearSpaceTypeError('`x2` {!r} is not an element of '
+                                           '{!r}'.format(x2, self))
 
-            # Call method
             self._lincomb(a, x1, b, x2, out)
 
         return out
 
     def dist(self, x1, x2):
-        """Calculate the distance between two vectors.
+        """Return the distance between ``x1`` and ``x2``.
 
         Parameters
         ----------
         x1, x2 : `LinearSpaceVector`
-            Vectors whose distance to compute
+            Elements whose distance to compute.
 
         Returns
         -------
         dist : float
-               Distance between vectors
+            Distance between ``x1`` and ``x2``.
         """
         if x1 not in self:
-            raise LinearSpaceTypeError('`x1` {!r} not in space {!r}'
-                                       ''.format(x1, self))
+            raise LinearSpaceTypeError('`x1` {!r} is not an element of '
+                                       '{!r}'.format(x1, self))
         if x2 not in self:
-            raise LinearSpaceTypeError('`x2` {!r} not in space {!r}'
-                                       ''.format(x2, self))
+            raise LinearSpaceTypeError('`x2` {!r} is not an element of '
+                                       '{!r}'.format(x2, self))
 
         return float(self._dist(x1, x2))
 
     def norm(self, x):
-        """Calculate the norm of a vector.
+        """Return the norm of ``x``.
 
         Parameters
         ----------
         x : `LinearSpaceVector`
-            The vector
+            Element whose norm to compute.
 
         Returns
         -------
-        out : float
-            Norm of the vector
+        norm : float
+            Norm of ``x``.
         """
         if x not in self:
-            raise LinearSpaceTypeError('`x` {!r} not in space {!r}'
-                                       ''.format(x, self))
+            raise LinearSpaceTypeError('`x` {!r} is not an element of '
+                                       '{!r}'.format(x, self))
 
         return float(self._norm(x))
 
     def inner(self, x1, x2):
-        """Calculate the inner product of ``x1`` and ``x2``.
+        """Return the inner product of ``x1`` and ``x2``.
 
         Parameters
         ----------
         x1, x2 : `LinearSpaceVector`
-            Factors in the inner product
+            Elements whose inner product to compute.
 
         Returns
         -------
-        out : `LinearSpace.field` element
-            Product of the vectors. If ``out`` was provided, the
-            returned object is a reference to it.
+        inner : `LinearSpace.field` element
+            Inner product of ``x1`` and ``x2``.
         """
         if x1 not in self:
-            raise LinearSpaceTypeError('`x1` {!r} not in space {!r}'
-                                       ''.format(x1, self))
+            raise LinearSpaceTypeError('`x1` {!r} is not an element of '
+                                       '{!r}'.format(x1, self))
         if x2 not in self:
-            raise LinearSpaceTypeError('`x2` {!r} not in space {!r}'
-                                       ''.format(x2, self))
+            raise LinearSpaceTypeError('`x2` {!r} is not an element of '
+                                       '{!r}'.format(x2, self))
 
         return self.field.element(self._inner(x1, x2))
 
     def multiply(self, x1, x2, out=None):
-        """Calculate the pointwise product of ``x1`` and ``x2``.
+        """Return the pointwise product of ``x1`` and ``x2``.
 
         Parameters
         ----------
         x1, x2 : `LinearSpaceVector`
-            Multiplicands in the product
-
+            Multiplicands in the product.
         out : `LinearSpaceVector`, optional
-            Vector to write the product to
+            Element to which the result is written.
 
         Returns
         -------
         out : `LinearSpaceVector`
-            Product of the vectors. If ``out`` was provided, the
+            Product of the elements. If ``out`` was provided, the
             returned object is a reference to it.
         """
         if out is None:
             out = self.element()
-        elif out not in self:
-            raise LinearSpaceTypeError('`out` {!r} not in space {!r}'
-                                       ''.format(out, self))
 
+        if out not in self:
+            raise LinearSpaceTypeError('`out` {!r} is not an element of '
+                                       '{!r}'.format(out, self))
         if x1 not in self:
-            raise LinearSpaceTypeError('`x1` {!r} not in space {!r}'
-                                       ''.format(x1, self))
+            raise LinearSpaceTypeError('`x1` {!r} is not an element of '
+                                       '{!r}'.format(x1, self))
         if x2 not in self:
-            raise LinearSpaceTypeError('`x2` {!r} not in space {!r}'
-                                       ''.format(x2, self))
+            raise LinearSpaceTypeError('`x2` {!r} is not an element of '
+                                       '{!r}'.format(x2, self))
 
         self._multiply(x1, x2, out)
         return out
 
     def divide(self, x1, x2, out=None):
-        """Calculate the pointwise division of ``x1`` and ``x2``
+        """Return the pointwise quotient of ``x1`` and ``x2``
 
         Parameters
         ----------
         x1 : `LinearSpaceVector`
-            The dividend
-
+            Dividend in the quotient.
         x2 : `LinearSpaceVector`
-            The divisor
-
+            Divisor in the quotient.
         out : `LinearSpaceVector`, optional
-            Vector to write the ratio to
+            Element to which the result is written.
 
         Returns
         -------
         out : `LinearSpaceVector`
-            Ratio of the vectors. If ``out`` was provided, the
+            Quotient of the elements. If ``out`` was provided, the
             returned object is a reference to it.
         """
         if out is None:
             out = self.element()
-        elif out not in self:
-            raise LinearSpaceTypeError('`out` {!r} not in space {!r}'
-                                       ''.format(out, self))
 
+        if out not in self:
+            raise LinearSpaceTypeError('`out` {!r} is not an element of '
+                                       '{!r}'.format(out, self))
         if x1 not in self:
-            raise LinearSpaceTypeError('`x1` {!r} not in space {!r}'
-                                       ''.format(x1, self))
+            raise LinearSpaceTypeError('`x1` {!r} is not an element of '
+                                       '{!r}'.format(x1, self))
         if x2 not in self:
-            raise LinearSpaceTypeError('`x2` {!r} not in space {!r}'
-                                       ''.format(x2, self))
+            raise LinearSpaceTypeError('`x2` {!r} is not an element of '
+                                       '{!r}'.format(x2, self))
 
         self._divide(x1, x2, out)
         return out
 
     @property
     def element_type(self):
-        """`LinearSpaceVector`"""
+        """Type of elements of this space."""
         return LinearSpaceVector
 
 
 class LinearSpaceVector(object):
     """Abstract `LinearSpace` element.
 
-    Not intended for creation of vectors, use the space's
-    `LinearSpace.element` method instead.
+    Do not use this class directly -- to create an element of a vector
+    space, call the space's `LinearSpace.element` method instead.
     """
 
     def __init__(self, space):
-        """Default initializer of vectors.
+        """Initialize a new instance.
 
-        All deriving classes must call this method to set space.
+        All deriving classes must call this method to set the `space`
+        property.
         """
         if not isinstance(space, LinearSpace):
             raise TypeError('`space` {!r} is not a `LinearSpace` instance'
@@ -429,15 +401,12 @@ class LinearSpaceVector(object):
 
     @property
     def space(self):
-        """Space to which this vector belongs.
-
-        `LinearSpace`
-        """
+        """Space to which this vector belongs."""
         return self.__space
 
     # Convenience functions
     def assign(self, other):
-        """Assign the values of ``other`` to self."""
+        """Assign the values of ``other`` to ``self``."""
         return self.space.lincomb(1, other, out=self)
 
     def copy(self):
@@ -447,18 +416,32 @@ class LinearSpaceVector(object):
         return result
 
     def lincomb(self, a, x1, b=None, x2=None):
-        """Assign a linear combination to this vector.
+        """Implement ``self[:] = a * x1 + b * x2``.
 
-        Implemented as ``space.lincomb(a, x1, b, x2, out=self)``.
+        Parameters
+        ----------
+        a : element of ``space.field``
+            Scalar to multiply ``x1`` with.
+        x1 : `LinearSpaceVector`
+            First vector in the linear combination.
+        b : element of ``space.field``, optional
+            Scalar to multiply ``x2`` with. Required if ``x2`` is
+            provided.
+        x2 : `LinearSpaceVector`, optional
+            Second vector in the linear combination.
 
-        `LinearSpace.lincomb`
+        See also
+        --------
+        LinearSpace.lincomb
         """
         return self.space.lincomb(a, x1, b, x2, out=self)
 
     def set_zero(self):
         """Set this vector to zero.
 
-        `LinearSpace.zero`
+        See also
+        --------
+        LinearSpace.zero
         """
         return self.space.lincomb(0, self, 0, self, out=self)
 
@@ -565,7 +548,7 @@ class LinearSpaceVector(object):
         return self.__mul__(other)
 
     def __itruediv__(self, other):
-        """Implement ``self /= other`` (true division)."""
+        """Implement ``self /= other``."""
         if other in self.space.field:
             return self.space.lincomb(1.0 / other, self, out=self)
         elif other in self.space:
@@ -639,34 +622,37 @@ class LinearSpaceVector(object):
         return tmp
 
     def __neg__(self):
-        """Implement ``-self``."""
+        """Return ``-self``."""
         return (-1) * self
 
     def __pos__(self):
-        """Implement ``+self``."""
+        """Return ``+self``."""
         return self.copy()
 
     # Metric space method
     def __eq__(self, other):
         """Return ``self == other``.
 
-        Two vectors are equal if their distance is 0
+        Two elements are equal if their distance is zero.
 
         Parameters
         ----------
         other : `LinearSpaceVector`
-            Vector in this space.
+            Element of this space.
 
         Returns
         -------
         equals : bool
-            True if the vectors are equal, else false.
+            True if the vectors are equal, else False.
+
+        See also
+        --------
+        LinearSpace.dist
 
         Notes
         -----
         Equality is very sensitive to numerical errors, thus any
-        operations on a vector should be expected to break equality
-        testing.
+        arithmetic operations should be expected to break equality.
 
         Examples
         --------
@@ -680,7 +666,7 @@ class LinearSpaceVector(object):
         >>> x == y
         True
         >>> z = rn.element([0.3])
-        >>> x+x+x == z
+        >>> x + x + x == z
         False
         """
         if (not isinstance(other, LinearSpaceVector) or
@@ -689,7 +675,7 @@ class LinearSpaceVector(object):
             # reflexive.
             return False
         elif other is self:
-            # Optimization for the most common case
+            # Optimization for a common case
             return True
         else:
             return self.space.dist(self, other) == 0
@@ -701,14 +687,16 @@ class LinearSpaceVector(object):
     def __str__(self):
         """Return ``str(self)``.
 
-        This is a default implementation, only returning the space.
+        This is a default implementation that does not print any
+        information about the contents of the element.
         """
         return str(self.space) + "Vector"
 
     def __repr__(self):
         """Return ``repr(self)``.
 
-        This is a default implementation, only returning the space.
+        This is a default implementation that does not print any
+        information about the contents of the element.
         """
         return repr(self.space) + "Vector"
 
@@ -722,7 +710,7 @@ class LinearSpaceVector(object):
         return self.copy()
 
     def __deepcopy__(self, memo):
-        """Return a copy of this vector.
+        """Return a deep copy of this vector.
 
         See also
         --------
@@ -731,7 +719,7 @@ class LinearSpaceVector(object):
         return self.copy()
 
     def norm(self):
-        """Norm of this vector.
+        """Return the norm of this vector.
 
         See also
         --------
@@ -740,7 +728,7 @@ class LinearSpaceVector(object):
         return self.space.norm(self)
 
     def dist(self, other):
-        """Distance to ``other``.
+        """Return the distance of ``self`` to ``other``.
 
         See also
         --------
@@ -749,7 +737,7 @@ class LinearSpaceVector(object):
         return self.space.dist(self, other)
 
     def inner(self, other):
-        """Inner product with ``other``.
+        """Return the inner product of ``self`` and ``other``.
 
         See also
         --------
@@ -758,7 +746,9 @@ class LinearSpaceVector(object):
         return self.space.inner(self, other)
 
     def multiply(self, other, out=None):
-        """Implement ``out = self * other`` without creating new vectors.
+        """Return ``out = self * other``.
+
+        If ``out`` is provided, the result is written to it.
 
         See also
         --------
@@ -767,7 +757,9 @@ class LinearSpaceVector(object):
         return self.space.multiply(self, other, out=out)
 
     def divide(self, other, out=None):
-        """Implement ``out = self / other`` without creating new vectors.
+        """Return ``out = self / other``.
+
+        If ``out`` is provided, the result is written to it.
 
         See also
         --------
@@ -777,7 +769,7 @@ class LinearSpaceVector(object):
 
     @property
     def T(self):
-        """This vector's transpose, i.e. the functional ``(. , self)``.
+        """This vector's transpose, i.e. the functional ``<. , self>``.
 
         Returns
         -------
@@ -787,8 +779,8 @@ class LinearSpaceVector(object):
         -----
         This function is only defined in inner product spaces.
 
-        In a complex space, this takes the conjugate transpose of
-        the vector.
+        In a complex space, the conjugate transpose of is taken instead
+        of the transpose only.
 
         Examples
         --------
@@ -810,6 +802,7 @@ class LinearSpaceVector(object):
 
 
 class UniversalSpace(LinearSpace):
+
     """A dummy linear space class.
 
     Mostly raising `LinearSpaceNotImplementedError`.
@@ -885,16 +878,16 @@ class UniversalSpace(LinearSpace):
 class LinearSpaceTypeError(TypeError):
     """Exception for type errors in `LinearSpace`'s.
 
-    These are raised when the wrong type of element is fed to
+    This exception is raised when the wrong type of element is fed to
     `LinearSpace.lincomb` and related functions.
     """
 
 
 class LinearSpaceNotImplementedError(NotImplementedError):
-    """Exception for not implemented errors in `LinearSpace`'s.
+    """Exception for unimplemented functionality in `LinearSpace`'s.
 
-    These are raised when a method is called in `LinearSpace` that
-    has not been defined in a specific space.
+    This exception is raised when a method is called in `LinearSpace`
+    that has not been defined in a specific space.
     """
 
 

--- a/odl/solvers/advanced/chambolle_pock.py
+++ b/odl/solvers/advanced/chambolle_pock.py
@@ -61,7 +61,7 @@ def chambolle_pock_solver(op, x, tau, sigma, proximal_primal, proximal_dual,
     ----------
     op : `Operator`
         Forward operator, the operator ``K`` in the problem formulation.
-    x : element in the domain of ``op``
+    x : ``op.domain`` element
         Starting point of the iteration, updated in-place.
     tau : positive float
         Step size parameter for the update of the primal variable.

--- a/odl/solvers/advanced/chambolle_pock.py
+++ b/odl/solvers/advanced/chambolle_pock.py
@@ -71,16 +71,16 @@ def chambolle_pock_solver(op, x, tau, sigma, proximal_primal, proximal_dual,
         Step size parameter for the update of the dual variable. Controls
         the extent to which ``proximal_dual`` maps points towards the
         minimum of ``F^*``.
-    proximal_primal : callable
+    proximal_primal : `callable`
         `proximal factory` for the functional ``G``.
-    proximal_dual : callable
+    proximal_dual : `callable`
         `proximal factory` for the functional ``F^*``.
     niter : non-negative int, optional
         Number of iterations.
 
     Other Parameters
     ----------------
-    callback : callable, optional
+    callback : `callable`, optional
         Function called with the current iterate after each iteration.
     theta : float, optional
         Relaxation parameter, required to fulfill ``0 <= theta <= 1``.
@@ -198,7 +198,7 @@ def chambolle_pock_solver(op, x, tau, sigma, proximal_primal, proximal_dual,
     # Callback object
     callback = kwargs.pop('callback', None)
     if callback is not None and not callable(callback):
-        raise TypeError('`callback` {} is not `callable`'
+        raise TypeError('`callback` {} is not callable'
                         ''.format(callback))
 
     # Initialize the relaxation variable

--- a/odl/solvers/advanced/chambolle_pock.py
+++ b/odl/solvers/advanced/chambolle_pock.py
@@ -63,38 +63,42 @@ def chambolle_pock_solver(op, x, tau, sigma, proximal_primal, proximal_dual,
         Forward operator, the operator ``K`` in the problem formulation.
     x : element in the domain of ``op``
         Starting point of the iteration, updated in-place.
-    tau : positive `float`
+    tau : positive float
         Step size parameter for the update of the primal variable.
         Controls the extent to which ``proximal_primal`` maps points
         towards the minimum of G.
-    sigma : positive `float`
+    sigma : positive float
         Step size parameter for the update of the dual variable. Controls
         the extent to which ``proximal_dual`` maps points towards the
         minimum of ``F^*``.
-    proximal_primal : `callable`
+    proximal_primal : callable
         `proximal factory` for the functional ``G``.
-    proximal_dual : `callable`
+    proximal_dual : callable
         `proximal factory` for the functional ``F^*``.
-    niter : non-negative `int`, optional
+    niter : non-negative int, optional
         Number of iterations.
 
     Other Parameters
     ----------------
-    callback : `callable`, optional
+    callback : callable, optional
         Function called with the current iterate after each iteration.
-    theta : `float` in [0, 1], optional
-        Relaxation parameter. Default: 1
-    gamma : non-negative `float`, optional
-        Acceleration parameter. If not `None`, overwrites ``theta`` and uses
-        variable relaxation parameter and step sizes with ``tau`` and
-        ``sigma`` as initial values. Requires G or F^* to be uniformly
-        convex. Default: `None`
-    x_relax : element in the domain of ``op``, optional
-        Required to resume iteration. If `None` it is a copy of the primal
-        variable x. Default: `None`
-    y : element in the range of ``op``, optional
-        Required to resume iteration. If `None` it is set to a zero element
-        in Y which is the range of ``op``. Default: `None`
+    theta : float, optional
+        Relaxation parameter, required to fulfill ``0 <= theta <= 1``.
+        Default: 1
+    gamma : non-negative float, optional
+        Acceleration parameter. If not ``None``, it overrides ``theta`` and
+        causes variable relaxation parameter and step sizes to be used,
+        with ``tau`` and ``sigma`` as initial values. Requires ``G`` or
+        ``F^*`` to be uniformly convex.
+        Default: ``None``
+    x_relax : ``op.domain`` element, optional
+        Required to resume iteration. For ``None``, a copy of the primal
+        variable ``x`` is used.
+        Default: ``None``
+    y : ``op.range`` element, optional
+        Required to resume iteration. For ``None``, ``op.range.zero()``
+        is used.
+        Default: ``None``
 
     Notes
     -----

--- a/odl/solvers/advanced/douglas_rachford.py
+++ b/odl/solvers/advanced/douglas_rachford.py
@@ -58,11 +58,11 @@ def douglas_rachford_pd(x, prox_f, prox_cc_g, L, tau, sigma, niter,
         functions ``g_i``.
     L : `sequence` of `Operator`'s
         Sequence of `Opeartor`s` with as many elements as ``prox_cc_gs``.
-    tau : `float`
+    tau : float
         Step size parameter for ``prox_f``.
-    sigma : `sequence` of  `float`
+    sigma : `sequence` of floats
         Step size parameters for the ``prox_cc_g``s.
-    niter : `int`
+    niter : int
         Number of iterations.
     callback : `callable`, optional
         Function called with the current iterate after each iteration.
@@ -73,7 +73,7 @@ def douglas_rachford_pd(x, prox_f, prox_cc_g, L, tau, sigma, niter,
         Sequence of `proximal factory` for the convex conjuates of the
         functions ``l_i``.
         If omitted, the simpler problem without ``l_i``  will be considered.
-    lam : `float` or `callable`, optional
+    lam : float or `callable`, optional
         Overrelaxation step size. If callable, should take an index (zero
         indexed) and return the corresponding step size.
 
@@ -148,7 +148,7 @@ def douglas_rachford_pd(x, prox_f, prox_cc_g, L, tau, sigma, niter,
 
     lam_in = kwargs.pop('lam', 1.0)
     if not callable(lam_in) and not (0 < lam_in < 2):
-        raise ValueError('`lam` must `callable` or `float` between 0 and 2')
+        raise ValueError('`lam` must callable or a number between 0 and 2')
     lam = lam_in if callable(lam_in) else lambda _: lam_in
 
     # Check for unused parameters

--- a/odl/solvers/advanced/forward_backward.py
+++ b/odl/solvers/advanced/forward_backward.py
@@ -68,18 +68,18 @@ def forward_backward_pd(x, prox_f, prox_cc_g, L, grad_h, tau, sigma, niter,
         ``prox_cc_gs``.
     grad_h : `Operator`
         Operator representing the gradient of  ``h``.
-    tau : `float`
+    tau : float
         Step size-like parameter for ``prox_f``.
-    sigma : `sequence` of  `float`
+    sigma : `sequence` of floats
         Sequence of step size-like parameters for the sequence ``prox_cc_g``.
-    niter : `int`
+    niter : int
         Number of iterations.
     callback : `callable`, optional
         Function called with the current iterate after each iteration.
 
     Other Parameters
     ----------------
-    grad_cc_l : `sequence` of `Operator`, optional
+    grad_cc_l : `sequence` of `Operator`'s, optional
         Sequence of operators representing the gradients of  ``l_i^*``.
         If omitted, the simpler problem without ``l_i``  will be considered.
 

--- a/odl/solvers/advanced/proximal_operators.py
+++ b/odl/solvers/advanced/proximal_operators.py
@@ -332,7 +332,7 @@ def proximal_composition(proximal, operator, mu):
         proximal operator of ``F``
     operator : `Operator`
         The operator to compose the functional with
-    mu : `Operator.field` element
+    mu : ``operator.field`` element
         Scalar such that ``(operator.adjoint * operator)(x) = mu * x``
 
     Returns

--- a/odl/solvers/advanced/proximal_operators.py
+++ b/odl/solvers/advanced/proximal_operators.py
@@ -60,12 +60,12 @@ def combine_proximals(*factory_list):
 
     Parameters
     ----------
-    factory_list : list of `callable`
+    factory_list : list of callable
         A list containing proximal operator factories
 
     Returns
     -------
-    diag_op : `callable`
+    diag_op : callable
         Returns a diagonal product space operator factory to be initialized
         with the same step size parameter
     """
@@ -75,7 +75,7 @@ def combine_proximals(*factory_list):
 
         Parameters
         ----------
-        step_size : positive `float`
+        step_size : positive float
             Step size parameter
 
         Returns
@@ -106,13 +106,13 @@ def proximal_cconj(prox_factory):
 
     Parameters
     ----------
-    prox_factory : `callable`
+    prox_factory : callable
         A factory function that, when called with a step size, returns the
         proximal operator of ``F``
 
     Returns
     -------
-    prox : `callable`
+    prox : callable
         Factory for the proximal operator to be initialized
 
     Notes
@@ -125,7 +125,7 @@ def proximal_cconj(prox_factory):
 
         Parameters
         ----------
-        step_size : positive `float`
+        step_size : positive float
             Step size parameter
 
         Returns
@@ -327,7 +327,7 @@ def proximal_composition(proximal, operator, mu):
 
     Parameters
     ----------
-    prox_factory : `callable`
+    prox_factory : callable
         A factory function that, when called with a step size returns the
         proximal operator of ``F``
     operator : `Operator`
@@ -337,7 +337,7 @@ def proximal_composition(proximal, operator, mu):
 
     Returns
     -------
-    prox_factory : `callable`
+    prox_factory : callable
         Factory for the proximal operator to be initialized
 
     Notes
@@ -351,7 +351,7 @@ def proximal_composition(proximal, operator, mu):
 
         Parameters
         ----------
-        step_size : positive `float`
+        step_size : positive float
             Step size parameter
 
         Returns
@@ -385,7 +385,7 @@ def proximal_zero(space):
 
     Returns
     -------
-    prox_factory : `callable`
+    prox_factory : callable
         Factory for the proximal operator to be initialized
     """
 
@@ -394,7 +394,7 @@ def proximal_zero(space):
 
         Parameters
         ----------
-        tau : positive `float`
+        tau : positive float
             Unused step size parameter. Introduced to provide a unified
             interface.
 
@@ -435,13 +435,13 @@ def proximal_box_constraint(space, lower=None, upper=None):
     space : `LinearSpace`
         Domain of the functional G(x)
     lower : ``space.field`` element or ``space`` element-like, optional
-        The lower bound. Default: `None`, interpreted as -infinity
+        The lower bound. Default: None, interpreted as -infinity
     upper : ``space.field`` element or ``space`` element-like, optional
-        The upper bound. Default: `None`, interpreted as +infinity
+        The upper bound. Default: None, interpreted as +infinity
 
     Returns
     -------
-    prox_factory : `callable`
+    prox_factory : callable
         Factory for the proximal operator to be initialized
 
     See Also
@@ -469,7 +469,7 @@ def proximal_box_constraint(space, lower=None, upper=None):
 
             Parameters
             ----------
-            tau : positive `float`
+            tau : positive float
                 Step size parameter, not used.
             """
             super().__init__(domain=space, range=space, linear=False)
@@ -519,7 +519,7 @@ def proximal_nonnegativity(space):
 
     Returns
     -------
-    prox_factory : `callable`
+    prox_factory : callable
         Factory for the proximal operator to be initialized
 
     See Also
@@ -556,12 +556,12 @@ def proximal_cconj_l2(space, lam=1, g=None):
         That is, have an inner product (`LinearSpace.inner`).
     g : ``space`` element
         An element in ``space``
-    lam : positive `float`
+    lam : positive float
         Scaling factor or regularization parameter
 
     Returns
     -------
-    prox_factory : `callable`
+    prox_factory : callable
         Factory for the proximal operator to be initialized
 
     Notes
@@ -601,12 +601,12 @@ def proximal_l2(space, lam=1, g=None):
         That is, have an inner product (`LinearSpace.inner`).
     g : ``space`` element
         An element in ``space``
-    lam : positive `float`
+    lam : positive float
         Scaling factor or regularization parameter
 
     Returns
     -------
-    prox_factory : `callable`
+    prox_factory : callable
         Factory for the proximal operator to be initialized
 
     Notes
@@ -634,7 +634,7 @@ def proximal_l2(space, lam=1, g=None):
 
             Parameters
             ----------
-            sigma : positive `float`
+            sigma : positive float
                 Step size parameter
             """
             self.sigma = float(sigma)
@@ -696,12 +696,12 @@ def proximal_cconj_l2_squared(space, lam=1, g=None):
         That is, have an inner product (`LinearSpace.inner`).
     g : ``space`` element
         An element in ``space``
-    lam : positive `float`
+    lam : positive float
         Scaling factor or regularization parameter
 
     Returns
     -------
-    prox_factory : `callable`
+    prox_factory : callable
         Factory for the proximal operator to be initialized
 
     See Also
@@ -723,7 +723,7 @@ def proximal_cconj_l2_squared(space, lam=1, g=None):
 
             Parameters
             ----------
-            sigma : positive `float`
+            sigma : positive float
                 Step size parameter
             """
             self.sigma = float(sigma)
@@ -766,12 +766,12 @@ def proximal_l2_squared(space, lam=1, g=None):
         That is, have an inner product (`LinearSpace.inner`).
     g : ``space`` element
         An element in ``space``
-    lam : positive `float`
+    lam : positive float
         Scaling factor or regularization parameter
 
     Returns
     -------
-    prox_factory : `callable`
+    prox_factory : callable
         Factory for the proximal operator to be initialized
 
     See Also
@@ -832,15 +832,15 @@ def proximal_cconj_l1(space, lam=1, g=None, isotropic=False):
         Domain of the functional F
     g : ``space`` element
         An element in ``space``
-    lam : positive `float`
+    lam : positive float
         Scaling factor or regularization parameter
-    isotropic : `bool`
+    isotropic : bool
         True if the norm should first be taken pointwise. Only available if
         ``space`` is a `ProductSpace`.
 
     Returns
     -------
-    prox_factory : `callable`
+    prox_factory : callable
         Factory for the proximal operator to be initialized
 
     See Also
@@ -869,7 +869,7 @@ def proximal_cconj_l1(space, lam=1, g=None, isotropic=False):
 
             Parameters
             ----------
-            sigma : positive `float`
+            sigma : positive float
                 Step size parameter
             """
             # sigma is not used
@@ -951,15 +951,15 @@ def proximal_l1(space, lam=1, g=None, isotropic=False):
         Domain of the functional F
     g : ``space`` element
         An element in ``space``
-    lam : positive `float`
+    lam : positive float
         Scaling factor or regularization parameter
-    isotropic : `bool`
+    isotropic : bool
         True if the norm should first be taken pointwise. Only available if
         ``space`` is a `ProductSpace`.
 
     Returns
     -------
-    prox_factory : `callable`
+    prox_factory : callable
         Factory for the proximal operator to be initialized
 
     See Also
@@ -1005,14 +1005,14 @@ def proximal_cconj_kl(space, lam=1, g=None):
     space : `DiscreteLp` or `ProductSpace` of `DiscreteLp` spaces
         Space X which is the domain of the functional F
     g : ``space`` element
-        Data term
-    lam : positive `float`
-        Scaling factor
+        Data term.
+    lam : positive float
+        Scaling factor.
 
     Returns
     -------
-    prox_factory : `callable`
-        Factory for the proximal operator to be initialized
+    prox_factory : callable
+        Factory for the proximal operator to be initialized.
 
     Notes
     -----
@@ -1039,7 +1039,7 @@ def proximal_cconj_kl(space, lam=1, g=None):
 
             Parameters
             ----------
-            sigma : positive `float`
+            sigma : positive float
             """
             self.sigma = float(sigma)
             super().__init__(domain=space, range=space, linear=False)

--- a/odl/solvers/advanced/proximal_operators.py
+++ b/odl/solvers/advanced/proximal_operators.py
@@ -60,12 +60,12 @@ def combine_proximals(*factory_list):
 
     Parameters
     ----------
-    factory_list : list of callable
-        A list containing proximal operator factories
+    factory_list : `sequence` of `callable`'s
+        Proximal operator factories to be combined.
 
     Returns
     -------
-    diag_op : callable
+    diag_op : function
         Returns a diagonal product space operator factory to be initialized
         with the same step size parameter
     """
@@ -80,7 +80,7 @@ def combine_proximals(*factory_list):
 
         Returns
         -------
-        diag_op : `Operator`
+        diag_op : `DiagonalOperator`
         """
         return DiagonalOperator(
             *[factory(step_size) for factory in factory_list])
@@ -106,13 +106,13 @@ def proximal_cconj(prox_factory):
 
     Parameters
     ----------
-    prox_factory : callable
+    prox_factory : `callable`
         A factory function that, when called with a step size, returns the
         proximal operator of ``F``
 
     Returns
     -------
-    prox : callable
+    prox_factory : function
         Factory for the proximal operator to be initialized
 
     Notes
@@ -158,7 +158,7 @@ def proximal_translation(prox_factory, y):
 
     Returns
     -------
-    prox : `callable`
+    prox_factory : function
         Factory for the proximal operator to be initialized
 
     Notes
@@ -171,7 +171,7 @@ def proximal_translation(prox_factory, y):
 
         Parameters
         ----------
-        step_size : positive `float`
+        step_size : positive float
             Step size parameter
 
         Returns
@@ -202,12 +202,12 @@ def proximal_arg_scaling(prox_factory, scaling):
     prox_factory : `callable`
         A factory function that, when called with a step size, returns the
         proximal operator of ``F``
-    scaling : `float`
+    scaling : float
         Scaling parameter
 
     Returns
     -------
-    prox : `callable`
+    prox_factory : function
         Factory for the proximal operator to be initialized
 
     Notes
@@ -224,7 +224,7 @@ def proximal_arg_scaling(prox_factory, scaling):
 
         Parameters
         ----------
-        step_size : positive `float`
+        step_size : positive float
             Step size parameter
 
         Returns
@@ -256,7 +256,7 @@ def proximal_quadratic_perturbation(prox_factory, a, u=None):
     prox_factory : `callable`
         A factory function that, when called with a step size, returns the
         proximal operator of ``F``
-    a : non-negative `float`
+    a : non-negative float
         Scaling of the quadratic term
     u : Element in domain of F, optional
         Defines the linear functional
@@ -264,7 +264,7 @@ def proximal_quadratic_perturbation(prox_factory, a, u=None):
 
     Returns
     -------
-    prox : `callable`
+    prox_factory : function
         Factory for the proximal operator to be initialized
 
     Notes
@@ -280,8 +280,8 @@ def proximal_quadratic_perturbation(prox_factory, a, u=None):
                          ''.format(a))
 
     if u is not None and not isinstance(u, LinearSpaceVector):
-        raise TypeError('vector {!r} not None or a LinearSpaceVector instance.'
-                        ''.format(u))
+        raise TypeError('`u` must be `None` or a `LinearSpaceVector` '
+                        'instance, got {!r}.'.format(u))
 
     def quadratic_perturbation_prox_factory(step_size):
         """Create proximal for the quadratic perturbation with a given
@@ -289,7 +289,7 @@ def proximal_quadratic_perturbation(prox_factory, a, u=None):
 
         Parameters
         ----------
-        step_size : positive `float`
+        step_size : positive float
             Step size parameter
 
         Returns
@@ -327,7 +327,7 @@ def proximal_composition(proximal, operator, mu):
 
     Parameters
     ----------
-    prox_factory : callable
+    prox_factory : `callable`
         A factory function that, when called with a step size returns the
         proximal operator of ``F``
     operator : `Operator`
@@ -337,7 +337,7 @@ def proximal_composition(proximal, operator, mu):
 
     Returns
     -------
-    prox_factory : callable
+    prox_factory : function
         Factory for the proximal operator to be initialized
 
     Notes
@@ -385,7 +385,7 @@ def proximal_zero(space):
 
     Returns
     -------
-    prox_factory : callable
+    prox_factory : function
         Factory for the proximal operator to be initialized
     """
 
@@ -434,14 +434,16 @@ def proximal_box_constraint(space, lower=None, upper=None):
     ----------
     space : `LinearSpace`
         Domain of the functional G(x)
-    lower : ``space.field`` element or ``space`` element-like, optional
-        The lower bound. Default: None, interpreted as -infinity
-    upper : ``space.field`` element or ``space`` element-like, optional
-        The upper bound. Default: None, interpreted as +infinity
+    lower : ``space.field`` element or ``space`` `element-like`, optional
+        The lower bound.
+        Default: ``None``, interpreted as -infinity
+    upper : ``space.field`` element or ``space`` `element-like`, optional
+        The upper bound.
+        Default: ``None``, interpreted as +infinity
 
     Returns
     -------
-    prox_factory : callable
+    prox_factory : function
         Factory for the proximal operator to be initialized
 
     See Also
@@ -519,7 +521,7 @@ def proximal_nonnegativity(space):
 
     Returns
     -------
-    prox_factory : callable
+    prox_factory : function
         Factory for the proximal operator to be initialized
 
     See Also
@@ -561,7 +563,7 @@ def proximal_cconj_l2(space, lam=1, g=None):
 
     Returns
     -------
-    prox_factory : callable
+    prox_factory : function
         Factory for the proximal operator to be initialized
 
     Notes
@@ -606,7 +608,7 @@ def proximal_l2(space, lam=1, g=None):
 
     Returns
     -------
-    prox_factory : callable
+    prox_factory : function
         Factory for the proximal operator to be initialized
 
     Notes
@@ -701,7 +703,7 @@ def proximal_cconj_l2_squared(space, lam=1, g=None):
 
     Returns
     -------
-    prox_factory : callable
+    prox_factory : function
         Factory for the proximal operator to be initialized
 
     See Also
@@ -771,7 +773,7 @@ def proximal_l2_squared(space, lam=1, g=None):
 
     Returns
     -------
-    prox_factory : callable
+    prox_factory : function
         Factory for the proximal operator to be initialized
 
     See Also
@@ -807,8 +809,8 @@ def proximal_cconj_l1(space, lam=1, g=None, isotropic=False):
 
         prox[sigma * F^*](y) = lam (y - sigma g) / (max(lam, |y - sigma g|)
 
-    An alternative formulation is available for `ProductSpace`'s, in that case
-    the ``isotropic`` parameter can be used, giving
+    An alternative formulation is available for `ProductSpace`'s, in which
+    case the ``isotropic`` parameter can be used, giving
 
         F(x) = lam || ||x - g||_2 ||_1
 
@@ -835,12 +837,13 @@ def proximal_cconj_l1(space, lam=1, g=None, isotropic=False):
     lam : positive float
         Scaling factor or regularization parameter
     isotropic : bool
-        True if the norm should first be taken pointwise. Only available if
-        ``space`` is a `ProductSpace`.
+        If ``True``, take the vectorial 2-norm point-wise. Otherwise,
+        use the vectorial 1-norm. Only available if ``space`` is a
+        `ProductSpace`.
 
     Returns
     -------
-    prox_factory : callable
+    prox_factory : function
         Factory for the proximal operator to be initialized
 
     See Also
@@ -954,12 +957,13 @@ def proximal_l1(space, lam=1, g=None, isotropic=False):
     lam : positive float
         Scaling factor or regularization parameter
     isotropic : bool
-        True if the norm should first be taken pointwise. Only available if
-        ``space`` is a `ProductSpace`.
+        If ``True``, take the vectorial 2-norm point-wise. Otherwise,
+        use the vectorial 1-norm. Only available if ``space`` is a
+        `ProductSpace`.
 
     Returns
     -------
-    prox_factory : callable
+    prox_factory : function
         Factory for the proximal operator to be initialized
 
     See Also
@@ -1011,7 +1015,7 @@ def proximal_cconj_kl(space, lam=1, g=None):
 
     Returns
     -------
-    prox_factory : callable
+    prox_factory : function
         Factory for the proximal operator to be initialized.
 
     Notes

--- a/odl/solvers/findroot/newton.py
+++ b/odl/solvers/findroot/newton.py
@@ -61,18 +61,18 @@ Goldfarb%E2%80%93Shanno_algorithm>`_
     grad : `Operator`
         Gradient mapping of the objective function, i.e. the mapping
         :math:`x \mapsto \\nabla f(x) \\in \mathcal{X}`
-    x : `element` of the domain of ``grad``
+    x : element of the domain of ``grad``
         Starting point of the iteration
     line_search : `LineSearch`
         Strategy to choose the step length
-    niter : `int`, optional
+    niter : int, optional
         Number of iterations
     callback : `callable`, optional
         Object executing code per iteration, e.g. plotting each iterate.
 
     Returns
     -------
-    `None`
+    None
     """
 
     if x not in grad.domain:
@@ -135,18 +135,18 @@ def broydens_first_method(grad, x, line_search, niter=1, callback=None):
     grad : `Operator`
         Gradient mapping of the objective function, i.e. the mapping
         :math:`x \mapsto \\nabla f(x) \\in \mathcal{X}`
-    x : `element` of the domain of ``grad``
+    x : element of the domain of ``grad``
         Starting point of the iteration
     line_search : `LineSearch`
         Strategy to choose the step length
-    niter : `int`, optional
+    niter : int, optional
         Number of iterations
     callback : `callable`, optional
         Object executing code per iteration, e.g. plotting each iterate.
 
     Returns
     -------
-    `None`
+    None
     """
     hess = IdentityOperator(grad.range)
     grad_x = grad(x)
@@ -207,11 +207,11 @@ def broydens_second_method(grad, x, line_search, niter=1, callback=None):
     grad : `Operator`
         Gradient mapping of the objective function, i.e. the mapping
         :math:`x \mapsto \\nabla f(x) \\in \mathcal{X}`
-    x : `element` of the domain of ``grad``
+    x : element of the domain of ``grad``
         Starting point of the iteration
     line_search : `LineSearch`
         Strategy to choose the step length
-    niter : `int`, optional
+    niter : int, optional
         Number of iterations
     callback : `callable`, optional
         Object executing code per iteration, e.g. plotting each iterate

--- a/odl/solvers/findroot/newton.py
+++ b/odl/solvers/findroot/newton.py
@@ -61,7 +61,7 @@ Goldfarb%E2%80%93Shanno_algorithm>`_
     grad : `Operator`
         Gradient mapping of the objective function, i.e. the mapping
         :math:`x \mapsto \\nabla f(x) \\in \mathcal{X}`
-    x : element of the domain of ``grad``
+    x : ``grad.domain`` element
         Starting point of the iteration
     line_search : `LineSearch`
         Strategy to choose the step length
@@ -135,7 +135,7 @@ def broydens_first_method(grad, x, line_search, niter=1, callback=None):
     grad : `Operator`
         Gradient mapping of the objective function, i.e. the mapping
         :math:`x \mapsto \\nabla f(x) \\in \mathcal{X}`
-    x : element of the domain of ``grad``
+    x : ``grad.domain`` element
         Starting point of the iteration
     line_search : `LineSearch`
         Strategy to choose the step length
@@ -207,7 +207,7 @@ def broydens_second_method(grad, x, line_search, niter=1, callback=None):
     grad : `Operator`
         Gradient mapping of the objective function, i.e. the mapping
         :math:`x \mapsto \\nabla f(x) \\in \mathcal{X}`
-    x : element of the domain of ``grad``
+    x : ``grad.domain`` element
         Starting point of the iteration
     line_search : `LineSearch`
         Strategy to choose the step length

--- a/odl/solvers/iterative/iterative.py
+++ b/odl/solvers/iterative/iterative.py
@@ -79,17 +79,17 @@ def landweber(op, x, rhs, niter=1, omega=1, projection=None, callback=None):
         property, which returns a new operator which in turn has an
         `Operator.adjoint` property, i.e. ``op.derivative(x).adjoint`` must be
         well-defined for ``x`` in the operator domain.
-    x : `element` of the domain of ``op``
+    x : element of the domain of ``op``
         Vector to which the result is written. Its initial value is
         used as starting point of the iteration, and its values are
         updated in each iteration step.
-    rhs : `element` of the range of ``op``
+    rhs : element of the range of ``op``
         Right-hand side of the equation defining the inverse problem
-    niter : `int`, optional
+    niter : int, optional
         Maximum number of iterations
-    omega : positive `float`, optional
+    omega : positive float, optional
         Relaxation parameter in the iteration
-    projection : `callable`, optional
+    projection : callable, optional
         Function that can be used to modify the iterates in each iteration,
         for example enforcing positivity. The function should take one
         argument and modify it in-place.
@@ -98,7 +98,7 @@ def landweber(op, x, rhs, niter=1, omega=1, projection=None, callback=None):
 
     Returns
     -------
-    `None`
+    None
     """
     # TODO: add a book reference
 
@@ -145,11 +145,11 @@ def conjugate_gradient(op, x, rhs, niter=1, callback=None):
         Operator in the inverse problem. It must be linear and
         self-adjoint. This implies in particular that its domain and
         range are equal.
-    x : `element` of the domain of ``op``
+    x : element of the domain of ``op``
         Vector to which the result is written. Its initial value is
         used as starting point of the iteration, and its values are
         updated in each iteration step.
-    rhs : `element` of the range of ``op``
+    rhs : element of the range of ``op``
         Right-hand side of the equation defining the inverse problem
     niter : int, optional
         Maximum number of iterations
@@ -158,7 +158,7 @@ def conjugate_gradient(op, x, rhs, niter=1, callback=None):
 
     Returns
     -------
-    `None`
+    None
 
     See Also
     --------
@@ -236,11 +236,11 @@ Conjugate_gradient_on_the_normal_equations>`_.
         an implementation of `Operator.derivative`, which
         in turn must implement `Operator.adjoint`, i.e.
         the call ``op.derivative(x).adjoint`` must be valid.
-    x : `element` of the domain of ``op``
+    x : element of the domain of ``op``
         Vector to which the result is written. Its initial value is
         used as starting point of the iteration, and its values are
         updated in each iteration step.
-    rhs : `element` of the range of ``op``
+    rhs : element of the range of ``op``
         Right-hand side of the equation defining the inverse problem
     niter : int, optional
         Maximum number of iterations
@@ -249,7 +249,7 @@ Conjugate_gradient_on_the_normal_equations>`_.
 
     Returns
     -------
-    `None`
+    None
 
     See Also
     --------
@@ -304,13 +304,13 @@ def exp_zero_seq(base):
 
     Parameters
     ----------
-    base : `float`
+    base : float
         Base of the sequence. Its absolute value must be larger than
         1.
 
     Yields
     ------
-    val : `float`
+    val : float
         The next value in the exponential sequence
     """
     value = 1.0
@@ -345,15 +345,15 @@ def gauss_newton(op, x, rhs, niter=1, zero_seq=exp_zero_seq(2.0),
         an implementation of `Operator.derivative`, which
         in turn must implement `Operator.adjoint`, i.e.
         the call ``op.derivative(x).adjoint`` must be valid.
-    x : `element` of the domain of ``op``
+    x : element of the domain of ``op``
         Vector to which the result is written. Its initial value is
         used as starting point of the iteration, and its values are
         updated in each iteration step.
-    rhs : `element` of the range of ``op``
+    rhs : element of the range of ``op``
         Right-hand side of the equation defining the inverse problem
-    niter : `int`, optional
+    niter : int, optional
         Maximum number of iterations
-    zero_seq : `iterable`, optional
+    zero_seq : iterable, optional
         Zero sequence whose values are used for the regularization of
         the linearized problem in each Newton step
     callback : `callable`, optional

--- a/odl/solvers/iterative/iterative.py
+++ b/odl/solvers/iterative/iterative.py
@@ -89,7 +89,7 @@ def landweber(op, x, rhs, niter=1, omega=1, projection=None, callback=None):
         Maximum number of iterations
     omega : positive float, optional
         Relaxation parameter in the iteration
-    projection : callable, optional
+    projection : `callable`, optional
         Function that can be used to modify the iterates in each iteration,
         for example enforcing positivity. The function should take one
         argument and modify it in-place.

--- a/odl/solvers/iterative/iterative.py
+++ b/odl/solvers/iterative/iterative.py
@@ -79,11 +79,11 @@ def landweber(op, x, rhs, niter=1, omega=1, projection=None, callback=None):
         property, which returns a new operator which in turn has an
         `Operator.adjoint` property, i.e. ``op.derivative(x).adjoint`` must be
         well-defined for ``x`` in the operator domain.
-    x : element of the domain of ``op``
+    x : ``op.domain`` element
         Vector to which the result is written. Its initial value is
         used as starting point of the iteration, and its values are
         updated in each iteration step.
-    rhs : element of the range of ``op``
+    rhs : ``op.range`` element
         Right-hand side of the equation defining the inverse problem
     niter : int, optional
         Maximum number of iterations
@@ -145,11 +145,11 @@ def conjugate_gradient(op, x, rhs, niter=1, callback=None):
         Operator in the inverse problem. It must be linear and
         self-adjoint. This implies in particular that its domain and
         range are equal.
-    x : element of the domain of ``op``
+    x : ``op.domain`` element
         Vector to which the result is written. Its initial value is
         used as starting point of the iteration, and its values are
         updated in each iteration step.
-    rhs : element of the range of ``op``
+    rhs : ``op.range`` element
         Right-hand side of the equation defining the inverse problem
     niter : int, optional
         Maximum number of iterations
@@ -236,11 +236,11 @@ Conjugate_gradient_on_the_normal_equations>`_.
         an implementation of `Operator.derivative`, which
         in turn must implement `Operator.adjoint`, i.e.
         the call ``op.derivative(x).adjoint`` must be valid.
-    x : element of the domain of ``op``
+    x : ``op.domain`` element
         Vector to which the result is written. Its initial value is
         used as starting point of the iteration, and its values are
         updated in each iteration step.
-    rhs : element of the range of ``op``
+    rhs : ``op.range`` element
         Right-hand side of the equation defining the inverse problem
     niter : int, optional
         Maximum number of iterations
@@ -345,11 +345,11 @@ def gauss_newton(op, x, rhs, niter=1, zero_seq=exp_zero_seq(2.0),
         an implementation of `Operator.derivative`, which
         in turn must implement `Operator.adjoint`, i.e.
         the call ``op.derivative(x).adjoint`` must be valid.
-    x : element of the domain of ``op``
+    x : ``op.domain`` element
         Vector to which the result is written. Its initial value is
         used as starting point of the iteration, and its values are
         updated in each iteration step.
-    rhs : element of the range of ``op``
+    rhs : ``op.range`` element
         Right-hand side of the equation defining the inverse problem
     niter : int, optional
         Maximum number of iterations

--- a/odl/solvers/scalar/gradient.py
+++ b/odl/solvers/scalar/gradient.py
@@ -64,7 +64,7 @@ def steepest_descent(grad, x, niter=1, line_search=1, projection=None,
     line_search : float or `LineSearch`, optional
         Strategy to choose the step length. If a float is given, uses it as a
         fixed step length.
-    projection : callable, optional
+    projection : `callable`, optional
         Function that can be used to modify the iterates in each iteration,
         for example enforcing positivity. The function should take one
         argument and modify it in-place.

--- a/odl/solvers/scalar/gradient.py
+++ b/odl/solvers/scalar/gradient.py
@@ -57,7 +57,7 @@ def steepest_descent(grad, x, niter=1, line_search=1, projection=None,
     grad : `Operator`
         Gradient of the objective function,
         :math:`x \mapsto \\nabla f(x)`
-    x : element of the domain of ``deriv``
+    x : ``grad.range`` element
         Starting point of the iteration
     niter : int, optional
         Number of iterations

--- a/odl/solvers/scalar/gradient.py
+++ b/odl/solvers/scalar/gradient.py
@@ -57,14 +57,14 @@ def steepest_descent(grad, x, niter=1, line_search=1, projection=None,
     grad : `Operator`
         Gradient of the objective function,
         :math:`x \mapsto \\nabla f(x)`
-    x : `element` of the domain of ``deriv``
+    x : element of the domain of ``deriv``
         Starting point of the iteration
-    niter : `int`, optional
+    niter : int, optional
         Number of iterations
     line_search : float or `LineSearch`, optional
         Strategy to choose the step length. If a float is given, uses it as a
         fixed step length.
-    projection : `callable`, optional
+    projection : callable, optional
         Function that can be used to modify the iterates in each iteration,
         for example enforcing positivity. The function should take one
         argument and modify it in-place.

--- a/odl/solvers/scalar/steplen.py
+++ b/odl/solvers/scalar/steplen.py
@@ -45,9 +45,9 @@ class StepLength(with_metaclass(ABCMeta, object)):
 
         Parameters
         ----------
-        x : `Operator.domain` element
+        x : `LinearSpaceVector`
             The current point
-        direction : `Operator.domain` element
+        direction : `LinearSpaceVector`
             Search direction in which the line search should be computed
         dir_derivative : float
             Directional derivative along the ``direction``
@@ -69,9 +69,9 @@ class LineSearch(with_metaclass(ABCMeta, object)):
 
         Parameters
         ----------
-        x : `Operator.domain` element
+        x : `LinearSpaceVector`
             The current point
-        direction : `Operator.domain` element
+        direction : `LinearSpaceVector`
             Search direction in which the line search should be computed
         dir_derivative : float
             Directional derivative along the ``direction``
@@ -134,9 +134,9 @@ class BacktrackingLineSearch(LineSearch):
 
         Parameters
         ----------
-        x : `Operator.domain` element
+        x : `LinearSpaceVector`
             The current point
-        direction : `Operator.domain` element
+        direction : `LinearSpaceVector`
             Search direction in which the line search should be computed
         dir_derivative : float
             Directional derivative along the ``direction``
@@ -199,9 +199,9 @@ class ConstantLineSearch(LineSearch):
 
         Parameters
         ----------
-        x : `Operator.domain` element
+        x : `LinearSpaceVector`
             The current point
-        direction : `Operator.domain` element
+        direction : `LinearSpaceVector`
             Search direction in which the line search should be computed
         dir_derivative : float
             Directional derivative along the ``direction``
@@ -242,9 +242,9 @@ class BarzilaiBorweinStep(object):
 
         Parameters
         ----------
-        x : `Operator.domain` element
+        x : `LinearSpaceVector`
             The current point
-        x0 : `Operator.domain` element
+        x0 : `LinearSpaceVector`
             The previous point
 
         Returns

--- a/odl/solvers/scalar/steplen.py
+++ b/odl/solvers/scalar/steplen.py
@@ -45,16 +45,17 @@ class StepLength(with_metaclass(ABCMeta, object)):
 
         Parameters
         ----------
-        x : `Operator.domain` `element`
+        x : `Operator.domain` element
             The current point
-        direction : `Operator.domain` `element`
+        direction : `Operator.domain` element
             Search direction in which the line search should be computed
-        dir_derivative : `float`
+        dir_derivative : float
             Directional derivative along the ``direction``
 
         Returns
         -------
-        step : `float`
+        step : float
+            The step length
         """
 
 
@@ -68,16 +69,17 @@ class LineSearch(with_metaclass(ABCMeta, object)):
 
         Parameters
         ----------
-        x : `Operator.domain` `element`
+        x : `Operator.domain` element
             The current point
-        direction : `Operator.domain` `element`
+        direction : `Operator.domain` element
             Search direction in which the line search should be computed
-        dir_derivative : `float`
+        dir_derivative : float
             Directional derivative along the ``direction``
 
         Returns
         -------
-        step : `float`
+        step : float
+            Computed step length.
         """
 
 
@@ -101,18 +103,17 @@ class BacktrackingLineSearch(LineSearch):
 
         Parameters
         ----------
-        function : `callable`
+        function : callable
             The cost function of the optimization problem to be solved.
-        tau : `float`, optional
+        tau : float, optional
             The amount the step length is decreased in each iteration,
             as long as it does not fulfill the decrease condition.
             The step length is updated as ``step_length *= tau``.
-        c : `float`, optional
-            The 'discount factor' on the
-            ``step length * direction derivative``,
-            which the new point needs to be smaller than in order to
-            fulfill the condition and be accepted (see the references).
-        max_num_iter : `int`, optional
+        c : float, optional
+            The "discount factor" on ``step length * direction derivative``,
+            yielding the threshold under which the function value must lie to
+            be accepted (see the references).
+        max_num_iter : int, optional
             Maximum number of iterations allowed each time the line
             search method is called. If not set, this number is calculated
             to allow a shortest step length of 0.0001.
@@ -133,16 +134,16 @@ class BacktrackingLineSearch(LineSearch):
 
         Parameters
         ----------
-        x : `Operator.domain` `element`
+        x : `Operator.domain` element
             The current point
-        direction : `Operator.domain` `element`
+        direction : `Operator.domain` element
             Search direction in which the line search should be computed
-        dir_derivative : `float`
+        dir_derivative : float
             Directional derivative along the ``direction``
 
         Returns
         -------
-        step : `float`
+        step : float
             The computed step length
         """
         alpha = 1.0
@@ -188,7 +189,7 @@ class ConstantLineSearch(LineSearch):
 
         Parameters
         ----------
-        constant : `float`
+        constant : float
             The constant step length
         """
         self.constant = constant
@@ -198,16 +199,16 @@ class ConstantLineSearch(LineSearch):
 
         Parameters
         ----------
-        x : `Operator.domain` `element`
+        x : `Operator.domain` element
             The current point
-        direction : `Operator.domain` `element`
+        direction : `Operator.domain` element
             Search direction in which the line search should be computed
-        dir_derivative : `float`
+        dir_derivative : float
             Directional derivative along the ``direction``
 
         Returns
         -------
-        step : `float`
+        step : float
             The constant step length
         """
         return self.constant
@@ -230,7 +231,7 @@ class BarzilaiBorweinStep(object):
         ----------
         gradf : `Operator`
             The gradient of the objective function at a point
-        step0 : `float`, optional
+        step0 : float, optional
             Initial step length parameter
         """
         self.gradf = gradf
@@ -241,14 +242,15 @@ class BarzilaiBorweinStep(object):
 
         Parameters
         ----------
-        x : `Operator.domain` `element`
+        x : `Operator.domain` element
             The current point
-        x0 : `Operator.domain` `element`
+        x0 : `Operator.domain` element
             The previous point
 
         Returns
         -------
-        step : `float`
+        step : float
+            Computed step length.
         """
         if x == x0:
             return self.step0

--- a/odl/solvers/scalar/steplen.py
+++ b/odl/solvers/scalar/steplen.py
@@ -103,7 +103,7 @@ class BacktrackingLineSearch(LineSearch):
 
         Parameters
         ----------
-        function : callable
+        function : `callable`
             The cost function of the optimization problem to be solved.
         tau : float, optional
             The amount the step length is decreased in each iteration,

--- a/odl/solvers/util/callback.py
+++ b/odl/solvers/util/callback.py
@@ -87,7 +87,7 @@ class _CallbackAnd(SolverCallback):
 
         Parameters
         ----------
-        callback1, ..., callbackN : callable
+        callback1, ..., callbackN : `callable`
             Callables to be called in sequence as listed.
         """
         callbacks = [c if isinstance(c, SolverCallback) else CallbackApply(c)
@@ -123,7 +123,7 @@ class CallbackStore(SolverCallback):
         results : list, optional
             List in which to store the iterates.
             Default: new list (``[]``)
-        results : callable, optional
+        results : `callable`, optional
             Function to be called on all incoming results before storage.
             Default: copy
 
@@ -193,7 +193,7 @@ class CallbackApply(SolverCallback):
 
         Parameters
         ----------
-        function : callable
+        function : `callable`
             Function to call for each iteration
         """
         assert callable(function)

--- a/odl/solvers/util/callback.py
+++ b/odl/solvers/util/callback.py
@@ -44,7 +44,7 @@ class SolverCallback(object):
 
         Returns
         -------
-        `None`
+        None
         """
 
     def __and__(self, other):
@@ -87,7 +87,7 @@ class _CallbackAnd(SolverCallback):
 
         Parameters
         ----------
-        callback1, ..., callbackN : `callable`
+        callback1, ..., callbackN : callable
             Callables to be called in sequence as listed.
         """
         callbacks = [c if isinstance(c, SolverCallback) else CallbackApply(c)
@@ -120,11 +120,11 @@ class CallbackStore(SolverCallback):
 
         Parameters
         ----------
-        results : `list`, optional
+        results : list, optional
             List in which to store the iterates.
             Default: new list (``[]``)
-        results : `callable`, optional
-            Function to be called on all incomming results before storage.
+        results : callable, optional
+            Function to be called on all incoming results before storage.
             Default: copy
 
         Examples
@@ -193,7 +193,7 @@ class CallbackApply(SolverCallback):
 
         Parameters
         ----------
-        function : `callable`
+        function : callable
             Function to call for each iteration
         """
         assert callable(function)
@@ -223,7 +223,7 @@ class CallbackPrintIteration(SolverCallback):
 
         Parameters
         ----------
-        text : `str`
+        text : string
             Text to display before the iteration count. Default: 'iter ='
         """
         self.text = text if text is not None else self._default_text
@@ -295,7 +295,7 @@ class CallbackShow(SolverCallback):
 
         Parameters
         ----------
-        display_step : positive `int`, optional
+        display_step : positive int, optional
             Number of iterations between plots. Default: 1
 
         Other Parameters

--- a/odl/solvers/vector/newton.py
+++ b/odl/solvers/vector/newton.py
@@ -51,7 +51,7 @@ def newtons_method(op, x, line_search, num_iter=10, cg_iter=None,
     ----------
     op : `Operator`
         Gradient of the objective function, ``x --> grad f(x)``
-    x : element in the domain of ``op``
+    x : ``op.domain`` element
         Starting point of the iteration
     line_search : `LineSearch`
         Strategy to choose the step length

--- a/odl/solvers/vector/newton.py
+++ b/odl/solvers/vector/newton.py
@@ -55,9 +55,9 @@ def newtons_method(op, x, line_search, num_iter=10, cg_iter=None,
         Starting point of the iteration
     line_search : `LineSearch`
         Strategy to choose the step length
-    num_iter : `int`, optional
+    num_iter : int, optional
         Number of iterations
-    cg_iter : `int`, optional
+    cg_iter : int, optional
         Number of iterations in the the conjugate gradient solver,
         for computing the search direction.
     callback : `callable`, optional

--- a/odl/space/base_ntuples.py
+++ b/odl/space/base_ntuples.py
@@ -81,9 +81,9 @@ class NtuplesBase(Set):
 
         Returns
         -------
-        contains : `bool`
-            `True` if ``other`` is an `NtuplesBaseVector` instance and
-            ``other.space`` is equal to this space, `False` otherwise.
+        contains : bool
+            True if ``other`` is an `NtuplesBaseVector` instance and
+            ``other.space`` is equal to this space, False otherwise.
 
         Examples
         --------
@@ -103,9 +103,9 @@ class NtuplesBase(Set):
 
         Returns
         -------
-        equals : `bool`
-            `True` if ``other`` is an instance of this space's type
-            with the same `size` and `dtype`, otherwise `False`.
+        equals : bool
+            True if ``other`` is an instance of this space's type
+            with the same `size` and `dtype`, False otherwise.
 
         Examples
         --------
@@ -185,19 +185,19 @@ class NtuplesBaseVector(with_metaclass(ABCMeta, object)):
 
         Parameters
         ----------
-        start : `int`, optional
-            Start position. `None` means the first element.
-        start : `int`, optional
+        start : int, optional
+            Start position. None means the first element.
+        start : int, optional
             One element past the last element to be extracted.
-            `None` means the last element.
-        start : `int`, optional
-            Step length. `None` means 1.
-        out : `numpy.ndarray`
+            None means the last element.
+        start : int, optional
+            Step length. None means 1.
+        out : numpy.ndarray
             Array to write result to.
 
         Returns
         -------
-        asarray : `numpy.ndarray`
+        asarray : numpy.ndarray
             Numpy array of the same type as the space.
         """
 
@@ -207,7 +207,7 @@ class NtuplesBaseVector(with_metaclass(ABCMeta, object)):
 
         Parameters
         ----------
-        indices : `int` or `slice`
+        indices : int or slice
             The position(s) that should be accessed
 
         Returns
@@ -222,9 +222,9 @@ class NtuplesBaseVector(with_metaclass(ABCMeta, object)):
 
         Parameters
         ----------
-        indices : `int` or `slice`
+        indices : int or slice
             The position(s) that should be set
-        values : scalar, `array-like` or `NtuplesBaseVector`
+        values : scalar, array-like or `NtuplesBaseVector`
             The value(s) that are to be assigned.
 
             If ``index`` is an integer, ``value`` must be single value.
@@ -240,9 +240,9 @@ class NtuplesBaseVector(with_metaclass(ABCMeta, object)):
 
         Returns
         -------
-        equals : `bool`
-            `True` if all entries of ``other`` are equal to this
-            vector's entries, `False` otherwise.
+        equals : bool
+            True if all entries of ``other`` are equal to this
+            vector's entries, False otherwise.
         """
 
     @property
@@ -292,12 +292,12 @@ class NtuplesBaseVector(with_metaclass(ABCMeta, object)):
 
         Parameters
         ----------
-        dtype : `object`
+        dtype :
             Specifier for the data type of the output array
 
         Returns
         -------
-        array : `numpy.ndarray`
+        array : numpy.ndarray
         """
         if dtype is None:
             return self.asarray()
@@ -309,7 +309,7 @@ class NtuplesBaseVector(with_metaclass(ABCMeta, object)):
 
         Parameters
         ----------
-        obj : `numpy.ndarray`
+        obj : numpy.ndarray
             The array that should be wrapped
 
         Returns
@@ -415,17 +415,17 @@ class NtuplesBaseVector(with_metaclass(ABCMeta, object)):
 
         Parameters
         ----------
-        title : `str`, optional
+        title : string, optional
             Set the title of the figure
 
-        method : `str`, optional
+        method : string, optional
             1d methods:
 
             'plot' : graph plot
 
             'scatter' : point plot
 
-        show : `bool`, optional
+        show : bool, optional
             If the plot should be showed now or deferred until later.
 
         fig : `matplotlib.figure.Figure`
@@ -469,9 +469,9 @@ class FnBase(NtuplesBase, LinearSpace):
 
         Parameters
         ----------
-        size : `int`
+        size : int
             The number of dimensions of the space
-        dtype : `object`
+        dtype :
             The data type of the storage array. Can be provided in any
             way the `numpy.dtype` function understands, most notably
             as built-in type, as one of NumPy's internal datatype
@@ -503,12 +503,12 @@ class FnBase(NtuplesBase, LinearSpace):
 
     @property
     def is_rn(self):
-        """Return `True` if the space represents R^n, i.e. real tuples."""
+        """True if the space represents R^n, i.e. real tuples."""
         return self.__is_real and self.__is_floating
 
     @property
     def is_cn(self):
-        """Return `True` if the space represents C^n, i.e. complex tuples."""
+        """True if the space represents C^n, i.e. complex tuples."""
         return (not self.__is_real) and self.__is_floating
 
     @property
@@ -543,7 +543,7 @@ class FnBase(NtuplesBase, LinearSpace):
         dtype :
             Data type of the returned space. Can be given in any way
             `numpy.dtype` understands, e.g. as string ('complex64')
-            or data type (`complex`).
+            or data type (complex).
 
         Returns
         -------

--- a/odl/space/base_ntuples.py
+++ b/odl/space/base_ntuples.py
@@ -82,8 +82,8 @@ class NtuplesBase(Set):
         Returns
         -------
         contains : bool
-            True if ``other`` is an `NtuplesBaseVector` instance and
-            ``other.space`` is equal to this space, False otherwise.
+            ``True`` if ``other`` is an `NtuplesBaseVector` instance and
+            ``other.space`` is equal to this space, ``False`` otherwise.
 
         Examples
         --------
@@ -104,8 +104,8 @@ class NtuplesBase(Set):
         Returns
         -------
         equals : bool
-            True if ``other`` is an instance of this space's type
-            with the same `size` and `dtype`, False otherwise.
+            ``True`` if ``other`` is an instance of this space's type
+            with the same `size` and `dtype`, ``False`` otherwise.
 
         Examples
         --------
@@ -153,7 +153,7 @@ class NtuplesBase(Set):
 
         Returns
         -------
-        available_dtypes : sequence
+        available_dtypes : `sequence`
         """
         raise NotImplementedError('abstract method')
 
@@ -189,12 +189,12 @@ class NtuplesBaseVector(with_metaclass(ABCMeta, object)):
         step : int, optional
             Vector index step between consecutive array ellements.
             ``None`` is equivalent to 1.
-        out : numpy.ndarray
+        out : `numpy.ndarray`
             Array to write the result to.
 
         Returns
         -------
-        out : numpy.ndarray
+        out : `numpy.ndarray`
             Numpy array of the same `dtype` as this vector. If ``out``
             was given, the returned object is a reference to it.
         """
@@ -205,7 +205,7 @@ class NtuplesBaseVector(with_metaclass(ABCMeta, object)):
 
         Parameters
         ----------
-        indices : int or slice
+        indices : int or `slice`
             The position(s) that should be accessed. An integer results
             in a single entry to be returned. For a slice, the output
             is a vector of the same type.
@@ -222,9 +222,9 @@ class NtuplesBaseVector(with_metaclass(ABCMeta, object)):
 
         Parameters
         ----------
-        indices : int or slice
+        indices : int or `slice`
             The position(s) that should be assigned to.
-        values : scalar, array-like or `NtuplesBaseVector`
+        values : scalar, `array-like` or `NtuplesBaseVector`
             The value(s) that are to be assigned.
 
             If ``index`` is an integer, ``value`` must be a single
@@ -242,7 +242,7 @@ class NtuplesBaseVector(with_metaclass(ABCMeta, object)):
         Returns
         -------
         equals : bool
-            True if all entries of ``other`` are equal to this
+            ``True`` if all entries of ``other`` are equal to this
             vector's entries, False otherwise.
         """
 
@@ -298,7 +298,7 @@ class NtuplesBaseVector(with_metaclass(ABCMeta, object)):
 
         Returns
         -------
-        array : numpy.ndarray
+        array : `numpy.ndarray`
         """
         if dtype is None:
             return self.asarray()
@@ -310,7 +310,7 @@ class NtuplesBaseVector(with_metaclass(ABCMeta, object)):
 
         Parameters
         ----------
-        obj : numpy.ndarray
+        obj : `numpy.ndarray`
             Array that should be wrapped.
 
         Returns
@@ -332,7 +332,7 @@ class NtuplesBaseVector(with_metaclass(ABCMeta, object)):
 
         Returns
         -------
-        int : `int`
+        int : int
             Integer representing this vector.
 
         Raises
@@ -366,7 +366,7 @@ class NtuplesBaseVector(with_metaclass(ABCMeta, object)):
 
         Returns
         -------
-        float : `float`
+        float : float
             Floating point number representing this vector.
 
         Raises
@@ -428,7 +428,7 @@ class NtuplesBaseVector(with_metaclass(ABCMeta, object)):
             'plot' : graph plot
 
         show : bool, optional
-            If True, the plot is shown immediately. Otherwise, display is
+            If ``True``, the plot is shown immediately. Otherwise, display is
             deferred to a later point in time.
         fig : `matplotlib.figure.Figure`, optional
             Figure to draw into. Expected to be of same "style" as
@@ -505,12 +505,12 @@ class FnBase(NtuplesBase, LinearSpace):
 
     @property
     def is_rn(self):
-        """True if the space represents R^n, i.e. real tuples."""
+        """``True`` if the space represents R^n, i.e. real tuples."""
         return self.__is_real and self.__is_floating
 
     @property
     def is_cn(self):
-        """True if the space represents C^n, i.e. complex tuples."""
+        """``True`` if the space represents C^n, i.e. complex tuples."""
         return (not self.__is_real) and self.__is_floating
 
     @property

--- a/odl/space/entry_points.py
+++ b/odl/space/entry_points.py
@@ -24,9 +24,9 @@ hooking into the setuptools entry point 'odl.space' and exposing the methods
 
 Attributes
 ----------
-NTUPLES_IMPLS : `dict`
+NTUPLES_IMPLS : dict
     A dictionary that maps a string to an `NtuplesBase` implementation.
-FN_IMPLS : `dict`
+FN_IMPLS : dict
     A dictionary that maps a string to an `FnBase` implementation.
 
 Notes

--- a/odl/space/fspace.py
+++ b/odl/space/fspace.py
@@ -98,7 +98,7 @@ class FunctionSet(Set):
         out_dtype : optional
             Data type of the return value of a function in this space.
             Can be given in any way `numpy.dtype` understands, e.g. as
-            string ('bool') or data type (`bool`).
+            string ('bool') or data type (bool).
             If no data type is given, a "lazy" evaluation is applied,
             i.e. an adequate data type is inferred during function
             evaluation.
@@ -138,10 +138,10 @@ class FunctionSet(Set):
 
         Parameters
         ----------
-        fcall : `callable`, optional
+        fcall : callable, optional
             The actual instruction for out-of-place evaluation.
             It must return an `FunctionSet.range` element or a
-            `numpy.ndarray` of such (vectorized call).
+            numpy.ndarray of such (vectorized call).
 
         vectorized : bool
             Whether ``fcall`` supports vectorized evaluation.
@@ -171,9 +171,9 @@ class FunctionSet(Set):
 
         Returns
         -------
-        equals : `bool`
-            `True` if ``other`` is a `FunctionSet` with same
-            `FunctionSet.domain` and `FunctionSet.range`, `False` otherwise.
+        equals : bool
+            True if ``other`` is a `FunctionSet` with same
+            `FunctionSet.domain` and `FunctionSet.range`, False otherwise.
         """
         if other is self:
             return True
@@ -188,10 +188,10 @@ class FunctionSet(Set):
 
         Returns
         -------
-        equals : `bool`
-            `True` if ``other`` is a `FunctionSetVector`
+        equals : bool
+            True if ``other`` is a `FunctionSetVector`
             whose `FunctionSetVector.space` attribute
-            equals this space, `False` otherwise.
+            equals this space, False otherwise.
         """
         return (isinstance(other, self.element_type) and
                 self == other.space)
@@ -223,10 +223,10 @@ class FunctionSetVector(Operator):
         ----------
         fset : `FunctionSet`
             Set of functions this element lives in.
-        fcall : `callable`
+        fcall : callable
             The actual instruction for out-of-place evaluation.
             It must return an `FunctionSet.range` element or a
-            `numpy.ndarray` of such (vectorized call).
+            ``numpy.ndarray`` of such (vectorized call).
         """
         self.__space = fset
         super().__init__(self.space.domain, self.space.range, linear=False)
@@ -298,7 +298,7 @@ class FunctionSetVector(Operator):
 
         Parameters
         ----------
-        x : domain `element-like`, `meshgrid` or `numpy.ndarray`
+        x : domain `element-like`, `meshgrid` or numpy.ndarray
             Input argument for the function evaluation. Conditions
             on ``x`` depend on its type:
 
@@ -310,7 +310,7 @@ class FunctionSetVector(Operator):
             array:  shape must be ``(d, N)``, where ``d`` is the number
             of dimensions of the function domain
 
-        out : `numpy.ndarray`, optional
+        out : numpy.ndarray, optional
             Output argument holding the result of the function
             evaluation, can only be used for vectorized
             functions. Its shape must be equal to
@@ -318,11 +318,11 @@ class FunctionSetVector(Operator):
 
         Other Parameters
         ----------------
-        bounds_check : `bool`
-            If `True`, check if all input points lie in the function
+        bounds_check : bool
+            If True, check if all input points lie in the function
             domain in the case of vectorized evaluation. This requires
             the domain to implement `Set.contains_all`.
-            Default: `True`
+            Default: True
 
         Returns
         -------
@@ -335,7 +335,7 @@ class FunctionSetVector(Operator):
         TypeError
             If ``x`` is not a valid vectorized evaluation argument
 
-            If ``out`` is not a range element or a `numpy.ndarray`
+            If ``out`` is not a range element or a numpy.ndarray
             of range elements
 
         ValueError
@@ -452,7 +452,7 @@ class FunctionSetVector(Operator):
         """Assign ``other`` to this vector.
 
         This is implemented without `FunctionSpace.lincomb` to ensure that
-        ``vec == other`` evaluates to `True` after
+        ``vec == other`` evaluates to True after
         ``vec.assign(other)``.
         """
         if other not in self.space:
@@ -475,10 +475,10 @@ class FunctionSetVector(Operator):
 
         Returns
         -------
-        equals : `bool`
-            `True` if ``other`` is a `FunctionSetVector` with
+        equals : bool
+            True if ``other`` is a `FunctionSetVector` with
             ``other.space`` equal to this vector's space and evaluation
-            function of ``other`` and this vector is equal. `False`
+            function of ``other`` and this vector is equal. False
             otherwise.
         """
         if other is self:
@@ -534,12 +534,12 @@ class FunctionSpace(FunctionSet, LinearSpace):
         field : `Field`, optional
             The range of the functions, usually the `RealNumbers` or
             `ComplexNumbers`. If not given, the field is either inferred
-            from ``out_dtype``, or, if the latter is also `None`, set
+            from ``out_dtype``, or, if the latter is also None, set
             to ``RealNumbers()``.
         out_dtype : optional
             Data type of the return value of a function in this space.
             Can be given in any way `numpy.dtype` understands, e.g. as
-            string ('float64') or data type (`float`).
+            string ('float64') or data type (float).
             By default, 'float64' is used for real and 'complex128'
             for complex spaces.
         """
@@ -630,10 +630,10 @@ class FunctionSpace(FunctionSet, LinearSpace):
 
         Parameters
         ----------
-        fcall : `callable`, optional
+        fcall : callable, optional
             The actual instruction for out-of-place evaluation.
             It must return an `FunctionSet.range` element or a
-            `numpy.ndarray` of such (vectorized call).
+            numpy.ndarray of such (vectorized call).
 
             If fcall is a `FunctionSetVector`, it is wrapped
             as a new `FunctionSpaceVector`.
@@ -719,10 +719,10 @@ class FunctionSpace(FunctionSet, LinearSpace):
 
         Returns
         -------
-        equals : `bool`
-            `True` if ``other`` is a `FunctionSpace` with same
+        equals : bool
+            True if ``other`` is a `FunctionSpace` with same
             `FunctionSpace.domain` and `FunctionSpace.range`,
-            `False` otherwise.
+            False otherwise.
         """
         if other is self:
             return True
@@ -742,7 +742,7 @@ class FunctionSpace(FunctionSet, LinearSpace):
         out_dtype : optional
             Output data type of the returned space. Can be given in any
             way `numpy.dtype` understands, e.g. as string ('complex64')
-            or data type (`complex`). `None` is interpreted as 'float64'.
+            or data type (complex). None is interpreted as 'float64'.
 
         Returns
         -------
@@ -1161,10 +1161,10 @@ class FunctionSpaceVector(LinearSpaceVector, FunctionSetVector):
         ----------
         fspace : `FunctionSpace`
             Set of functions this element lives in.
-        fcall : `callable`
+        fcall : callable
             The actual instruction for out-of-place evaluation.
             It must return an `FunctionSet.range` element or a
-            `numpy.ndarray` of such (vectorized call).
+            ``numpy.ndarray`` of such (vectorized call).
         """
         if not isinstance(fspace, FunctionSpace):
             raise TypeError('`fspace` {!r} not a `FunctionSpace` '

--- a/odl/space/fspace.py
+++ b/odl/space/fspace.py
@@ -298,7 +298,7 @@ class FunctionSetVector(Operator):
 
         Parameters
         ----------
-        x : domain `element-like`, `meshgrid` or `numpy.ndarray`
+        x : `domain` `element-like`, `meshgrid` or `numpy.ndarray`
             Input argument for the function evaluation. Conditions
             on ``x`` depend on its type:
 

--- a/odl/space/fspace.py
+++ b/odl/space/fspace.py
@@ -129,7 +129,7 @@ class FunctionSet(Set):
     def out_dtype(self):
         """Output data type of this function.
 
-        If None, dtype is not uniquely pre-defined.
+        If ``None``, the output data type is not uniquely pre-defined.
         """
         return self.__out_dtype
 
@@ -138,10 +138,10 @@ class FunctionSet(Set):
 
         Parameters
         ----------
-        fcall : callable, optional
+        fcall : `callable`, optional
             The actual instruction for out-of-place evaluation.
-            It must return an `FunctionSet.range` element or a
-            numpy.ndarray of such (vectorized call).
+            It must return a `FunctionSet.range` element or a
+            `numpy.ndarray` of such (vectorized call).
 
         vectorized : bool
             Whether ``fcall`` supports vectorized evaluation.
@@ -157,7 +157,7 @@ class FunctionSet(Set):
             evaluation
         """
         if not callable(fcall):
-            raise TypeError('`fcall` {!r} is not `callable`'.format(fcall))
+            raise TypeError('`fcall` {!r} is not callable'.format(fcall))
         elif fcall in self:
             return fcall
         else:
@@ -172,8 +172,8 @@ class FunctionSet(Set):
         Returns
         -------
         equals : bool
-            True if ``other`` is a `FunctionSet` with same
-            `FunctionSet.domain` and `FunctionSet.range`, False otherwise.
+            ``True`` if ``other`` is a `FunctionSet` with same
+            `FunctionSet.domain` and `FunctionSet.range`, ``False`` otherwise.
         """
         if other is self:
             return True
@@ -189,9 +189,9 @@ class FunctionSet(Set):
         Returns
         -------
         equals : bool
-            True if ``other`` is a `FunctionSetVector`
+            ``True`` if ``other`` is a `FunctionSetVector`
             whose `FunctionSetVector.space` attribute
-            equals this space, False otherwise.
+            equals this space, ``False`` otherwise.
         """
         return (isinstance(other, self.element_type) and
                 self == other.space)
@@ -223,10 +223,10 @@ class FunctionSetVector(Operator):
         ----------
         fset : `FunctionSet`
             Set of functions this element lives in.
-        fcall : callable
+        fcall : `callable`
             The actual instruction for out-of-place evaluation.
-            It must return an `FunctionSet.range` element or a
-            ``numpy.ndarray`` of such (vectorized call).
+            It must return a `FunctionSet.range` element or a
+            `numpy.ndarray` of such (vectorized call).
         """
         self.__space = fset
         super().__init__(self.space.domain, self.space.range, linear=False)
@@ -282,7 +282,7 @@ class FunctionSetVector(Operator):
     def out_dtype(self):
         """Output data type of this function.
 
-        If None, dtype is not uniquely pre-defined.
+        If ``None``, the output data type is not uniquely pre-defined.
         """
         return self.space.out_dtype
 
@@ -298,7 +298,7 @@ class FunctionSetVector(Operator):
 
         Parameters
         ----------
-        x : domain `element-like`, `meshgrid` or numpy.ndarray
+        x : domain `element-like`, `meshgrid` or `numpy.ndarray`
             Input argument for the function evaluation. Conditions
             on ``x`` depend on its type:
 
@@ -310,7 +310,7 @@ class FunctionSetVector(Operator):
             array:  shape must be ``(d, N)``, where ``d`` is the number
             of dimensions of the function domain
 
-        out : numpy.ndarray, optional
+        out : `numpy.ndarray`, optional
             Output argument holding the result of the function
             evaluation, can only be used for vectorized
             functions. Its shape must be equal to
@@ -319,10 +319,10 @@ class FunctionSetVector(Operator):
         Other Parameters
         ----------------
         bounds_check : bool
-            If True, check if all input points lie in the function
+            If ``True``, check if all input points lie in the function
             domain in the case of vectorized evaluation. This requires
             the domain to implement `Set.contains_all`.
-            Default: True
+            Default: ``True``
 
         Returns
         -------
@@ -335,7 +335,7 @@ class FunctionSetVector(Operator):
         TypeError
             If ``x`` is not a valid vectorized evaluation argument
 
-            If ``out`` is not a range element or a numpy.ndarray
+            If ``out`` is not a range element or a `numpy.ndarray`
             of range elements
 
         ValueError
@@ -476,9 +476,9 @@ class FunctionSetVector(Operator):
         Returns
         -------
         equals : bool
-            True if ``other`` is a `FunctionSetVector` with
+            ``True`` if ``other`` is a `FunctionSetVector` with
             ``other.space`` equal to this vector's space and evaluation
-            function of ``other`` and this vector is equal. False
+            function of ``other`` and this vector is equal, ``False``
             otherwise.
         """
         if other is self:
@@ -534,13 +534,13 @@ class FunctionSpace(FunctionSet, LinearSpace):
         field : `Field`, optional
             The range of the functions, usually the `RealNumbers` or
             `ComplexNumbers`. If not given, the field is either inferred
-            from ``out_dtype``, or, if the latter is also None, set
+            from ``out_dtype``, or, if the latter is also ``None``, set
             to ``RealNumbers()``.
         out_dtype : optional
             Data type of the return value of a function in this space.
             Can be given in any way `numpy.dtype` understands, e.g. as
-            string ('float64') or data type (float).
-            By default, 'float64' is used for real and 'complex128'
+            string (``'float64'``) or data type (``float``).
+            By default, ``'float64'`` is used for real and ``'complex128'``
             for complex spaces.
         """
         if not isinstance(domain, Set):
@@ -630,10 +630,10 @@ class FunctionSpace(FunctionSet, LinearSpace):
 
         Parameters
         ----------
-        fcall : callable, optional
+        fcall : `callable`, optional
             The actual instruction for out-of-place evaluation.
-            It must return an `FunctionSet.range` element or a
-            numpy.ndarray of such (vectorized call).
+            It must return a `FunctionSet.range` element or a
+            `numpy.ndarray` of such (vectorized call).
 
             If fcall is a `FunctionSetVector`, it is wrapped
             as a new `FunctionSpaceVector`.
@@ -720,9 +720,9 @@ class FunctionSpace(FunctionSet, LinearSpace):
         Returns
         -------
         equals : bool
-            True if ``other`` is a `FunctionSpace` with same
+            ``True`` if ``other`` is a `FunctionSpace` with same
             `FunctionSpace.domain` and `FunctionSpace.range`,
-            False otherwise.
+            ``False`` otherwise.
         """
         if other is self:
             return True
@@ -1161,7 +1161,7 @@ class FunctionSpaceVector(LinearSpaceVector, FunctionSetVector):
         ----------
         fspace : `FunctionSpace`
             Set of functions this element lives in.
-        fcall : callable
+        fcall : `callable`
             The actual instruction for out-of-place evaluation.
             It must return an `FunctionSet.range` element or a
             ``numpy.ndarray`` of such (vectorized call).

--- a/odl/space/npy_ntuples.py
+++ b/odl/space/npy_ntuples.py
@@ -1101,7 +1101,7 @@ class NumpyFn(FnBase, NumpyNtuples):
 
         Returns
         -------
-        dtype : type
+        dtype : `numpy.dtype`
             Numpy data type specifier. The returned defaults are:
 
             ``RealNumbers()`` : ``np.dtype('float64')``

--- a/odl/space/npy_ntuples.py
+++ b/odl/space/npy_ntuples.py
@@ -64,16 +64,16 @@ class NumpyNtuples(NtuplesBase):
 
         Parameters
         ----------
-        inp : array-like, optional
+        inp : `array-like`, optional
             Input to initialize the new element.
 
-            If ``inp`` is None, an empty element is created with no
+            If ``inp`` is ``None``, an empty element is created with no
             guarantee of its state (memory allocation only).
 
-            If ``inp`` is a numpy.ndarray of shape ``(size,)``
+            If ``inp`` is a `numpy.ndarray` of shape ``(size,)``
             and the same data type as this space, the array is wrapped,
             not copied.
-            Other array-like objects are copied.
+            Other `array-like` objects are copied.
 
         Returns
         -------
@@ -210,7 +210,7 @@ class NumpyNtuplesVector(NtuplesBaseVector):
 
     @property
     def data(self):
-        """Raw ``numpy.ndarray`` representing the data."""
+        """Raw Numpy array representing the data."""
         return self.__data
 
     def asarray(self, start=None, stop=None, step=None, out=None):
@@ -219,19 +219,19 @@ class NumpyNtuplesVector(NtuplesBaseVector):
         Parameters
         ----------
         start : int, optional
-            Start position. None means the first element.
-        start : int, optional
+            Start position. ``None`` means the first element.
+        stop : int, optional
             One element past the last element to be extracted.
-            None means the last element.
-        start : int, optional
-            Step length. None means 1.
-        out : numpy.ndarray, optional
-            Array in which the result should be written in-place.
-            Has to be contiguous and of the correct dtype.
+            ``None`` means the last element.
+        step : int, optional
+            Step length. ``None`` is equivalent to 1.
+        out : `numpy.ndarray`, optional
+            Array to which the result should be written.
+            Has to be contiguous and of the correct data type.
 
         Returns
         -------
-        asarray : numpy.ndarray
+        asarray : `numpy.ndarray`
             Numpy array of the same type as the space.
 
         Examples
@@ -286,8 +286,8 @@ class NumpyNtuplesVector(NtuplesBaseVector):
         Returns
         -------
         equals : bool
-            True if all entries of other are equal to this
-            vector's entries, False otherwise.
+            ``True`` if all entries of other are equal to this
+            vector's entries, ``False`` otherwise.
 
         Notes
         -----
@@ -347,7 +347,7 @@ class NumpyNtuplesVector(NtuplesBaseVector):
 
         Parameters
         ----------
-        indices : int or slice
+        indices : int or `slice`
             The position(s) that should be accessed
 
         Returns
@@ -377,7 +377,7 @@ class NumpyNtuplesVector(NtuplesBaseVector):
 
         Parameters
         ----------
-        indices : int or slice
+        indices : int or `slice`
             The position(s) that should be set
         values : scalar or `array-like`
             The value(s) that are to be assigned.
@@ -640,7 +640,7 @@ class NumpyFn(FnBase, NumpyNtuples):
         Other Parameters
         ----------------
 
-        dist : callable, optional
+        dist : `callable`, optional
             The distance function defining a metric on the space.
             It must accept two `FnVector` arguments and
             fulfill the following mathematical conditions for any
@@ -658,7 +658,7 @@ class NumpyFn(FnBase, NumpyNtuples):
             This option cannot be combined with ``weight``,
             ``norm`` or ``inner``.
 
-        norm : callable, optional
+        norm : `callable`, optional
             The norm implementation. It must accept an
             `FnVector` argument, return a float and satisfy the
             following conditions for all vectors ``x, y`` and scalars
@@ -674,7 +674,7 @@ class NumpyFn(FnBase, NumpyNtuples):
             This option cannot be combined with ``weight``,
             ``dist`` or ``inner``.
 
-        inner : callable, optional
+        inner : `callable`, optional
             The inner product implementation. It must accept two
             `FnVector` arguments, return a element from
             the field of the space (real or complex number) and
@@ -699,7 +699,7 @@ class NumpyFn(FnBase, NumpyNtuples):
 
             This option can only be used if ``exponent`` is 2.0.
 
-            Default: False.
+            Default: ``False``.
 
         kwargs :
             Further keyword arguments are passed to the weighting
@@ -791,7 +791,7 @@ class NumpyFn(FnBase, NumpyNtuples):
 
     @property
     def is_weighted(self):
-        """True if the weighting is not `NumpyFnNoWeighting`."""
+        """``True`` if the weighting is not `NumpyFnNoWeighting`."""
         return not isinstance(self.weighting, NumpyFnNoWeighting)
 
     def _lincomb(self, a, x1, b, x2, out):
@@ -1001,10 +1001,9 @@ class NumpyFn(FnBase, NumpyNtuples):
         Returns
         -------
         equals : bool
-            True if other is an instance of this space's type
-            with the same
-            `NtuplesBase.size` and `NtuplesBase.dtype`,
-            and identical distance function, False otherwise.
+            ``True`` if ``other`` is an instance of this space's type
+            with the same `NtuplesBase.size` and `NtuplesBase.dtype`,
+            and identical distance function, ``False`` otherwise.
 
         Examples
         --------
@@ -1102,7 +1101,7 @@ class NumpyFn(FnBase, NumpyNtuples):
 
         Returns
         -------
-        dtype : `type`
+        dtype : type
             Numpy data type specifier. The returned defaults are:
 
             ``RealNumbers()`` : ``np.dtype('float64')``
@@ -1165,7 +1164,7 @@ class NumpyFnVector(FnBaseVector, NumpyNtuplesVector):
 
         Parameters
         ----------
-        newreal : array-like or scalar
+        newreal : `array-like` or scalar
             The new real part for this vector.
 
         Examples
@@ -1304,7 +1303,7 @@ class MatVecOperator(Operator):
 
         Parameters
         ----------
-        matrix : array-like or  ``scipy.sparse.spmatrix``
+        matrix : `array-like` or  ``scipy.sparse.spmatrix``
             Matrix representing the linear operator. Its shape must be
             ``(m, n)``, where ``n`` is the size of ``domain`` and ``m`` the
             size of ``range``. Its dtype must be castable to the range
@@ -1431,14 +1430,14 @@ def npy_weighted_inner(weight):
 
     Parameters
     ----------
-    weight : scalar or array-like
+    weight : scalar or `array-like`
         Weight of the inner product. A scalar is interpreted as a
         constant weight, a 1-dim. array as a weighting vector and a
         2-dimensional array as a weighting matrix.
 
     Returns
     -------
-    inner : callable
+    inner : `callable`
         Inner product function with given weight. Constant weightings
         are applicable to spaces of any size, for arrays the sizes
         of the weighting and the space must match.
@@ -1455,7 +1454,7 @@ def npy_weighted_norm(weight, exponent=2.0):
 
     Parameters
     ----------
-    weight : scalar or array-like
+    weight : scalar or `array-like`
         Weight of the norm. A scalar is interpreted as a
         constant weight, a 1-dim. array as a weighting vector and a
         2-dimensional array as a weighting matrix.
@@ -1465,7 +1464,7 @@ def npy_weighted_norm(weight, exponent=2.0):
 
     Returns
     -------
-    norm : callable
+    norm : `callable`
         Norm function with given weight. Constant weightings
         are applicable to spaces of any size, for arrays the sizes
         of the weighting and the space must match.
@@ -1482,7 +1481,7 @@ def npy_weighted_dist(weight, exponent=2.0, use_inner=False):
 
     Parameters
     ----------
-    weight : scalar or array-like
+    weight : scalar or `array-like`
         Weight of the distance. A scalar is interpreted as a
         constant weight, a 1-dim. array as a weighting vector and a
         2-dimensional array as a weighting matrix.
@@ -1502,7 +1501,7 @@ def npy_weighted_dist(weight, exponent=2.0, use_inner=False):
 
     Returns
     -------
-    dist : callable
+    dist : `callable`
         Distance function with given weight. Constant weightings
         are applicable to spaces of any size, for arrays the sizes
         of the weighting and the space must match.
@@ -1594,7 +1593,7 @@ class NumpyFnMatrixWeighting(MatrixWeightingBase):
 
         Parameters
         ----------
-        matrix :  ``scipy.sparse.spmatrix`` or array-like, 2-dim.
+        matrix :  ``scipy.sparse.spmatrix`` or `array-like`, 2-dim.
             Square weighting matrix of the inner product
         exponent : positive float
             Exponent of the norm. For values other than 2.0, the inner
@@ -1612,14 +1611,14 @@ class NumpyFnMatrixWeighting(MatrixWeightingBase):
 
             This option can only be used if ``exponent`` is 2.0.
         precomp_mat_pow : bool, optional
-            If True, precompute the matrix power ``W ** (1/p)``
+            If ``True``, precompute the matrix power ``W ** (1/p)``
             during initialization. This has no effect if ``exponent``
             is 1.0, 2.0 or ``inf``.
 
             Default: False
 
         cache_mat_pow : bool, optional
-            If True, cache the matrix power ``W ** (1/p)``. This can
+            If ``True``, cache the matrix power ``W ** (1/p)``. This can
             happen either during initialization or in the first call to
             ``norm`` or ``dist``, resp. This has no effect if
             ``exponent`` is 1.0, 2.0 or ``inf``.
@@ -1627,7 +1626,7 @@ class NumpyFnMatrixWeighting(MatrixWeightingBase):
             Default: True
 
         cache_mat_decomp : bool, optional
-            If True, cache the eigenbasis decomposition of the
+            If ``True``, cache the eigenbasis decomposition of the
             matrix. This can happen either during initialization or in
             the first call to ``norm`` or ``dist``, resp. This has no
             effect if ``exponent`` is 1.0, 2.0 or ``inf``.
@@ -1757,7 +1756,7 @@ class NumpyFnVectorWeighting(VectorWeightingBase):
 
         Parameters
         ----------
-        vector : array-like, one-dim.
+        vector : `array-like`, one-dim.
             Weighting vector of the inner product, norm and distance
         exponent : positive float
             Exponent of the norm. For values other than 2.0, the inner
@@ -2016,7 +2015,7 @@ class NumpyFnCustomInnerProduct(CustomInnerProductBase):
 
         Parameters
         ----------
-        inner : callable
+        inner : `callable`
             The inner product implementation. It must accept two
             `FnVector` arguments, return an element from their space's
             field (real or complex number) and satisfy the following
@@ -2051,7 +2050,7 @@ class NumpyFnCustomNorm(CustomNormBase):
 
         Parameters
         ----------
-        norm : callable
+        norm : `callable`
             The norm implementation. It must accept an `FnVector`
             argument, return a float and satisfy the following
             conditions for all vectors ``x, y`` and scalars ``s``:
@@ -2076,7 +2075,7 @@ class NumpyFnCustomDist(CustomDistBase):
 
         Parameters
         ----------
-        dist : callable
+        dist : `callable`
             The distance function defining a metric on `NumpyFn`. It must
             accept two `FnVector` arguments, return a float and
             fulfill the following mathematical conditions for any three

--- a/odl/space/npy_ntuples.py
+++ b/odl/space/npy_ntuples.py
@@ -64,13 +64,13 @@ class NumpyNtuples(NtuplesBase):
 
         Parameters
         ----------
-        inp : `array-like`, optional
+        inp : array-like, optional
             Input to initialize the new element.
 
-            If ``inp`` is `None`, an empty element is created with no
+            If ``inp`` is None, an empty element is created with no
             guarantee of its state (memory allocation only).
 
-            If ``inp`` is a `numpy.ndarray` of shape ``(size,)``
+            If ``inp`` is a numpy.ndarray of shape ``(size,)``
             and the same data type as this space, the array is wrapped,
             not copied.
             Other array-like objects are copied.
@@ -210,7 +210,7 @@ class NumpyNtuplesVector(NtuplesBaseVector):
 
     @property
     def data(self):
-        """Raw `numpy.ndarray` representing the data."""
+        """Raw ``numpy.ndarray`` representing the data."""
         return self.__data
 
     def asarray(self, start=None, stop=None, step=None, out=None):
@@ -218,20 +218,20 @@ class NumpyNtuplesVector(NtuplesBaseVector):
 
         Parameters
         ----------
-        start : `int`, optional
+        start : int, optional
             Start position. None means the first element.
-        start : `int`, optional
+        start : int, optional
             One element past the last element to be extracted.
             None means the last element.
-        start : `int`, optional
+        start : int, optional
             Step length. None means 1.
-        out : `numpy.ndarray`, optional
+        out : numpy.ndarray, optional
             Array in which the result should be written in-place.
             Has to be contiguous and of the correct dtype.
 
         Returns
         -------
-        asarray : `numpy.ndarray`
+        asarray : numpy.ndarray
             Numpy array of the same type as the space.
 
         Examples
@@ -285,9 +285,9 @@ class NumpyNtuplesVector(NtuplesBaseVector):
 
         Returns
         -------
-        equals : `bool`
-            `True` if all entries of other are equal to this
-            vector's entries, `False` otherwise.
+        equals : bool
+            True if all entries of other are equal to this
+            vector's entries, False otherwise.
 
         Notes
         -----
@@ -347,7 +347,7 @@ class NumpyNtuplesVector(NtuplesBaseVector):
 
         Parameters
         ----------
-        indices : `int` or `slice`
+        indices : int or slice
             The position(s) that should be accessed
 
         Returns
@@ -377,7 +377,7 @@ class NumpyNtuplesVector(NtuplesBaseVector):
 
         Parameters
         ----------
-        indices : `int` or `slice`
+        indices : int or slice
             The position(s) that should be set
         values : scalar or `array-like`
             The value(s) that are to be assigned.
@@ -390,7 +390,7 @@ class NumpyNtuplesVector(NtuplesBaseVector):
 
         Returns
         -------
-        `None`
+        None
 
         Examples
         --------
@@ -490,7 +490,7 @@ def _blas_is_applicable(*args):
     """Whether BLAS routines can be applied or not.
 
     BLAS routines are available for single and double precision
-    `float` or `complex` data only. If the arrays are non-contiguous,
+    float or complex data only. If the arrays are non-contiguous,
     BLAS methods are usually slower, and array-writing routines do
     not work at all. Hence, only contiguous arrays are allowed.
 
@@ -597,12 +597,12 @@ class NumpyFn(FnBase, NumpyNtuples):
 
         Parameters
         ----------
-        size : positive `int`
+        size : positive int
             The number of dimensions of the space
-        dtype : `object`
+        dtype :
             The data type of the storage array. Can be provided in any
             way the `numpy.dtype` function understands, most notably
-            as built-in type, as `numpy.dtype` or as `string`.
+            as built-in type, as `numpy.dtype` or as string.
 
             Only scalar data types are allowed.
 
@@ -626,7 +626,7 @@ class NumpyFn(FnBase, NumpyNtuples):
             This option cannot be combined with ``dist``,
             ``norm`` or ``inner``.
 
-        exponent : positive `float`, optional
+        exponent : positive float, optional
             Exponent of the norm. For values other than 2.0, no
             inner product is defined.
             If ``weight`` is a sparse matrix, only 1.0, 2.0 and
@@ -640,7 +640,7 @@ class NumpyFn(FnBase, NumpyNtuples):
         Other Parameters
         ----------------
 
-        dist : `callable`, optional
+        dist : callable, optional
             The distance function defining a metric on the space.
             It must accept two `FnVector` arguments and
             fulfill the following mathematical conditions for any
@@ -658,9 +658,9 @@ class NumpyFn(FnBase, NumpyNtuples):
             This option cannot be combined with ``weight``,
             ``norm`` or ``inner``.
 
-        norm : `callable`, optional
+        norm : callable, optional
             The norm implementation. It must accept an
-            `FnVector` argument, return a `float` and satisfy the
+            `FnVector` argument, return a float and satisfy the
             following conditions for all vectors ``x, y`` and scalars
             ``s``:
 
@@ -674,7 +674,7 @@ class NumpyFn(FnBase, NumpyNtuples):
             This option cannot be combined with ``weight``,
             ``dist`` or ``inner``.
 
-        inner : `callable`, optional
+        inner : callable, optional
             The inner product implementation. It must accept two
             `FnVector` arguments, return a element from
             the field of the space (real or complex number) and
@@ -688,7 +688,7 @@ class NumpyFn(FnBase, NumpyNtuples):
             This option cannot be combined with ``weight``,
             ``dist`` or ``norm``.
 
-        dist_using_inner : `bool`, optional
+        dist_using_inner : bool, optional
             Calculate ``dist`` using the formula
 
                 ``||x - y||^2 = ||x||^2 + ||y||^2 - 2 * Re <x, y>``
@@ -699,7 +699,7 @@ class NumpyFn(FnBase, NumpyNtuples):
 
             This option can only be used if ``exponent`` is 2.0.
 
-            Default: `False`.
+            Default: False.
 
         kwargs :
             Further keyword arguments are passed to the weighting
@@ -791,7 +791,7 @@ class NumpyFn(FnBase, NumpyNtuples):
 
     @property
     def is_weighted(self):
-        """Return `True` if the weighting is not `NumpyFnNoWeighting`."""
+        """True if the weighting is not `NumpyFnNoWeighting`."""
         return not isinstance(self.weighting, NumpyFnNoWeighting)
 
     def _lincomb(self, a, x1, b, x2, out):
@@ -811,7 +811,7 @@ class NumpyFn(FnBase, NumpyNtuples):
 
         Returns
         -------
-        `None`
+        None
 
         Examples
         --------
@@ -836,7 +836,7 @@ class NumpyFn(FnBase, NumpyNtuples):
 
         Returns
         -------
-        dist : `float`
+        dist : float
             Distance between the vectors
 
         Examples
@@ -881,7 +881,7 @@ class NumpyFn(FnBase, NumpyNtuples):
 
         Returns
         -------
-        norm : `float`
+        norm : float
             Norm of the vector
 
         Examples
@@ -915,7 +915,7 @@ class NumpyFn(FnBase, NumpyNtuples):
 
         Returns
         -------
-        inner : `field` `element`
+        inner : `field` element
             Inner product of the vectors
 
         Examples
@@ -953,7 +953,7 @@ class NumpyFn(FnBase, NumpyNtuples):
 
         Returns
         -------
-        `None`
+        None
 
         Examples
         --------
@@ -980,7 +980,7 @@ class NumpyFn(FnBase, NumpyNtuples):
 
         Returns
         -------
-        `None`
+        None
 
         Examples
         --------
@@ -1000,11 +1000,11 @@ class NumpyFn(FnBase, NumpyNtuples):
 
         Returns
         -------
-        equals : `bool`
-            `True` if other is an instance of this space's type
+        equals : bool
+            True if other is an instance of this space's type
             with the same
             `NtuplesBase.size` and `NtuplesBase.dtype`,
-            and identical distance function, otherwise `False`.
+            and identical distance function, False otherwise.
 
         Examples
         --------
@@ -1165,7 +1165,7 @@ class NumpyFnVector(FnBaseVector, NumpyNtuplesVector):
 
         Parameters
         ----------
-        newreal : `array-like` or scalar
+        newreal : array-like or scalar
             The new real part for this vector.
 
         Examples
@@ -1304,7 +1304,7 @@ class MatVecOperator(Operator):
 
         Parameters
         ----------
-        matrix : `array-like` or  ``scipy.sparse.spmatrix``
+        matrix : array-like or  ``scipy.sparse.spmatrix``
             Matrix representing the linear operator. Its shape must be
             ``(m, n)``, where ``n`` is the size of ``domain`` and ``m`` the
             size of ``range``. Its dtype must be castable to the range
@@ -1431,14 +1431,14 @@ def npy_weighted_inner(weight):
 
     Parameters
     ----------
-    weight : scalar or `array-like`
+    weight : scalar or array-like
         Weight of the inner product. A scalar is interpreted as a
         constant weight, a 1-dim. array as a weighting vector and a
         2-dimensional array as a weighting matrix.
 
     Returns
     -------
-    inner : `callable`
+    inner : callable
         Inner product function with given weight. Constant weightings
         are applicable to spaces of any size, for arrays the sizes
         of the weighting and the space must match.
@@ -1455,17 +1455,17 @@ def npy_weighted_norm(weight, exponent=2.0):
 
     Parameters
     ----------
-    weight : scalar or `array-like`
+    weight : scalar or array-like
         Weight of the norm. A scalar is interpreted as a
         constant weight, a 1-dim. array as a weighting vector and a
         2-dimensional array as a weighting matrix.
-    exponent : positive `float`
+    exponent : positive float
         Exponent of the norm. If ``weight`` is a sparse matrix, only
         1.0, 2.0 and ``inf`` are allowed.
 
     Returns
     -------
-    norm : `callable`
+    norm : callable
         Norm function with given weight. Constant weightings
         are applicable to spaces of any size, for arrays the sizes
         of the weighting and the space must match.
@@ -1482,14 +1482,14 @@ def npy_weighted_dist(weight, exponent=2.0, use_inner=False):
 
     Parameters
     ----------
-    weight : scalar or `array-like`
+    weight : scalar or array-like
         Weight of the distance. A scalar is interpreted as a
         constant weight, a 1-dim. array as a weighting vector and a
         2-dimensional array as a weighting matrix.
-    exponent : positive `float`
+    exponent : positive float
         Exponent of the norm. If ``weight`` is a sparse matrix, only
         1.0, 2.0 and ``inf`` are allowed.
-    use_inner : `bool`, optional
+    use_inner : bool, optional
         Calculate ``dist`` using the formula
 
             ``||x - y||^2 = ||x||^2 + ||y||^2 - 2 * Re <x, y>``
@@ -1502,7 +1502,7 @@ def npy_weighted_dist(weight, exponent=2.0, use_inner=False):
 
     Returns
     -------
-    dist : `callable`
+    dist : callable
         Distance function with given weight. Constant weightings
         are applicable to spaces of any size, for arrays the sizes
         of the weighting and the space must match.
@@ -1594,14 +1594,14 @@ class NumpyFnMatrixWeighting(MatrixWeightingBase):
 
         Parameters
         ----------
-        matrix :  ``scipy.sparse.spmatrix`` or `array-like`, 2-dim.
+        matrix :  ``scipy.sparse.spmatrix`` or array-like, 2-dim.
             Square weighting matrix of the inner product
-        exponent : positive `float`
+        exponent : positive float
             Exponent of the norm. For values other than 2.0, the inner
             product is not defined.
             If ``matrix`` is a sparse matrix, only 1.0, 2.0 and ``inf``
             are allowed.
-        dist_using_inner : `bool`, optional
+        dist_using_inner : bool, optional
             Calculate ``dist`` using the formula
 
                 ``||x - y||^2 = ||x||^2 + ||y||^2 - 2 * Re <x, y>``
@@ -1611,28 +1611,28 @@ class NumpyFnMatrixWeighting(MatrixWeightingBase):
             exactly zero for equal (but not identical) ``x`` and ``y``.
 
             This option can only be used if ``exponent`` is 2.0.
-        precomp_mat_pow : `bool`, optional
-            If `True`, precompute the matrix power ``W ** (1/p)``
+        precomp_mat_pow : bool, optional
+            If True, precompute the matrix power ``W ** (1/p)``
             during initialization. This has no effect if ``exponent``
             is 1.0, 2.0 or ``inf``.
 
-            Default: `False`
+            Default: False
 
-        cache_mat_pow : `bool`, optional
-            If `True`, cache the matrix power ``W ** (1/p)``. This can
+        cache_mat_pow : bool, optional
+            If True, cache the matrix power ``W ** (1/p)``. This can
             happen either during initialization or in the first call to
             ``norm`` or ``dist``, resp. This has no effect if
             ``exponent`` is 1.0, 2.0 or ``inf``.
 
-            Default: `True`
+            Default: True
 
-        cache_mat_decomp : `bool`, optional
-            If `True`, cache the eigenbasis decomposition of the
+        cache_mat_decomp : bool, optional
+            If True, cache the eigenbasis decomposition of the
             matrix. This can happen either during initialization or in
             the first call to ``norm`` or ``dist``, resp. This has no
             effect if ``exponent`` is 1.0, 2.0 or ``inf``.
 
-            Default: `False`
+            Default: False
 
         Notes
         -----
@@ -1657,7 +1657,7 @@ class NumpyFnMatrixWeighting(MatrixWeightingBase):
 
         Returns
         -------
-        inner : `float` or `complex`
+        inner : float or complex
             The inner product of the vectors
         """
         if self.exponent != 2.0:
@@ -1681,7 +1681,7 @@ class NumpyFnMatrixWeighting(MatrixWeightingBase):
 
         Returns
         -------
-        norm : `float`
+        norm : float
             The norm of the vector
         """
         if self.exponent == 2.0:
@@ -1757,12 +1757,12 @@ class NumpyFnVectorWeighting(VectorWeightingBase):
 
         Parameters
         ----------
-        vector : `array-like`, one-dim.
+        vector : array-like, one-dim.
             Weighting vector of the inner product, norm and distance
-        exponent : positive `float`
+        exponent : positive float
             Exponent of the norm. For values other than 2.0, the inner
             product is not defined.
-        dist_using_inner : `bool`, optional
+        dist_using_inner : bool, optional
             Calculate ``dist`` using the formula
 
                 ``||x - y||^2 = ||x||^2 + ||y||^2 - 2 * Re <x, y>``
@@ -1786,7 +1786,7 @@ class NumpyFnVectorWeighting(VectorWeightingBase):
 
         Returns
         -------
-        inner : `float` or `complex`
+        inner : float or complex
             The inner product of the two provided vectors
         """
         if self.exponent != 2.0:
@@ -1810,7 +1810,7 @@ class NumpyFnVectorWeighting(VectorWeightingBase):
 
         Returns
         -------
-        norm : `float`
+        norm : float
             The norm of the provided vector
         """
         if self.exponent == 2.0:
@@ -1858,12 +1858,12 @@ class NumpyFnConstWeighting(ConstWeightingBase):
 
         Parameters
         ----------
-        constant : positive `float`
+        constant : positive float
             Weighting constant of the inner product.
-        exponent : positive `float`
+        exponent : positive float
             Exponent of the norm. For values other than 2.0, the inner
             product is not defined.
-        dist_using_inner : `bool`, optional
+        dist_using_inner : bool, optional
             Calculate ``dist`` using the formula
 
                 ``||x - y||^2 = ||x||^2 + ||y||^2 - 2 * Re <x, y>``
@@ -1887,7 +1887,7 @@ class NumpyFnConstWeighting(ConstWeightingBase):
 
         Returns
         -------
-        inner : `float` or `complex`
+        inner : float or complex
             The inner product of the two provided vectors
         """
         if self.exponent != 2.0:
@@ -1908,7 +1908,7 @@ class NumpyFnConstWeighting(ConstWeightingBase):
 
         Returns
         -------
-        norm : `float`
+        norm : float
             The norm of the vector
         """
         if self.exponent == 2.0:
@@ -1929,7 +1929,7 @@ class NumpyFnConstWeighting(ConstWeightingBase):
 
         Returns
         -------
-        dist : `float`
+        dist : float
             The distance between the vectors
         """
         if self.dist_using_inner:
@@ -1989,10 +1989,10 @@ class NumpyFnNoWeighting(NoWeightingBase, NumpyFnConstWeighting):
 
         Parameters
         ----------
-        exponent : positive `float`
+        exponent : positive float
             Exponent of the norm. For values other than 2.0, the inner
             product is not defined.
-        dist_using_inner : `bool`, optional
+        dist_using_inner : bool, optional
             Calculate ``dist`` using the formula
 
                 ``||x - y||^2 = ||x||^2 + ||y||^2 - 2 * Re <x, y>``
@@ -2016,7 +2016,7 @@ class NumpyFnCustomInnerProduct(CustomInnerProductBase):
 
         Parameters
         ----------
-        inner : `callable`
+        inner : callable
             The inner product implementation. It must accept two
             `FnVector` arguments, return an element from their space's
             field (real or complex number) and satisfy the following
@@ -2026,7 +2026,7 @@ class NumpyFnCustomInnerProduct(CustomInnerProductBase):
             - ``<s*x + y, z> = s * <x, z> + <y, z>``
             - ``<x, x> = 0``  if and only if  ``x = 0``
 
-        dist_using_inner : `bool`, optional
+        dist_using_inner : bool, optional
             Calculate ``dist`` using the formula
 
                 ``||x - y||^2 = ||x||^2 + ||y||^2 - 2 * Re <x, y>``
@@ -2051,9 +2051,9 @@ class NumpyFnCustomNorm(CustomNormBase):
 
         Parameters
         ----------
-        norm : `callable`
+        norm : callable
             The norm implementation. It must accept an `FnVector`
-            argument, return a `float` and satisfy the following
+            argument, return a float and satisfy the following
             conditions for all vectors ``x, y`` and scalars ``s``:
 
             - ``||x|| >= 0``
@@ -2076,9 +2076,9 @@ class NumpyFnCustomDist(CustomDistBase):
 
         Parameters
         ----------
-        dist : `callable`
+        dist : callable
             The distance function defining a metric on `NumpyFn`. It must
-            accept two `FnVector` arguments, return a `float` and and
+            accept two `FnVector` arguments, return a float and
             fulfill the following mathematical conditions for any three
             vectors ``x, y, z``:
 

--- a/odl/space/pspace.py
+++ b/odl/space/pspace.py
@@ -55,11 +55,11 @@ class ProductSpace(LinearSpace):
 
         Parameters
         ----------
-        space1,...,spaceN : `LinearSpace` or `int`
+        space1,...,spaceN : `LinearSpace` or int
             The individual spaces ("factors / parts") in the product
             space. Can also be given as ``space, n`` with ``n`` integer,
             in which case the power space ``space ** n`` is created.
-        exponent : non-zero `float` or ``float('inf')``, optional
+        exponent : non-zero float or ``float('inf')``, optional
             Order of the product distance/norm, i.e.
 
             ``dist(x, y) = np.linalg.norm(x-y, ord=exponent)``
@@ -80,7 +80,7 @@ class ProductSpace(LinearSpace):
             Use weighted inner product, norm, and dist. The following
             types are supported as ``weight``:
 
-            `None` : no weighting (default)
+            None : no weighting (default)
 
             `WeightingBase` : weighting class, used directly. Such a
             class instance can be retrieved from the space by the
@@ -94,7 +94,7 @@ class ProductSpace(LinearSpace):
 
         Other Parameters
         ----------------
-        dist : `callable`, optional
+        dist : callable, optional
             The distance function defining a metric on the space.
             It must accept two `ProductSpaceVector` arguments and
             fulfill the following mathematical conditions for any
@@ -111,9 +111,9 @@ class ProductSpace(LinearSpace):
 
             Cannot be combined with: ``weight, norm, inner``
 
-        norm : `callable`, optional
+        norm : callable, optional
             The norm implementation. It must accept an
-            `ProductSpaceVector` argument, return a `float` and satisfy the
+            `ProductSpaceVector` argument, return a float and satisfy the
             following conditions for all vectors ``x, y`` and scalars
             ``s``:
 
@@ -126,7 +126,7 @@ class ProductSpace(LinearSpace):
 
             Cannot be combined with: ``weight, dist, inner``
 
-        inner : `callable`, optional
+        inner : callable, optional
             The inner product implementation. It must accept two
             `ProductSpaceVector` arguments, return a element from
             the field of the space (real or complex number) and
@@ -139,7 +139,7 @@ class ProductSpace(LinearSpace):
 
             Cannot be combined with: ``weight, dist, norm``
 
-        dist_using_inner : `bool`, optional
+        dist_using_inner : bool, optional
             Calculate ``dist`` using the formula
 
                 ``||x - y||^2 = ||x||^2 + ||y||^2 - 2 * Re <x, y>``
@@ -150,7 +150,7 @@ class ProductSpace(LinearSpace):
 
             This option can only be used if ``exponent`` is 2.0.
 
-            Default: `False`.
+            Default: False.
 
             Cannot be combined with: ``dist``
 
@@ -322,12 +322,12 @@ class ProductSpace(LinearSpace):
 
     @property
     def is_power_space(self):
-        """`True` if all member spaces are equal."""
+        """True if all member spaces are equal."""
         return all(spc == self.spaces[0] for spc in self.spaces[1:])
 
     @property
     def exponent(self):
-        """Exponent of the product space norm/dist, `None` for custom."""
+        """Exponent of the product space norm/dist, None for custom."""
         return self.weighting.exponent
 
     @property
@@ -337,7 +337,7 @@ class ProductSpace(LinearSpace):
 
     @property
     def is_weighted(self):
-        """Return `True` if the weighting is not `ProductSpaceNoWeighting`."""
+        """Return True if the weighting is not `ProductSpaceNoWeighting`."""
         return not isinstance(self.weighting, ProductSpaceNoWeighting)
 
     def element(self, inp=None, cast=True):
@@ -346,13 +346,13 @@ class ProductSpace(LinearSpace):
         Parameters
         ----------
         inp : optional
-            If ``inp`` is `None`, a new element is created from
+            If ``inp`` is None, a new element is created from
             scratch by allocation in the spaces. If ``inp`` is
             already an element of this space, it is re-wrapped.
             Otherwise, a new element is created from the
             components by calling the ``element()`` methods
             in the component spaces.
-        cast : `bool`
+        cast : bool
             True if casting should be allowed
 
         Returns
@@ -504,9 +504,9 @@ class ProductSpace(LinearSpace):
 
         Returns
         -------
-        equals : `bool`
-            `True` if ``other`` is a `ProductSpace` instance, has
-            the same length and the same factors. `False` otherwise.
+        equals : bool
+            True if ``other`` is a `ProductSpace` instance, has
+            the same length and the same factors. False otherwise.
 
         Examples
         --------
@@ -755,7 +755,7 @@ class ProductSpaceVector(LinearSpaceVector):
 
         Parameters
         ----------
-        title : `str`
+        title : string
             Title of the figures
 
         indices : index expression, optional
@@ -765,13 +765,13 @@ class ProductSpaceVector(LinearSpaceVector):
             Single index (``indices=0``)
             => display that part
 
-            Single `slice` (``indices=slice(None)``), or
-            index `list` (``indices=[0, 1, 3]``)
+            Single slice (``indices=slice(None)``), or
+            index list (``indices=[0, 1, 3]``)
             => display those parts
 
-            Any `tuple`, for example:
+            Any tuple, for example:
             Created by `numpy.s_` ``indices=np.s_[0, :, :]`` or
-            Using a raw `tuple` ``indices=([0, 3], slice(None))``
+            Using a raw tuple ``indices=([0, 3], slice(None))``
             => take the first elements to select the parts and
             pass the rest on to the underlying show methods.
 
@@ -859,12 +859,12 @@ class ProductSpaceVectorWeighting(VectorWeightingBase):
 
         Parameters
         ----------
-        vector : 1-dim. `array-like`
+        vector : 1-dim. array-like
             Weighting vector of the inner product
-        exponent : positive `float`, optional
+        exponent : positive float, optional
             Exponent of the norm. For values other than 2.0, no inner
             product is defined.
-        dist_using_inner : `bool`, optional
+        dist_using_inner : bool, optional
             Calculate ``dist`` using the formula
 
                 ``||x - y||^2 = ||x||^2 + ||y||^2 - 2 * Re <x, y>``
@@ -888,7 +888,7 @@ class ProductSpaceVectorWeighting(VectorWeightingBase):
 
         Returns
         -------
-        inner : `float` or `complex`
+        inner : float or complex
             The inner product of the two provided vectors
         """
         if self.exponent != 2.0:
@@ -916,7 +916,7 @@ class ProductSpaceVectorWeighting(VectorWeightingBase):
 
         Returns
         -------
-        norm : `float`
+        norm : float
             The norm of the provided vector
         """
         if self.exponent == 2.0:
@@ -967,12 +967,12 @@ class ProductSpaceConstWeighting(ConstWeightingBase):
 
         Parameters
         ----------
-        constant : positive `float`
+        constant : positive float
             Weighting constant of the inner product
-        exponent : positive `float`, optional
+        exponent : positive float, optional
             Exponent of the norm. For values other than 2.0, no inner
             product is defined.
-        dist_using_inner : `bool`, optional
+        dist_using_inner : bool, optional
             Calculate ``dist`` using the formula
 
                 ``||x - y||^2 = ||x||^2 + ||y||^2 - 2 * Re <x, y>``
@@ -996,7 +996,7 @@ class ProductSpaceConstWeighting(ConstWeightingBase):
 
         Returns
         -------
-        inner : `float` or `complex`
+        inner : float or complex
             The inner product of the two provided vectors
         """
         if self.exponent != 2.0:
@@ -1024,7 +1024,7 @@ class ProductSpaceConstWeighting(ConstWeightingBase):
 
         Returns
         -------
-        norm : `float`
+        norm : float
             The norm of the vector
         """
         if self.exponent == 2.0:
@@ -1051,7 +1051,7 @@ class ProductSpaceConstWeighting(ConstWeightingBase):
 
         Returns
         -------
-        dist : `float`
+        dist : float
             The distance between the vectors
         """
         if self.dist_using_inner:
@@ -1119,10 +1119,10 @@ class ProductSpaceNoWeighting(NoWeightingBase, ProductSpaceConstWeighting):
 
         Parameters
         ----------
-        exponent : positive `float`
+        exponent : positive float
             Exponent of the norm. For values other than 2.0, the inner
             product is not defined.
-        dist_using_inner : `bool`, optional
+        dist_using_inner : bool, optional
             Calculate ``dist`` using the formula
 
                 ``||x - y||^2 = ||x||^2 + ||y||^2 - 2 * Re <x, y>``
@@ -1146,7 +1146,7 @@ class ProductSpaceCustomInnerProduct(CustomInnerProductBase):
 
         Parameters
         ----------
-        inner : `callable`
+        inner : callable
             The inner product implementation. It must accept two
             `ProductSpaceVector` arguments, return a element from
             the field of the space (real or complex number) and
@@ -1157,7 +1157,7 @@ class ProductSpaceCustomInnerProduct(CustomInnerProductBase):
             - ``<s*x + y, z> = s * <x, z> + <y, z>``
             - ``<x, x> = 0``  if and only if  ``x = 0``
 
-        dist_using_inner : `bool`, optional
+        dist_using_inner : bool, optional
             Calculate ``dist`` using the formula
 
                 ``||x - y||^2 = ||x||^2 + ||y||^2 - 2 * Re <x, y>``
@@ -1184,9 +1184,9 @@ class ProductSpaceCustomNorm(CustomNormBase):
 
         Parameters
         ----------
-        norm : `callable`
+        norm : callable
             The norm implementation. It must accept a
-            `ProductSpaceVector` argument, return a `float` and satisfy
+            `ProductSpaceVector` argument, return a float and satisfy
             the following conditions for all vectors
             ``x, y`` and scalars ``s``:
 
@@ -1210,7 +1210,7 @@ class ProductSpaceCustomDist(CustomDistBase):
 
         Parameters
         ----------
-        dist : `callable`
+        dist : callable
             The distance function defining a metric on
             `ProductSpace`. It must accept two `ProductSpaceVector`
             arguments and fulfill the following mathematical conditions

--- a/odl/space/pspace.py
+++ b/odl/space/pspace.py
@@ -80,13 +80,13 @@ class ProductSpace(LinearSpace):
             Use weighted inner product, norm, and dist. The following
             types are supported as ``weight``:
 
-            None : no weighting (default)
+            ``None`` : no weighting (default)
 
             `WeightingBase` : weighting class, used directly. Such a
             class instance can be retrieved from the space by the
             `ProductSpace.weighting` property.
 
-            array-like : weigh each component with one entry from the
+            `array-like` : weigh each component with one entry from the
             array. The array must be one-dimensional and have the same
             length as the number of spaces.
 
@@ -94,7 +94,7 @@ class ProductSpace(LinearSpace):
 
         Other Parameters
         ----------------
-        dist : callable, optional
+        dist : `callable`, optional
             The distance function defining a metric on the space.
             It must accept two `ProductSpaceVector` arguments and
             fulfill the following mathematical conditions for any
@@ -111,7 +111,7 @@ class ProductSpace(LinearSpace):
 
             Cannot be combined with: ``weight, norm, inner``
 
-        norm : callable, optional
+        norm : `callable`, optional
             The norm implementation. It must accept an
             `ProductSpaceVector` argument, return a float and satisfy the
             following conditions for all vectors ``x, y`` and scalars
@@ -126,7 +126,7 @@ class ProductSpace(LinearSpace):
 
             Cannot be combined with: ``weight, dist, inner``
 
-        inner : callable, optional
+        inner : `callable`, optional
             The inner product implementation. It must accept two
             `ProductSpaceVector` arguments, return a element from
             the field of the space (real or complex number) and
@@ -150,7 +150,7 @@ class ProductSpace(LinearSpace):
 
             This option can only be used if ``exponent`` is 2.0.
 
-            Default: False.
+            Default: ``False``.
 
             Cannot be combined with: ``dist``
 
@@ -322,12 +322,12 @@ class ProductSpace(LinearSpace):
 
     @property
     def is_power_space(self):
-        """True if all member spaces are equal."""
+        """``True`` if all member spaces are equal."""
         return all(spc == self.spaces[0] for spc in self.spaces[1:])
 
     @property
     def exponent(self):
-        """Exponent of the product space norm/dist, None for custom."""
+        """Exponent of the product space norm/dist, ``None`` for custom."""
         return self.weighting.exponent
 
     @property
@@ -337,7 +337,7 @@ class ProductSpace(LinearSpace):
 
     @property
     def is_weighted(self):
-        """Return True if the weighting is not `ProductSpaceNoWeighting`."""
+        """Return ``True`` if weighting is not `ProductSpaceNoWeighting`."""
         return not isinstance(self.weighting, ProductSpaceNoWeighting)
 
     def element(self, inp=None, cast=True):
@@ -346,14 +346,16 @@ class ProductSpace(LinearSpace):
         Parameters
         ----------
         inp : optional
-            If ``inp`` is None, a new element is created from
+            If ``inp`` is ``None``, a new element is created from
             scratch by allocation in the spaces. If ``inp`` is
             already an element of this space, it is re-wrapped.
             Otherwise, a new element is created from the
             components by calling the ``element()`` methods
             in the component spaces.
         cast : bool
-            True if casting should be allowed
+            If ``True``, casting is allowed. Otherwise, a ``TypeError``
+            is raised for input that is not a sequence of elements of
+            the spaces that make up this product space.
 
         Returns
         -------
@@ -505,8 +507,8 @@ class ProductSpace(LinearSpace):
         Returns
         -------
         equals : bool
-            True if ``other`` is a `ProductSpace` instance, has
-            the same length and the same factors. False otherwise.
+            ``True`` if ``other`` is a `ProductSpace` instance, has
+            the same length and the same factors. ``False`` otherwise.
 
         Examples
         --------
@@ -859,7 +861,7 @@ class ProductSpaceVectorWeighting(VectorWeightingBase):
 
         Parameters
         ----------
-        vector : 1-dim. array-like
+        vector : 1-dim. `array-like`
             Weighting vector of the inner product
         exponent : positive float, optional
             Exponent of the norm. For values other than 2.0, no inner
@@ -1146,7 +1148,7 @@ class ProductSpaceCustomInnerProduct(CustomInnerProductBase):
 
         Parameters
         ----------
-        inner : callable
+        inner : `callable`
             The inner product implementation. It must accept two
             `ProductSpaceVector` arguments, return a element from
             the field of the space (real or complex number) and
@@ -1184,7 +1186,7 @@ class ProductSpaceCustomNorm(CustomNormBase):
 
         Parameters
         ----------
-        norm : callable
+        norm : `callable`
             The norm implementation. It must accept a
             `ProductSpaceVector` argument, return a float and satisfy
             the following conditions for all vectors
@@ -1210,7 +1212,7 @@ class ProductSpaceCustomDist(CustomDistBase):
 
         Parameters
         ----------
-        dist : callable
+        dist : `callable`
             The distance function defining a metric on
             `ProductSpace`. It must accept two `ProductSpaceVector`
             arguments and fulfill the following mathematical conditions

--- a/odl/space/space_utils.py
+++ b/odl/space/space_utils.py
@@ -37,10 +37,10 @@ def vector(array, dtype=None, impl='numpy'):
 
     Parameters
     ----------
-    array : `array-like`
+    array : array-like
         Array from which to create the vector. Scalars become
         one-dimensional vectors.
-    dtype : `object`, optional
+    dtype : optional
         Set the data type of the vector manually with this option.
         By default, the space type is inferred from the input data.
     impl : `str`

--- a/odl/space/space_utils.py
+++ b/odl/space/space_utils.py
@@ -37,13 +37,13 @@ def vector(array, dtype=None, impl='numpy'):
 
     Parameters
     ----------
-    array : array-like
+    array : `array-like`
         Array from which to create the vector. Scalars become
         one-dimensional vectors.
     dtype : optional
         Set the data type of the vector manually with this option.
         By default, the space type is inferred from the input data.
-    impl : `str`
+    impl : string
         Implementation backend for the vector. See `NTUPLES_IMPLS` and
         `FN_IMPLS` for more information.
 
@@ -105,7 +105,7 @@ def ntuples(size, dtype, impl='numpy', **kwargs):
 
     Parameters
     ----------
-    size : positive `int`
+    size : positive int
         The number of dimensions of the space
     dtype : `object`
         The data type of the storage array. Can be provided in any
@@ -114,7 +114,7 @@ def ntuples(size, dtype, impl='numpy', **kwargs):
         objects or as string.
 
         Only complex floating-point data types are allowed.
-    impl : `str`
+    impl : string
         The backend to use. See `NTUPLES_IMPLS` for available options.
     kwargs :
         Extra keyword arguments to pass to the implmentation.
@@ -136,7 +136,7 @@ def fn(size, dtype=None, impl='numpy', **kwargs):
 
     Parameters
     ----------
-    size : positive `int`
+    size : positive int
         The number of dimensions of the space
     dtype : `object`
         The data type of the storage array. Can be provided in any
@@ -146,7 +146,7 @@ def fn(size, dtype=None, impl='numpy', **kwargs):
 
         Default: default of the implementation given by calling
         ``default_dtype()`` on the `FnBase` implementation.
-    impl : `str`
+    impl : string
         The backend to use. See `FN_IMPLS` for available options.
     kwargs :
         Extra keyword arguments to pass to the implmentation.
@@ -174,7 +174,7 @@ def cn(size, dtype=None, impl='numpy', **kwargs):
 
     Parameters
     ----------
-    size : positive `int`
+    size : positive int
         The number of dimensions of the space
     dtype : `object`
         The data type of the storage array. Can be provided in any
@@ -186,7 +186,7 @@ def cn(size, dtype=None, impl='numpy', **kwargs):
 
         Default: default of the implementation given by calling
         ``default_dtype(ComplexNumbers())`` on the `FnBase` implementation.
-    impl : `str`
+    impl : string
         The backend to use. See `FN_IMPLS` for available options.
     kwargs :
         Extra keyword arguments to pass to the implmentation.
@@ -217,7 +217,7 @@ def rn(size, dtype=None, impl='numpy', **kwargs):
 
     Parameters
     ----------
-    size : positive `int`
+    size : positive int
         The number of dimensions of the space
     dtype : `object`
         The data type of the storage array. Can be provided in any
@@ -228,7 +228,7 @@ def rn(size, dtype=None, impl='numpy', **kwargs):
         Only real floating-point data types are allowed.
         Default: default of the implementation given by calling
         ``default_dtype(RealNumbers())`` on the `FnBase` implementation.
-    impl : `str`
+    impl : string
         The backend to use. See `FN_IMPLS` for available options.
     kwargs :
         Extra keyword arguments to pass to the implmentation.

--- a/odl/space/weighting.py
+++ b/odl/space/weighting.py
@@ -63,12 +63,12 @@ class WeightingBase(object):
 
         Parameters
         ----------
-        impl : `str`
+        impl : string
             Specifier for the implementation backend
-        exponent : positive `float`, optional
+        exponent : positive float, optional
             Exponent of the norm. For values other than 2.0, the inner
             product is not defined.
-        dist_using_inner : `bool`, optional
+        dist_using_inner : bool, optional
             Calculate `dist` using the formula
 
                 ``||x - y||^2 = ||x||^2 + ||y||^2 - 2 * Re <x, y>``
@@ -79,7 +79,7 @@ class WeightingBase(object):
 
             This option can only be used if ``exponent`` is 2.0.
 
-            Default: `False`.
+            Default: False.
         """
         self.__impl = str(impl).lower()
         self.__exponent = float(exponent)
@@ -111,8 +111,8 @@ class WeightingBase(object):
 
         Returns
         -------
-        equal : `bool`
-            `True` if ``other`` is a the same weighting, `False`
+        equal : bool
+            True if ``other`` is a the same weighting, False
             otherwise.
 
         Notes
@@ -133,10 +133,10 @@ class WeightingBase(object):
 
         Returns
         -------
-        equivalent : `bool`
-            `True` if ``other`` is a `WeightingBase` instance which
+        equivalent : bool
+            True if ``other`` is a `WeightingBase` instance which
             yields the same result as this inner product for any
-            input, `False` otherwise.
+            input, False otherwise.
         """
         return self == other
 
@@ -150,7 +150,7 @@ class WeightingBase(object):
 
         Returns
         -------
-        inner : `float` or `complex`
+        inner : float or complex
             The inner product of the two provided vectors
         """
         raise NotImplementedError
@@ -168,7 +168,7 @@ class WeightingBase(object):
 
         Returns
         -------
-        norm : `float`
+        norm : float
             The norm of the vector
         """
         return float(np.sqrt(self.inner(x, x).real))
@@ -186,7 +186,7 @@ class WeightingBase(object):
 
         Returns
         -------
-        dist : `float`
+        dist : float
             The distance between the vectors
         """
         if self.dist_using_inner:
@@ -217,16 +217,16 @@ class MatrixWeightingBase(WeightingBase):
 
         Parameters
         ----------
-        matrix :  ``scipy.sparse.spmatrix`` or `array-like`, 2-dim.
+        matrix :  ``scipy.sparse.spmatrix`` or array-like, 2-dim.
             Square weighting matrix of the inner product
-        impl : `str`
+        impl : string
             Specifier for the implementation backend
-        exponent : positive `float`, optional
+        exponent : positive float, optional
             Exponent of the norm. For values other than 2.0, the inner
             product is not defined.
             If ``matrix`` is a sparse matrix, only 1.0, 2.0 and ``inf``
             are allowed.
-        dist_using_inner : `bool`, optional
+        dist_using_inner : bool, optional
             Calculate `dist` using the following formula::
 
                 ||x - y||^2 = ||x||^2 + ||y||^2 - 2 * Re <x, y>
@@ -236,28 +236,28 @@ class MatrixWeightingBase(WeightingBase):
             exactly zero for equal (but not identical) ``x`` and ``y``.
 
             This option can only be used if ``exponent`` is 2.0.
-        precomp_mat_pow : `bool`, optional
-            If `True`, precompute the matrix power ``W ** (1/p)``
+        precomp_mat_pow : bool, optional
+            If True, precompute the matrix power ``W ** (1/p)``
             during initialization. This has no effect if ``exponent``
             is 1.0, 2.0 or ``inf``.
 
-            Default: `False`
+            Default: False
 
-        cache_mat_pow : `bool`, optional
-            If `True`, cache the matrix power ``W ** (1/p)``. This can
+        cache_mat_pow : bool, optional
+            If True, cache the matrix power ``W ** (1/p)``. This can
             happen either during initialization or in the first call to
             ``norm`` or ``dist``, resp. This has no effect if
             ``exponent`` is 1.0, 2.0 or ``inf``.
 
-            Default: `True`
+            Default: True
 
-        cache_mat_decomp : `bool`, optional
-            If `True`, cache the eigenbasis decomposition of the
+        cache_mat_decomp : bool, optional
+            If True, cache the eigenbasis decomposition of the
             matrix. This can happen either during initialization or in
             the first call to ``norm`` or ``dist``, resp. This has no
             effect if ``exponent`` is 1.0, 2.0 or ``inf``.
 
-            Default: `False`
+            Default: False
 
         Notes
         -----
@@ -348,16 +348,16 @@ class MatrixWeightingBase(WeightingBase):
 
         Parameters
         ----------
-        cache : `bool` or `None`, optional
-            If `True`, store the decomposition internally. For `None`,
+        cache : bool or None, optional
+            If True, store the decomposition internally. For None,
             the ``cache_mat_decomp`` from class initialization is used.
 
         Returns
         -------
-        eigval : `numpy.ndarray`
+        eigval : numpy.ndarray
             One-dimensional array of eigenvalues. Its length is equal
             to the number of matrix rows.
-        eigvec : `numpy.ndarray`
+        eigvec : numpy.ndarray
             Two-dimensional array of eigenvectors. It has the same shape
             as the decomposed matrix.
 
@@ -393,9 +393,9 @@ class MatrixWeightingBase(WeightingBase):
 
         Returns
         -------
-        equals : `bool`
-            `True` if other is a `MatrixWeightingBase` instance
-            with **identical** matrix, `False` otherwise.
+        equals : bool
+            True if other is a `MatrixWeightingBase` instance
+            with **identical** matrix, False otherwise.
 
         See also
         --------
@@ -412,10 +412,10 @@ class MatrixWeightingBase(WeightingBase):
 
         Returns
         -------
-        equivalent : `bool`
-            `True` if other is a `WeightingBase` instance with the same
+        equivalent : bool
+            True if other is a `WeightingBase` instance with the same
             `WeightingBase.impl`, which yields the same result as this
-            weighting for any input, `False` otherwise. This is checked
+            weighting for any input, False otherwise. This is checked
             by entry-wise comparison of matrices/vectors/constants.
         """
         # Optimization for equality
@@ -533,16 +533,16 @@ class VectorWeightingBase(WeightingBase):
 
         Parameters
         ----------
-        vector : `array-like`, one-dim.
+        vector : array-like, one-dim.
             Weighting vector of the inner product
-        impl : `str`
+        impl : string
             Specifier for the implementation backend
-        exponent : positive `float`
+        exponent : positive float
             Exponent of the norm. For values other than 2.0, the inner
             product is not defined.
             If ``matrix`` is a sparse matrix, only 1.0, 2.0 and ``inf``
             are allowed.
-        dist_using_inner : `bool`, optional
+        dist_using_inner : bool, optional
             Calculate `dist` using the formula
 
                 ``||x - y||^2 = ||x||^2 + ||y||^2 - 2 * Re <x, y>``
@@ -582,9 +582,9 @@ class VectorWeightingBase(WeightingBase):
 
         Returns
         -------
-        equals : `bool`
-            `True` if other is a `VectorWeightingBase` instance with
-            **identical** vector, `False` otherwise.
+        equals : bool
+            True if other is a `VectorWeightingBase` instance with
+            **identical** vector, False otherwise.
 
         See also
         --------
@@ -601,10 +601,10 @@ class VectorWeightingBase(WeightingBase):
 
         Returns
         -------
-        equivalent : `bool`
-            `True` if other is a `WeightingBase` instance with the same
+        equivalent : bool
+            True if other is a `WeightingBase` instance with the same
             `WeightingBase.impl`, which yields the same result as this
-            weighting for any input, `False` otherwise. This is checked
+            weighting for any input, False otherwise. This is checked
             by entry-wise comparison of matrices/vectors/constants.
         """
         # Optimization for equality
@@ -661,14 +661,14 @@ class ConstWeightingBase(WeightingBase):
 
         Parameters
         ----------
-        constant : positive `float`
+        constant : positive float
             Weighting constant of the inner product.
-        impl : `str`
+        impl : string
             Specifier for the implementation backend
-        exponent : positive `float`, optional
+        exponent : positive float, optional
             Exponent of the norm. For values other than 2.0, the inner
             product is not defined.
-        dist_using_inner : `bool`, optional
+        dist_using_inner : bool, optional
             Calculate `dist` using the formula
 
                 ``||x - y||^2 = ||x||^2 + ||y||^2 - 2 * Re <x, y>``
@@ -698,9 +698,9 @@ class ConstWeightingBase(WeightingBase):
 
         Returns
         -------
-        equal : `bool`
-            `True` if other is a `ConstWeightingBase` instance with the
-            same constant, `False` otherwise.
+        equal : bool
+            True if other is a `ConstWeightingBase` instance with the
+            same constant, False otherwise.
         """
         if other is self:
             return True
@@ -713,10 +713,10 @@ class ConstWeightingBase(WeightingBase):
 
         Returns
         -------
-        equivalent : `bool`
-            `True` if other is a `WeightingBase` instance with the same
+        equivalent : bool
+            True if other is a `WeightingBase` instance with the same
             `WeightingBase.impl`, which yields the same result as this
-            weighting for any input, `False` otherwise. This is checked
+            weighting for any input, False otherwise. This is checked
             by entry-wise comparison of matrices/vectors/constants.
         """
         if isinstance(other, ConstWeightingBase):
@@ -772,12 +772,12 @@ class NoWeightingBase(ConstWeightingBase):
 
         Parameters
         ----------
-        exponent : positive `float`
+        exponent : positive float
             Exponent of the norm. For values other than 2.0, the inner
             product is not defined.
-        impl : `str`
+        impl : string
             Specifier for the implementation backend
-        dist_using_inner : `bool`, optional
+        dist_using_inner : bool, optional
             Calculate `dist` using the formula
 
                 ``||x - y||^2 = ||x||^2 + ||y||^2 - 2 * Re <x, y>``
@@ -823,7 +823,7 @@ class CustomInnerProductBase(WeightingBase):
 
         Parameters
         ----------
-        inner : `callable`
+        inner : callable
             The inner product implementation. It must accept two
             `LinearSpaceVector` arguments, return an element from
             their space's field (real or complex number) and
@@ -834,9 +834,9 @@ class CustomInnerProductBase(WeightingBase):
             - ``<s*x + y, z> = s * <x, z> + <y, z>``
             - ``<x, x> = 0``  if and only if  ``x = 0``
 
-        impl : `str`
+        impl : string
             Specifier for the implementation backend
-        dist_using_inner : `bool`, optional
+        dist_using_inner : bool, optional
             Calculate `dist` using the formula
 
                 ``||x - y||^2 = ||x||^2 + ||y||^2 - 2 * Re <x, y>``
@@ -865,9 +865,9 @@ class CustomInnerProductBase(WeightingBase):
 
         Returns
         -------
-        equal : `bool`
-            `True` if other is a `CustomInnerProductBase`
-            instance with the same inner product, `False` otherwise.
+        equal : bool
+            True if other is a `CustomInnerProductBase`
+            instance with the same inner product, False otherwise.
         """
         return super().__eq__(other) and self.inner == other.inner
 
@@ -903,9 +903,9 @@ class CustomNormBase(WeightingBase):
 
         Parameters
         ----------
-        norm : `callable`
+        norm : callable
             The norm implementation. It must accept a
-            `LinearSpaceVector` argument, return a `float` and satisfy
+            `LinearSpaceVector` argument, return a float and satisfy
             the following conditions for all vectors
             ``x, y`` and scalars ``s``:
 
@@ -913,7 +913,7 @@ class CustomNormBase(WeightingBase):
             - ``||x|| = 0``  if and only if  ``x = 0``
             - ``||s * x|| = |s| * ||x||``
             - ``||x + y|| <= ||x|| + ||y||``
-        impl : `str`
+        impl : string
             Specifier for the implementation backend
         """
         super().__init__(impl=impl, exponent=1.0, dist_using_inner=False)
@@ -937,9 +937,9 @@ class CustomNormBase(WeightingBase):
 
         Returns
         -------
-        equal : `bool`
-            `True` if other is a `CustomNormBase` instance with the same
-            norm, `False` otherwise.
+        equal : bool
+            True if other is a `CustomNormBase` instance with the same
+            norm, False otherwise.
         """
         return super().__eq__(other) and self.norm == other.norm
 
@@ -972,17 +972,17 @@ class CustomDistBase(WeightingBase):
 
         Parameters
         ----------
-        dist : `callable`
+        dist : callable
             The distance function defining a metric on a `LinearSpace`.
             It must accept two `LinearSpaceVector` arguments, return a
-            `float` and and fulfill the following mathematical conditions
+            float and and fulfill the following mathematical conditions
             for any three vectors ``x, y, z``:
 
             - ``dist(x, y) >= 0``
             - ``dist(x, y) = 0``  if and only if  ``x = y``
             - ``dist(x, y) = dist(y, x)``
             - ``dist(x, y) <= dist(x, z) + dist(z, y)``
-        impl : `str`
+        impl : string
             Specifier for the implementation backend
         """
         super().__init__(impl=impl, exponent=1.0, dist_using_inner=False)
@@ -1010,9 +1010,9 @@ class CustomDistBase(WeightingBase):
 
         Returns
         -------
-        equal : `bool`
-            `True` if other is a `CustomDistBase` instance with the same
-            dist, `False` otherwise.
+        equal : bool
+            True if other is a `CustomDistBase` instance with the same
+            dist, False otherwise.
         """
         return super().__eq__(other) and self.dist == other.dist
 

--- a/odl/space/weighting.py
+++ b/odl/space/weighting.py
@@ -103,7 +103,7 @@ class WeightingBase(object):
 
     @property
     def dist_using_inner(self):
-        """True if the distance should be calculated using inner."""
+        """``True`` if the distance should be calculated using inner."""
         return self.__dist_using_inner
 
     def __eq__(self, other):
@@ -112,7 +112,7 @@ class WeightingBase(object):
         Returns
         -------
         equal : bool
-            True if ``other`` is a the same weighting, False
+            ``True`` if ``other`` is a the same weighting, ``False``
             otherwise.
 
         Notes
@@ -134,9 +134,9 @@ class WeightingBase(object):
         Returns
         -------
         equivalent : bool
-            True if ``other`` is a `WeightingBase` instance which
+            ``True`` if ``other`` is a `WeightingBase` instance which
             yields the same result as this inner product for any
-            input, False otherwise.
+            input, ``False`` otherwise.
         """
         return self == other
 
@@ -217,7 +217,7 @@ class MatrixWeightingBase(WeightingBase):
 
         Parameters
         ----------
-        matrix :  ``scipy.sparse.spmatrix`` or array-like, 2-dim.
+        matrix :  ``scipy.sparse.spmatrix`` or 2-dim. `array-like`
             Square weighting matrix of the inner product
         impl : string
             Specifier for the implementation backend
@@ -237,27 +237,27 @@ class MatrixWeightingBase(WeightingBase):
 
             This option can only be used if ``exponent`` is 2.0.
         precomp_mat_pow : bool, optional
-            If True, precompute the matrix power ``W ** (1/p)``
+            If ``True``, precompute the matrix power ``W ** (1/p)``
             during initialization. This has no effect if ``exponent``
             is 1.0, 2.0 or ``inf``.
 
-            Default: False
+            Default: ``False``
 
         cache_mat_pow : bool, optional
-            If True, cache the matrix power ``W ** (1/p)``. This can
+            If ``True``, cache the matrix power ``W ** (1/p)``. This can
             happen either during initialization or in the first call to
             ``norm`` or ``dist``, resp. This has no effect if
             ``exponent`` is 1.0, 2.0 or ``inf``.
 
-            Default: True
+            Default: ``True``
 
         cache_mat_decomp : bool, optional
-            If True, cache the eigenbasis decomposition of the
+            If ``True``, cache the eigenbasis decomposition of the
             matrix. This can happen either during initialization or in
             the first call to ``norm`` or ``dist``, resp. This has no
             effect if ``exponent`` is 1.0, 2.0 or ``inf``.
 
-            Default: False
+            Default: ``False``
 
         Notes
         -----
@@ -349,15 +349,15 @@ class MatrixWeightingBase(WeightingBase):
         Parameters
         ----------
         cache : bool or None, optional
-            If True, store the decomposition internally. For None,
+            If ``True``, store the decomposition internally. For None,
             the ``cache_mat_decomp`` from class initialization is used.
 
         Returns
         -------
-        eigval : numpy.ndarray
+        eigval : `numpy.ndarray`
             One-dimensional array of eigenvalues. Its length is equal
             to the number of matrix rows.
-        eigvec : numpy.ndarray
+        eigvec : `numpy.ndarray`
             Two-dimensional array of eigenvectors. It has the same shape
             as the decomposed matrix.
 
@@ -394,8 +394,8 @@ class MatrixWeightingBase(WeightingBase):
         Returns
         -------
         equals : bool
-            True if other is a `MatrixWeightingBase` instance
-            with **identical** matrix, False otherwise.
+            ``True`` if other is a `MatrixWeightingBase` instance
+            with **identical** matrix, ``False`` otherwise.
 
         See also
         --------
@@ -413,9 +413,9 @@ class MatrixWeightingBase(WeightingBase):
         Returns
         -------
         equivalent : bool
-            True if other is a `WeightingBase` instance with the same
+            ``True`` if other is a `WeightingBase` instance with the same
             `WeightingBase.impl`, which yields the same result as this
-            weighting for any input, False otherwise. This is checked
+            weighting for any input, ``False`` otherwise. This is checked
             by entry-wise comparison of matrices/vectors/constants.
         """
         # Optimization for equality
@@ -533,7 +533,7 @@ class VectorWeightingBase(WeightingBase):
 
         Parameters
         ----------
-        vector : array-like, one-dim.
+        vector : 1-dim. `array-like`
             Weighting vector of the inner product
         impl : string
             Specifier for the implementation backend
@@ -583,8 +583,8 @@ class VectorWeightingBase(WeightingBase):
         Returns
         -------
         equals : bool
-            True if other is a `VectorWeightingBase` instance with
-            **identical** vector, False otherwise.
+            ``True`` if other is a `VectorWeightingBase` instance with
+            **identical** vector, ``False`` otherwise.
 
         See also
         --------
@@ -602,9 +602,9 @@ class VectorWeightingBase(WeightingBase):
         Returns
         -------
         equivalent : bool
-            True if other is a `WeightingBase` instance with the same
+            ``True`` if other is a `WeightingBase` instance with the same
             `WeightingBase.impl`, which yields the same result as this
-            weighting for any input, False otherwise. This is checked
+            weighting for any input, ``False`` otherwise. This is checked
             by entry-wise comparison of matrices/vectors/constants.
         """
         # Optimization for equality
@@ -699,8 +699,8 @@ class ConstWeightingBase(WeightingBase):
         Returns
         -------
         equal : bool
-            True if other is a `ConstWeightingBase` instance with the
-            same constant, False otherwise.
+            ``True`` if other is a `ConstWeightingBase` instance with the
+            same constant, ``False`` otherwise.
         """
         if other is self:
             return True
@@ -714,9 +714,9 @@ class ConstWeightingBase(WeightingBase):
         Returns
         -------
         equivalent : bool
-            True if other is a `WeightingBase` instance with the same
+            ``True`` if other is a `WeightingBase` instance with the same
             `WeightingBase.impl`, which yields the same result as this
-            weighting for any input, False otherwise. This is checked
+            weighting for any input, ``False`` otherwise. This is checked
             by entry-wise comparison of matrices/vectors/constants.
         """
         if isinstance(other, ConstWeightingBase):
@@ -823,7 +823,7 @@ class CustomInnerProductBase(WeightingBase):
 
         Parameters
         ----------
-        inner : callable
+        inner : `callable`
             The inner product implementation. It must accept two
             `LinearSpaceVector` arguments, return an element from
             their space's field (real or complex number) and
@@ -866,8 +866,8 @@ class CustomInnerProductBase(WeightingBase):
         Returns
         -------
         equal : bool
-            True if other is a `CustomInnerProductBase`
-            instance with the same inner product, False otherwise.
+            ``True`` if other is a `CustomInnerProductBase`
+            instance with the same inner product, ``False`` otherwise.
         """
         return super().__eq__(other) and self.inner == other.inner
 
@@ -903,7 +903,7 @@ class CustomNormBase(WeightingBase):
 
         Parameters
         ----------
-        norm : callable
+        norm : `callable`
             The norm implementation. It must accept a
             `LinearSpaceVector` argument, return a float and satisfy
             the following conditions for all vectors
@@ -938,8 +938,8 @@ class CustomNormBase(WeightingBase):
         Returns
         -------
         equal : bool
-            True if other is a `CustomNormBase` instance with the same
-            norm, False otherwise.
+            ``True`` if other is a `CustomNormBase` instance with the same
+            norm, ``False`` otherwise.
         """
         return super().__eq__(other) and self.norm == other.norm
 
@@ -972,7 +972,7 @@ class CustomDistBase(WeightingBase):
 
         Parameters
         ----------
-        dist : callable
+        dist : `callable`
             The distance function defining a metric on a `LinearSpace`.
             It must accept two `LinearSpaceVector` arguments, return a
             float and and fulfill the following mathematical conditions
@@ -1011,8 +1011,8 @@ class CustomDistBase(WeightingBase):
         Returns
         -------
         equal : bool
-            True if other is a `CustomDistBase` instance with the same
-            dist, False otherwise.
+            ``True`` if other is a `CustomDistBase` instance with the same
+            dist, ``False`` otherwise.
         """
         return super().__eq__(other) and self.dist == other.dist
 

--- a/odl/tomo/backends/astra_cpu.py
+++ b/odl/tomo/backends/astra_cpu.py
@@ -54,12 +54,13 @@ def astra_cpu_forward_projector(vol_data, geometry, proj_space, out=None):
         Space to which the calling operator maps
     out : `DiscreteLpVector`, optional
         Vector in the projection space to which the result is written. If
-        None creates an element in the projection space ``proj_space``
+        ``None``, an element in ``proj_space`` is created.
 
     Returns
     -------
     out : ``proj_space`` element
-        Projection data resulting from the application of the projector
+        Projection data resulting from the application of the projector.
+        If ``out`` was provided, the returned object is a reference to it.
     """
     if not isinstance(vol_data, DiscreteLpVector):
         raise TypeError('volume data {!r} is not a `DiscreteLpVector` '
@@ -137,15 +138,16 @@ def astra_cpu_back_projector(proj_data, geometry, reco_space, out=None):
         Geometry defining the tomographic setup
     reco_space : `DiscreteLp`
         Space to which the calling operator maps
-    out : `DiscreteLpVector` or None, optional
-        Vector in the reconstruction space to which the result is written. If
-        None creates an element in the reconstruction space ``reco_space``
+    out : `DiscreteLpVector`, optional
+        Vector in the reconstruction space to which the result is written.
+        If ``None``, an element in ``reco_space`` is created.
 
     Returns
     -------
     out : ``reco_space`` element
         Reconstruction data resulting from the application of the backward
-        projector
+        projector. If ``out`` was provided, the returned object is a
+        reference to it.
     """
     if not isinstance(proj_data, DiscreteLpVector):
         raise TypeError('projection data {!r} is not a DiscreteLpVector '

--- a/odl/tomo/backends/astra_cpu.py
+++ b/odl/tomo/backends/astra_cpu.py
@@ -52,7 +52,7 @@ def astra_cpu_forward_projector(vol_data, geometry, proj_space, out=None):
         Geometry defining the tomographic setup
     proj_space : `DiscreteLp`
         Space to which the calling operator maps
-    out : `DiscreteLpVector`, optional
+    out : ``proj_space`` element, optional
         Vector in the projection space to which the result is written. If
         ``None``, an element in ``proj_space`` is created.
 
@@ -138,7 +138,7 @@ def astra_cpu_back_projector(proj_data, geometry, reco_space, out=None):
         Geometry defining the tomographic setup
     reco_space : `DiscreteLp`
         Space to which the calling operator maps
-    out : `DiscreteLpVector`, optional
+    out : ``reco_space`` element, optional
         Vector in the reconstruction space to which the result is written.
         If ``None``, an element in ``reco_space`` is created.
 

--- a/odl/tomo/backends/astra_cpu.py
+++ b/odl/tomo/backends/astra_cpu.py
@@ -54,11 +54,11 @@ def astra_cpu_forward_projector(vol_data, geometry, proj_space, out=None):
         Space to which the calling operator maps
     out : `DiscreteLpVector`, optional
         Vector in the projection space to which the result is written. If
-        `None` creates an element in the projection space ``proj_space``
+        None creates an element in the projection space ``proj_space``
 
     Returns
     -------
-    out : ``proj_space`` `element`
+    out : ``proj_space`` element
         Projection data resulting from the application of the projector
     """
     if not isinstance(vol_data, DiscreteLpVector):
@@ -137,9 +137,9 @@ def astra_cpu_back_projector(proj_data, geometry, reco_space, out=None):
         Geometry defining the tomographic setup
     reco_space : `DiscreteLp`
         Space to which the calling operator maps
-    out : `DiscreteLpVector` or `None`, optional
+    out : `DiscreteLpVector` or None, optional
         Vector in the reconstruction space to which the result is written. If
-        `None` creates an element in the reconstruction space ``reco_space``
+        None creates an element in the reconstruction space ``reco_space``
 
     Returns
     -------

--- a/odl/tomo/backends/astra_cuda.py
+++ b/odl/tomo/backends/astra_cuda.py
@@ -59,7 +59,7 @@ def astra_cuda_forward_projector(vol_data, geometry, proj_space, out=None):
         Space to which the calling operator maps
     out : `DiscreteLpVector`, optional
         Vector in the projection space to which the result is written. If
-        `None` creates an element in the projection space ``proj_space``
+        None creates an element in the projection space ``proj_space``
 
     Returns
     -------
@@ -164,7 +164,7 @@ def astra_cuda_back_projector(proj_data, geometry, reco_space, out=None):
             Space to which the calling operator maps
         out : `DiscreteLpVector`, optional
             Vector in the reconstruction space to which the result is written.
-            If `None` creates an element in the reconstruction space
+            If None creates an element in the reconstruction space
             ``reco_space``
 
         Returns

--- a/odl/tomo/backends/astra_cuda.py
+++ b/odl/tomo/backends/astra_cuda.py
@@ -57,7 +57,7 @@ def astra_cuda_forward_projector(vol_data, geometry, proj_space, out=None):
         Geometry defining the tomographic setup
     proj_space : `DiscreteLp`
         Space to which the calling operator maps
-    out : `DiscreteLpVector`, optional
+    out : ``proj_space`` element, optional
         Vector in the projection space to which the result is written. If
         ``None``, an element in ``proj_space`` is created.
 
@@ -163,7 +163,7 @@ def astra_cuda_back_projector(proj_data, geometry, reco_space, out=None):
         Geometry defining the tomographic setup
     reco_space : `DiscreteLp`
         Space to which the calling operator maps
-    out : `DiscreteLpVector`, optional
+    out : ``reco_space`` element, optional
         Vector in the reconstruction space to which the result is written.
         If ``None``, an element in ``reco_space`` is created.
 

--- a/odl/tomo/backends/astra_cuda.py
+++ b/odl/tomo/backends/astra_cuda.py
@@ -59,12 +59,13 @@ def astra_cuda_forward_projector(vol_data, geometry, proj_space, out=None):
         Space to which the calling operator maps
     out : `DiscreteLpVector`, optional
         Vector in the projection space to which the result is written. If
-        None creates an element in the projection space ``proj_space``
+        ``None``, an element in ``proj_space`` is created.
 
     Returns
     -------
     out : ``proj_space`` element
-        Projection data resulting from the application of the projector
+        Projection data resulting from the application of the projector.
+        If ``out`` was provided, the returned object is a reference to it.
     """
     if not isinstance(vol_data, DiscreteLpVector):
         raise TypeError('volume data {!r} is not a DiscreteLpVector '
@@ -154,24 +155,24 @@ def astra_cuda_forward_projector(vol_data, geometry, proj_space, out=None):
 def astra_cuda_back_projector(proj_data, geometry, reco_space, out=None):
     """Run an ASTRA backward projection on the given data using the GPU.
 
-        Parameters
-        ----------
-        proj_data : `DiscreteLp` element
-            Projection data to which the backward projector is applied
-        geometry : `Geometry`
-            Geometry defining the tomographic setup
-        reco_space : `DiscreteLp`
-            Space to which the calling operator maps
-        out : `DiscreteLpVector`, optional
-            Vector in the reconstruction space to which the result is written.
-            If None creates an element in the reconstruction space
-            ``reco_space``
+    Parameters
+    ----------
+    proj_data : `DiscreteLp` element
+        Projection data to which the backward projector is applied
+    geometry : `Geometry`
+        Geometry defining the tomographic setup
+    reco_space : `DiscreteLp`
+        Space to which the calling operator maps
+    out : `DiscreteLpVector`, optional
+        Vector in the reconstruction space to which the result is written.
+        If ``None``, an element in ``reco_space`` is created.
 
-        Returns
-        -------
-        out : ``reco_space`` element
-            Reconstruction data resulting from the application of the backward
-            projector
+    Returns
+    -------
+    out : ``reco_space`` element
+        Reconstruction data resulting from the application of the backward
+        projector. If ``out`` was provided, the returned object is a
+        reference to it.
         """
     if not isinstance(proj_data, DiscreteLpVector):
         raise TypeError('projection data {!r} is not a DiscreteLpVector '

--- a/odl/tomo/backends/astra_setup.py
+++ b/odl/tomo/backends/astra_setup.py
@@ -173,7 +173,7 @@ def astra_conebeam_3d_geom_to_vec(geometry):
 
     Returns
     -------
-    vectors : `numpy.ndarray`
+    vectors : numpy.ndarray
         Numpy array of shape ``(number of angles, 12)``
     """
 
@@ -228,7 +228,7 @@ def astra_conebeam_2d_geom_to_vec(geometry):
 
     Returns
     -------
-    vectors : `numpy.ndarray`
+    vectors : numpy.ndarray
         Numpy array of shape ``(number of angles, 6)``
     """
 
@@ -283,7 +283,7 @@ def astra_parallel_3d_geom_to_vec(geometry):
 
     Returns
     -------
-    vectors : `numpy.ndarray`
+    vectors : numpy.ndarray
         Numpy array of shape ``(number of angles, 12)``
     """
 
@@ -404,10 +404,10 @@ def astra_data(astra_geom, datatype, data=None, ndim=2, allow_copy=False):
     datatype : {'volume', 'projection'}
         Type of the data container
     data : `DiscreteLpVector`, optional
-        Data for the initialization of the data structure. If `None` creates
+        Data for the initialization of the data structure. If None creates
         an ASTRA data object filled with zeros
     ndim : {2, 3}, optional
-        Dimension of the data. If ``data`` is not `None`, this parameter
+        Dimension of the data. If ``data`` is not None, this parameter
         has no effect.
     allow_copy : `bool`, optional
         True if copying ``data`` should be allowed. This means that anything
@@ -416,7 +416,7 @@ def astra_data(astra_geom, datatype, data=None, ndim=2, allow_copy=False):
 
     Returns
     -------
-    id : `int`
+    id : int
         ASTRA internal ID for the new data structure
     """
     if data is not None:
@@ -485,7 +485,7 @@ def astra_projector(vol_interp, astra_vol_geom, astra_proj_geom, ndim, impl):
 
     Returns
     -------
-    proj_id : `int`
+    proj_id : int
         ASTRA reference ID to the ASTRA dict with initialized 'type' key
     """
     if vol_interp not in ('nearest', 'linear'):
@@ -559,18 +559,18 @@ def astra_algorithm(direction, ndim, vol_id, sino_id, proj_id, impl):
         projection
     ndim : {2, 3}
         Number of dimensions of the projector
-    vol_id : `int`
+    vol_id : int
         ASTRA ID of the volume data object
-    sino_id : `int`
+    sino_id : int
         ASTRA ID of the projection data object
-    proj_id : `int`
+    proj_id : int
         ASTRA ID of the projector
     impl : {'cpu', 'cuda'}
         Implementation of the projector
 
     Returns
     -------
-    id : `int`
+    id : int
         ASTRA internal ID for the new algorithm structure
     """
     if direction not in ('forward', 'backward'):

--- a/odl/tomo/backends/astra_setup.py
+++ b/odl/tomo/backends/astra_setup.py
@@ -81,7 +81,7 @@ def astra_volume_geometry(discr_reco):
 
     Returns
     -------
-    astra_geom : `dict`
+    astra_geom : dict
         The ASTRA volume geometry
 
     Raises
@@ -173,7 +173,7 @@ def astra_conebeam_3d_geom_to_vec(geometry):
 
     Returns
     -------
-    vectors : numpy.ndarray
+    vectors : `numpy.ndarray`
         Numpy array of shape ``(number of angles, 12)``
     """
 
@@ -228,7 +228,7 @@ def astra_conebeam_2d_geom_to_vec(geometry):
 
     Returns
     -------
-    vectors : numpy.ndarray
+    vectors : `numpy.ndarray`
         Numpy array of shape ``(number of angles, 6)``
     """
 
@@ -283,7 +283,7 @@ def astra_parallel_3d_geom_to_vec(geometry):
 
     Returns
     -------
-    vectors : numpy.ndarray
+    vectors : `numpy.ndarray`
         Numpy array of shape ``(number of angles, 12)``
     """
 
@@ -331,7 +331,7 @@ def astra_projection_geometry(geometry):
 
     Returns
     -------
-    proj_geom : `dict`
+    proj_geom : dict
         Dictionary defining the ASTRA projection geometry.
     """
     if not isinstance(geometry, Geometry):
@@ -398,16 +398,16 @@ def astra_data(astra_geom, datatype, data=None, ndim=2, allow_copy=False):
 
     Parameters
     ----------
-    astra_geom : `dict`
+    astra_geom : dict
         ASTRA geometry object for the data creator, must correspond to the
         given data type
     datatype : {'volume', 'projection'}
         Type of the data container
     data : `DiscreteLpVector`, optional
-        Data for the initialization of the data structure. If None creates
-        an ASTRA data object filled with zeros
+        Data for the initialization of the data structure. If ``None``,
+        an ASTRA data object filled with zeros is created.
     ndim : {2, 3}, optional
-        Dimension of the data. If ``data`` is not None, this parameter
+        Dimension of the data. If ``data`` is not ``None``, this parameter
         has no effect.
     allow_copy : `bool`, optional
         True if copying ``data`` should be allowed. This means that anything
@@ -426,7 +426,7 @@ def astra_data(astra_geom, datatype, data=None, ndim=2, allow_copy=False):
             ndim = data.ndim
         else:
             raise TypeError('`data` {!r} is neither DiscreteLp.Vector '
-                            'instance or a numpy.ndarray'.format(data))
+                            'instance nor a `numpy.ndarray`'.format(data))
     else:
         ndim = int(ndim)
 
@@ -461,7 +461,7 @@ def astra_data(astra_geom, datatype, data=None, ndim=2, allow_copy=False):
             else:
                 # Something else than NumPy data representation
                 raise NotImplementedError('ASTRA supports data wrapping only '
-                                          'for numpy.ndarray instances, got '
+                                          'for `numpy.ndarray` instances, got '
                                           '{!r}'.format(data))
     else:
         return create(astra_dtype_str, astra_geom)
@@ -474,9 +474,9 @@ def astra_projector(vol_interp, astra_vol_geom, astra_proj_geom, ndim, impl):
     ----------
     vol_interp : {'nearest', 'linear'}
         Interpolation type of the volume discretization
-    astra_vol_geom : `dict`
+    astra_vol_geom : dict
         ASTRA volume geometry dictionary
-    astra_proj_geom : `dict`
+    astra_proj_geom : dict
         ASTRA projection geometry dictionary
     ndim : {2, 3}
         Number of dimensions of the projector

--- a/odl/tomo/backends/stir_bindings.py
+++ b/odl/tomo/backends/stir_bindings.py
@@ -270,11 +270,11 @@ def stir_projector_from_file(volume_file, projection_file):
 
     Parameters
     ----------
-    volume_file : `str`
+    volume_file : string
         Full file path to the STIR input file containing information on the
         volume. This is usually a '.hv' file. For STIR reasons,
         a '.v' file is also needed.
-    projection_file : `str`
+    projection_file : string
         Full file path to the STIR input file with information on the
         projection data. This is usually a '.hs' file. For STIR reasons,
         a '.s' file is also needed.

--- a/odl/tomo/geometry/conebeam.py
+++ b/odl/tomo/geometry/conebeam.py
@@ -73,7 +73,7 @@ class HelicalConeFlatGeometry(DivergentBeamGeometry, AxisOrientedGeometry):
         pitch : float
             Constant vertical distance that a point on the helix
             traverses when increasing the angle parameter by ``2 * pi``
-        axis : array-like, shape ``(3,)``, optional
+        axis : `array-like`, shape ``(3,)``, optional
             Fixed rotation axis, the symmetry axis of the helix
 
         Other Parameters
@@ -82,7 +82,7 @@ class HelicalConeFlatGeometry(DivergentBeamGeometry, AxisOrientedGeometry):
             Initial state of the vector pointing from source to detector
             reference point. The zero vector is not allowed.
             By default, a `perpendicular_vector` to ``axis`` is used.
-        det_init_axes : 2-tuple of array-like (shape ``(2,)``), optional
+        det_init_axes : 2-tuple of `array-like`'s (shape ``(2,)``), optional
             Initial axes defining the detector orientation.
             By default, the normalized cross product of ``axis`` and
             ``src_to_det_init`` is used as first axis and ``axis`` as
@@ -180,7 +180,7 @@ class HelicalConeFlatGeometry(DivergentBeamGeometry, AxisOrientedGeometry):
 
         Returns
         -------
-        point : numpy.ndarray, shape (3,)
+        point : `numpy.ndarray`, shape (3,)
             Detector reference point corresponding to the given angle
 
         See also
@@ -223,7 +223,7 @@ class HelicalConeFlatGeometry(DivergentBeamGeometry, AxisOrientedGeometry):
 
         Returns
         -------
-        point : numpy.ndarray, shape (3,)
+        point : `numpy.ndarray`, shape (3,)
             Detector reference point corresponding to the given angle
 
         See also
@@ -318,11 +318,11 @@ class CircularConeFlatGeometry(HelicalConeFlatGeometry):
             Radius of the detector circle
         axis : array-like, shape ``(3,)``, optional
             Fixed rotation axis, the symmetry axis of the helix
-        src_to_det_init : array-like (shape ``(2,)``), optional
+        src_to_det_init : array-like, shape ``(2,)``, optional
             Initial state of the vector pointing from source to detector
             reference point. The zero vector is not allowed.
             By default, a `perpendicular_vector` to ``axis`` is used.
-        det_init_axes : 2-tuple of array-like (shape ``(2,)``), optional
+        det_init_axes : 2-tuple of `array-like`'s (shape ``(2,)``), optional
             Initial axes defining the detector orientation.
             By default, the normalized cross product of ``axis`` and
             ``src_to_det_init`` is used as first axis and ``axis`` as

--- a/odl/tomo/geometry/conebeam.py
+++ b/odl/tomo/geometry/conebeam.py
@@ -66,14 +66,14 @@ class HelicalConeFlatGeometry(DivergentBeamGeometry, AxisOrientedGeometry):
             Partition of the angle interval
         dpart : 2-dim. `RectPartition`
             Partition of the detector parameter rectangle
-        src_radius : nonnegative `float`
+        src_radius : nonnegative float
             Radius of the source circle
-        det_radius : nonnegative `float`
+        det_radius : nonnegative float
             Radius of the detector circle
-        pitch : `float`
+        pitch : float
             Constant vertical distance that a point on the helix
             traverses when increasing the angle parameter by ``2 * pi``
-        axis : `array-like`, shape ``(3,)``, optional
+        axis : array-like, shape ``(3,)``, optional
             Fixed rotation axis, the symmetry axis of the helix
 
         Other Parameters
@@ -82,12 +82,12 @@ class HelicalConeFlatGeometry(DivergentBeamGeometry, AxisOrientedGeometry):
             Initial state of the vector pointing from source to detector
             reference point. The zero vector is not allowed.
             By default, a `perpendicular_vector` to ``axis`` is used.
-        det_init_axes : 2-tuple of `array-like` (shape ``(2,)``), optional
+        det_init_axes : 2-tuple of array-like (shape ``(2,)``), optional
             Initial axes defining the detector orientation.
             By default, the normalized cross product of ``axis`` and
             ``src_to_det_init`` is used as first axis and ``axis`` as
             second.
-        pitch_offset : `float`, optional
+        pitch_offset : float, optional
             Offset along the ``axis`` at ``angle=0``
         """
         AxisOrientedGeometry.__init__(self, axis)
@@ -174,13 +174,13 @@ class HelicalConeFlatGeometry(DivergentBeamGeometry, AxisOrientedGeometry):
 
         Parameters
         ----------
-        angle : `float`
+        angle : float
             Rotation angle given in radians, must be contained in
             this geometry's `motion_params`
 
         Returns
         -------
-        point : `numpy.ndarray`, shape (3,)
+        point : numpy.ndarray, shape (3,)
             Detector reference point corresponding to the given angle
 
         See also
@@ -217,13 +217,13 @@ class HelicalConeFlatGeometry(DivergentBeamGeometry, AxisOrientedGeometry):
 
         Parameters
         ----------
-        angle : `float`
+        angle : float
             Rotation angle given in radians, must be contained in
             this geometry's `motion_params`
 
         Returns
         -------
-        point : `numpy.ndarray`, shape (3,)
+        point : numpy.ndarray, shape (3,)
             Detector reference point corresponding to the given angle
 
         See also
@@ -312,17 +312,17 @@ class CircularConeFlatGeometry(HelicalConeFlatGeometry):
             Partition of the angle interval
         dpart : 2-dim. `RectPartition`
             Partition of the detector parameter rectangle
-        src_radius : nonnegative `float`
+        src_radius : nonnegative float
             Radius of the source circle
-        det_radius : nonnegative `float`
+        det_radius : nonnegative float
             Radius of the detector circle
-        axis : `array-like`, shape ``(3,)``, optional
+        axis : array-like, shape ``(3,)``, optional
             Fixed rotation axis, the symmetry axis of the helix
-        src_to_det_init : `array-like`, shape ``(2,)``, optional
+        src_to_det_init : array-like (shape ``(2,)``), optional
             Initial state of the vector pointing from source to detector
             reference point. The zero vector is not allowed.
             By default, a `perpendicular_vector` to ``axis`` is used.
-        det_init_axes : 2-tuple of `array-like` (shape ``(2,)``), optional
+        det_init_axes : 2-tuple of array-like (shape ``(2,)``), optional
             Initial axes defining the detector orientation.
             By default, the normalized cross product of ``axis`` and
             ``src_to_det_init`` is used as first axis and ``axis`` as

--- a/odl/tomo/geometry/detector.py
+++ b/odl/tomo/geometry/detector.py
@@ -68,7 +68,7 @@ class Detector(with_metaclass(ABCMeta, object)):
 
         Parameters
         ----------
-        param : element of `params`
+        param : `params` element
             Parameter value where to evaluate the function
 
         Returns
@@ -113,7 +113,7 @@ class Detector(with_metaclass(ABCMeta, object)):
 
         Parameters
         ----------
-        param : element of `params`
+        param : `params` element
             The parameter value where to evaluate the function
 
         Returns
@@ -135,7 +135,7 @@ class Detector(with_metaclass(ABCMeta, object)):
 
         Parameters
         ----------
-        param : element of `params`
+        param : `params` element
             The parameter value where to evaluate the function
 
         Returns
@@ -168,7 +168,7 @@ class FlatDetector(Detector):
 
         Parameters
         ----------
-        param : element of `params`, optional
+        param : `params` element, optional
             Parameter value where to evaluate the function
 
         Returns
@@ -234,7 +234,7 @@ class Flat1dDetector(FlatDetector):
 
         Parameters
         ----------
-        param : element of `params`
+        param : `params` element
             The parameter value where to evaluate the function
 
         Returns
@@ -254,7 +254,7 @@ class Flat1dDetector(FlatDetector):
 
         Parameters
         ----------
-        param : element of `params`, optional
+        param : `params` element, optional
             The parameter value where to evaluate the function
 
         Returns
@@ -340,7 +340,7 @@ class Flat2dDetector(FlatDetector):
 
         Parameters
         ----------
-        param : element of `params`
+        param : `params` element
             The parameter value where to evaluate the function
 
         Returns
@@ -360,7 +360,7 @@ class Flat2dDetector(FlatDetector):
 
         Parameters
         ----------
-        param : element of `params`, optional
+        param : `params` element, optional
             The parameter value where to evaluate the function
 
         Returns
@@ -427,7 +427,7 @@ class CircleSectionDetector(Detector):
 
         Parameters
         ----------
-        param : element of `params`
+        param : `params` element
             The parameter value where to evaluate the function
         """
         if param in self.params or self.params.contains_all(param):
@@ -442,7 +442,7 @@ class CircleSectionDetector(Detector):
 
         Parameters
         ----------
-        param : element of `params`
+        param : `params` element
             The parameter value where to evaluate the function
         """
         if param in self.params or self.params.contains_all(param):
@@ -456,7 +456,7 @@ class CircleSectionDetector(Detector):
 
         Parameters
         ----------
-        param : element of `params`
+        param : `params` element
             The parameter value where to evaluate the function
 
         Returns

--- a/odl/tomo/geometry/detector.py
+++ b/odl/tomo/geometry/detector.py
@@ -197,7 +197,7 @@ class Flat1dDetector(FlatDetector):
         part : 1-dim. `RectPartition`
             Partition of the parameter interval, corresponding to the
             line elements
-        axis : array-like, shape ``(2,)``
+        axis : `array-like`, shape ``(2,)``
             Principal axis of the detector
         """
         super().__init__(part)
@@ -239,7 +239,7 @@ class Flat1dDetector(FlatDetector):
 
         Returns
         -------
-        point : numpy.ndarray, shape (2,)
+        point : `numpy.ndarray`, shape (2,)
             The point on the detector surface corresponding to the
             given parameters
         """
@@ -259,7 +259,7 @@ class Flat1dDetector(FlatDetector):
 
         Returns
         -------
-        derivative : numpy.ndarray, shape (2,)
+        derivative : `numpy.ndarray`, shape (2,)
             The constant derivative
         """
         if param is not None and param not in self.params:
@@ -293,7 +293,7 @@ class Flat2dDetector(FlatDetector):
         part : 1-dim. `RectPartition`
             Partition of the parameter interval, corresponding to the
             pixels
-        axes : 2-tuple of array-like (shape ``(3,)``)
+        axes : 2-tuple of `array-like`'s (shape ``(3,)``)
             Principal axes of the detector, e.g.
             ``[(0, 1, 0), (0, 0, 1)]``
         """
@@ -345,7 +345,7 @@ class Flat2dDetector(FlatDetector):
 
         Returns
         -------
-        point : numpy.ndarray, shape (3,)
+        point : `numpy.ndarray`, shape (3,)
             The point on the detector surface corresponding to the
             given parameters
         """
@@ -365,7 +365,7 @@ class Flat2dDetector(FlatDetector):
 
         Returns
         -------
-        derivatives : 2-tuple of numpy.ndarray (shape ``(3,)``)
+        derivatives : 2-tuple of `numpy.ndarray`'s (shape ``(3,)``)
             The constant partial derivatives given by the detector axes
         """
         if param is not None and param not in self.params:

--- a/odl/tomo/geometry/detector.py
+++ b/odl/tomo/geometry/detector.py
@@ -140,7 +140,7 @@ class Detector(with_metaclass(ABCMeta, object)):
 
         Returns
         -------
-        measure : `float`
+        measure : float
             The density value at the given parameter
 
         .. _Arc length:
@@ -173,7 +173,7 @@ class FlatDetector(Detector):
 
         Returns
         -------
-        measure : `float`
+        measure : float
             Constant density 1.0
         """
         if param not in self.params:
@@ -197,7 +197,7 @@ class Flat1dDetector(FlatDetector):
         part : 1-dim. `RectPartition`
             Partition of the parameter interval, corresponding to the
             line elements
-        axis : `array-like`, shape ``(2,)``
+        axis : array-like, shape ``(2,)``
             Principal axis of the detector
         """
         super().__init__(part)
@@ -239,7 +239,7 @@ class Flat1dDetector(FlatDetector):
 
         Returns
         -------
-        point : `numpy.ndarray`, shape (2,)
+        point : numpy.ndarray, shape (2,)
             The point on the detector surface corresponding to the
             given parameters
         """
@@ -259,7 +259,7 @@ class Flat1dDetector(FlatDetector):
 
         Returns
         -------
-        derivative : `numpy.ndarray`, shape (2,)
+        derivative : numpy.ndarray, shape (2,)
             The constant derivative
         """
         if param is not None and param not in self.params:
@@ -293,7 +293,7 @@ class Flat2dDetector(FlatDetector):
         part : 1-dim. `RectPartition`
             Partition of the parameter interval, corresponding to the
             pixels
-        axes : 2-tuple of `array-like` (shape ``(3,)``)
+        axes : 2-tuple of array-like (shape ``(3,)``)
             Principal axes of the detector, e.g.
             ``[(0, 1, 0), (0, 0, 1)]``
         """
@@ -345,7 +345,7 @@ class Flat2dDetector(FlatDetector):
 
         Returns
         -------
-        point : `numpy.ndarray`, shape (3,)
+        point : numpy.ndarray, shape (3,)
             The point on the detector surface corresponding to the
             given parameters
         """
@@ -365,7 +365,7 @@ class Flat2dDetector(FlatDetector):
 
         Returns
         -------
-        derivatives : 2-tuple of `numpy.ndarray` (shape ``(3,)``)
+        derivatives : 2-tuple of numpy.ndarray (shape ``(3,)``)
             The constant partial derivatives given by the detector axes
         """
         if param is not None and param not in self.params:
@@ -404,7 +404,7 @@ class CircleSectionDetector(Detector):
         part : 1-dim. `RectPartition`
             Partition of the parameter interval, corresponding to the
             angle sections along the line
-        circ_rad : positive `float`
+        circ_rad : positive float
             Radius of the circle along which the detector is curved
         """
         super().__init__(part)
@@ -461,7 +461,7 @@ class CircleSectionDetector(Detector):
 
         Returns
         -------
-        measure : `float`
+        measure : float
             The constant density ``r``, equal to the length of the
             tangent to the detector circle at any point
         """

--- a/odl/tomo/geometry/fanbeam.py
+++ b/odl/tomo/geometry/fanbeam.py
@@ -68,7 +68,7 @@ class FanFlatGeometry(DivergentBeamGeometry):
             Initial state of the vector pointing from source to detector
             reference point. The zero vector is not allowed.
             Default: ``(1, 0)``.
-        det_init_axis : array-like (shape ``(2,)``), optional
+        det_init_axis : `array-like` (shape ``(2,)``), optional
             Initial axis defining the detector orientation.
             By default, a normalized `perpendicular_vector` to
             ``src_to_det_init`` is used.
@@ -136,7 +136,7 @@ class FanFlatGeometry(DivergentBeamGeometry):
 
         Returns
         -------
-        point : numpy.ndarray, shape ``(2,)``
+        point : `numpy.ndarray`, shape ``(2,)``
             Source position corresponding to the given angle
         """
         if angle not in self.motion_params:
@@ -167,7 +167,7 @@ class FanFlatGeometry(DivergentBeamGeometry):
 
         Returns
         -------
-        point : numpy.ndarray, shape (2,)
+        point : `numpy.ndarray`, shape (2,)
             Detector reference point corresponding to the given angle
 
         See also
@@ -200,7 +200,7 @@ class FanFlatGeometry(DivergentBeamGeometry):
 
         Returns
         -------
-        rot : numpy.ndarray, shape (2, 2)
+        rot : `numpy.ndarray`, shape (2, 2)
             The rotation matrix mapping the standard basis vectors in
             the fixed ("lab") coordinate system to the basis vectors of
             the local coordinate system of the detector reference point,

--- a/odl/tomo/geometry/fanbeam.py
+++ b/odl/tomo/geometry/fanbeam.py
@@ -60,15 +60,15 @@ class FanFlatGeometry(DivergentBeamGeometry):
             Partition of the angle interval
         dpart : 1-dim. `RectPartition`
             Partition of the detector parameter interval
-        src_radius : nonnegative `float`
+        src_radius : nonnegative float
             Radius of the source circle
-        det_radius : nonnegative `float`
+        det_radius : nonnegative float
             Radius of the detector circle
-        src_to_det_init : `array-like`, shape ``(2,)``, optional
+        src_to_det_init : `array-like` (shape ``(2,)``), optional
             Initial state of the vector pointing from source to detector
             reference point. The zero vector is not allowed.
             Default: ``(1, 0)``.
-        det_init_axis : `array-like` (shape ``(2,)``), optional
+        det_init_axis : array-like (shape ``(2,)``), optional
             Initial axis defining the detector orientation.
             By default, a normalized `perpendicular_vector` to
             ``src_to_det_init`` is used.
@@ -130,13 +130,13 @@ class FanFlatGeometry(DivergentBeamGeometry):
 
         Parameters
         ----------
-        angle : `float`
+        angle : float
             Rotation angle given in radians, must be contained in
             this geometry's `motion_params`
 
         Returns
         -------
-        point : `numpy.ndarray`, shape ``(2,)``
+        point : numpy.ndarray, shape ``(2,)``
             Source position corresponding to the given angle
         """
         if angle not in self.motion_params:
@@ -161,13 +161,13 @@ class FanFlatGeometry(DivergentBeamGeometry):
 
         Parameters
         ----------
-        angle : `float`
+        angle : float
             Rotation angle given in radians, must be contained in
             this geometry's `motion_params`
 
         Returns
         -------
-        point : `numpy.ndarray`, shape (2,)
+        point : numpy.ndarray, shape (2,)
             Detector reference point corresponding to the given angle
 
         See also
@@ -194,13 +194,13 @@ class FanFlatGeometry(DivergentBeamGeometry):
 
         Parameters
         ----------
-        angle : `float`
+        angle : float
             Rotation angle given in radians, must be contained in
             this geometry's `motion_params`
 
         Returns
         -------
-        rot : `numpy.ndarray`, shape (2, 2)
+        rot : numpy.ndarray, shape (2, 2)
             The rotation matrix mapping the standard basis vectors in
             the fixed ("lab") coordinate system to the basis vectors of
             the local coordinate system of the detector reference point,

--- a/odl/tomo/geometry/geometry.py
+++ b/odl/tomo/geometry/geometry.py
@@ -56,7 +56,7 @@ class Geometry(with_metaclass(ABCMeta, object)):
 
         Parameters
         ----------
-        ndim : positive `int`
+        ndim : positive int
             Number of dimensions of this geometry, i.e. dimensionality
             of the physical space in which this geometry is embedded
         motion_part : `RectPartition`
@@ -159,7 +159,7 @@ class Geometry(with_metaclass(ABCMeta, object)):
 
         Returns
         -------
-        point : `numpy.ndarray`, shape (`ndim`,)
+        point : numpy.ndarray, shape (`ndim`,)
             The reference point, an `ndim`-dimensional vector
         """
 
@@ -176,7 +176,7 @@ class Geometry(with_metaclass(ABCMeta, object)):
 
         Returns
         -------
-        rot : `numpy.ndarray`, shape (`ndim`, `ndim`)
+        rot : numpy.ndarray, shape (`ndim`, `ndim`)
             The rotation matrix mapping the standard basis vectors in
             the fixed ("lab") coordinate system to the basis vectors of
             the local coordinate system of the detector reference point,
@@ -194,12 +194,12 @@ class Geometry(with_metaclass(ABCMeta, object)):
             Motion parameter at which to evaluate
         dpar : element of detector parameters `det_params`
             Detector parameter at which to evaluate
-        normalized : `bool`, optional
-            If `True`, return a normalized (unit) vector. Default: `True`
+        normalized : bool, optional
+            If True, return a normalized (unit) vector. Default: True
 
         Returns
         -------
-        vec : `numpy.ndarray`, shape (`ndim`,)
+        vec : numpy.ndarray, shape (`ndim`,)
             (Unit) vector pointing from the detector to the source
         """
         raise NotImplementedError
@@ -216,8 +216,8 @@ class Geometry(with_metaclass(ABCMeta, object)):
 
         Returns
         -------
-        pos : `numpy.ndarray`, shape (`ndim`,)
-            Source position, a `ndim`-dimensional vector
+        pos : ``numpy.ndarray`` (shape (`ndim`,))
+            Source position, an `ndim`-dimensional vector
         """
         # TODO: check and write test
         return np.asarray(
@@ -259,8 +259,8 @@ class DivergentBeamGeometry(Geometry):
 
         Returns
         -------
-        pos : `numpy.ndarray`, shape (`ndim`,)
-            Source position, a `ndim`-dimensional vector
+        pos : ``numpy.ndarray`` (shape (`ndim`,))
+            Source position, an `ndim`-dimensional vector
         """
 
     def det_to_src(self, mpar, dpar, normalized=True):
@@ -278,12 +278,12 @@ class DivergentBeamGeometry(Geometry):
             Motion parameter at which to evaluate
         dpar : element of detector parameters `det_params`
             Detector parameter at which to evaluate
-        normalized : `bool`, optional
-            If `True`, return a normalized (unit) vector.
+        normalized : bool, optional
+            If True, return a normalized (unit) vector.
 
         Returns
         -------
-        vec : `numpy.ndarray`, shape (`ndim`,)
+        vec : numpy.ndarray, shape (`ndim`,)
             (Unit) vector pointing from the detector to the source
         """
         if mpar not in self.motion_params:
@@ -311,7 +311,7 @@ class AxisOrientedGeometry(object):
 
         Parameters
         ----------
-        axis : 3-element `array-like`
+        axis : 3-element array-like
             Vector defining the fixed rotation axis after normalization
         """
         if np.linalg.norm(axis) <= 1e-10:
@@ -340,13 +340,13 @@ class AxisOrientedGeometry(object):
 
         Parameters
         ----------
-        angle : `float`
+        angle : float
             The motion parameter given in radian. It must be
             contained in this geometry's `motion_params`.
 
         Returns
         -------
-        rot_mat : `numpy.ndarray`, shape ``(3, 3)``
+        rot_mat : numpy.ndarray, shape ``(3, 3)``
             The rotation matrix mapping the standard basis vectors in
             the fixed ("lab") coordinate system to the basis vectors of
             the local coordinate system of the detector reference point,

--- a/odl/tomo/geometry/geometry.py
+++ b/odl/tomo/geometry/geometry.py
@@ -159,7 +159,7 @@ class Geometry(with_metaclass(ABCMeta, object)):
 
         Returns
         -------
-        point : numpy.ndarray, shape (`ndim`,)
+        point : `numpy.ndarray`, shape (`ndim`,)
             The reference point, an `ndim`-dimensional vector
         """
 
@@ -176,7 +176,7 @@ class Geometry(with_metaclass(ABCMeta, object)):
 
         Returns
         -------
-        rot : numpy.ndarray, shape (`ndim`, `ndim`)
+        rot : `numpy.ndarray`, shape (`ndim`, `ndim`)
             The rotation matrix mapping the standard basis vectors in
             the fixed ("lab") coordinate system to the basis vectors of
             the local coordinate system of the detector reference point,
@@ -195,11 +195,11 @@ class Geometry(with_metaclass(ABCMeta, object)):
         dpar : element of detector parameters `det_params`
             Detector parameter at which to evaluate
         normalized : bool, optional
-            If True, return a normalized (unit) vector. Default: True
+            If ``True``, return a normalized (unit) vector.
 
         Returns
         -------
-        vec : numpy.ndarray, shape (`ndim`,)
+        vec : `numpy.ndarray`, shape (`ndim`,)
             (Unit) vector pointing from the detector to the source
         """
         raise NotImplementedError
@@ -216,7 +216,7 @@ class Geometry(with_metaclass(ABCMeta, object)):
 
         Returns
         -------
-        pos : ``numpy.ndarray`` (shape (`ndim`,))
+        pos : `numpy.ndarray` (shape (`ndim`,))
             Source position, an `ndim`-dimensional vector
         """
         # TODO: check and write test
@@ -233,7 +233,7 @@ class Geometry(with_metaclass(ABCMeta, object)):
 
         Returns
         -------
-        implementations : `dict`
+        implementations : dict
         """
         return self._implementation_cache
 
@@ -259,7 +259,7 @@ class DivergentBeamGeometry(Geometry):
 
         Returns
         -------
-        pos : ``numpy.ndarray`` (shape (`ndim`,))
+        pos : `numpy.ndarray` (shape (`ndim`,))
             Source position, an `ndim`-dimensional vector
         """
 
@@ -279,11 +279,11 @@ class DivergentBeamGeometry(Geometry):
         dpar : element of detector parameters `det_params`
             Detector parameter at which to evaluate
         normalized : bool, optional
-            If True, return a normalized (unit) vector.
+            If ``True``, return a normalized (unit) vector.
 
         Returns
         -------
-        vec : numpy.ndarray, shape (`ndim`,)
+        vec : `numpy.ndarray`, shape (`ndim`,)
             (Unit) vector pointing from the detector to the source
         """
         if mpar not in self.motion_params:
@@ -311,7 +311,7 @@ class AxisOrientedGeometry(object):
 
         Parameters
         ----------
-        axis : 3-element array-like
+        axis : `array-like` (shape ``(3,)``)
             Vector defining the fixed rotation axis after normalization
         """
         if np.linalg.norm(axis) <= 1e-10:
@@ -346,7 +346,7 @@ class AxisOrientedGeometry(object):
 
         Returns
         -------
-        rot_mat : numpy.ndarray, shape ``(3, 3)``
+        rot_mat : `numpy.ndarray`, shape ``(3, 3)``
             The rotation matrix mapping the standard basis vectors in
             the fixed ("lab") coordinate system to the basis vectors of
             the local coordinate system of the detector reference point,

--- a/odl/tomo/geometry/geometry.py
+++ b/odl/tomo/geometry/geometry.py
@@ -153,7 +153,7 @@ class Geometry(with_metaclass(ABCMeta, object)):
 
         Parameters
         ----------
-        mpar : element of motion parameters
+        mpar : `motion_params` element
             Motion parameter for which to calculate the detector
             reference point
 
@@ -170,7 +170,7 @@ class Geometry(with_metaclass(ABCMeta, object)):
 
         Parameters
         ----------
-        mpar : element of motion parameters `motion_params`
+        mpar : `motion_params` element
             Motion parameter for which to calculate the detector
             reference rotation
 
@@ -190,9 +190,9 @@ class Geometry(with_metaclass(ABCMeta, object)):
 
         Parameters
         ----------
-        mpar : element of motion parameters `motion_params`
+        mpar : `motion_params` element
             Motion parameter at which to evaluate
-        dpar : element of detector parameters `det_params`
+        dpar : `det_params` element
             Detector parameter at which to evaluate
         normalized : bool, optional
             If ``True``, return a normalized (unit) vector.
@@ -209,9 +209,9 @@ class Geometry(with_metaclass(ABCMeta, object)):
 
         Parameters
         ----------
-        mpar : element of motion parameters `motion_params`
+        mpar : `motion_params` element
             Motion parameter at which to evaluate
-        dpar : element of detector parameters `det_params`
+        dpar : `det_params` element
             Detector parameter at which to evaluate
 
         Returns
@@ -254,7 +254,7 @@ class DivergentBeamGeometry(Geometry):
 
         Parameters
         ----------
-        mpar : element of motion parameters `motion_params`
+        mpar : `motion_params` element
             Motion parameter for which to calculate the source position
 
         Returns
@@ -274,9 +274,9 @@ class DivergentBeamGeometry(Geometry):
 
         Parameters
         ----------
-        mpar : element of motion parameters `motion_params`
+        mpar : `motion_params` element
             Motion parameter at which to evaluate
-        dpar : element of detector parameters `det_params`
+        dpar : `det_params` element
             Detector parameter at which to evaluate
         normalized : bool, optional
             If ``True``, return a normalized (unit) vector.

--- a/odl/tomo/geometry/parallel.py
+++ b/odl/tomo/geometry/parallel.py
@@ -56,7 +56,7 @@ class ParallelGeometry(Geometry):
             Partition of the angle set
         detector : `Detector`
             The detector to use in this geometry
-        det_init_pos : `array-like`
+        det_init_pos : array-like
             Initial position of the detector reference point
         """
         super().__init__(ndim, apart, detector)
@@ -84,13 +84,13 @@ class ParallelGeometry(Geometry):
 
         Parameters
         ----------
-        angles : `float`
+        angles : float
             Parameters describing the detector rotation, must be
             contained in `motion_params`.
 
         Returns
         -------
-        point : `numpy.ndarray`, shape (`ndim`,)
+        point : numpy.ndarray, shape (`ndim`,)
             The reference point for the given parameters
         """
         if angles not in self.motion_params:
@@ -109,19 +109,19 @@ class ParallelGeometry(Geometry):
 
         Parameters
         ----------
-        angles : `array-like`
+        angles : array-like
             Euler angles given in radians, must be contained
             in this geometry's `motion_params`
-        dpar : `float`
+        dpar : float
             Detector parameters, must be contained in this
             geometry's `det_params`
-        normalized : `bool`, optional
-            If `True`, return the normalized version of the vector.
+        normalized : bool, optional
+            If True, return the normalized version of the vector.
             For parallel geometry, this is the only sensible option.
 
         Returns
         -------
-        vec : `numpy.ndarray`, shape (`ndim`,)
+        vec : numpy.ndarray, shape (`ndim`,)
             Unit vector pointing from the detector to the source
 
         Raises
@@ -166,12 +166,12 @@ class Parallel2dGeometry(ParallelGeometry):
             Partition of the angle interval
         dpart : 1-dim. `RectPartition`
             Partition of the detector parameter interval
-        det_init_pos : `array-like`, shape ``(2,)``, optional
+        det_init_pos : array-like, shape ``(2,)``, optional
             Initial position of the detector reference point. The zero
             vector is only allowed if ``det_init_axis`` is explicitly
             given.
             Default: ``(1, 0)``.
-        det_init_axis : `array-like` (shape ``(2,)``), optional
+        det_init_axis : array-like (shape ``(2,)``), optional
             Initial axis defining the detector orientation.
             By default, a normalized `perpendicular_vector` to
             ``det_init_pos`` is used, which is only valid if
@@ -217,13 +217,13 @@ class Parallel2dGeometry(ParallelGeometry):
 
         Parameters
         ----------
-        angle : `float`
+        angle : float
             Rotation angle given in radians, must be contained in
             this geometry's `motion_params`
 
         Returns
         -------
-        rot : `numpy.ndarray`, shape (2, 2)
+        rot : numpy.ndarray, shape (2, 2)
             The rotation matrix mapping the standard basis vectors in
             the fixed ("lab") coordinate system to the basis vectors of
             the local coordinate system of the detector reference point,
@@ -274,12 +274,12 @@ class Parallel3dEulerGeometry(ParallelGeometry):
             Partition of the angle parameter set
         dpart : 2-dim. `RectPartition`
             Partition of the detector parameter interval
-        det_init_pos : `array-like`, shape ``(3,)``, optional
+        det_init_pos : array-like, shape ``(3,)``, optional
             Initial position of the detector reference point. The zero
             vector is only allowed if ``det_init_axes`` is explicitly
             given.
             Default: ``(1, 0, 0)``
-        det_init_axes : 2-tuple of `array-like` (shape ``(3,)``), optional
+        det_init_axes : 2-tuple of array-like (shape ``(3,)``), optional
             Initial axes defining the detector orientation.
             By default, a normalized `perpendicular_vector` to
             ``det_init_pos`` is taken as first axis, and the normalized
@@ -311,13 +311,13 @@ class Parallel3dEulerGeometry(ParallelGeometry):
 
         Parameters
         ----------
-        angles : `array-like`
+        angles : array-like
             Angles in radians defining the rotation, must be contained
             in this geometry's ``motion_params``
 
         Returns
         -------
-        rot : `numpy.ndarray`, shape ``(3, 3)``
+        rot : numpy.ndarray, shape ``(3, 3)``
             The rotation matrix mapping the standard basis vectors in
             the fixed ("lab") coordinate system to the basis vectors of
             the local coordinate system of the detector reference point,
@@ -364,14 +364,14 @@ class Parallel3dAxisGeometry(ParallelGeometry, AxisOrientedGeometry):
             Partition of the angle interval
         dpart : 2-dim. `RectPartition`
             Partition of the detector parameter interval
-        axis : `array-like`, shape ``(3,)``, optional
+        axis : array-like, shape ``(3,)``, optional
             Fixed rotation axis defined by a 3-element vector
-        det_init_pos : `array-like`, shape ``(3,)``, optional
+        det_init_pos : array-like, shape ``(3,)``, optional
             Initial position of the detector reference point. The zero
             vector is only allowed if ``det_init_axes`` is explicitly
             given.
             By default, a `perpendicular_vector` to ``axis`` is used.
-        det_init_axes : 2-tuple of `array-like` (shape ``(3,)``), optional
+        det_init_axes : 2-tuple of array-like (shape ``(3,)``), optional
             Initial axes defining the detector orientation.
             By default, the normalized cross product of ``axis`` and
             ``det_init_pos`` is used as first axis and ``axis`` as second.

--- a/odl/tomo/geometry/parallel.py
+++ b/odl/tomo/geometry/parallel.py
@@ -56,7 +56,7 @@ class ParallelGeometry(Geometry):
             Partition of the angle set
         detector : `Detector`
             The detector to use in this geometry
-        det_init_pos : array-like
+        det_init_pos : `array-like`
             Initial position of the detector reference point
         """
         super().__init__(ndim, apart, detector)
@@ -90,7 +90,7 @@ class ParallelGeometry(Geometry):
 
         Returns
         -------
-        point : numpy.ndarray, shape (`ndim`,)
+        point : `numpy.ndarray`, shape (`ndim`,)
             The reference point for the given parameters
         """
         if angles not in self.motion_params:
@@ -109,19 +109,19 @@ class ParallelGeometry(Geometry):
 
         Parameters
         ----------
-        angles : array-like
+        angles : `array-like`
             Euler angles given in radians, must be contained
             in this geometry's `motion_params`
         dpar : float
             Detector parameters, must be contained in this
             geometry's `det_params`
         normalized : bool, optional
-            If True, return the normalized version of the vector.
+            If ``True``, return the normalized version of the vector.
             For parallel geometry, this is the only sensible option.
 
         Returns
         -------
-        vec : numpy.ndarray, shape (`ndim`,)
+        vec : `numpy.ndarray`, shape (`ndim`,)
             Unit vector pointing from the detector to the source
 
         Raises
@@ -166,12 +166,12 @@ class Parallel2dGeometry(ParallelGeometry):
             Partition of the angle interval
         dpart : 1-dim. `RectPartition`
             Partition of the detector parameter interval
-        det_init_pos : array-like, shape ``(2,)``, optional
+        det_init_pos : `array-like`, shape ``(2,)``, optional
             Initial position of the detector reference point. The zero
             vector is only allowed if ``det_init_axis`` is explicitly
             given.
             Default: ``(1, 0)``.
-        det_init_axis : array-like (shape ``(2,)``), optional
+        det_init_axis : `array-like` (shape ``(2,)``), optional
             Initial axis defining the detector orientation.
             By default, a normalized `perpendicular_vector` to
             ``det_init_pos`` is used, which is only valid if
@@ -223,7 +223,7 @@ class Parallel2dGeometry(ParallelGeometry):
 
         Returns
         -------
-        rot : numpy.ndarray, shape (2, 2)
+        rot : `numpy.ndarray`, shape (2, 2)
             The rotation matrix mapping the standard basis vectors in
             the fixed ("lab") coordinate system to the basis vectors of
             the local coordinate system of the detector reference point,
@@ -274,12 +274,12 @@ class Parallel3dEulerGeometry(ParallelGeometry):
             Partition of the angle parameter set
         dpart : 2-dim. `RectPartition`
             Partition of the detector parameter interval
-        det_init_pos : array-like, shape ``(3,)``, optional
+        det_init_pos : `array-like`, shape ``(3,)``, optional
             Initial position of the detector reference point. The zero
             vector is only allowed if ``det_init_axes`` is explicitly
             given.
             Default: ``(1, 0, 0)``
-        det_init_axes : 2-tuple of array-like (shape ``(3,)``), optional
+        det_init_axes : 2-tuple of `array-like`'s (shape ``(3,)``), optional
             Initial axes defining the detector orientation.
             By default, a normalized `perpendicular_vector` to
             ``det_init_pos`` is taken as first axis, and the normalized
@@ -311,13 +311,13 @@ class Parallel3dEulerGeometry(ParallelGeometry):
 
         Parameters
         ----------
-        angles : array-like
+        angles : `array-like`
             Angles in radians defining the rotation, must be contained
             in this geometry's ``motion_params``
 
         Returns
         -------
-        rot : numpy.ndarray, shape ``(3, 3)``
+        rot : `numpy.ndarray`, shape ``(3, 3)``
             The rotation matrix mapping the standard basis vectors in
             the fixed ("lab") coordinate system to the basis vectors of
             the local coordinate system of the detector reference point,
@@ -364,14 +364,14 @@ class Parallel3dAxisGeometry(ParallelGeometry, AxisOrientedGeometry):
             Partition of the angle interval
         dpart : 2-dim. `RectPartition`
             Partition of the detector parameter interval
-        axis : array-like, shape ``(3,)``, optional
+        axis : `array-like`, shape ``(3,)``, optional
             Fixed rotation axis defined by a 3-element vector
-        det_init_pos : array-like, shape ``(3,)``, optional
+        det_init_pos : `array-like`, shape ``(3,)``, optional
             Initial position of the detector reference point. The zero
             vector is only allowed if ``det_init_axes`` is explicitly
             given.
             By default, a `perpendicular_vector` to ``axis`` is used.
-        det_init_axes : 2-tuple of array-like (shape ``(3,)``), optional
+        det_init_axes : 2-tuple of `array-like`'s (shape ``(3,)``), optional
             Initial axes defining the detector orientation.
             By default, the normalized cross product of ``axis`` and
             ``det_init_pos`` is used as first axis and ``axis`` as second.

--- a/odl/tomo/geometry/spect.py
+++ b/odl/tomo/geometry/spect.py
@@ -45,15 +45,15 @@ class ParallelHoleCollimatorGeometry(Parallel3dAxisGeometry):
             Partition of the angle interval
         dpart : 2-dim. `RectPartition`
             Partition of the detector parameter rectangle
-        det_rad : positive `float`
+        det_rad : positive float
             Radius of the circular detector orbit.
-        axis : `array-like`, shape ``(3,)``, optional
+        axis : array-like, shape ``(3,)``, optional
             Fixed rotation axis.
-        orig_to_det_init : `array-like`, shape ``(3,)``, optional
+        orig_to_det_init : array-like, shape ``(3,)``, optional
             Vector pointing towards the detector reference point in
             the initial position.
             Default: a `perpendicular_vector` to ``axis``.
-        det_init_axes : 2-tuple of `array-like` (shape ``(3,)``), optional
+        det_init_axes : 2-tuple of array-like (shape ``(3,)``), optional
             Initial axes defining the detector orientation.
             Default: the normalized cross product of ``axis`` and
             ``orig_to_det_init`` is used as first axis and ``axis`` as second.

--- a/odl/tomo/geometry/spect.py
+++ b/odl/tomo/geometry/spect.py
@@ -47,13 +47,13 @@ class ParallelHoleCollimatorGeometry(Parallel3dAxisGeometry):
             Partition of the detector parameter rectangle
         det_rad : positive float
             Radius of the circular detector orbit.
-        axis : array-like, shape ``(3,)``, optional
+        axis : `array-like`, shape ``(3,)``, optional
             Fixed rotation axis.
-        orig_to_det_init : array-like, shape ``(3,)``, optional
+        orig_to_det_init : `array-like`, shape ``(3,)``, optional
             Vector pointing towards the detector reference point in
             the initial position.
             Default: a `perpendicular_vector` to ``axis``.
-        det_init_axes : 2-tuple of array-like (shape ``(3,)``), optional
+        det_init_axes : 2-tuple of `array-like`'s (shape ``(3,)``), optional
             Initial axes defining the detector orientation.
             Default: the normalized cross product of ``axis`` and
             ``orig_to_det_init`` is used as first axis and ``axis`` as second.

--- a/odl/tomo/operators/ray_trafo.py
+++ b/odl/tomo/operators/ray_trafo.py
@@ -171,7 +171,7 @@ class RayTransform(Operator):
            Element in the domain of the operator to be forward projected
         out : `DiscreteLpVector`, optional
             Vector in the projection space to which the result is written.
-            If `None` creates an element in the range of the operator.
+            If None creates an element in the range of the operator.
 
         Returns
         -------
@@ -295,7 +295,7 @@ class RayBackProjection(Operator):
            Element in the domain of the operator which is back-projected
         out : `DiscreteLpVector`, optional
             Element in the reconstruction space to which the result is
-            written. If `None` an element in the range of the operator is
+            written. If None an element in the range of the operator is
             created.
 
         Returns

--- a/odl/tomo/operators/ray_trafo.py
+++ b/odl/tomo/operators/ray_trafo.py
@@ -167,14 +167,14 @@ class RayTransform(Operator):
 
         Parameters
         ----------
-        x : `DiscreteLpVector`
-           Element in the domain of the operator to be forward projected
-        out : `DiscreteLpVector`, optional
+        x : `domain` element
+           Element in the domain of the operator to be forward projected.
+        out : `range` element, optional
             Vector in the projection space to which the result is written.
 
         Returns
         -------
-        out : `DiscreteLpVector`
+        out : `range` element
             Element in the projection space holding the result. If ``out``
             was provided, the returned object is a reference to it.
         """
@@ -291,15 +291,15 @@ class RayBackProjection(Operator):
 
         Parameters
         ----------
-        x : `DiscreteLpVector`
-           Element in the domain of the operator which is back-projected
-        out : `DiscreteLpVector`, optional
+        x : `domain` element
+           Element in the domain of the operator which is back-projected.
+        out : `range` element, optional
             Element in the reconstruction space to which the result is
             written.
 
         Returns
         -------
-        out : `DiscreteLpVector`
+        out : `range` element
             Element in the projection space holding the result. If ``out``
             was provided, the returned object is a reference to it.
         """

--- a/odl/tomo/operators/ray_trafo.py
+++ b/odl/tomo/operators/ray_trafo.py
@@ -171,12 +171,12 @@ class RayTransform(Operator):
            Element in the domain of the operator to be forward projected
         out : `DiscreteLpVector`, optional
             Vector in the projection space to which the result is written.
-            If None creates an element in the range of the operator.
 
         Returns
         -------
         out : `DiscreteLpVector`
-            Returns an element in the projection space
+            Element in the projection space holding the result. If ``out``
+            was provided, the returned object is a reference to it.
         """
         if self.impl.startswith('astra'):
             backend, data_impl = self.impl.split('_')
@@ -295,13 +295,13 @@ class RayBackProjection(Operator):
            Element in the domain of the operator which is back-projected
         out : `DiscreteLpVector`, optional
             Element in the reconstruction space to which the result is
-            written. If None an element in the range of the operator is
-            created.
+            written.
 
         Returns
         -------
         out : `DiscreteLpVector`
-            Returns an element in the projection space
+            Element in the projection space holding the result. If ``out``
+            was provided, the returned object is a reference to it.
         """
 
         if self.impl.startswith('astra'):

--- a/odl/tomo/util/utility.py
+++ b/odl/tomo/util/utility.py
@@ -35,7 +35,7 @@ def euler_matrix(*angles):
 
     Parameters
     ----------
-    angle1,...,angleN : `float`
+    angle1,...,angleN : float
         One angle results in a (2x2) matrix representing a
         counter-clockwise rotation. Two or three angles result in a
         (3x3) matrix and are interpreted as Euler angles of a 3d
@@ -44,7 +44,7 @@ def euler_matrix(*angles):
 
     Returns
     -------
-    mat : `numpy.ndarray`, shape ``(2, 2)`` or ``(3, 3)``
+    mat : numpy.ndarray, shape ``(2, 2)`` or ``(3, 3)``
         The rotation matrix
 
     .. _Euler angles:
@@ -101,14 +101,14 @@ def axis_rotation(axis, angle, vectors):
     ----------
     axis : array-like, shape (3,)
         The rotation axis, assumed to be a unit vector
-    angle : `float`
+    angle : float
         The rotation angle
     vectors : array-like, shape ``(3,)`` or ``(N, 3)``
         The vector(s) to be rotated
 
     Returns
     -------
-    rot_vec : `numpy.ndarray`
+    rot_vec : numpy.ndarray
         The rotated vector(s)
 
     .. _Rodriguez' rotation formula:
@@ -153,12 +153,12 @@ def axis_rotation_matrix(axis, angle):
     ----------
     axis : array-like, shape ``(3,)``
         The rotation axis, assumed to be a unit vector
-    angle : `float`
+    angle : float
         The rotation angle
 
     Returns
     -------
-    mat : `numpy.ndarray`, shape ``(3, 3)``
+    mat : numpy.ndarray, shape ``(3, 3)``
         The axis rotation matrix
 
     .. _Rodriguez' rotation formula:
@@ -252,12 +252,12 @@ def perpendicular_vector(vec):
 
     Parameters
     ----------
-    vec : `array-like`
+    vec : array-like
         Vector of arbitrary length
 
     Returns
     -------
-    perp_vec : `numpy.ndarray`
+    perp_vec : numpy.ndarray
         Array of same size such that ``<vec, perp_vec> == 0``
 
     Examples

--- a/odl/tomo/util/utility.py
+++ b/odl/tomo/util/utility.py
@@ -44,7 +44,7 @@ def euler_matrix(*angles):
 
     Returns
     -------
-    mat : numpy.ndarray, shape ``(2, 2)`` or ``(3, 3)``
+    mat : `numpy.ndarray`, shape ``(2, 2)`` or ``(3, 3)``
         The rotation matrix
 
     .. _Euler angles:
@@ -99,16 +99,16 @@ def axis_rotation(axis, angle, vectors):
 
     Parameters
     ----------
-    axis : array-like, shape (3,)
+    axis : `array-like`, shape ``(3,)``
         The rotation axis, assumed to be a unit vector
     angle : float
         The rotation angle
-    vectors : array-like, shape ``(3,)`` or ``(N, 3)``
+    vectors : `array-like`, shape ``(3,)`` or ``(N, 3)``
         The vector(s) to be rotated
 
     Returns
     -------
-    rot_vec : numpy.ndarray
+    rot_vec : `numpy.ndarray`
         The rotated vector(s)
 
     .. _Rodriguez' rotation formula:
@@ -151,14 +151,14 @@ def axis_rotation_matrix(axis, angle):
 
     Parameters
     ----------
-    axis : array-like, shape ``(3,)``
+    axis : `array-like`, shape ``(3,)``
         The rotation axis, assumed to be a unit vector
     angle : float
         The rotation angle
 
     Returns
     -------
-    mat : numpy.ndarray, shape ``(3, 3)``
+    mat : `numpy.ndarray`, shape ``(3, 3)``
         The axis rotation matrix
 
     .. _Rodriguez' rotation formula:
@@ -252,12 +252,12 @@ def perpendicular_vector(vec):
 
     Parameters
     ----------
-    vec : array-like
+    vec : `array-like`
         Vector of arbitrary length
 
     Returns
     -------
-    perp_vec : numpy.ndarray
+    perp_vec : `numpy.ndarray`
         Array of same size such that ``<vec, perp_vec> == 0``
 
     Examples

--- a/odl/trafos/fourier.py
+++ b/odl/trafos/fourier.py
@@ -95,16 +95,16 @@ def reciprocal(grid, shift=True, axes=None, halfcomplex=False):
     ----------
     grid : `RegularGrid`
         Original sampling grid
-    shift : `bool` or sequence of `bool`, optional
-        If `True`, the grid is shifted by half a stride in the negative
+    shift : bool or sequence of bool, optional
+        If ``True``, the grid is shifted by half a stride in the negative
         direction. With a sequence, this option is applied separately on
         each axis.
     axes : int or sequence of int, optional
         Dimensions in which to calculate the reciprocal. The sequence
         must have the same length as ``shift`` if the latter is given
-        as a sequence. `None` means all axes in ``grid``.
-    halfcomplex : `bool`, optional
-        If `True`, return the half of the grid with last coordinate
+        as a sequence. None means all axes in ``grid``.
+    halfcomplex : bool, optional
+        If ``True``, return the half of the grid with last coordinate
         less than zero. This is related to the fact that for real-valued
         functions, the other half is the mirrored complex conjugate of
         the given half and therefore needs not be stored.
@@ -215,9 +215,9 @@ def inverse_reciprocal(grid, x0, axes=None, halfcomplex=False,
     axes : int or sequence of int, optional
         Dimensions in which to calculate the reciprocal. The sequence
         must have the same length as ``shift`` if the latter is given
-        as a sequence. `None` means all axes in ``grid``.
-    halfcomplex : `bool`, optional
-        If `True`, interpret the given grid as the reciprocal as used
+        as a sequence. None means all axes in ``grid``.
+    halfcomplex : bool, optional
+        If ``True``, interpret the given grid as the reciprocal as used
         in a half-complex FFT (see above). Otherwise, the grid is
         regarded as being used in a complex-to-complex transform.
     halfcx_parity : {'even', 'odd'}
@@ -269,7 +269,7 @@ def _local_to_pyfftw(flag):
 
 
 def _pyfftw_destroys_input(flags, direction, halfcomplex, ndim):
-    """Return `True` if FFTW destroys an input array, `False` otherwise."""
+    """Return ``True`` if FFTW destroys an input array, ``False`` otherwise."""
     if any(flag in flags or _pyfftw_to_local(flag) in flags
            for flag in ('FFTW_MEASURE', 'FFTW_PATIENT', 'FFTW_EXHAUSTIVE',
                         'FFTW_DESTROY_INPUT')):
@@ -367,9 +367,9 @@ def pyfftw_call(array_in, array_out, direction='forward', axes=None,
 
     Parameters
     ----------
-    array_in : `numpy.ndarray`
+    array_in : numpy.ndarray
         Array to be transformed
-    array_out : `numpy.ndarray`
+    array_out : numpy.ndarray
         Output array storing the transformed values, may be aligned
         with ``array_in``.
     direction : {'forward', 'backward'}
@@ -377,9 +377,9 @@ def pyfftw_call(array_in, array_out, direction='forward', axes=None,
     axes : int or sequence of int, optional
         Dimensions along which to take the transform. `None` means
         using all axis and is equivalent to ``np.arange(ndim)``.
-    halfcomplex : `bool`, optional
-        If `True`, calculate only the negative frequency part along the
-        last axis. If `False`, calculate the full complex FFT.
+    halfcomplex : bool, optional
+        If ``True``, calculate only the negative frequency part along the
+        last axis. If ``False``, calculate the full complex FFT.
         This option can only be used with real input data.
 
     Other Parameters
@@ -393,19 +393,19 @@ def pyfftw_call(array_in, array_out, direction='forward', axes=None,
         FFTW plan. See the `FFTW doc on planner flags
         <http://www.fftw.org/fftw3_doc/Planner-Flags.html>`_.
         Default: 'estimate'
-    planning_timelimit : `float`, optional
-        Limit planning time to roughly this amount of seconds.
-        Default: `None` (no limit)
-    threads : `int`, optional
+    planning_timelimit : float, optional
+        Limit planning time to roughly this many seconds.
+        Default: None (no limit)
+    threads : int, optional
         Number of threads to use.
         Default: Number of CPUs if the number of data points is larger
         than 1000, else 1.
-    normalise_idft : `bool`, optional
-        If `True`, the backward transform is normalized by
+    normalise_idft : bool, optional
+        If ``True``, the backward transform is normalized by
         ``1 / N``, where ``N`` is the total number of points in
         ``array_in[axes]``. This ensures that the IDFT is the true
         inverse of the forward DFT.
-        Default: `False`
+        Default: ``False``
     import_wisdom : filename or file handle, optional
         File to load FFTW wisdom from. If the file does not exist,
         it is ignored.
@@ -540,8 +540,9 @@ class DiscreteFourierTransformBase(Operator):
 
         Parameters
         ----------
-        inverse : `bool`
-            True if the operator should be the inverse transform, False else.
+        inverse : bool
+            ``True`` if the operator should be the inverse transform,
+            else ``False``.
         domain : `DiscreteLp`
             Domain of the Fourier transform. If its
             `DiscreteLp.exponent` is equal to 2.0, this operator has
@@ -551,13 +552,13 @@ class DiscreteFourierTransformBase(Operator):
             is determined from ``domain`` and the other parameters as
             a `discr_sequence_space` with exponent ``p / (p - 1)``
             (read as 'inf' for p=1 and 1 for p='inf').
-        axes : int or sequence of `int`, optional
-            Dimensions in which a transform is to be calculated. `None`
+        axes : int or sequence of int, optional
+            Dimensions in which a transform is to be calculated. ``None``
             means all axes.
         sign : {'-', '+'}, optional
-            Sign of the complex exponent. Default: '-'
-        halfcomplex : `bool`, optional
-            If `True`, calculate only the negative frequency part
+            Sign of the complex exponent.
+        halfcomplex : bool, optional
+            If ``True``, calculate only the negative frequency part
             along the last axis in ``axes`` for real input. This
             reduces the size of the range to ``floor(N[i]/2) + 1`` in
             this axis ``i``, where ``N`` is the shape of the input
@@ -640,9 +641,9 @@ class DiscreteFourierTransformBase(Operator):
 
         Parameters
         ----------
-        x : domain `element`
+        x : domain element
             Discretized function to be transformed
-        out : range `element`
+        out : range element
             Element to which the output is written
 
         Notes
@@ -678,7 +679,7 @@ class DiscreteFourierTransformBase(Operator):
 
     @property
     def halfcomplex(self):
-        """Return `True` if the last transform axis is halved."""
+        """Return ``True`` if the last transform axis is halved."""
         return self._halfcomplex
 
     @property
@@ -709,12 +710,12 @@ class DiscreteFourierTransformBase(Operator):
 
         Parameters
         ----------
-        x : `numpy.ndarray`
+        x : numpy.ndarray
             Input array to be transformed
 
         Returns
         -------
-        out : `numpy.ndarray`
+        out : numpy.ndarray
             Result of the transform
         """
         raise NotImplementedError('abstract method')
@@ -724,26 +725,26 @@ class DiscreteFourierTransformBase(Operator):
 
         Parameters
         ----------
-        x : `numpy.ndarray`
+        x : numpy.ndarray
             Input array to be transformed
-        out : `numpy.ndarray`
+        out : numpy.ndarray
             Output array storing the result
-        flags : sequence of `str`, optional
+        flags : sequence of string, optional
             Flags for the transform. ``'FFTW_UNALIGNED'`` is not
             supported, and ``'FFTW_DESTROY_INPUT'`` is enabled by
             default. See the `pyfftw API documentation`_
             for futher information.
             Default: ``('FFTW_MEASURE',)``
-        threads : positive `int`, optional
+        threads : positive int, optional
             Number of threads to use. Default: 1
-        planning_timelimit : `float` or `None`, optional
+        planning_timelimit : float or None, optional
             Rough upper limit in seconds for the planning step of the
-            transform. `None` means no limit. See the
+            transform. None means no limit. See the
             `pyfftw API documentation`_ for futher information.
 
         Returns
         -------
-        out : `numpy.ndarray`
+        out : numpy.ndarray
             Result of the transform. If ``out`` was given, the returned
             object is a reference to it.
 
@@ -755,7 +756,7 @@ class DiscreteFourierTransformBase(Operator):
         assert isinstance(x, np.ndarray)
         assert isinstance(out, np.ndarray)
 
-        kwargs.pop('normalise_idft', None)  # Using 'False' here
+        kwargs.pop('normalise_idft', None)  # Using `False` here
         kwargs.pop('axes', None)
         kwargs.pop('halfcomplex', None)
         flags = list(_pyfftw_to_local(flag) for flag in
@@ -781,7 +782,7 @@ class DiscreteFourierTransformBase(Operator):
     def init_fftw_plan(self, planning_effort='measure', **kwargs):
         """Initialize the FFTW plan for this transform for later use.
 
-        If the implementation of this operator is not 'pyfftw', this
+        If the implementation of this operator is not ``'pyfftw'``, this
         method should not be called.
 
         Parameters
@@ -790,16 +791,16 @@ class DiscreteFourierTransformBase(Operator):
             Flag for the amount of effort put into finding an optimal
             FFTW plan. See the `FFTW doc on planner flags
             <http://www.fftw.org/fftw3_doc/Planner-Flags.html>`_.
-        planning_timelimit : `float`, optional
+        planning_timelimit : float, optional
             Limit planning time to roughly this amount of seconds.
-            Default: `None` (no limit)
-        threads : `int`, optional
+            Default: None (no limit)
+        threads : int, optional
             Number of threads to use. Default: 1
 
         Raises
         ------
         ValueError
-            If `impl` is not 'pyfftw'
+            If `impl` is not ``'pyfftw'``
 
         Notes
         -----
@@ -829,13 +830,12 @@ class DiscreteFourierTransformBase(Operator):
         Raises
         ------
         ValueError
-            If `impl` is not 'pyfftw'
+            If `impl` is not ``'pyfftw'``
 
         Notes
         -----
         If no plan exists, this is a no-op.
         """
-
         if self.impl != 'pyfftw':
             raise ValueError('cannot create fftw plan without fftw backend')
 
@@ -885,13 +885,13 @@ class DiscreteFourierTransform(DiscreteFourierTransformBase):
             is determined from ``domain`` and the other parameters as
             a `discr_sequence_space` with exponent ``p / (p - 1)``
             (read as 'inf' for p=1 and 1 for p='inf').
-        axes : int or sequence of `int`, optional
-            Dimensions in which a transform is to be calculated. `None`
+        axes : int or sequence of int, optional
+            Dimensions in which a transform is to be calculated. ``None``
             means all axes.
         sign : {'-', '+'}, optional
-            Sign of the complex exponent. Default: '-'
-        halfcomplex : `bool`, optional
-            If `True`, calculate only the negative frequency part
+            Sign of the complex exponent.
+        halfcomplex : bool, optional
+            If ``True``, calculate only the negative frequency part
             along the last axis in ``axes`` for real input. This
             reduces the size of the range to ``floor(N[i]/2) + 1`` in
             this axis ``i``, where ``N`` is the shape of the input
@@ -899,7 +899,7 @@ class DiscreteFourierTransform(DiscreteFourierTransformBase):
             Otherwise, calculate the full complex FFT. If ``dom_dtype``
             is a complex type, this option has no effect.
         impl : {'numpy', 'pyfftw'}
-            Backend for the FFT implementation. The 'pyfftw' backend
+            Backend for the FFT implementation. The ``'pyfftw'`` backend
             is faster but requires the ``pyfftw`` package.
 
         Examples
@@ -958,7 +958,7 @@ class DiscreteFourierTransform(DiscreteFourierTransformBase):
         assert isinstance(x, np.ndarray)
         assert isinstance(out, np.ndarray)
 
-        kwargs.pop('normalise_idft', None)  # Using 'False' here
+        kwargs.pop('normalise_idft', None)  # Using `False` here
         kwargs.pop('axes', None)
         kwargs.pop('halfcomplex', None)
         flags = list(_pyfftw_to_local(flag) for flag in
@@ -1034,13 +1034,13 @@ class DiscreteFourierTransformInverse(DiscreteFourierTransformBase):
             domain is determined from ``range`` and the other parameters
             as a `discr_sequence_space` with exponent ``p / (p - 1)``
             (read as 'inf' for p=1 and 1 for p='inf').
-        axes : sequence of `int`, optional
+        axes : sequence of int, optional
             Dimensions in which a transform is to be calculated. `None`
             means all axes.
         sign : {'-', '+'}, optional
             Sign of the complex exponent.
-        halfcomplex : `bool`, optional
-            If `True`, interpret the last axis in ``axes`` as the
+        halfcomplex : bool, optional
+            If ``True``, interpret the last axis in ``axes`` as the
             negative frequency part of the transform of a real signal
             and calculate a "half-complex-to-real" inverse FFT. In this
             case, the domain has by default the shape
@@ -1109,13 +1109,13 @@ class DiscreteFourierTransformInverse(DiscreteFourierTransformBase):
             Input vector to be transformed
         out : range element
             Output vector storing the result
-        flags : sequence of `str`, optional
+        flags : sequence of str, optional
             Flags for the transform. ``'FFTW_UNALIGNED'`` is not
             supported, and ``'FFTW_DESTROY_INPUT'`` is enabled by
             default. See the `pyfftw API documentation`_
             for futher information.
             Default: ``('FFTW_MEASURE',)``
-        threads : positive `int`, optional
+        threads : positive int, optional
             Number of threads to use. Default: 1
         planning_timelimit : `float` or `None`, optional
             Rough upper limit in seconds for the planning step of the
@@ -1133,7 +1133,7 @@ class DiscreteFourierTransformInverse(DiscreteFourierTransformBase):
         .. _pyfftw API documentation:
            http://hgomersall.github.io/pyFFTW/pyfftw/pyfftw.html
         """
-        kwargs.pop('normalise_idft', None)  # Using 'True' here
+        kwargs.pop('normalise_idft', None)  # Using `True` here
         kwargs.pop('axes', None)
         kwargs.pop('halfcomplex', None)
         flags = list(_pyfftw_to_local(flag) for flag in
@@ -1196,20 +1196,20 @@ def dft_preprocess_data(arr, shift=True, axes=None, sign='-', out=None):
 
     Parameters
     ----------
-    arr : `array-like`
+    arr : array-like
         Array to be pre-processed. If its data type is a real
         non-floating type, it is converted to 'float64'.
     shift : bool or or sequence of bool, optional
-        If `True`, the grid is shifted by half a stride in the negative
+        If ``True``, the grid is shifted by half a stride in the negative
         direction. With a sequence, this option is applied separately on
         each axis.
     axes : int or sequence of int, optional
         Dimensions in which to calculate the reciprocal. The sequence
         must have the same length as ``shift`` if the latter is given
-        as a sequence. `None` means all axes in ``arr``.
+        as a sequence. ``None`` means all axes in ``arr``.
     sign : {'-', '+'}, optional
-        Sign of the complex exponent
-    out : `numpy.ndarray`, optional
+        Sign of the complex exponent.
+    out : numpy.ndarray, optional
         Array in which the result is stored. If ``out is arr``,
         an in-place modification is performed. For real data type,
         this is only possible for ``shift=True`` since the factors are
@@ -1217,7 +1217,7 @@ def dft_preprocess_data(arr, shift=True, axes=None, sign='-', out=None):
 
     Returns
     -------
-    out : `numpy.ndarray`
+    out : numpy.ndarray
         Result of the pre-processing. If ``out`` was given, the returned
         object is a reference to it.
 
@@ -1225,7 +1225,7 @@ def dft_preprocess_data(arr, shift=True, axes=None, sign='-', out=None):
     -----
     If ``out`` is not specified, the data type of the returned array
     is the same as that of ``arr`` except when ``arr`` has real data
-    type and ``shift`` is not `True`. In this case, the return type
+    type and ``shift`` is not ``True``. In this case, the return type
     is the complex counterpart of ``arr.dtype``.
     """
     arr = np.asarray(arr)
@@ -1300,14 +1300,14 @@ def _interp_kernel_ft(norm_freqs, interp):
 
     Parameters
     ----------
-    norm_freqs : `numpy.ndarray`
+    norm_freqs : numpy.ndarray
         Normalized frequencies between -1/2 and 1/2
     interp : {'nearest', 'linear'}
         Type of interpolation kernel
 
     Returns
     -------
-    ker_ft : `numpy.ndarray`
+    ker_ft : numpy.ndarray
         Values of the kernel FT at the given frequencies
     """
     # Numpy's sinc(x) is equal to the 'math' sinc(pi * x)
@@ -1352,7 +1352,7 @@ def dft_postprocess_data(arr, real_grid, recip_grid, shift, axes,
 
     Parameters
     ----------
-    arr : `array-like`
+    arr : array-like
         Array to be pre-processed. An array with real data type is
         converted to its complex counterpart.
     real_grid : `RegularGrid`
@@ -1360,26 +1360,26 @@ def dft_postprocess_data(arr, real_grid, recip_grid, shift, axes,
     recip_grid : `RegularGrid`
         Reciprocal grid in the transform
     shift : bool or sequence of bool
-        If `True`, the grid is shifted by half a stride in the negative
+        If ``True``, the grid is shifted by half a stride in the negative
         direction in the corresponding axes. The sequence must have the
         same length as ``axes``.
-    axes : int or sequence of `int`
+    axes : int or sequence of int
         Dimensions along which to take the transform. The sequence must
         have the same length as ``shifts``.
-    interp : `str` or `sequence` of `str`
-        Interpolation scheme used in the real-space
+    interp : string or sequence of string
+        Interpolation scheme used in the real-space.
     sign : {'-', '+'}, optional
-        Sign of the complex exponent
+        Sign of the complex exponent.
     op : {'multiply', 'divide'}
         Operation to perform with the stride times the interpolation
         kernel FT
-    out : `numpy.ndarray`, optional
+    out : numpy.ndarray, optional
         Array in which the result is stored. If ``out is arr``, an
         in-place modification is performed.
 
     Returns
     -------
-    out : `numpy.ndarray`
+    out : numpy.ndarray
         Result of the post-processing. If ``out`` was given, the returned
         object is a reference to it.
     """
@@ -1484,24 +1484,24 @@ def reciprocal_space(space, axes=None, halfcomplex=False, shift=True,
     space : `DiscreteLp`
         Real space whose reciprocal is calculated. It must be
         uniformly discretized.
-    axes : sequence of `int`, optional
+    axes : sequence of int, optional
         Dimensions along which the Fourier transform is taken.
         Default: all axes
-    halfcomplex : `bool`, optional
-        If `True`, take only the negative frequency part along the last
-        axis for. If `False`, use the full frequency space.
+    halfcomplex : bool, optional
+        If ``True``, take only the negative frequency part along the last
+        axis for. If ``False``, use the full frequency space.
         This option can only be used if ``space`` is a space of
         real-valued functions.
-        Default: `False`
-    shift : `bool` or sequence of `bool`, optional
-        If `True`, the reciprocal grid is shifted by half a stride in
+        Default: ``False``
+    shift : bool or sequence of bool, optional
+        If ``True``, the reciprocal grid is shifted by half a stride in
         the negative direction. With a boolean sequence, this option
         is applied separately to each axis.
         If a sequence is provided, it must have the same length as
-        ``axes`` if supplied. Note that this must be set to `True`
+        ``axes`` if supplied. Note that this must be set to ``True``
         in the halved axis in half-complex transforms.
-        Default: `True`
-    exponent : `float`, optional
+        Default: ``True``
+    exponent : float, optional
         Create a space with this exponent. By default, the conjugate
         exponent ``q = p / (p - 1)`` of the exponent of ``space`` is
         used, where ``q = inf`` for ``p = 1`` and vice versa.
@@ -1554,7 +1554,7 @@ def reciprocal_space(space, axes=None, halfcomplex=False, shift=True,
                             axes=axes)
 
     # Make a partition with nodes on the boundary in the last transform axis
-    # if halfcomplex = True, otherwise a standard partition.
+    # if `halfcomplex == True`, otherwise a standard partition.
     if halfcomplex:
         end = {axes[-1]: recip_grid.max_pt[axes[-1]]}
         part = uniform_partition_fromgrid(recip_grid, end=end)
@@ -1600,8 +1600,9 @@ class FourierTransformBase(Operator):
 
         Parameters
         ----------
-        inverse : `bool`
-            True if the operator should be the inverse transform, False else.
+        inverse : bool
+            ``True`` if the operator should be the inverse transform, else
+            ``False``.
         domain : `DiscreteLp`
             Domain of the Fourier transform. If the
             `DiscreteLp.exponent` of ``domain`` and ``range`` are equal
@@ -1620,30 +1621,30 @@ class FourierTransformBase(Operator):
             Default: all axes
         sign : {'-', '+'}, optional
             Sign of the complex exponent. Default: '-'
-        halfcomplex : `bool`, optional
-            If `True`, calculate only the negative frequency part
-            along the last axis for real input. If `False`,
+        halfcomplex : bool, optional
+            If ``True``, calculate only the negative frequency part
+            along the last axis for real input. If ``False``,
             calculate the full complex FFT.
             For complex ``domain``, it has no effect.
-            Default: `True`
-        shift : `bool` or sequence of `bool`, optional
-            If `True`, the reciprocal grid is shifted by half a stride in
+            Default: ``True``
+        shift : bool or sequence of bool, optional
+            If ``True``, the reciprocal grid is shifted by half a stride in
             the negative direction. With a boolean sequence, this option
             is applied separately to each axis.
             If a sequence is provided, it must have the same length as
-            ``axes`` if supplied. Note that this must be set to `True`
+            ``axes`` if supplied. Note that this must be set to ``True``
             in the halved axis in half-complex transforms.
-            Default: `True`
+            Default: ``True``
 
         Other Parameters
         ----------------
-        tmp_r : `DiscreteLpVector` or `numpy.ndarray`
+        tmp_r : `DiscreteLpVector` or numpy.ndarray
             Temporary for calculations in the real space (domain of
             this transform). It is shared with the inverse.
 
             Variants using this: R2C, R2HC, C2R (inverse)
 
-        tmp_f : `DiscreteLpVector` or `numpy.ndarray`
+        tmp_f : `DiscreteLpVector` or numpy.ndarray
             Temporary for calculations in the frequency (reciprocal)
             space. It is shared with the inverse.
 
@@ -1723,8 +1724,8 @@ class FourierTransformBase(Operator):
         # casts to complex otherwise, and then no half-complex transform
         # is possible.
         if self.halfcomplex and not self.shifts[-1]:
-            raise ValueError('`shift` must be True in the halved (last) axis '
-                             'in half-complex transforms')
+            raise ValueError('`shift` must be `True` in the halved (last) '
+                             'axis in half-complex transforms')
 
         if range is None:
             # self._halfcomplex and self._axes need to be set for this
@@ -1755,9 +1756,9 @@ class FourierTransformBase(Operator):
 
         Parameters
         ----------
-        x : domain `element`
+        x : domain element
             Discretized function to be transformed
-        out : range `element`
+        out : range element
             Element to which the output is written
 
         Notes
@@ -1782,12 +1783,12 @@ class FourierTransformBase(Operator):
 
         Parameters
         ----------
-        x : `numpy.ndarray`
+        x : numpy.ndarray
             Array representing the function to be transformed
 
         Returns
         -------
-        out : `numpy.ndarray`
+        out : numpy.ndarray
             Result of the transform
         """
         raise NotImplementedError('abstract method')
@@ -1797,23 +1798,23 @@ class FourierTransformBase(Operator):
 
         Parameters
         ----------
-        x : `numpy.ndarray`
+        x : numpy.ndarray
             Array representing the function to be transformed
-        out : `numpy.ndarray`
+        out : numpy.ndarray
             Array to which the output is written
         planning_effort : {'estimate', 'measure', 'patient', 'exhaustive'}
             Flag for the amount of effort put into finding an optimal
             FFTW plan. See the `FFTW doc on planner flags
             <http://www.fftw.org/fftw3_doc/Planner-Flags.html>`_.
-        planning_timelimit : `float`, optional
+        planning_timelimit : float, optional
             Limit planning time to roughly this amount of seconds.
-            Default: `None` (no limit)
-        threads : `int`, optional
+            Default: None (no limit)
+        threads : int, optional
             Number of threads to use. Default: 1
 
         Returns
         -------
-        out : `numpy.ndarray`
+        out : numpy.ndarray
             Result of the transform. The returned object is a reference
             to the input parameter ``out``.
         """
@@ -1836,7 +1837,7 @@ class FourierTransformBase(Operator):
 
     @property
     def halfcomplex(self):
-        """Return `True` if the last transform axis is halved."""
+        """Return ``True`` if the last transform axis is halved."""
         return self._halfcomplex
 
     @property
@@ -1880,9 +1881,9 @@ class FourierTransformBase(Operator):
 
         Parameters
         ----------
-        r : `bool`, optional
+        r : bool, optional
             Create temporary for the real space
-        f : `bool`, optional
+        f : bool, optional
             Create temporary for the frequency space
 
         Notes
@@ -1910,7 +1911,7 @@ class FourierTransformBase(Operator):
             self._tmp_f = fspace.element().asarray()
 
     def clear_temporaries(self):
-        """Set the temporaries to `None`."""
+        """Set the temporaries to None."""
         self._tmp_r = None
         self._tmp_f = None
 
@@ -1926,10 +1927,10 @@ class FourierTransformBase(Operator):
             Flag for the amount of effort put into finding an optimal
             FFTW plan. See the `FFTW doc on planner flags
             <http://www.fftw.org/fftw3_doc/Planner-Flags.html>`_.
-        planning_timelimit : `float`, optional
+        planning_timelimit : float, optional
             Limit planning time to roughly this amount of seconds.
-            Default: `None` (no limit)
-        threads : `int`, optional
+            Default: None (no limit)
+        threads : int, optional
             Number of threads to use. Default: 1
 
         Raises
@@ -2065,20 +2066,20 @@ class FourierTransform(FourierTransformBase):
             Default: all axes
         sign : {'-', '+'}, optional
             Sign of the complex exponent. Default: '-'
-        halfcomplex : `bool`, optional
-            If `True`, calculate only the negative frequency part
-            along the last axis for real input. If `False`,
+        halfcomplex : bool, optional
+            If ``True``, calculate only the negative frequency part
+            along the last axis for real input. If ``False``,
             calculate the full complex FFT.
             For complex ``domain``, it has no effect.
-            Default: `True`
-        shift : `bool` or sequence of `bool`, optional
-            If `True`, the reciprocal grid is shifted by half a stride in
+            Default: ``True``
+        shift : bool or sequence of bool, optional
+            If ``True``, the reciprocal grid is shifted by half a stride in
             the negative direction. With a boolean sequence, this option
             is applied separately to each axis.
             If a sequence is provided, it must have the same length as
-            ``axes`` if supplied. Note that this must be set to `True`
+            ``axes`` if supplied. Note that this must be set to ``True``
             in the halved axis in half-complex transforms.
-            Default: `True`
+            Default: ``True``
 
         Other Parameters
         ----------------
@@ -2214,7 +2215,7 @@ class FourierTransform(FourierTransformBase):
         planning_timelimit : `float`, optional
             Limit planning time to roughly this amount of seconds.
             Default: `None` (no limit)
-        threads : `int`, optional
+        threads : int, optional
             Number of threads to use. Default: 1
 
         Returns
@@ -2227,7 +2228,7 @@ class FourierTransform(FourierTransformBase):
         # given during init or implicitly assumed.
         kwargs.pop('axes', None)
         kwargs.pop('halfcomplex', None)
-        kwargs.pop('normalise_idft', None)  # We use 'False'
+        kwargs.pop('normalise_idft', None)  # We use `False`
 
         # Pre-processing before calculating the sums, in-place for C2C and R2C
         if self.halfcomplex:
@@ -2299,31 +2300,31 @@ class FourierTransformInverse(FourierTransformBase):
             Dimensions along which to take the transform.
             Default: all axes
         sign : {'-', '+'}, optional
-            Sign of the complex exponent. Default: '+'
-        halfcomplex : `bool`, optional
-            If `True`, calculate only the negative frequency part
-            along the last axis for real input. If `False`,
+            Sign of the complex exponent. Default: ``'+'``
+        halfcomplex : bool, optional
+            If ``True``, calculate only the negative frequency part
+            along the last axis for real input. If ``False``,
             calculate the full complex FFT.
             For complex ``domain``, it has no effect.
-            Default: `True`
-        shift : `bool` or sequence of `bool`, optional
-            If `True`, the reciprocal grid is shifted by half a stride in
+            Default: ``True``
+        shift : bool or sequence of bool, optional
+            If ``True``, the reciprocal grid is shifted by half a stride in
             the negative direction. With a boolean sequence, this option
             is applied separately to each axis.
             If a sequence is provided, it must have the same length as
-            ``axes`` if supplied. Note that this must be set to `True`
+            ``axes`` if supplied. Note that this must be set to ``True``
             in the halved axis in half-complex transforms.
-            Default: `True`
+            Default: ``True``
 
         Other Parameters
         ----------------
-        tmp_r : `DiscreteLpVector` or `numpy.ndarray`
+        tmp_r : `DiscreteLpVector` or numpy.ndarray
             Temporary for calculations in the real space (range of
             this transform). It is shared with the inverse.
 
             Variants using this: C2R, R2C (forward), R2HC (forward)
 
-        tmp_f : `DiscreteLpVector` or `numpy.ndarray`
+        tmp_f : `DiscreteLpVector` or numpy.ndarray
             Temporary for calculations in the frequency (reciprocal)
             space. It is shared with the inverse.
 
@@ -2406,12 +2407,12 @@ class FourierTransformInverse(FourierTransformBase):
 
         Parameters
         ----------
-        x : `numpy.ndarray`
+        x : numpy.ndarray
             Array representing the function to be transformed
 
         Returns
         -------
-        out : `numpy.ndarray`
+        out : numpy.ndarray
             Result of the transform
         """
         # Pre-processing before calculating the DFT
@@ -2446,23 +2447,23 @@ class FourierTransformInverse(FourierTransformBase):
 
         Parameters
         ----------
-        x : `numpy.ndarray`
+        x : numpy.ndarray
             Array representing the function to be transformed
-        out : `numpy.ndarray`
+        out : numpy.ndarray
             Array to which the output is written
         planning_effort : {'estimate', 'measure', 'patient', 'exhaustive'}
             Flag for the amount of effort put into finding an optimal
             FFTW plan. See the `FFTW doc on planner flags
             <http://www.fftw.org/fftw3_doc/Planner-Flags.html>`_.
-        planning_timelimit : `float`, optional
+        planning_timelimit : float, optional
             Limit planning time to roughly this amount of seconds.
-            Default: `None` (no limit)
-        threads : `int`, optional
+            Default: None (no limit)
+        threads : int, optional
             Number of threads to use. Default: 1
 
         Returns
         -------
-        out : `numpy.ndarray`
+        out : numpy.ndarray
             Result of the transform. If ``out`` was given, the returned
             object is a reference to it.
         """
@@ -2471,7 +2472,7 @@ class FourierTransformInverse(FourierTransformBase):
         # given during init or implicitly assumed.
         kwargs.pop('axes', None)
         kwargs.pop('halfcomplex', None)
-        kwargs.pop('normalise_idft', None)  # We use 'True'
+        kwargs.pop('normalise_idft', None)  # We use `True`
 
         # Pre-processing in IFT = post-processing in FT, but with division
         # instead of multiplication and switched grids. In-place for C2C only.

--- a/odl/trafos/fourier.py
+++ b/odl/trafos/fourier.py
@@ -641,9 +641,9 @@ class DiscreteFourierTransformBase(Operator):
 
         Parameters
         ----------
-        x : domain element
+        x : `domain` element
             Discretized function to be transformed
-        out : range element
+        out : `range` element
             Element to which the output is written
 
         Notes
@@ -1105,10 +1105,10 @@ class DiscreteFourierTransformInverse(DiscreteFourierTransformBase):
 
         Parameters
         ----------
-        x : domain element
-            Input vector to be transformed
-        out : range element
-            Output vector storing the result
+        x : `domain` element
+            Input vector to be transformed.
+        out : `range` element
+            Output vector storing the result.
         flags : `sequence` of strings, optional
             Flags for the transform. ``'FFTW_UNALIGNED'`` is not
             supported, and ``'FFTW_DESTROY_INPUT'`` is enabled by
@@ -1124,7 +1124,7 @@ class DiscreteFourierTransformInverse(DiscreteFourierTransformBase):
 
         Returns
         -------
-        out : `DiscreteLpVector`
+        out : `range` element
             Result of the transform. If ``out`` was given, the returned
             object is a reference to it.
 
@@ -1756,9 +1756,9 @@ class FourierTransformBase(Operator):
 
         Parameters
         ----------
-        x : domain element
+        x : `domain` element
             Discretized function to be transformed
-        out : range element
+        out : `range` element
             Element to which the output is written
 
         Notes

--- a/odl/trafos/fourier.py
+++ b/odl/trafos/fourier.py
@@ -95,14 +95,14 @@ def reciprocal(grid, shift=True, axes=None, halfcomplex=False):
     ----------
     grid : `RegularGrid`
         Original sampling grid
-    shift : bool or sequence of bool, optional
+    shift : bool or `sequence` of bools, optional
         If ``True``, the grid is shifted by half a stride in the negative
         direction. With a sequence, this option is applied separately on
         each axis.
-    axes : int or sequence of int, optional
+    axes : int or `sequence` of ints, optional
         Dimensions in which to calculate the reciprocal. The sequence
         must have the same length as ``shift`` if the latter is given
-        as a sequence. None means all axes in ``grid``.
+        as a sequence. ``None`` means all axes in ``grid``.
     halfcomplex : bool, optional
         If ``True``, return the half of the grid with last coordinate
         less than zero. This is related to the fact that for real-valued
@@ -210,12 +210,12 @@ def inverse_reciprocal(grid, x0, axes=None, halfcomplex=False,
     ----------
     grid : `RegularGrid`
         Original sampling grid
-    x0 : array-like
+    x0 : `array-like`
         Minimal point of the inverse reciprocal grid
-    axes : int or sequence of int, optional
+    axes : int or `sequence` of ints, optional
         Dimensions in which to calculate the reciprocal. The sequence
         must have the same length as ``shift`` if the latter is given
-        as a sequence. None means all axes in ``grid``.
+        as a sequence. ``None`` means all axes in ``grid``.
     halfcomplex : bool, optional
         If ``True``, interpret the given grid as the reciprocal as used
         in a half-complex FFT (see above). Otherwise, the grid is
@@ -367,15 +367,15 @@ def pyfftw_call(array_in, array_out, direction='forward', axes=None,
 
     Parameters
     ----------
-    array_in : numpy.ndarray
+    array_in : `numpy.ndarray`
         Array to be transformed
-    array_out : numpy.ndarray
+    array_out : `numpy.ndarray`
         Output array storing the transformed values, may be aligned
         with ``array_in``.
     direction : {'forward', 'backward'}
         Direction of the transform
-    axes : int or sequence of int, optional
-        Dimensions along which to take the transform. `None` means
+    axes : int or `sequence` of ints, optional
+        Dimensions along which to take the transform. ``None`` means
         using all axis and is equivalent to ``np.arange(ndim)``.
     halfcomplex : bool, optional
         If ``True``, calculate only the negative frequency part along the
@@ -393,9 +393,9 @@ def pyfftw_call(array_in, array_out, direction='forward', axes=None,
         FFTW plan. See the `FFTW doc on planner flags
         <http://www.fftw.org/fftw3_doc/Planner-Flags.html>`_.
         Default: 'estimate'
-    planning_timelimit : float, optional
+    planning_timelimit : float or ``None``, optional
         Limit planning time to roughly this many seconds.
-        Default: None (no limit)
+        Default: ``None`` (no limit)
     threads : int, optional
         Number of threads to use.
         Default: Number of CPUs if the number of data points is larger
@@ -541,8 +541,8 @@ class DiscreteFourierTransformBase(Operator):
         Parameters
         ----------
         inverse : bool
-            ``True`` if the operator should be the inverse transform,
-            else ``False``.
+            If ``True``, the inverse transform is created, otherwise the
+            forward transform.
         domain : `DiscreteLp`
             Domain of the Fourier transform. If its
             `DiscreteLp.exponent` is equal to 2.0, this operator has
@@ -552,7 +552,7 @@ class DiscreteFourierTransformBase(Operator):
             is determined from ``domain`` and the other parameters as
             a `discr_sequence_space` with exponent ``p / (p - 1)``
             (read as 'inf' for p=1 and 1 for p='inf').
-        axes : int or sequence of int, optional
+        axes : int or `sequence` of ints, optional
             Dimensions in which a transform is to be calculated. ``None``
             means all axes.
         sign : {'-', '+'}, optional
@@ -710,12 +710,12 @@ class DiscreteFourierTransformBase(Operator):
 
         Parameters
         ----------
-        x : numpy.ndarray
+        x : `numpy.ndarray`
             Input array to be transformed
 
         Returns
         -------
-        out : numpy.ndarray
+        out : `numpy.ndarray`
             Result of the transform
         """
         raise NotImplementedError('abstract method')
@@ -725,11 +725,11 @@ class DiscreteFourierTransformBase(Operator):
 
         Parameters
         ----------
-        x : numpy.ndarray
+        x : `numpy.ndarray`
             Input array to be transformed
-        out : numpy.ndarray
+        out : `numpy.ndarray`
             Output array storing the result
-        flags : sequence of string, optional
+        flags : `sequence` of strings, optional
             Flags for the transform. ``'FFTW_UNALIGNED'`` is not
             supported, and ``'FFTW_DESTROY_INPUT'`` is enabled by
             default. See the `pyfftw API documentation`_
@@ -737,14 +737,14 @@ class DiscreteFourierTransformBase(Operator):
             Default: ``('FFTW_MEASURE',)``
         threads : positive int, optional
             Number of threads to use. Default: 1
-        planning_timelimit : float or None, optional
+        planning_timelimit : float or ``None``, optional
             Rough upper limit in seconds for the planning step of the
-            transform. None means no limit. See the
+            transform. ``None`` means no limit. See the
             `pyfftw API documentation`_ for futher information.
 
         Returns
         -------
-        out : numpy.ndarray
+        out : `numpy.ndarray`
             Result of the transform. If ``out`` was given, the returned
             object is a reference to it.
 
@@ -885,7 +885,7 @@ class DiscreteFourierTransform(DiscreteFourierTransformBase):
             is determined from ``domain`` and the other parameters as
             a `discr_sequence_space` with exponent ``p / (p - 1)``
             (read as 'inf' for p=1 and 1 for p='inf').
-        axes : int or sequence of int, optional
+        axes : int or `sequence` of ints, optional
             Dimensions in which a transform is to be calculated. ``None``
             means all axes.
         sign : {'-', '+'}, optional
@@ -1034,7 +1034,7 @@ class DiscreteFourierTransformInverse(DiscreteFourierTransformBase):
             domain is determined from ``range`` and the other parameters
             as a `discr_sequence_space` with exponent ``p / (p - 1)``
             (read as 'inf' for p=1 and 1 for p='inf').
-        axes : sequence of int, optional
+        axes : `sequence` of ints, optional
             Dimensions in which a transform is to be calculated. `None`
             means all axes.
         sign : {'-', '+'}, optional
@@ -1109,7 +1109,7 @@ class DiscreteFourierTransformInverse(DiscreteFourierTransformBase):
             Input vector to be transformed
         out : range element
             Output vector storing the result
-        flags : sequence of str, optional
+        flags : `sequence` of strings, optional
             Flags for the transform. ``'FFTW_UNALIGNED'`` is not
             supported, and ``'FFTW_DESTROY_INPUT'`` is enabled by
             default. See the `pyfftw API documentation`_
@@ -1117,9 +1117,9 @@ class DiscreteFourierTransformInverse(DiscreteFourierTransformBase):
             Default: ``('FFTW_MEASURE',)``
         threads : positive int, optional
             Number of threads to use. Default: 1
-        planning_timelimit : `float` or `None`, optional
+        planning_timelimit : float, optional
             Rough upper limit in seconds for the planning step of the
-            transform. `None` means no limit. See the
+            transform. The default is no limit. See the
             `pyfftw API documentation`_ for futher information.
 
         Returns
@@ -1196,20 +1196,21 @@ def dft_preprocess_data(arr, shift=True, axes=None, sign='-', out=None):
 
     Parameters
     ----------
-    arr : array-like
+    arr : `array-like`
         Array to be pre-processed. If its data type is a real
         non-floating type, it is converted to 'float64'.
-    shift : bool or or sequence of bool, optional
+    shift : bool or or `sequence` of bools, optional
         If ``True``, the grid is shifted by half a stride in the negative
         direction. With a sequence, this option is applied separately on
         each axis.
-    axes : int or sequence of int, optional
+    axes : int or `sequence` of ints, optional
         Dimensions in which to calculate the reciprocal. The sequence
         must have the same length as ``shift`` if the latter is given
-        as a sequence. ``None`` means all axes in ``arr``.
+        as a sequence.
+        Default: all axes.
     sign : {'-', '+'}, optional
         Sign of the complex exponent.
-    out : numpy.ndarray, optional
+    out : `numpy.ndarray`, optional
         Array in which the result is stored. If ``out is arr``,
         an in-place modification is performed. For real data type,
         this is only possible for ``shift=True`` since the factors are
@@ -1217,7 +1218,7 @@ def dft_preprocess_data(arr, shift=True, axes=None, sign='-', out=None):
 
     Returns
     -------
-    out : numpy.ndarray
+    out : `numpy.ndarray`
         Result of the pre-processing. If ``out`` was given, the returned
         object is a reference to it.
 
@@ -1300,14 +1301,14 @@ def _interp_kernel_ft(norm_freqs, interp):
 
     Parameters
     ----------
-    norm_freqs : numpy.ndarray
+    norm_freqs : `numpy.ndarray`
         Normalized frequencies between -1/2 and 1/2
     interp : {'nearest', 'linear'}
         Type of interpolation kernel
 
     Returns
     -------
-    ker_ft : numpy.ndarray
+    ker_ft : `numpy.ndarray`
         Values of the kernel FT at the given frequencies
     """
     # Numpy's sinc(x) is equal to the 'math' sinc(pi * x)
@@ -1352,34 +1353,34 @@ def dft_postprocess_data(arr, real_grid, recip_grid, shift, axes,
 
     Parameters
     ----------
-    arr : array-like
+    arr : `array-like`
         Array to be pre-processed. An array with real data type is
         converted to its complex counterpart.
     real_grid : `RegularGrid`
         Real space grid in the transform
     recip_grid : `RegularGrid`
         Reciprocal grid in the transform
-    shift : bool or sequence of bool
+    shift : bool or `sequence` of bools
         If ``True``, the grid is shifted by half a stride in the negative
         direction in the corresponding axes. The sequence must have the
         same length as ``axes``.
-    axes : int or sequence of int
+    axes : int or `sequence` of ints
         Dimensions along which to take the transform. The sequence must
         have the same length as ``shifts``.
-    interp : string or sequence of string
+    interp : string or `sequence` of strings
         Interpolation scheme used in the real-space.
     sign : {'-', '+'}, optional
         Sign of the complex exponent.
     op : {'multiply', 'divide'}
         Operation to perform with the stride times the interpolation
         kernel FT
-    out : numpy.ndarray, optional
+    out : `numpy.ndarray`, optional
         Array in which the result is stored. If ``out is arr``, an
         in-place modification is performed.
 
     Returns
     -------
-    out : numpy.ndarray
+    out : `numpy.ndarray`
         Result of the post-processing. If ``out`` was given, the returned
         object is a reference to it.
     """
@@ -1484,16 +1485,15 @@ def reciprocal_space(space, axes=None, halfcomplex=False, shift=True,
     space : `DiscreteLp`
         Real space whose reciprocal is calculated. It must be
         uniformly discretized.
-    axes : sequence of int, optional
+    axes : `sequence` of ints, optional
         Dimensions along which the Fourier transform is taken.
         Default: all axes
     halfcomplex : bool, optional
         If ``True``, take only the negative frequency part along the last
-        axis for. If ``False``, use the full frequency space.
+        axis for. For ``False``, use the full frequency space.
         This option can only be used if ``space`` is a space of
         real-valued functions.
-        Default: ``False``
-    shift : bool or sequence of bool, optional
+    shift : bool or `sequence` of bools, optional
         If ``True``, the reciprocal grid is shifted by half a stride in
         the negative direction. With a boolean sequence, this option
         is applied separately to each axis.
@@ -1601,8 +1601,8 @@ class FourierTransformBase(Operator):
         Parameters
         ----------
         inverse : bool
-            ``True`` if the operator should be the inverse transform, else
-            ``False``.
+            If ``True``, create the inverse transform, otherwise the forward
+            transform.
         domain : `DiscreteLp`
             Domain of the Fourier transform. If the
             `DiscreteLp.exponent` of ``domain`` and ``range`` are equal
@@ -1616,7 +1616,7 @@ class FourierTransformBase(Operator):
         impl : {'numpy', 'pyfftw'}
             Backend for the FFT implementation. The 'pyfftw' backend
             is faster but requires the ``pyfftw`` package.
-        axes : int or sequence of int, optional
+        axes : int or `sequence` of ints, optional
             Dimensions along which to take the transform.
             Default: all axes
         sign : {'-', '+'}, optional
@@ -1627,7 +1627,7 @@ class FourierTransformBase(Operator):
             calculate the full complex FFT.
             For complex ``domain``, it has no effect.
             Default: ``True``
-        shift : bool or sequence of bool, optional
+        shift : bool or `sequence` of bools, optional
             If ``True``, the reciprocal grid is shifted by half a stride in
             the negative direction. With a boolean sequence, this option
             is applied separately to each axis.
@@ -1638,13 +1638,13 @@ class FourierTransformBase(Operator):
 
         Other Parameters
         ----------------
-        tmp_r : `DiscreteLpVector` or numpy.ndarray
+        tmp_r : `DiscreteLpVector` or `numpy.ndarray`
             Temporary for calculations in the real space (domain of
             this transform). It is shared with the inverse.
 
             Variants using this: R2C, R2HC, C2R (inverse)
 
-        tmp_f : `DiscreteLpVector` or numpy.ndarray
+        tmp_f : `DiscreteLpVector` or `numpy.ndarray`
             Temporary for calculations in the frequency (reciprocal)
             space. It is shared with the inverse.
 
@@ -1783,12 +1783,12 @@ class FourierTransformBase(Operator):
 
         Parameters
         ----------
-        x : numpy.ndarray
+        x : `numpy.ndarray`
             Array representing the function to be transformed
 
         Returns
         -------
-        out : numpy.ndarray
+        out : `numpy.ndarray`
             Result of the transform
         """
         raise NotImplementedError('abstract method')
@@ -1798,23 +1798,23 @@ class FourierTransformBase(Operator):
 
         Parameters
         ----------
-        x : numpy.ndarray
+        x : `numpy.ndarray`
             Array representing the function to be transformed
-        out : numpy.ndarray
+        out : `numpy.ndarray`
             Array to which the output is written
         planning_effort : {'estimate', 'measure', 'patient', 'exhaustive'}
             Flag for the amount of effort put into finding an optimal
             FFTW plan. See the `FFTW doc on planner flags
             <http://www.fftw.org/fftw3_doc/Planner-Flags.html>`_.
-        planning_timelimit : float, optional
-            Limit planning time to roughly this amount of seconds.
-            Default: None (no limit)
+        planning_timelimit : float or ``None``, optional
+            Limit planning time to roughly this many seconds.
+            Default: ``None`` (no limit)
         threads : int, optional
             Number of threads to use. Default: 1
 
         Returns
         -------
-        out : numpy.ndarray
+        out : `numpy.ndarray`
             Result of the transform. The returned object is a reference
             to the input parameter ``out``.
         """
@@ -1911,7 +1911,7 @@ class FourierTransformBase(Operator):
             self._tmp_f = fspace.element().asarray()
 
     def clear_temporaries(self):
-        """Set the temporaries to None."""
+        """Set the temporaries to ``None``."""
         self._tmp_r = None
         self._tmp_f = None
 
@@ -1927,9 +1927,9 @@ class FourierTransformBase(Operator):
             Flag for the amount of effort put into finding an optimal
             FFTW plan. See the `FFTW doc on planner flags
             <http://www.fftw.org/fftw3_doc/Planner-Flags.html>`_.
-        planning_timelimit : float, optional
-            Limit planning time to roughly this amount of seconds.
-            Default: None (no limit)
+        planning_timelimit : float or ``None``, optional
+            Limit planning time to roughly this many seconds.
+            Default: ``None`` (no limit)
         threads : int, optional
             Number of threads to use. Default: 1
 
@@ -2061,7 +2061,7 @@ class FourierTransform(FourierTransformBase):
         impl : {'numpy', 'pyfftw'}
             Backend for the FFT implementation. The 'pyfftw' backend
             is faster but requires the ``pyfftw`` package.
-        axes : int or sequence of int, optional
+        axes : int or `sequence` of ints, optional
             Dimensions along which to take the transform.
             Default: all axes
         sign : {'-', '+'}, optional
@@ -2072,7 +2072,7 @@ class FourierTransform(FourierTransformBase):
             calculate the full complex FFT.
             For complex ``domain``, it has no effect.
             Default: ``True``
-        shift : bool or sequence of bool, optional
+        shift : bool or `sequence` of bools, optional
             If ``True``, the reciprocal grid is shifted by half a stride in
             the negative direction. With a boolean sequence, this option
             is applied separately to each axis.
@@ -2212,9 +2212,9 @@ class FourierTransform(FourierTransformBase):
             Flag for the amount of effort put into finding an optimal
             FFTW plan. See the `FFTW doc on planner flags
             <http://www.fftw.org/fftw3_doc/Planner-Flags.html>`_.
-        planning_timelimit : `float`, optional
-            Limit planning time to roughly this amount of seconds.
-            Default: `None` (no limit)
+        planning_timelimit : float or ``None``, optional
+            Limit planning time to roughly this many seconds.
+            Default: ``None`` (no limit)
         threads : int, optional
             Number of threads to use. Default: 1
 
@@ -2296,7 +2296,7 @@ class FourierTransformInverse(FourierTransformBase):
         impl : {'numpy', 'pyfftw'}
             Backend for the FFT implementation. The 'pyfftw' backend
             is faster but requires the ``pyfftw`` package.
-        axes : int or sequence of int, optional
+        axes : int or `sequence` of ints, optional
             Dimensions along which to take the transform.
             Default: all axes
         sign : {'-', '+'}, optional
@@ -2307,7 +2307,7 @@ class FourierTransformInverse(FourierTransformBase):
             calculate the full complex FFT.
             For complex ``domain``, it has no effect.
             Default: ``True``
-        shift : bool or sequence of bool, optional
+        shift : bool or `sequence` of bools, optional
             If ``True``, the reciprocal grid is shifted by half a stride in
             the negative direction. With a boolean sequence, this option
             is applied separately to each axis.
@@ -2318,13 +2318,13 @@ class FourierTransformInverse(FourierTransformBase):
 
         Other Parameters
         ----------------
-        tmp_r : `DiscreteLpVector` or numpy.ndarray
+        tmp_r : `DiscreteLpVector` or `numpy.ndarray`
             Temporary for calculations in the real space (range of
             this transform). It is shared with the inverse.
 
             Variants using this: C2R, R2C (forward), R2HC (forward)
 
-        tmp_f : `DiscreteLpVector` or numpy.ndarray
+        tmp_f : `DiscreteLpVector` or `numpy.ndarray`
             Temporary for calculations in the frequency (reciprocal)
             space. It is shared with the inverse.
 
@@ -2407,12 +2407,12 @@ class FourierTransformInverse(FourierTransformBase):
 
         Parameters
         ----------
-        x : numpy.ndarray
+        x : `numpy.ndarray`
             Array representing the function to be transformed
 
         Returns
         -------
-        out : numpy.ndarray
+        out : `numpy.ndarray`
             Result of the transform
         """
         # Pre-processing before calculating the DFT
@@ -2447,23 +2447,23 @@ class FourierTransformInverse(FourierTransformBase):
 
         Parameters
         ----------
-        x : numpy.ndarray
+        x : `numpy.ndarray`
             Array representing the function to be transformed
-        out : numpy.ndarray
+        out : `numpy.ndarray`
             Array to which the output is written
         planning_effort : {'estimate', 'measure', 'patient', 'exhaustive'}
             Flag for the amount of effort put into finding an optimal
             FFTW plan. See the `FFTW doc on planner flags
             <http://www.fftw.org/fftw3_doc/Planner-Flags.html>`_.
-        planning_timelimit : float, optional
-            Limit planning time to roughly this amount of seconds.
-            Default: None (no limit)
+        planning_timelimit : float or ``None``, optional
+            Limit planning time to roughly this many seconds.
+            Default: ``None`` (no limit)
         threads : int, optional
             Number of threads to use. Default: 1
 
         Returns
         -------
-        out : numpy.ndarray
+        out : `numpy.ndarray`
             Result of the transform. If ``out`` was given, the returned
             object is a reference to it.
         """

--- a/odl/trafos/wavelet.py
+++ b/odl/trafos/wavelet.py
@@ -644,7 +644,7 @@ dwt-discrete-wavelet-transform.html#maximum-decomposition-level\
 
         Parameters
         ----------
-        x : `DiscreteLpVector`
+        x : `domain` element
 
         Returns
         -------
@@ -829,11 +829,13 @@ dwt-discrete-wavelet-transform.html#maximum-decomposition-level\
 
         Parameters
         ----------
-        coeff : `DiscreteLpVector`
+        coeff : `domain` element
+            Wavelet coefficients supplied to the wavelet reconstruction.
 
         Returns
         -------
-        arr : `DiscreteLpVector`
+        arr : `numpy.ndarray`
+            Result of the wavelet reconstruction.
 
         """
         if len(self.range.shape) == 1:
@@ -848,7 +850,7 @@ dwt-discrete-wavelet-transform.html#maximum-decomposition-level\
             coeff_dict = array_to_pywt_coeff(coeff, self.size_list)
             x = wavelet_reconstruction3d(coeff_dict, self.wbasis,
                                          self.pad_mode, self.nscales)
-            return self.range.element(x)
+            return x
 
     @property
     def adjoint(self):

--- a/odl/trafos/wavelet.py
+++ b/odl/trafos/wavelet.py
@@ -50,10 +50,10 @@ def coeff_size_list(shape, nscales, wbasis, pad_mode):
 
     Parameters
     ----------
-    shape : `tuple`
+    shape : tuple
         Number of pixels/voxels in the image. Its length must be 1, 2 or 3.
 
-    nscales : `int`
+    nscales : int
         Number of scales in the multidimensional wavelet
         transform.  This parameter is checked against the maximum number of
         scales returned by ``pywt.dwt_max_level``. For more information
@@ -67,7 +67,7 @@ dwt-discrete-wavelet-transform.html#maximum-decomposition-level\
         `PyWavelets documentation on wavelet bases
         <http://www.pybytes.com/pywavelets/ref/wavelets.html>`_.
 
-    pad_mode : `str`
+    pad_mode : str
         Signal extention mode. Possible extension modes are
 
         'zpd': zero-padding -- signal is extended by adding zero samples
@@ -86,7 +86,7 @@ dwt-discrete-wavelet-transform.html#maximum-decomposition-level\
 
     Returns
     -------
-    size_list : `list`
+    size_list : list
         A list containing the sizes of the wavelet (approximation
         and detail) coefficients at different scaling levels:
 
@@ -144,7 +144,7 @@ def pywt_coeff_to_array(coeff, size_list):
 
     Parameters
     ----------
-    coeff : ordered `list`
+    coeff : ordered list
         Coefficient are organized in the list in the following way:
 
         In 1D:
@@ -196,7 +196,7 @@ def pywt_coeff_to_array(coeff, size_list):
 
         ``N`` refers to the number of scaling levels
 
-    size_list : `list`
+    size_list : list
         A list containing the sizes of the wavelet (approximation
         and detail) coefficients at different scaling levels.
 
@@ -215,7 +215,7 @@ def pywt_coeff_to_array(coeff, size_list):
 
     Returns
     -------
-    arr : `numpy.ndarray`
+    arr : numpy.ndarray
         Flattened and concatenated coefficient array
         The length of the array depends on the size of input image to
         be transformed and on the chosen wavelet basis.
@@ -274,7 +274,7 @@ def array_to_pywt_coeff(coeff, size_list):
 
     Returns
     -------
-    coeff : ordered `list`
+    coeff : ordered list
         Coefficient are organized in the list in the following way:
 
         In 1D:
@@ -365,19 +365,19 @@ def wavelet_decomposition3d(x, wbasis, pad_mode, nscales):
         `PyWavelets documentation on wavelet bases
         <http://www.pybytes.com/pywavelets/ref/wavelets.html>`_.
 
-    pad_mode : `str`
+    pad_mode : str
         Signal extention mode. For possible extensions see the
         `Pywavelets documentation on signal extenstion modes
         <http://www.pybytes.com/pywavelets/ref/\
 signal-extension-modes.html>`_.
 
 
-    nscales : `int`
+    nscales : int
        Number of scales in the coefficient list.
 
     Returns
     -------
-    coeff_list : `list`
+    coeff_list : list
 
         A list of coefficient organized in the following way
          ```[aaaN, (aadN, adaN, addN, daaN, dadN, ddaN, dddN), ...
@@ -448,7 +448,7 @@ def wavelet_reconstruction3d(coeff_list, wbasis, pad_mode, nscales):
 
     Parameters
     ----------
-    coeff_list : `list`
+    coeff_list : list
         A list of wavelet approximation and detail coefficients
         organized in the following way
         ```[caaaN, (aadN, adaN, addN, daaN, dadN, ddaN, dddN), ...
@@ -479,19 +479,19 @@ def wavelet_reconstruction3d(coeff_list, wbasis, pad_mode, nscales):
         For more information see PyWavelet `documentation
         <http://www.pybytes.com/pywavelets/ref/wavelets.html>`_
 
-    pad_mode : `str`
+    pad_mode : str
         Signal extention mode. For possible extensions see the
         `signal extenstion modes
         <http://www.pybytes.com/pywavelets/ref/\
 signal-extension-modes.html>`_
         of PyWavelets.
 
-    nscales : `int`
+    nscales : int
         Number of scales in the coefficient list.
 
     Returns
     -------
-    x : `numpy.ndarray`.
+    x : numpy.ndarray.
         A wavalet reconstruction.
     """
     aaa = coeff_list[0]
@@ -522,7 +522,7 @@ class WaveletTransform(Operator):
             The exponent :math:`p` of the discrete :math:`L^p`
             space must be equal to 2.0.
 
-        nscales : `int`
+        nscales : int
             Number of scales in the coefficient list.
             The maximum number of usable scales can be determined
             by ``pywt.dwt_max_level``. For more information see
@@ -531,7 +531,7 @@ class WaveletTransform(Operator):
 dwt-discrete-wavelet-transform.html#maximum-decomposition-level\
 -dwt-max-level>`_ .
 
-        wbasis :  {`str`, ``pywt.Wavelet``}
+        wbasis :  {string, ``pywt.Wavelet``}
             If a string is given, converts to a ``pywt.Wavelet``.
             Describes properties of a selected wavelet basis.
             See PyWavelet `documentation
@@ -553,7 +553,7 @@ dwt-discrete-wavelet-transform.html#maximum-decomposition-level\
 
             Discrete FIR approximation of Meyer wavelet (``dmey``)
 
-        pad_mode : `str`
+        pad_mode : str
              Signal extention modes as defined by ``pywt.MODES.modes``
              http://www.pybytes.com/pywavelets/ref/signal-extension-modes.html
 
@@ -648,7 +648,7 @@ dwt-discrete-wavelet-transform.html#maximum-decomposition-level\
 
         Returns
         -------
-        arr : `numpy.ndarray`
+        arr : numpy.ndarray
             Flattened and concatenated coefficient array
             The length of the array depends on the size of input image to
             be transformed and on the chosen wavelet basis.
@@ -723,7 +723,7 @@ class WaveletTransformInverse(Operator):
             The exponent :math:`p` of the discrete :math:`L^p`
             space must be equal to 2.0.
 
-        nscales : `int`
+        nscales : int
             Number of scales in the coefficient list.
             The maximum number of usable scales can be determined
             by ``pywt.dwt_max_level``. For more information see
@@ -753,7 +753,7 @@ dwt-discrete-wavelet-transform.html#maximum-decomposition-level\
 
             Discrete FIR approximation of Meyer wavelet (``dmey``)
 
-        pad_mode : `str`
+        pad_mode : str
              Signal extention modes as defined by ``pywt.MODES.modes``
              http://www.pybytes.com/pywavelets/ref/signal-extension-modes.html
 

--- a/odl/trafos/wavelet.py
+++ b/odl/trafos/wavelet.py
@@ -67,7 +67,7 @@ dwt-discrete-wavelet-transform.html#maximum-decomposition-level\
         `PyWavelets documentation on wavelet bases
         <http://www.pybytes.com/pywavelets/ref/wavelets.html>`_.
 
-    pad_mode : str
+    pad_mode : string
         Signal extention mode. Possible extension modes are
 
         'zpd': zero-padding -- signal is extended by adding zero samples
@@ -215,7 +215,7 @@ def pywt_coeff_to_array(coeff, size_list):
 
     Returns
     -------
-    arr : numpy.ndarray
+    arr : `numpy.ndarray`
         Flattened and concatenated coefficient array
         The length of the array depends on the size of input image to
         be transformed and on the chosen wavelet basis.
@@ -365,7 +365,7 @@ def wavelet_decomposition3d(x, wbasis, pad_mode, nscales):
         `PyWavelets documentation on wavelet bases
         <http://www.pybytes.com/pywavelets/ref/wavelets.html>`_.
 
-    pad_mode : str
+    pad_mode : string
         Signal extention mode. For possible extensions see the
         `Pywavelets documentation on signal extenstion modes
         <http://www.pybytes.com/pywavelets/ref/\
@@ -479,7 +479,7 @@ def wavelet_reconstruction3d(coeff_list, wbasis, pad_mode, nscales):
         For more information see PyWavelet `documentation
         <http://www.pybytes.com/pywavelets/ref/wavelets.html>`_
 
-    pad_mode : str
+    pad_mode : string
         Signal extention mode. For possible extensions see the
         `signal extenstion modes
         <http://www.pybytes.com/pywavelets/ref/\
@@ -491,7 +491,7 @@ signal-extension-modes.html>`_
 
     Returns
     -------
-    x : numpy.ndarray.
+    x : `numpy.ndarray`
         A wavalet reconstruction.
     """
     aaa = coeff_list[0]
@@ -553,7 +553,7 @@ dwt-discrete-wavelet-transform.html#maximum-decomposition-level\
 
             Discrete FIR approximation of Meyer wavelet (``dmey``)
 
-        pad_mode : str
+        pad_mode : string
              Signal extention modes as defined by ``pywt.MODES.modes``
              http://www.pybytes.com/pywavelets/ref/signal-extension-modes.html
 
@@ -648,7 +648,7 @@ dwt-discrete-wavelet-transform.html#maximum-decomposition-level\
 
         Returns
         -------
-        arr : numpy.ndarray
+        arr : `numpy.ndarray`
             Flattened and concatenated coefficient array
             The length of the array depends on the size of input image to
             be transformed and on the chosen wavelet basis.
@@ -753,7 +753,7 @@ dwt-discrete-wavelet-transform.html#maximum-decomposition-level\
 
             Discrete FIR approximation of Meyer wavelet (``dmey``)
 
-        pad_mode : str
+        pad_mode : string
              Signal extention modes as defined by ``pywt.MODES.modes``
              http://www.pybytes.com/pywavelets/ref/signal-extension-modes.html
 

--- a/odl/util/graphics.py
+++ b/odl/util/graphics.py
@@ -89,15 +89,15 @@ def show_discrete_data(values, grid, title=None, method='',
 
     Parameters
     ----------
-    values : `numpy.ndarray`
+    values : numpy.ndarray
         The values to visualize
     grid : `TensorGrid` or `RectPartition`
         Grid of the values
 
-    title : `str`, optional
+    title : string, optional
         Set the title of the figure
 
-    method : `str`, optional
+    method : string, optional
         1d methods:
 
         'plot' : graph plot
@@ -116,7 +116,7 @@ def show_discrete_data(values, grid, title=None, method='',
         'wireframe', 'plot_wireframe' : surface plot
 
 
-    show : `bool`, optional
+    show : bool, optional
         If the plot should be showed now or deferred until later
 
     fig : `matplotlib.figure.Figure`
@@ -127,7 +127,7 @@ def show_discrete_data(values, grid, title=None, method='',
     interp : {'nearest', 'linear'}
         Interpolation method to use.
 
-    axis_labels : `str`
+    axis_labels : string
         Axis labels, default: ['x', 'y']
 
     kwargs : {'figsize', 'saveto', ...}

--- a/odl/util/graphics.py
+++ b/odl/util/graphics.py
@@ -89,7 +89,7 @@ def show_discrete_data(values, grid, title=None, method='',
 
     Parameters
     ----------
-    values : numpy.ndarray
+    values : `numpy.ndarray`
         The values to visualize
     grid : `TensorGrid` or `RectPartition`
         Grid of the values

--- a/odl/util/normalize.py
+++ b/odl/util/normalize.py
@@ -59,11 +59,11 @@ def normalized_scalar_param_list(param, length, param_conv=None,
     length : positive int
         Desired length of the output list.
     param_conv : callable, optional
-        Conversion applied to each list element. None means no conversion.
+        Conversion applied to each list element. ``None`` means no conversion.
     keep_none : bool, optional
-        If True, None is not converted.
+        If ``True``, ``None`` is not converted.
     return_nonconv : bool, optional
-        If True, return also the list where no conversion has been
+        If ``True``, return also the list where no conversion has been
         applied.
 
     Returns
@@ -94,7 +94,7 @@ def normalized_scalar_param_list(param, length, param_conv=None,
     [None, None, None]
 
     List entries can be explicitly converted using ``param_conv``. If
-    ``None`` should be kept, set ``keep_none`` to True:
+    ``None`` should be kept, set ``keep_none`` to ``True``:
 
     >>> normalized_scalar_param_list(1, 3, param_conv=float)
     [1.0, 1.0, 1.0]
@@ -175,12 +175,12 @@ def normalized_index_expression(indices, shape, int_to_slice=False):
     Parameters
     ----------
     indices : int, slice, Ellipsis or sequence of these
-        Index expression to be normalized
+        Index expression to be normalized.
     shape : sequence of int
         Target shape for error checking of out-of-bounds indices.
         Also needed to determine the number of axes.
     int_to_slice : bool, optional
-        If True, turn integers into corresponding slice objects.
+        If ``True``, turn integers into corresponding slice objects.
 
     Returns
     -------

--- a/odl/util/normalize.py
+++ b/odl/util/normalize.py
@@ -58,7 +58,7 @@ def normalized_scalar_param_list(param, length, param_conv=None,
         Input parameter to turn into a list.
     length : positive int
         Desired length of the output list.
-    param_conv : callable, optional
+    param_conv : `callable`, optional
         Conversion applied to each list element. ``None`` means no conversion.
     keep_none : bool, optional
         If ``True``, ``None`` is not converted.
@@ -174,9 +174,9 @@ def normalized_index_expression(indices, shape, int_to_slice=False):
 
     Parameters
     ----------
-    indices : int, slice, Ellipsis or sequence of these
+    indices : int, `slice`, `Ellipsis` or `sequence` of these
         Index expression to be normalized.
-    shape : sequence of int
+    shape : `sequence` of ints
         Target shape for error checking of out-of-bounds indices.
         Also needed to determine the number of axes.
     int_to_slice : bool, optional
@@ -184,7 +184,7 @@ def normalized_index_expression(indices, shape, int_to_slice=False):
 
     Returns
     -------
-    normalized : tuple of int or slice
+    normalized : tuple of ints or `slice`'s
         Normalized index expression
 
     Examples

--- a/odl/util/numerics.py
+++ b/odl/util/numerics.py
@@ -44,35 +44,35 @@ def apply_on_boundary(array, func, only_once=True, which_boundaries=None,
     ----------
     array : array-like
         Modify the boundary of this array
-    func : `callable` or `sequence`
+    func : callable or sequence
         If a single function is given, assign
         ``array[slice] = func(array[slice])`` on the boundary slices,
         e.g. use ``lamda x: x / 2`` to divide values by 2.
         A sequence of functions is applied per axis separately. It
         must have length ``array.ndim`` and may consist of one function
         or a 2-tuple of functions per axis.
-        `None` entries in a sequence cause the axis (side) to be
+        None entries in a sequence cause the axis (side) to be
         skipped.
-    only_once : `bool`, optional
-        If `True`, ensure that each boundary point appears in exactly
+    only_once : bool, optional
+        If True, ensure that each boundary point appears in exactly
         one slice. If ``func`` is a list of functions, the
         ``axis_order`` determines which functions are applied to nodes
         which appear in multiple slices, according to the principle
         "first-come, first-served".
-    which_boundaries : `sequence`, optional
+    which_boundaries : sequence, optional
         If provided, this sequence determines per axis whether to
         apply the function at the boundaries in each axis. The entry
-        in each axis may consist in a single `bool` or a 2-tuple of
-        `bool`. In the latter case, the first tuple entry decides for
+        in each axis may consist in a single bool or a 2-tuple of
+        bool. In the latter case, the first tuple entry decides for
         the left, the second for the right boundary. The length of the
-        sequence must be ``array.ndim``. `None` is interpreted as
+        sequence must be ``array.ndim``. None is interpreted as
         'all boundaries'.
-    axis_order : `sequence` of `int`, optional
+    axis_order : sequence of int, optional
         Permutation of ``range(array.ndim)`` defining the order in which
         to process the axes. If combined with ``only_once`` and a
         function list, this determines which function is evaluated in
         the points that are potentially processed multiple times.
-    out : `numpy.ndarray`, optional
+    out : numpy.ndarray, optional
         Location in which to store the result, can be the same as ``array``.
         Default: copy of ``array``
 
@@ -217,20 +217,20 @@ def fast_1d_tensor_mult(ndarr, onedim_arrs, axes=None, out=None):
 
     Parameters
     ----------
-    ndarr : `array-like`
+    ndarr : array-like
         Array to multiply to
     onedim_arrs : sequence of array-like
         One-dimensional arrays to be multiplied with ``ndarr``. The
         sequence may not be longer than ``ndarr.ndim``.
-    axes : sequence of `int`, optional
-        Take the 1d transform along these axes. `None` corresponds to
+    axes : sequence of int, optional
+        Take the 1d transform along these axes. None corresponds to
         the last ``len(onedim_arrs)`` axes, in ascending order.
-    out : `numpy.ndarray`, optional
+    out : numpy.ndarray, optional
         Array in which the result is stored
 
     Returns
     -------
-    out : `numpy.ndarray`
+    out : numpy.ndarray
         Result of the modification. If ``out`` was given, the returned
         object is a reference to it.
     """

--- a/odl/util/numerics.py
+++ b/odl/util/numerics.py
@@ -42,37 +42,37 @@ def apply_on_boundary(array, func, only_once=True, which_boundaries=None,
 
     Parameters
     ----------
-    array : array-like
+    array : `array-like`
         Modify the boundary of this array
-    func : callable or sequence
+    func : `callable` or `sequence` of `callable`'s
         If a single function is given, assign
         ``array[slice] = func(array[slice])`` on the boundary slices,
         e.g. use ``lamda x: x / 2`` to divide values by 2.
-        A sequence of functions is applied per axis separately. It
+        A `sequence` of functions is applied per axis separately. It
         must have length ``array.ndim`` and may consist of one function
         or a 2-tuple of functions per axis.
-        None entries in a sequence cause the axis (side) to be
+        ``None`` entries in a sequence cause the axis (side) to be
         skipped.
     only_once : bool, optional
-        If True, ensure that each boundary point appears in exactly
+        If ``True``, ensure that each boundary point appears in exactly
         one slice. If ``func`` is a list of functions, the
         ``axis_order`` determines which functions are applied to nodes
         which appear in multiple slices, according to the principle
         "first-come, first-served".
-    which_boundaries : sequence, optional
+    which_boundaries : `sequence`, optional
         If provided, this sequence determines per axis whether to
         apply the function at the boundaries in each axis. The entry
         in each axis may consist in a single bool or a 2-tuple of
         bool. In the latter case, the first tuple entry decides for
         the left, the second for the right boundary. The length of the
-        sequence must be ``array.ndim``. None is interpreted as
-        'all boundaries'.
-    axis_order : sequence of int, optional
+        sequence must be ``array.ndim``. ``None`` is interpreted as
+        "all boundaries".
+    axis_order : `sequence` of ints, optional
         Permutation of ``range(array.ndim)`` defining the order in which
         to process the axes. If combined with ``only_once`` and a
         function list, this determines which function is evaluated in
         the points that are potentially processed multiple times.
-    out : numpy.ndarray, optional
+    out : `numpy.ndarray`, optional
         Location in which to store the result, can be the same as ``array``.
         Default: copy of ``array``
 
@@ -85,7 +85,7 @@ def apply_on_boundary(array, func, only_once=True, which_boundaries=None,
            [ 0.5,  1. ,  0.5],
            [ 0.5,  0.5,  0.5]])
 
-    If called with ``only_once=False``, applies function repeatedly
+    If called with ``only_once=False``, the function is applied repeatedly:
 
     >>> apply_on_boundary(arr, lambda x: x / 2, only_once=False)
     array([[ 0.25,  0.5 ,  0.25],
@@ -98,7 +98,7 @@ def apply_on_boundary(array, func, only_once=True, which_boundaries=None,
            [ 0.5,  1. ,  0.5],
            [ 0.5,  1. ,  0.5]])
 
-    Also accepts out parameter:
+    Use the ``out`` parameter to store the result in an existing array:
 
     >>> out = np.empty_like(arr)
     >>> result = apply_on_boundary(arr, lambda x: x / 2, out=out)
@@ -217,20 +217,20 @@ def fast_1d_tensor_mult(ndarr, onedim_arrs, axes=None, out=None):
 
     Parameters
     ----------
-    ndarr : array-like
+    ndarr : `array-like`
         Array to multiply to
-    onedim_arrs : sequence of array-like
+    onedim_arrs : `sequence` of `array-like`'s
         One-dimensional arrays to be multiplied with ``ndarr``. The
         sequence may not be longer than ``ndarr.ndim``.
-    axes : sequence of int, optional
-        Take the 1d transform along these axes. None corresponds to
+    axes : `sequence` of ints, optional
+        Take the 1d transform along these axes. ``None`` corresponds to
         the last ``len(onedim_arrs)`` axes, in ascending order.
-    out : numpy.ndarray, optional
+    out : `numpy.ndarray`, optional
         Array in which the result is stored
 
     Returns
     -------
-    out : numpy.ndarray
+    out : `numpy.ndarray`
         Result of the modification. If ``out`` was given, the returned
         object is a reference to it.
     """
@@ -318,14 +318,14 @@ def resize_array(arr, newshp, offset=None, pad_mode='constant', pad_const=0,
 
     Parameters
     ----------
-    arr : array-like
+    arr : `array-like`
         Array to be resized.
-    newshp : sequence of int
+    newshp : `sequence` of ints
         Desired shape of the output array.
-    offset: sequence of int, optional
+    offset: `sequence` of ints, optional
         Specifies how many entries are added to/removed from the "left"
         side (corresponding to low indices) of ``arr``.
-    pad_mode : str, optional
+    pad_mode : string, optional
         Method to be used to fill in missing values in an enlarged array.
 
         ``'constant'``: Fill with ``pad_const``.

--- a/odl/util/testutils.py
+++ b/odl/util/testutils.py
@@ -75,7 +75,7 @@ def dtype_places(dtype, default=None):
 
 
 def almost_equal(a, b, places=None):
-    """True if scalars a and b are almost equal."""
+    """Return ``True`` if the scalars ``a`` and ``b`` are almost equal."""
     if a is None and b is None:
         return True
 
@@ -103,7 +103,7 @@ def almost_equal(a, b, places=None):
 
 
 def all_equal(iter1, iter2):
-    """True if all elements in ``a`` and ``b`` are equal."""
+    """Return ``True`` if all elements in ``a`` and ``b`` are equal."""
     # Direct comparison for scalars, tuples or lists
     try:
         if iter1 == iter2:
@@ -160,7 +160,7 @@ def all_almost_equal_array(v1, v2, places):
 
 
 def all_almost_equal(iter1, iter2, places=None):
-    """True if all elements in ``a`` and ``b`` are almost equal."""
+    """Return ``True`` if all elements in ``a`` and ``b`` are almost equal."""
     try:
         if iter1 is iter2 or iter1 == iter2:
             return True
@@ -197,7 +197,7 @@ def all_almost_equal(iter1, iter2, places=None):
 
 
 def is_subdict(subdict, dictionary):
-    """True if all items of ``subdict`` are in ``dictionary``."""
+    """Return ``True`` if all items of ``subdict`` are in ``dictionary``."""
     return all(item in dictionary.items() for item in subdict.items())
 
 

--- a/odl/util/testutils.py
+++ b/odl/util/testutils.py
@@ -75,7 +75,7 @@ def dtype_places(dtype, default=None):
 
 
 def almost_equal(a, b, places=None):
-    """`True` if scalars a and b are almost equal."""
+    """True if scalars a and b are almost equal."""
     if a is None and b is None:
         return True
 
@@ -103,7 +103,7 @@ def almost_equal(a, b, places=None):
 
 
 def all_equal(iter1, iter2):
-    """`True` if all elements in ``a`` and ``b`` are equal."""
+    """True if all elements in ``a`` and ``b`` are equal."""
     # Direct comparison for scalars, tuples or lists
     try:
         if iter1 == iter2:
@@ -160,7 +160,7 @@ def all_almost_equal_array(v1, v2, places):
 
 
 def all_almost_equal(iter1, iter2, places=None):
-    """`True` if all elements in ``a`` and ``b`` are almost equal."""
+    """True if all elements in ``a`` and ``b`` are almost equal."""
     try:
         if iter1 is iter2 or iter1 == iter2:
             return True
@@ -197,7 +197,7 @@ def all_almost_equal(iter1, iter2, places=None):
 
 
 def is_subdict(subdict, dictionary):
-    """`True` if all items of ``subdict`` are in ``dictionary``."""
+    """True if all items of ``subdict`` are in ``dictionary``."""
     return all(item in dictionary.items() for item in subdict.items())
 
 

--- a/odl/util/ufuncs.py
+++ b/odl/util/ufuncs.py
@@ -27,7 +27,7 @@ for more information.
 Notes
 -----
 The default implementation of these methods make heavy use of the
-``NtuplesBaseVector.__array__`` to extract a `numpy.ndarray` from the vector,
+``NtuplesBaseVector.__array__`` to extract a numpy.ndarray from the vector,
 and then apply a ufunc to it. Afterwards, ``NtuplesBaseVector.__array_wrap__``
 is used to re-wrap the data into the appropriate space.
 """

--- a/odl/util/ufuncs.py
+++ b/odl/util/ufuncs.py
@@ -27,7 +27,7 @@ for more information.
 Notes
 -----
 The default implementation of these methods make heavy use of the
-``NtuplesBaseVector.__array__`` to extract a numpy.ndarray from the vector,
+``NtuplesBaseVector.__array__`` to extract a `numpy.ndarray` from the vector,
 and then apply a ufunc to it. Afterwards, ``NtuplesBaseVector.__array_wrap__``
 is used to re-wrap the data into the appropriate space.
 """

--- a/odl/util/utility.py
+++ b/odl/util/utility.py
@@ -19,9 +19,9 @@
 
 Attributes
 ----------
-TYPE_MAP_R2C : `dict`
+TYPE_MAP_R2C : dict
     Dictionary mapping real dtypes to complex dtypes
-TYPE_MAP_C2R : `dict`
+TYPE_MAP_C2R : dict
     Dictionary mapping complex dtypes to real dtypes
 """
 
@@ -59,7 +59,7 @@ def array1d_repr(array, nprint=6):
 
     Parameters
     ----------
-    array : array-like
+    array : `array-like`
         The array to print
     nprint : int
         Maximum number of elements to print
@@ -78,7 +78,7 @@ def array1d_str(array, nprint=6):
 
     Parameters
     ----------
-    array : array-like
+    array : `array-like`
         The array to print
     nprint : int
         Maximum number of elements to print
@@ -99,7 +99,7 @@ def arraynd_repr(array, nprint=None):
 
     Parameters
     ----------
-    array : array-like
+    array : `array-like`
         The array to print
     nprint : int
         Maximum number of elements to print.
@@ -140,7 +140,7 @@ def arraynd_str(array, nprint=None):
 
     Parameters
     ----------
-    array : array-like
+    array : `array-like`
         The array to print
     nprint : int
         Maximum number of elements to print.
@@ -229,32 +229,32 @@ def with_metaclass(meta, *bases):
 
 
 def is_scalar_dtype(dtype):
-    """True if ``dtype`` is scalar, False otherwise."""
+    """Return ``True`` if ``dtype`` is a scalar type."""
     return np.issubsctype(dtype, np.number)
 
 
 def is_int_dtype(dtype):
-    """True if ``dtype`` is integer, False otherwise."""
+    """Return ``True`` if ``dtype`` is an integer type."""
     return np.issubsctype(dtype, np.integer)
 
 
 def is_floating_dtype(dtype):
-    """True if ``dtype`` is floating-point, False otherwise."""
+    """Return ``True`` if ``dtype`` is a floating point type."""
     return is_real_floating_dtype(dtype) or is_complex_floating_dtype(dtype)
 
 
 def is_real_dtype(dtype):
-    """True if ``dtype`` is real (including integer), False otherwise."""
+    """Return ``True`` if ``dtype`` is a real (including integer) type."""
     return is_scalar_dtype(dtype) and not is_complex_floating_dtype(dtype)
 
 
 def is_real_floating_dtype(dtype):
-    """True if ``dtype`` is real floating-point, False otherwise."""
+    """Return ``True`` if ``dtype`` is a real floating point type."""
     return np.issubsctype(dtype, np.floating)
 
 
 def is_complex_floating_dtype(dtype):
-    """True if ``dtype`` is complex floating-point, False otherwise."""
+    """Return ``True`` if ``dtype`` is a complex floating point type."""
     return np.issubsctype(dtype, np.complexfloating)
 
 

--- a/odl/util/utility.py
+++ b/odl/util/utility.py
@@ -140,7 +140,7 @@ def arraynd_str(array, nprint=None):
 
     Parameters
     ----------
-    array : `array-like`
+    array : array-like
         The array to print
     nprint : int
         Maximum number of elements to print.
@@ -177,7 +177,7 @@ def arraynd_str(array, nprint=None):
 
 
 def dtype_repr(dtype):
-    """Stringification of data type with default for `int` and `float`."""
+    """Stringification of data type with default for int and float."""
     if dtype == np.dtype(int):
         return "'int'"
     elif dtype == np.dtype(float):
@@ -229,32 +229,32 @@ def with_metaclass(meta, *bases):
 
 
 def is_scalar_dtype(dtype):
-    """`True` if ``dtype`` is scalar, else `False`."""
+    """True if ``dtype`` is scalar, False otherwise."""
     return np.issubsctype(dtype, np.number)
 
 
 def is_int_dtype(dtype):
-    """`True` if ``dtype`` is integer, else `False`."""
+    """True if ``dtype`` is integer, False otherwise."""
     return np.issubsctype(dtype, np.integer)
 
 
 def is_floating_dtype(dtype):
-    """`True` if ``dtype`` is floating-point, else `False`."""
+    """True if ``dtype`` is floating-point, False otherwise."""
     return is_real_floating_dtype(dtype) or is_complex_floating_dtype(dtype)
 
 
 def is_real_dtype(dtype):
-    """`True` if ``dtype`` is real (including integer), else `False`."""
+    """True if ``dtype`` is real (including integer), False otherwise."""
     return is_scalar_dtype(dtype) and not is_complex_floating_dtype(dtype)
 
 
 def is_real_floating_dtype(dtype):
-    """`True` if ``dtype`` is real floating-point, else `False`."""
+    """True if ``dtype`` is real floating-point, False otherwise."""
     return np.issubsctype(dtype, np.floating)
 
 
 def is_complex_floating_dtype(dtype):
-    """`True` if ``dtype`` is complex floating-point, else `False`."""
+    """True if ``dtype`` is complex floating-point, False otherwise."""
     return np.issubsctype(dtype, np.complexfloating)
 
 
@@ -263,13 +263,13 @@ def conj_exponent(exp):
 
     Parameters
     ----------
-    exp : positive `float` or inf
+    exp : positive float or inf
         Exponent for which to calculate the conjugate. Must be
         at least 1.0.
 
     Returns
     -------
-    conj : positive `float` or inf
+    conj : positive float or inf
         Conjugate exponent. For ``exp=1``, return ``float('inf')``,
         for ``exp=float('inf')`` return 1. In all other cases, return
         ``exp / (exp - 1)``.

--- a/odl/util/vectorization.py
+++ b/odl/util/vectorization.py
@@ -168,12 +168,12 @@ class OptionalArgDecorator(object):
 
         Parameters
         ----------
-        func : callable
+        func : `callable`
             Original function to be wrapped
 
         Returns
         -------
-        wrapped : callable
+        wrapped : `callable`
             The wrapped function
         """
         return self._wrapper(func, *self.wrapper_args, **self.wrapper_kwargs)
@@ -245,7 +245,7 @@ class _NumpyVectorizeWrapper(object):
 
         Parameters
         ----------
-        func : callable
+        func : `callable`
             Python function or method to be wrapped
         vect_args :
             positional arguments for `numpy.vectorize`
@@ -262,14 +262,14 @@ class _NumpyVectorizeWrapper(object):
 
         Parameters
         ----------
-        x : array-like or sequence of array-like
+        x : `array-like` or `sequence` of `array-like`'s
             Input argument(s) to the wrapped function
-        out : numpy.ndarray, optional
+        out : `numpy.ndarray`, optional
             Appropriately sized array to write to
 
         Returns
         -------
-        out : numpy.ndarray
+        out : `numpy.ndarray`
             Result of the vectorized function evaluation. If ``out``
             was given, the returned object is a reference to it.
         """

--- a/odl/util/vectorization.py
+++ b/odl/util/vectorization.py
@@ -168,12 +168,12 @@ class OptionalArgDecorator(object):
 
         Parameters
         ----------
-        func : `callable`
+        func : callable
             Original function to be wrapped
 
         Returns
         -------
-        wrapped : `callable`
+        wrapped : callable
             The wrapped function
         """
         return self._wrapper(func, *self.wrapper_args, **self.wrapper_kwargs)
@@ -245,7 +245,7 @@ class _NumpyVectorizeWrapper(object):
 
         Parameters
         ----------
-        func : `callable`
+        func : callable
             Python function or method to be wrapped
         vect_args :
             positional arguments for `numpy.vectorize`
@@ -262,14 +262,14 @@ class _NumpyVectorizeWrapper(object):
 
         Parameters
         ----------
-        x : `array-like` or `sequence` of `array-like`
+        x : array-like or sequence of array-like
             Input argument(s) to the wrapped function
-        out : `numpy.ndarray`, optional
+        out : numpy.ndarray, optional
             Appropriately sized array to write to
 
         Returns
         -------
-        out : `numpy.ndarray`
+        out : numpy.ndarray
             Result of the vectorized function evaluation. If ``out``
             was given, the returned object is a reference to it.
         """


### PR DESCRIPTION
Extremely boring stuff. Most significant is the improvement of the docs and error messages in the `odl.set.space` module, which was kind of old and not up to current standards.

TODO (up to discussion also):

- [x] Double-backtick occurrences of `True`, `False` and `None`, possibly similar other names
- [x] Check if all places of single-vs-double underscore attributes are correct (tests should raise though if anything is wrong)
- [x] Rebase on master (it's only slightly behind, though, worst conflicts are fixed)