### PR TITLE
MAINT: remove python2/3 compatibility code from examples, closes #501

### DIFF
--- a/examples/diagnostics/diagonstics_space.py
+++ b/examples/diagnostics/diagonstics_space.py
@@ -17,11 +17,6 @@
 
 """Run the standardized diagonstics suite on some of the spaces."""
 
-# Imports for common Python 2/3 codebase
-from __future__ import print_function, division, absolute_import
-from future import standard_library
-standard_library.install_aliases()
-
 import odl
 
 print('\n\n TESTING FOR Lp SPACE \n\n')
@@ -45,4 +40,4 @@ if 'cuda' in odl.FN_IMPLS:
     print('\n\n TESTING FOR CUDA rn SPACE \n\n')
 
     spc = odl.rn(10, impl='cuda')
-    odl.diagnostics.SpaceTest(spc, eps=0.0001).run_tests()
+    odl.diagnostics.SpaceTest(spc, tol=0.0001).run_tests()

--- a/examples/operator/simple_operator.py
+++ b/examples/operator/simple_operator.py
@@ -17,19 +17,12 @@
 
 """An example of a very simple operator on rn."""
 
-# Imports for common Python 2/3 codebase
-from __future__ import print_function, division, absolute_import
-from future import standard_library
-standard_library.install_aliases()
-from builtins import super
-
-# Internal
 import odl
 
 
 class AddOp(odl.Operator):
     def __init__(self, size, add_this):
-        super().__init__(domain=odl.rn(size), range=odl.rn(size))
+        odl.Operator.__init__(self, domain=odl.rn(size), range=odl.rn(size))
         self.value = add_this
 
     def _call(self, x, out):

--- a/examples/solvers/chambolle_pock_deconvolve.py
+++ b/examples/solvers/chambolle_pock_deconvolve.py
@@ -28,11 +28,6 @@ For further details and a description of the solution method used, see
 :ref:`chambolle_pock` in the ODL documentation.
 """
 
-# Imports for common Python 2/3 codebase
-from __future__ import print_function, division, absolute_import
-from future import standard_library
-standard_library.install_aliases()
-
 import numpy as np
 import odl
 

--- a/examples/solvers/chambolle_pock_denoising.py
+++ b/examples/solvers/chambolle_pock_denoising.py
@@ -27,11 +27,6 @@ For further details and a description of the solution method used, see
 :ref:`chambolle_pock` in the ODL documentation.
 """
 
-# Imports for common Python 2/3 codebase
-from __future__ import print_function, division, absolute_import
-from future import standard_library
-standard_library.install_aliases()
-
 import numpy as np
 import scipy
 import odl

--- a/examples/solvers/chambolle_pock_tomography.py
+++ b/examples/solvers/chambolle_pock_tomography.py
@@ -53,7 +53,7 @@ geometry = odl.tomo.Parallel2dGeometry(angle_partition, detector_partition)
 # 'astra_cpu', 'astra_cuda'   Require astra tomography to be installed.
 #                             Astra is much faster than scikit. Webpage:
 #                             https://github.com/astra-toolbox/astra-toolbox
-impl = 'scikit'
+impl = 'astra_cuda'
 
 # Ray transform aka forward projection.
 ray_trafo = odl.tomo.RayTransform(reco_space, geometry, impl=impl)
@@ -89,7 +89,7 @@ prox_convconj_l2 = odl.solvers.proximal_cconj_l2_squared(ray_trafo.range,
                                                          g=data)
 
 # Isotropic TV-regularization i.e. the l1-norm
-prox_convconj_l1 = odl.solvers.proximal_cconj_l1(gradient.range, lam=0.005,
+prox_convconj_l1 = odl.solvers.proximal_cconj_l1(gradient.range, lam=0.03,
                                                  isotropic=True)
 
 # Combine proximal operators, order must correspond to the operator K
@@ -101,11 +101,12 @@ proximal_dual = odl.solvers.combine_proximals(prox_convconj_l2,
 
 
 # Estimated operator norm, add 10 percent to ensure ||K||_2^2 * sigma * tau < 1
-op_norm = 1.1 * odl.power_method_opnorm(op, rtol=0.01)
+op_norm = 1.1 * odl.power_method_opnorm(op)
 
-niter = 400  # Number of iterations
+niter = 100  # Number of iterations
 tau = 1.0 / op_norm  # Step size for the primal variable
 sigma = 1.0 / op_norm  # Step size for the dual variable
+gamma = 0.2
 
 # Optionally pass callback to the solver to display intermediate results
 callback = (odl.solvers.CallbackPrintIteration() &
@@ -117,7 +118,8 @@ x = op.domain.zero()
 # Run the algorithm
 odl.solvers.chambolle_pock_solver(
     op, x, tau=tau, sigma=sigma, proximal_primal=proximal_primal,
-    proximal_dual=proximal_dual, niter=niter, callback=callback)
+    proximal_dual=proximal_dual, niter=niter, callback=callback,
+    gamma=gamma)
 
 # Display images
 discr_phantom.show(title='original image')

--- a/examples/solvers/conjugate_gradient_tomography.py
+++ b/examples/solvers/conjugate_gradient_tomography.py
@@ -15,7 +15,7 @@
 # You should have received a copy of the GNU General Public License
 # along with ODL.  If not, see <http://www.gnu.org/licenses/>.
 
-"""Total variation tomography using the `conjugate_gradient_normal` solver.
+"""Tomography using the `conjugate_gradient_normal` solver.
 
 Solves the inverse problem
 
@@ -41,8 +41,8 @@ reco_space = odl.uniform_discr(
 # Angles: uniformly spaced, n = 360, min = 0, max = 2 * pi
 angle_partition = odl.uniform_partition(0, 2 * np.pi, 360)
 
-# Detector: uniformly sampled, n = 558, min = -30, max = 30
-detector_partition = odl.uniform_partition(-30, 30, 558)
+# Detector: uniformly sampled, n = 300, min = -30, max = 30
+detector_partition = odl.uniform_partition(-30, 30, 300)
 geometry = odl.tomo.Parallel2dGeometry(angle_partition, detector_partition)
 
 # The implementation of the ray transform to use, options:
@@ -80,5 +80,5 @@ odl.solvers.conjugate_gradient_normal(
 
 # Display images
 discr_phantom.show(title='original image')
-data.show(title='convolved image')
-x.show(title='deconvolved image', show=True)
+data.show(title='sinogram')
+x.show(title='reconstructed image', show=True)

--- a/examples/solvers/denoising_with_entropy_type_regularization.py
+++ b/examples/solvers/denoising_with_entropy_type_regularization.py
@@ -25,15 +25,9 @@ For details see :ref:`chambolle_pock`, :ref:`proximal_operators`, and
 references therein.
 """
 
-# Imports for common Python 2/3 codebase
-from __future__ import print_function, division, absolute_import
-from future import standard_library
-standard_library.install_aliases()
-
 import numpy as np
 import scipy
 import odl
-
 
 # Read test image:
 # convert integer values to float, and rotate to get the image upright

--- a/examples/solvers/scipy_solvers.py
+++ b/examples/solvers/scipy_solvers.py
@@ -24,11 +24,6 @@ This example solves the problem
 where b is a gaussian peak at the origin.
 """
 
-# Imports for common Python 2/3 codebase
-from __future__ import print_function, division, absolute_import
-from future import standard_library
-standard_library.install_aliases()
-
 import numpy as np
 import scipy.sparse.linalg as sl
 import odl

--- a/examples/space/simple_r.py
+++ b/examples/space/simple_r.py
@@ -17,11 +17,6 @@
 
 """An example of a very simple space, the real numbers."""
 
-# Imports for common Python 2/3 codebase
-from __future__ import print_function, division, absolute_import
-from future import standard_library
-standard_library.install_aliases()
-from builtins import super
 
 import odl
 
@@ -30,7 +25,7 @@ class Reals(odl.LinearSpace):
     """The real numbers."""
 
     def __init__(self):
-        super().__init__(odl.RealNumbers())
+        odl.LinearSpace.__init__(self, field=odl.RealNumbers())
 
     def _inner(self, x1, x2):
         return x1.__val__ * x2.__val__
@@ -45,32 +40,32 @@ class Reals(odl.LinearSpace):
         return isinstance(other, Reals)
 
     def element(self, value=0):
-        return Reals.Vector(self, value)
+        return RealNumber(self, value)
 
-    class Vector(odl.LinearSpaceVector):
-        """Real vectors are floats
-        """
 
-        __val__ = None
+class RealNumber(odl.LinearSpaceVector):
+    """Real vectors are floats."""
 
-        def __init__(self, space, v):
-            odl.LinearSpaceVector.__init__(self, space)
-            self.__val__ = v
+    __val__ = None
 
-        def __float__(self):
-            return self.__val__.__float__()
+    def __init__(self, space, v):
+        odl.LinearSpaceVector.__init__(self, space=space)
+        self.__val__ = v
 
-        def __str__(self):
-            return str(self.__val__)
+    def __float__(self):
+        return self.__val__.__float__()
 
-if __name__ == '__main__':
-    R = Reals()
-    x = R.element(5.0)
-    y = R.element(10.0)
+    def __str__(self):
+        return str(self.__val__)
 
-    print(x)
-    print(y)
-    print(x + y)
-    print(x * y)
-    print(x - y)
-    print(3.14 * x)
+
+R = Reals()
+x = R.element(5.0)
+y = R.element(10.0)
+
+print(x)
+print(y)
+print(x + y)
+print(x * y)
+print(x - y)
+print(3.14 * x)

--- a/examples/space/simple_rn.py
+++ b/examples/space/simple_rn.py
@@ -20,25 +20,17 @@
 Including some benchmarks with an optimized version.
 """
 
-# Imports for common Python 2/3 codebase
-from __future__ import print_function, division, absolute_import
-from future import standard_library
-standard_library.install_aliases()
-from builtins import super, range
-
-# External
 import numpy as np
-
-# Internal
 import odl
+from odl.space.base_ntuples import FnBase, FnBaseVector
 from odl.util.testutils import Timer
 
 
-class SimpleRn(odl.space.base_ntuples.FnBase):
+class SimpleRn(FnBase):
     """The real space R^n, non-optimized implmentation."""
 
     def __init__(self, size):
-        super().__init__(size, np.float)
+        FnBase.__init__(self, size, np.float)
 
     def zero(self):
         return self.element(np.zeros(self.size))
@@ -63,7 +55,7 @@ class SimpleRn(odl.space.base_ntuples.FnBase):
             return self.element(np.empty(self.size))
         if isinstance(args[0], np.ndarray):
             if args[0].shape == (self.size,):
-                return SimpleRn.Vector(self, args[0])
+                return RnVector(self, args[0])
             else:
                 raise ValueError('input array {} is of shape {}, expected '
                                  'shape ({},).'.format(args[0], args[0].shape,
@@ -73,19 +65,21 @@ class SimpleRn(odl.space.base_ntuples.FnBase):
                 *args, **kwargs).astype(np.float64, copy=False))
         return self.element(np.empty(self.dim, dtype=np.float64))
 
-    class Vector(odl.space.base_ntuples.FnBaseVector):
-        def __init__(self, space, data):
-            super().__init__(space)
-            self.data = data
 
-        def __getitem__(self, index):
-            return self.data.__getitem__(index)
+class RnVector(FnBaseVector):
+    def __init__(self, space, data):
+        FnBaseVector.__init__(self, space)
+        self.data = data
 
-        def __setitem__(self, index, value):
-            return self.data.__setitem__(index, value)
+    def __getitem__(self, index):
+        return self.data.__getitem__(index)
 
-        def asarray(self, *args):
-            return self.data(*args)
+    def __setitem__(self, index, value):
+        return self.data.__setitem__(index, value)
+
+    def asarray(self, *args):
+        return self.data(*args)
+
 
 r5 = SimpleRn(5)
 #odl.diagnostics.SpaceTest(r5).run_tests()

--- a/examples/space/vectorization.py
+++ b/examples/space/vectorization.py
@@ -17,10 +17,6 @@
 
 """Example showing how to use vectorization of FunctionSpaceVector's."""
 
-# Imports for common Python 2/3 codebase
-from __future__ import print_function, division, absolute_import
-from future import standard_library
-standard_library.install_aliases()
 import numpy as np
 import odl
 import timeit

--- a/examples/tomo/ray_trafo_circular_cone.py
+++ b/examples/tomo/ray_trafo_circular_cone.py
@@ -17,14 +17,8 @@
 
 """Example using the ray transform with circular cone beam geometry."""
 
-# Imports for common Python 2/3 codebase
-from __future__ import print_function, division, absolute_import
-from future import standard_library
-standard_library.install_aliases()
-
 import numpy as np
 import odl
-
 
 # Discrete reconstruction space: discretized functions on the cube
 # [-20, 20]^3 with 300 samples per dimension.

--- a/examples/tomo/ray_trafo_fanflat.py
+++ b/examples/tomo/ray_trafo_fanflat.py
@@ -17,14 +17,8 @@
 
 """Example using the ray transform with fan beam geometry."""
 
-# Imports for common Python 2/3 codebase
-from __future__ import print_function, division, absolute_import
-from future import standard_library
-standard_library.install_aliases()
-
 import numpy as np
 import odl
-
 
 # Discrete reconstruction space: discretized functions on the rectangle
 # [-20, 20]^2 with 300 samples per dimension.

--- a/examples/tomo/ray_trafo_helical.py
+++ b/examples/tomo/ray_trafo_helical.py
@@ -17,14 +17,8 @@
 
 """Example using the ray transform with helical cone beam geometry."""
 
-# Imports for common Python 2/3 codebase
-from __future__ import print_function, division, absolute_import
-from future import standard_library
-standard_library.install_aliases()
-
 import numpy as np
 import odl
-
 
 # Discrete reconstruction space: discretized functions on the cube
 # [-20, 20]^2 x [0, 40] with 300 samples per dimension.

--- a/examples/tomo/ray_trafo_parallel_2d.py
+++ b/examples/tomo/ray_trafo_parallel_2d.py
@@ -17,14 +17,8 @@
 
 """Example using the ray transform with 2d parallel beam geometry."""
 
-# Imports for common Python 2/3 codebase
-from __future__ import print_function, division, absolute_import
-from future import standard_library
-standard_library.install_aliases()
-
 import numpy as np
 import odl
-
 
 # Discrete reconstruction space: discretized functions on the rectangle
 # [-20, 20]^2 with 300 samples per dimension.

--- a/examples/tomo/ray_trafo_parallel_3d.py
+++ b/examples/tomo/ray_trafo_parallel_3d.py
@@ -17,14 +17,8 @@
 
 """Example using the ray transform with 3d parallel beam geometry."""
 
-# Imports for common Python 2/3 codebase
-from __future__ import print_function, division, absolute_import
-from future import standard_library
-standard_library.install_aliases()
-
 import numpy as np
 import odl
-
 
 # Discrete reconstruction space: discretized functions on the cube
 # [-20, 20]^3 with 300 samples per dimension.

--- a/examples/tomo/stir_project.py
+++ b/examples/tomo/stir_project.py
@@ -27,11 +27,6 @@ Note that running this example requires an installation of
 `STIR <http://stir.sourceforge.net/>`_ and its Python bindings.
 """
 
-# Imports for common Python 2/3 codebase
-from __future__ import print_function, division, absolute_import
-from future import standard_library
-standard_library.install_aliases()
-
 from os import path
 import stir
 import odl

--- a/examples/tomo/stir_reconstruct.py
+++ b/examples/tomo/stir_reconstruct.py
@@ -27,11 +27,6 @@ Note that running this example requires an installation of
 `STIR <http://stir.sourceforge.net/>`_ and its Python bindings.
 """
 
-# Imports for common Python 2/3 codebase
-from __future__ import print_function, division, absolute_import
-from future import standard_library
-standard_library.install_aliases()
-
 from os import path
 import odl
 

--- a/examples/visualization/show_productspace.py
+++ b/examples/visualization/show_productspace.py
@@ -17,10 +17,6 @@
 
 """Example on using show with ProductSpace's."""
 
-# Imports for common Python 2/3 codebase
-from __future__ import print_function, division, absolute_import
-from future import standard_library
-standard_library.install_aliases()
 import odl
 import numpy as np
 

--- a/examples/visualization/show_update_1d.py
+++ b/examples/visualization/show_update_1d.py
@@ -17,10 +17,6 @@
 
 """Example on using show and updating the figure in real time in 1d."""
 
-# Imports for common Python 2/3 codebase
-from __future__ import print_function, division, absolute_import
-from future import standard_library
-standard_library.install_aliases()
 import odl
 import matplotlib.pyplot as plt
 import numpy as np

--- a/examples/visualization/show_update_2d.py
+++ b/examples/visualization/show_update_2d.py
@@ -17,11 +17,6 @@
 
 """Example on using show and updating the figure in real time in 2d."""
 
-# Imports for common Python 2/3 codebase
-from __future__ import print_function, division, absolute_import
-from future import standard_library
-standard_library.install_aliases()
-
 import odl
 import matplotlib.pyplot as plt
 

--- a/examples/visualization/visualize_vector_examples.py
+++ b/examples/visualization/visualize_vector_examples.py
@@ -17,11 +17,6 @@
 
 """Visualization of the test functions in the diagnostics module."""
 
-# Imports for common Python 2/3 codebase
-from __future__ import print_function, division, absolute_import
-from future import standard_library
-standard_library.install_aliases()
-
 import odl
 
 disc = odl.uniform_discr(0, 1, 100)


### PR DESCRIPTION
Someone (@kohr-h) needs to run `py.test --examples` using python 3 to verify that this works as expected.