### PR TITLE
MAINT: unify min_pt, max_pt, shape and mid_pt, closes #452

### DIFF
--- a/doc/source/guide/introduction/about_odl.rst
+++ b/doc/source/guide/introduction/about_odl.rst
@@ -40,7 +40,7 @@ For the typical use cases in 1, 2 and 3 dimensions, there are convenience functi
 `Interval`,  `Rectangle` and `Cuboid`:
 
     >>> rect = odl.Rectangle([0, -1], [1, 1])
-    >>> rect.begin
+    >>> rect.min_pt
     array([ 0., -1.])
     >>> rect[0]
     Interval(0.0, 1.0)

--- a/doc/source/release_notes.rst
+++ b/doc/source/release_notes.rst
@@ -12,31 +12,29 @@ Next release
 New features
 ------------
 - Add ``ResizingOperator`` for shrinking and extending (padding) of discretized functions, including a variety of padding methods. (:pull:`499`)
-<<<<<<< HEAD
-- Add ``as_writable_array`` that allows casting arbitrary array-likes to a numpy array and then storing the results later on. This is
-  intended to be used with odl vectors that may not be stored in numpy format (like cuda vectors), but can be used with other types like lists.
-  (:pull:`524`)
+- Add ``as_writable_array`` that allows casting arbitrary array-likes to a numpy array and then storing the results later on.
+  This is intended to be used with odl vectors that may not be stored in numpy format (like cuda vectors), but can be used with other types like lists. (:pull:`524`)
 - Allow ASTRA backend to be used with arbitrary dtypes. (:pull:`524`)
 
 Improvements
 ------------
 - Add intelligence to ``power_method_opnorm`` so it can terminate early by checking if consecutive iterates are close. (:pull:`527`)
-=======
 - Add ``BroadcastOperator(op, n)``, ``ReductionOperator(op, n)`` and ``DiagonalOperator(op, n)`` syntax.
-  This is equivalent to ``BroadcastOperator(*([op] * n))`` etc, i.e. create ``n`` copies of the operator.
->>>>>>> ENH: allow syntax (op, n) in the ProductSpaceOperators, closes #517
+  This is equivalent to ``BroadcastOperator(*([op] * n))`` etc, i.e. create ``n`` copies of the operator. (:pull:`532`)
 
 Changes
 --------
-- Changed definition of ``LinearSpaceVector.multiply`` to match the definition used by numpy (:pull:`509`)
+- Changed definition of ``LinearSpaceVector.multiply`` to match the definition used by Numpy. (:pull:`509`)
 - The parameters ``padding_method`` in ``diff_ops.py`` and ``mode`` in ``wavelet.py`` have been renamed to ``pad_mode``.
-  The parameter ``padding_value`` is now called ``pad_const``.
-- Expose ``ellipse_phantom`` and ``shepp_logan_ellipses`` to ``odl.phantom``
+  The parameter ``padding_value`` is now called ``pad_const``. (:pull:`511`)
+- Expose ``ellipse_phantom`` and ``shepp_logan_ellipses`` to ``odl.phantom``. (:pull:`529`)
+- Unify the names of minimum (``min_pt``), maximum (``max_pt``) and middle (``mid_pt``) points as well as number of points (``shape``) in grids, interval products and factory functions for discretized spaces. (:pull:`541`)
 
 Bugfixes
 --------
-- Fixed ``python -c "import odl; odl.test()"`` not working on windows (:pull:`508`)
+- Fixed ``python -c "import odl; odl.test()"`` not working on Windows. (:pull:`508`)
 - Fixed a ``TypeError`` being raised in ``OperatorTest`` when running ``optest.ajoint()`` without specifying an operator norm. (:pull:`525`)
+
 
 ODL 0.4.0 Release Notes (2016-08-17)
 ====================================
@@ -48,6 +46,7 @@ New features
 ------------
 - Add ``deform`` package with linearized deformations (:pull:`488`)
 - Add option to interface with ProxImaL solvers using ODL operators. (:pull:`494`)
+
 
 ODL 0.3.1 Release Notes (2016-08-15)
 ====================================

--- a/examples/solvers/chambolle_pock_tomography.py
+++ b/examples/solvers/chambolle_pock_tomography.py
@@ -38,8 +38,7 @@ import odl
 # Discrete reconstruction space: discretized functions on the rectangle
 # [-20, 20]^2 with 300 samples per dimension.
 reco_space = odl.uniform_discr(
-    min_corner=[-20, -20], max_corner=[20, 20], nsamples=[300, 300],
-    dtype='float32')
+    min_pt=[-20, -20], max_pt=[20, 20], shape=[300, 300], dtype='float32')
 
 # Make a parallel beam geometry with flat detector
 # Angles: uniformly spaced, n = 360, min = 0, max = 2 * pi

--- a/examples/solvers/conjugate_gradient_tomography.py
+++ b/examples/solvers/conjugate_gradient_tomography.py
@@ -35,8 +35,7 @@ import odl
 # Discrete reconstruction space: discretized functions on the rectangle
 # [-20, 20]^2 with 300 samples per dimension.
 reco_space = odl.uniform_discr(
-    min_corner=[-20, -20], max_corner=[20, 20], nsamples=[300, 300],
-    dtype='float32')
+    min_pt=[-20, -20], max_pt=[20, 20], shape=[300, 300], dtype='float32')
 
 # Make a parallel beam geometry with flat detector
 # Angles: uniformly spaced, n = 360, min = 0, max = 2 * pi

--- a/examples/solvers/proximal_lang_tomography.py
+++ b/examples/solvers/proximal_lang_tomography.py
@@ -36,8 +36,7 @@ import proximal
 # Discrete reconstruction space: discretized functions on the rectangle
 # [-20, 20]^2 with 300 samples per dimension.
 reco_space = odl.uniform_discr(
-    min_corner=[-20, -20], max_corner=[20, 20], nsamples=[300, 300],
-    dtype='float32')
+    min_pt=[-20, -20], max_pt=[20, 20], shape=[300, 300], dtype='float32')
 
 # Make a parallel beam geometry with flat detector
 # Angles: uniformly spaced, n = 360, min = 0, max = 2 * pi

--- a/examples/tomo/filtered_backprojection_parallel_2d.py
+++ b/examples/tomo/filtered_backprojection_parallel_2d.py
@@ -33,8 +33,7 @@ import odl
 # Discrete reconstruction space: discretized functions on the rectangle
 # [-20, 20]^2 with 300 samples per dimension.
 reco_space = odl.uniform_discr(
-    min_corner=[-20, -20], max_corner=[20, 20], nsamples=[300, 300],
-    dtype='float32')
+    min_pt=[-20, -20], max_pt=[20, 20], shape=[300, 300], dtype='float32')
 
 # Angles: uniformly spaced, n = 1000, min = 0, max = pi
 angle_partition = odl.uniform_partition(0, np.pi, 1000)
@@ -49,7 +48,7 @@ geometry = odl.tomo.Parallel2dGeometry(angle_partition, detector_partition)
 # --- Create FilteredBackProjection (FBP) operator --- #
 
 
-# Ray transform aka forward projection. We use the ASTRA CUDA backend.
+# Ray transform (= forward projection). We use the ASTRA CUDA backend.
 ray_trafo = odl.tomo.RayTransform(reco_space, geometry, impl='astra_cuda')
 
 # Fourier transform in detector direction

--- a/examples/tomo/ray_trafo_circular_cone.py
+++ b/examples/tomo/ray_trafo_circular_cone.py
@@ -29,8 +29,8 @@ import odl
 # Discrete reconstruction space: discretized functions on the cube
 # [-20, 20]^3 with 300 samples per dimension.
 reco_space = odl.uniform_discr(
-    min_corner=[-20, -20, -20], max_corner=[20, 20, 20],
-    nsamples=[300, 300, 300], dtype='float32')
+    min_pt=[-20, -20, -20], max_pt=[20, 20, 20], shape=[300, 300, 300],
+    dtype='float32')
 
 # Make a circular cone beam geometry with flat detector
 # Angles: uniformly spaced, n = 360, min = 0, max = 2 * pi
@@ -41,7 +41,7 @@ geometry = odl.tomo.CircularConeFlatGeometry(
     angle_partition, detector_partition, src_radius=1000, det_radius=100,
     axis=[1, 0, 0])
 
-# ray transform aka forward projection. We use ASTRA CUDA backend.
+# Ray transform (= forward projection). We use the ASTRA CUDA backend.
 ray_trafo = odl.tomo.RayTransform(reco_space, geometry, impl='astra_cuda')
 
 # Create a discrete Shepp-Logan phantom (modified version)

--- a/examples/tomo/ray_trafo_fanflat.py
+++ b/examples/tomo/ray_trafo_fanflat.py
@@ -29,8 +29,7 @@ import odl
 # Discrete reconstruction space: discretized functions on the rectangle
 # [-20, 20]^2 with 300 samples per dimension.
 reco_space = odl.uniform_discr(
-    min_corner=[-20, -20], max_corner=[20, 20], nsamples=[300, 300],
-    dtype='float32')
+    min_pt=[-20, -20], max_pt=[20, 20], shape=[300, 300], dtype='float32')
 
 # Make a fan beam geometry with flat detector
 # Angles: uniformly spaced, n = 360, min = 0, max = 2 * pi
@@ -40,7 +39,7 @@ detector_partition = odl.uniform_partition(-30, 30, 558)
 geometry = odl.tomo.FanFlatGeometry(angle_partition, detector_partition,
                                     src_radius=1000, det_radius=100)
 
-# ray transform aka forward projection. We use ASTRA CUDA backend.
+# Ray transform (= forward projection). We use the ASTRA CUDA backend.
 ray_trafo = odl.tomo.RayTransform(reco_space, geometry, impl='astra_cuda')
 
 # Create a discrete Shepp-Logan phantom (modified version)

--- a/examples/tomo/ray_trafo_helical.py
+++ b/examples/tomo/ray_trafo_helical.py
@@ -29,8 +29,8 @@ import odl
 # Discrete reconstruction space: discretized functions on the cube
 # [-20, 20]^2 x [0, 40] with 300 samples per dimension.
 reco_space = odl.uniform_discr(
-    min_corner=[-20, -20, 0], max_corner=[20, 20, 40],
-    nsamples=[300, 300, 300], dtype='float32')
+    min_pt=[-20, -20, 0], max_pt=[20, 20, 40], shape=[300, 300, 300],
+    dtype='float32')
 
 # Make a helical cone beam geometry with flat detector
 # Angles: uniformly spaced, n = 2000, min = 0, max = 8 * 2 * pi
@@ -42,7 +42,7 @@ geometry = odl.tomo.HelicalConeFlatGeometry(
     angle_partition, detector_partition, src_radius=1000, det_radius=100,
     pitch=5.0)
 
-# ray transform aka forward projection. We use ASTRA CUDA backend.
+# Ray transform (= forward projection). We use ASTRA CUDA backend.
 ray_trafo = odl.tomo.RayTransform(reco_space, geometry, impl='astra_cuda')
 
 # Create a discrete Shepp-Logan phantom (modified version)

--- a/examples/tomo/ray_trafo_parallel_2d.py
+++ b/examples/tomo/ray_trafo_parallel_2d.py
@@ -29,8 +29,7 @@ import odl
 # Discrete reconstruction space: discretized functions on the rectangle
 # [-20, 20]^2 with 300 samples per dimension.
 reco_space = odl.uniform_discr(
-    min_corner=[-20, -20], max_corner=[20, 20], nsamples=[300, 300],
-    dtype='float32')
+    min_pt=[-20, -20], max_pt=[20, 20], shape=[300, 300], dtype='float32')
 
 # Make a parallel beam geometry with flat detector
 # Angles: uniformly spaced, n = 360, min = 0, max = 2 * pi
@@ -39,7 +38,7 @@ angle_partition = odl.uniform_partition(0, 2 * np.pi, 360)
 detector_partition = odl.uniform_partition(-30, 30, 558)
 geometry = odl.tomo.Parallel2dGeometry(angle_partition, detector_partition)
 
-# ray transform aka forward projection. We use ASTRA CUDA backend.
+# Ray transform (= forward projection). We use ASTRA CUDA backend.
 ray_trafo = odl.tomo.RayTransform(reco_space, geometry, impl='astra_cuda')
 
 # Create a discrete Shepp-Logan phantom (modified version)

--- a/examples/tomo/ray_trafo_parallel_3d.py
+++ b/examples/tomo/ray_trafo_parallel_3d.py
@@ -29,8 +29,8 @@ import odl
 # Discrete reconstruction space: discretized functions on the cube
 # [-20, 20]^3 with 300 samples per dimension.
 reco_space = odl.uniform_discr(
-    min_corner=[-20, -20, -20], max_corner=[20, 20, 20],
-    nsamples=[300, 300, 300], dtype='float32')
+    min_pt=[-20, -20, -20], max_pt=[20, 20, 20], shape=[300, 300, 300],
+    dtype='float32')
 
 # Make a parallel beam geometry with flat detector
 # Angles: uniformly spaced, n = 360, min = 0, max = 2 * pi
@@ -45,7 +45,7 @@ detector_partition = odl.uniform_partition([-30, -30], [30, 30], [558, 558])
 # give a zero result.
 geometry = odl.tomo.Parallel3dAxisGeometry(angle_partition, detector_partition)
 
-# ray transform aka forward projection. We use ASTRA CUDA backend.
+# Ray transform (= forward projection). We use ASTRA CUDA backend.
 ray_trafo = odl.tomo.RayTransform(reco_space, geometry, impl='astra_cuda')
 
 # Create a discrete Shepp-Logan phantom (modified version)

--- a/examples/tomo/scikit_ray_trafo_parallel_2d.py
+++ b/examples/tomo/scikit_ray_trafo_parallel_2d.py
@@ -15,7 +15,11 @@
 # You should have received a copy of the GNU General Public License
 # along with ODL.  If not, see <http://www.gnu.org/licenses/>.
 
-"""Example using the ray transform with 2d parallel beam geometry."""
+"""Example using the ray transform with 2d parallel beam geometry.
+
+This example makes use of the 'scikit' backend, which requires the
+`scikit-image <http://scikit-image.org/>`_ package.
+"""
 
 import numpy as np
 import odl
@@ -23,8 +27,7 @@ import odl
 # Discrete reconstruction space: discretized functions on the rectangle
 # [-20, 20]^2 with 300 samples per dimension.
 reco_space = odl.uniform_discr(
-    min_corner=[-20, -20], max_corner=[20, 20], nsamples=[300, 300],
-    dtype='float32')
+    min_pt=[-20, -20], max_pt=[20, 20], shape=[300, 300], dtype='float32')
 
 # Make a parallel beam geometry with flat detector
 # Angles: uniformly spaced, n = 360, min = 0, max = 2 * pi
@@ -33,7 +36,7 @@ angle_partition = odl.uniform_partition(0, 2 * np.pi, 360)
 detector_partition = odl.uniform_partition(-30, 30, 558)
 geometry = odl.tomo.Parallel2dGeometry(angle_partition, detector_partition)
 
-# ray transform aka forward projection. We use 'scikit' backend.
+# Ray transform (= forward projection). We use the 'scikit' backend.
 ray_trafo = odl.tomo.RayTransform(reco_space, geometry, impl='scikit')
 
 # Create a discrete Shepp-Logan phantom (modified version)

--- a/examples/tomo/stir_project.py
+++ b/examples/tomo/stir_project.py
@@ -15,13 +15,16 @@
 # You should have received a copy of the GNU General Public License
 # along with ODL.  If not, see <http://www.gnu.org/licenses/>.
 
-"""Example for projection and back-projection with STIR.
+"""Example for PET projection and back-projection using STIR.
 
-This example computes projection and back-projection using the 'stir'
-backend. It requires an installation of
+This example computes projection data and the back-projection of that
+data using the Shepp-Logan phantom in ODL as input. Definition
+of the acquisition geometry and computations are done entirely in STIR,
+where the communication between ODL and STIR is realized with files
+via hard disk.
+
+Note that running this example requires an installation of
 `STIR <http://stir.sourceforge.net/>`_ and its Python bindings.
-
-TODO: which modality? CT? PET?
 """
 
 # Imports for common Python 2/3 codebase
@@ -34,8 +37,7 @@ import stir
 import odl
 
 # Load STIR input files with data
-base = path.join(
-    path.join(path.dirname(path.abspath(__file__)), 'data'), 'stir')
+base = path.join(path.dirname(path.abspath(__file__)), 'data', 'stir')
 
 volume_file = str(path.join(base, 'initial.hv'))
 volume = stir.FloatVoxelsOnCartesianGrid.read_from_file(volume_file)
@@ -45,7 +47,8 @@ proj_data_in = stir.ProjData.read_from_file(projection_file)
 proj_data = stir.ProjDataInMemory(proj_data_in.get_exam_info(),
                                   proj_data_in.get_proj_data_info())
 
-# Create ODL spaces
+# Create ODL spaces matching the discretization as specified in the
+# interfiles.
 recon_sp = odl.uniform_discr([0, 0, 0], [1, 1, 1], (15, 64, 64))
 data_sp = odl.uniform_discr([0, 0, 0], [1, 1, 1], (37, 28, 56))
 
@@ -53,7 +56,7 @@ data_sp = odl.uniform_discr([0, 0, 0], [1, 1, 1], (37, 28, 56))
 proj = odl.tomo.backends.stir_bindings.ForwardProjectorByBinWrapper(
     recon_sp, data_sp, volume, proj_data)
 
-# Create shepp-logan phantom
+# Create Shepp-Logan phantom
 vol = odl.phantom.shepp_logan(proj.domain, modified=True)
 
 # Project and show

--- a/examples/tomo/stir_project.py
+++ b/examples/tomo/stir_project.py
@@ -15,24 +15,32 @@
 # You should have received a copy of the GNU General Public License
 # along with ODL.  If not, see <http://www.gnu.org/licenses/>.
 
-"""Example projection and back-projection with stir."""
+"""Example for projection and back-projection with STIR.
+
+This example computes projection and back-projection using the 'stir'
+backend. It requires an installation of
+`STIR <http://stir.sourceforge.net/>`_ and its Python bindings.
+
+TODO: which modality? CT? PET?
+"""
 
 # Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
 from future import standard_library
 standard_library.install_aliases()
 
-import os.path as pth
+from os import path
 import stir
 import odl
 
 # Load STIR input files with data
-base = pth.join(pth.join(pth.dirname(pth.abspath(__file__)), 'data'), 'stir')
+base = path.join(
+    path.join(path.dirname(path.abspath(__file__)), 'data'), 'stir')
 
-volume_file = str(pth.join(base, 'initial.hv'))
+volume_file = str(path.join(base, 'initial.hv'))
 volume = stir.FloatVoxelsOnCartesianGrid.read_from_file(volume_file)
 
-projection_file = str(pth.join(base, 'small.hs'))
+projection_file = str(path.join(base, 'small.hs'))
 proj_data_in = stir.ProjData.read_from_file(projection_file)
 proj_data = stir.ProjDataInMemory(proj_data_in.get_exam_info(),
                                   proj_data_in.get_proj_data_info())

--- a/examples/tomo/stir_reconstruct.py
+++ b/examples/tomo/stir_reconstruct.py
@@ -15,7 +15,14 @@
 # You should have received a copy of the GNU General Public License
 # along with ODL.  If not, see <http://www.gnu.org/licenses/>.
 
-"""Example reconstruction with stir."""
+"""Example reconstruction using the 'stir' backend.
+
+This example computes projections and uses them as input data for
+reconstruction using the 'stir' backend. It requires an installation of
+`STIR <http://stir.sourceforge.net/>`_ and its Python bindings.
+
+TODO: which modality? CT? PET?
+"""
 
 # Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import

--- a/odl/discr/discretization.py
+++ b/odl/discr/discretization.py
@@ -357,7 +357,7 @@ class DiscretizedSetVector(NtuplesBaseVector):
         Assign x according to continuous vector
 
         >>> x.sampling(lambda x: x)
-        >>> print(x) # Print values at gridpoints (which are centered)
+        >>> print(x)  # Print values at grid points (which are centered)
         [0.1, 0.3, 0.5, 0.7, 0.9]
 
         See Also
@@ -564,14 +564,14 @@ def dspace_type(space, impl, dtype=None):
     impl : string
         Implementation backend for the data space
     dtype : `numpy.dtype`, optional
-        Data type which the space is supposed to use. If ``None``, the
-        space type is purely determined from ``space`` and
-        ``impl``. If given, it must be compatible with the
+        Data type which the space is supposed to use. If ``None`` is
+        given, the space type is purely determined from ``space`` and
+        ``impl``. Otherwise, it must be compatible with the
         field of ``space``.
 
     Returns
     -------
-    stype : `type`
+    stype : type
         Space type selected after the space's field, the backend and
         the data type
     """

--- a/odl/discr/grid.py
+++ b/odl/discr/grid.py
@@ -832,25 +832,27 @@ class RegularGrid(TensorGrid):
 
         Parameters
         ----------
-        min_pt : `array-like` or float
-            Grid point with minimum coordinates, can be a single float
-            for 1D grids
-        max_pt : `array-like` or float
-            Grid point with maximum coordinates, can be a single float
-            for 1D grids
-        shape : `array-like` or int
-            The number of grid points per axis, can be an integer for
-            1D grids
+        min_pt, max_pt : float or `sequence` of floats
+            Points defining the minimum/maximum grid coordinates.
+        shape : int or `sequence` of ints
+            Number of grid points per axis.
 
         Examples
         --------
-        >>> rg = RegularGrid([-1.5, -1], [-0.5, 3], (2, 3))
+        >>> import odl
+        >>> rg = odl.RegularGrid([-1.5, -1], [-0.5, 3], (2, 3))
         >>> rg
         RegularGrid([-1.5, -1.0], [-0.5, 3.0], (2, 3))
         >>> rg.coord_vectors
         (array([-1.5, -0.5]), array([-1.,  1.,  3.]))
         >>> rg.ndim, rg.size
         (2, 6)
+
+        In 1D, we don't need sequences:
+
+        >>> rg = odl.RegularGrid(0, 1, 10)
+        >>> rg.shape
+        (10,)
         """
         min_pt = np.atleast_1d(min_pt).astype('float64')
         max_pt = np.atleast_1d(max_pt).astype('float64')
@@ -1275,7 +1277,7 @@ def uniform_sampling(min_pt, max_pt, shape, nodes_on_bdry=True):
 
     Parameters
     ----------
-    min_pt, max_pt : float or `array-like`
+    min_pt, max_pt : float or `sequence` of float
         Vectors of lower/upper ends of the intervals in the product.
     shape : int or `sequence` of ints
         Number of nodes per axis. Entries corresponding to degenerate axes
@@ -1302,16 +1304,23 @@ def uniform_sampling(min_pt, max_pt, shape, nodes_on_bdry=True):
 
     Examples
     --------
-    >>> grid = uniform_sampling([-1.5, 2], [-0.5, 3], (3, 3))
+    >>> import odl
+    >>> grid = odl.uniform_sampling([-1.5, 2], [-0.5, 3], (3, 3))
     >>> grid.coord_vectors
     (array([-1.5, -1. , -0.5]), array([ 2. ,  2.5,  3. ]))
 
     To have the nodes in the "middle", use ``nodes_on_bdry=False``:
 
-    >>> grid = uniform_sampling([-1.5, 2], [-0.5, 3], (2, 2),
-    ...                         nodes_on_bdry=False)
+    >>> grid = odl.uniform_sampling([-1.5, 2], [-0.5, 3], (2, 2),
+    ...                             nodes_on_bdry=False)
     >>> grid.coord_vectors
     (array([-1.25, -0.75]), array([ 2.25,  2.75]))
+
+    In 1D, we don't need sequences:
+
+    >>> grid = odl.uniform_sampling(0, 1, 3)
+    >>> grid.coord_vectors
+    (array([ 0. ,  0.5,  1. ]),)
     """
     return uniform_sampling_fromintv(IntervalProd(min_pt, max_pt), shape,
                                      nodes_on_bdry=nodes_on_bdry)

--- a/odl/discr/grid.py
+++ b/odl/discr/grid.py
@@ -780,13 +780,13 @@ class TensorGrid(Set):
         Parameters
         ----------
         dtype : `numpy.dtype`
-            The numpy dtype of the result array. Default: float
+            The Numpy data type of the result array. ``None`` means `float`.
 
         Examples
         --------
         >>> g = TensorGrid([0, 1], [-2, 0, 2])
 
-        Convert to array
+        Convert to an array:
 
         >>> np.asarray(g)
         array([[ 0., -2.],
@@ -796,7 +796,7 @@ class TensorGrid(Set):
                [ 1.,  0.],
                [ 1.,  2.]])
 
-        Calculate midpoint
+        Calculate the midpoint:
 
         >>> np.mean(g, axis=0)
         array([ 0.5,  0. ])
@@ -892,23 +892,23 @@ class RegularGrid(TensorGrid):
         coord_vecs = [np.linspace(mi, ma, num, endpoint=True, dtype=np.float64)
                       for mi, ma, num in zip(min_pt, max_pt, shape)]
         TensorGrid.__init__(self, *coord_vecs)
-        self.__center = (self.max_pt + self.min_pt) / 2
+        self.__mid_pt = (self.max_pt + self.min_pt) / 2
         self.__stride = np.zeros(len(shape), dtype='float64')
         idcs = np.where(shape > 1)
         self.__stride[idcs] = ((self.max_pt - self.min_pt)[idcs] /
                                (shape[idcs] - 1))
 
     @property
-    def center(self):
-        """Center of the grid. Not necessarily a grid point.
+    def mid_pt(self):
+        """Midpoint of the grid. Not necessarily a grid point.
 
         Examples
         --------
         >>> rg = RegularGrid([-1.5, -1], [-0.5, 3], (2, 3))
-        >>> rg.center
+        >>> rg.mid_pt
         array([-1.,  1.])
         """
-        return self.__center
+        return self.__mid_pt
 
     @property
     def stride(self):
@@ -1031,11 +1031,11 @@ class RegularGrid(TensorGrid):
                                  ''.format(self.ndim))
 
             new_shape = self.shape[:idx] + other.shape + self.shape[idx:]
-            new_minpt = (self.min_pt[:idx].tolist() + other.min_pt.tolist() +
-                         self.min_pt[idx:].tolist())
-            new_maxpt = (self.max_pt[:idx].tolist() + other.max_pt.tolist() +
-                         self.max_pt[idx:].tolist())
-            return RegularGrid(new_minpt, new_maxpt, new_shape)
+            new_min_pt = (list(self.min_pt[:idx]) + list(other.min_pt) +
+                          list(self.min_pt[idx:]))
+            new_max_pt = (list(self.max_pt[:idx]) + list(other.max_pt) +
+                          list(self.max_pt[idx:]))
+            return RegularGrid(new_min_pt, new_max_pt, new_shape)
 
         elif isinstance(other, TensorGrid):
             self_tg = TensorGrid(*self.coord_vectors)
@@ -1104,19 +1104,19 @@ class RegularGrid(TensorGrid):
                 (v[int(idx)] for idx, v in zip(indices, self.coord_vectors)),
                 dtype=float)
         else:
-            new_minpt = []
-            new_maxpt = []
+            new_min_pt = []
+            new_max_pt = []
             new_shape = []
 
-            for idx, minval, maxval, n, cvec in zip(
+            for idx, xmin, xmax, n, cvec in zip(
                     indices, self.min_pt, self.max_pt, self.shape,
                     self.coord_vectors):
                 if np.isscalar(idx):
                     idx = slice(idx, idx + 1)
 
                 if idx == slice(None):  # Take all along this axis
-                    new_minpt.append(minval)
-                    new_maxpt.append(maxval)
+                    new_min_pt.append(xmin)
+                    new_max_pt.append(xmax)
                     new_shape.append(n)
                 else:  # Slice
                     istart, istop, istep = idx.indices(n)
@@ -1128,11 +1128,11 @@ class RegularGrid(TensorGrid):
                         num = int(np.ceil((istop - istart) / istep))
                         last = istart + (num - 1) * istep
 
-                    new_minpt.append(cvec[istart])
-                    new_maxpt.append(cvec[last])
+                    new_min_pt.append(cvec[istart])
+                    new_max_pt.append(cvec[last])
                     new_shape.append(num)
 
-            return RegularGrid(new_minpt, new_maxpt, new_shape)
+            return RegularGrid(new_min_pt, new_max_pt, new_shape)
 
     def __str__(self):
         """Return ``str(self)``."""
@@ -1146,11 +1146,11 @@ class RegularGrid(TensorGrid):
         return '{}({})'.format(self.__class__.__name__, inner_str)
 
 
-def uniform_sampling_fromintv(intv_prod, num_nodes, nodes_on_bdry=True):
+def uniform_sampling_fromintv(intv_prod, shape, nodes_on_bdry=True):
     """Sample an interval product uniformly.
 
-    The resulting grid will include ``begin`` and ``end`` of
-    ``intv_prod`` as grid points. If you want a subdivision into
+    The resulting grid will include ``intv_prod.min_pt`` and
+    ``intv_prod.max_pt`` as grid points. If you want a subdivision into
     equally sized cells with grid points in the middle, use
     `uniform_partition` instead.
 
@@ -1158,10 +1158,9 @@ def uniform_sampling_fromintv(intv_prod, num_nodes, nodes_on_bdry=True):
     ----------
     intv_prod : `IntervalProd`
         Set to be sampled
-    num_nodes : int or `sequence` of ints
-        Number of nodes per axis. For dimension >= 2, a tuple
-        is required. All entries must be positive. Entries
-        corresponding to degenerate axes must be equal to 1.
+    shape : int or `sequence` of ints
+        Number of nodes per axis. Entries corresponding to degenerate axes
+        must be equal to 1.
     nodes_on_bdry : bool or `sequence`, optional
         If a sequence is provided, it determines per axis whether to
         place the last grid point on the boundary (``True``) or shift it
@@ -1205,7 +1204,7 @@ def uniform_sampling_fromintv(intv_prod, num_nodes, nodes_on_bdry=True):
     --------
     uniform_sampling : Sample an implicitly created `IntervalProd`
     """
-    num_nodes = np.atleast_1d(num_nodes).astype('int64', casting='safe')
+    shape = np.atleast_1d(shape).astype('int64', casting='safe')
 
     if not isinstance(intv_prod, IntervalProd):
         raise TypeError('{!r} is not an `IntervalProd` instance'
@@ -1220,7 +1219,7 @@ def uniform_sampling_fromintv(intv_prod, num_nodes, nodes_on_bdry=True):
         raise ValueError('`nodes_on_bdry` has length {}, expected {}'
                          ''.format(len(nodes_on_bdry), intv_prod.ndim))
     else:
-        num_nodes = tuple(int(n) for n in num_nodes)
+        shape = tuple(int(n) for n in shape)
 
     # We need to determine the placement of the grid minimum and maximum
     # points based on the choices in nodes_on_bdry. If in a given axis,
@@ -1246,8 +1245,8 @@ def uniform_sampling_fromintv(intv_prod, num_nodes, nodes_on_bdry=True):
     # gmin = a + (b - a) / (2 * n - 1).
 
     gmin, gmax = [], []
-    for n, beg, end, on_bdry in zip(num_nodes, intv_prod.begin, intv_prod.end,
-                                    nodes_on_bdry):
+    for n, xmin, xmax, on_bdry in zip(shape, intv_prod.min_pt,
+                                      intv_prod.max_pt, nodes_on_bdry):
 
         # Unpack the tuple if possible, else use bool globally for this axis
         try:
@@ -1256,34 +1255,31 @@ def uniform_sampling_fromintv(intv_prod, num_nodes, nodes_on_bdry=True):
             bdry_l = bdry_r = on_bdry
 
         if bdry_l and bdry_r:
-            gmin.append(beg)
-            gmax.append(end)
+            gmin.append(xmin)
+            gmax.append(xmax)
         elif bdry_l and not bdry_r:
-            gmin.append(beg)
-            gmax.append(end - (end - beg) / (2 * n - 1))
+            gmin.append(xmin)
+            gmax.append(xmax - (xmax - xmin) / (2 * n - 1))
         elif not bdry_l and bdry_r:
-            gmin.append(beg + (end - beg) / (2 * n - 1))
-            gmax.append(end)
+            gmin.append(xmin + (xmax - xmin) / (2 * n - 1))
+            gmax.append(xmax)
         else:
-            gmin.append(beg + (end - beg) / (2 * n))
-            gmax.append(end - (end - beg) / (2 * n))
+            gmin.append(xmin + (xmax - xmin) / (2 * n))
+            gmax.append(xmax - (xmax - xmin) / (2 * n))
 
-    return RegularGrid(gmin, gmax, num_nodes)
+    return RegularGrid(gmin, gmax, shape)
 
 
-def uniform_sampling(begin, end, num_nodes, nodes_on_bdry=True):
+def uniform_sampling(min_pt, max_pt, shape, nodes_on_bdry=True):
     """Sample an implicitly defined interval product uniformly.
 
     Parameters
     ----------
-    begin : `array-like` or float
-        The lower ends of the intervals in the product
-    end : `array-like` or float
-        The upper ends of the intervals in the product
-    num_nodes : int or `sequence` of ints
-        Number of nodes per axis. For dimension >= 2, a tuple
-        is required. All entries must be positive. Entries
-        corresponding to degenerate axes must be equal to 1.
+    min_pt, max_pt : float or `array-like`
+        Vectors of lower/upper ends of the intervals in the product.
+    shape : int or `sequence` of ints
+        Number of nodes per axis. Entries corresponding to degenerate axes
+        must be equal to 1.
     nodes_on_bdry : bool or `sequence`, optional
         If a sequence is provided, it determines per axis whether to
         place the last grid point on the boundary (``True``) or shift it
@@ -1317,7 +1313,7 @@ def uniform_sampling(begin, end, num_nodes, nodes_on_bdry=True):
     >>> grid.coord_vectors
     (array([-1.25, -0.75]), array([ 2.25,  2.75]))
     """
-    return uniform_sampling_fromintv(IntervalProd(begin, end), num_nodes,
+    return uniform_sampling_fromintv(IntervalProd(min_pt, max_pt), shape,
                                      nodes_on_bdry=nodes_on_bdry)
 
 

--- a/odl/discr/lp_discr.py
+++ b/odl/discr/lp_discr.py
@@ -961,14 +961,20 @@ def uniform_discr_fromspace(fspace, shape, exponent=2.0, interp='nearest',
 
     Other Parameters
     ----------------
-    nodes_on_bdry : bool or boolean `array-like`, optional
-        If ``True``, place the outermost grid points at the boundary. For
-        ``False``, they are shifted by half a cell size to the 'inner'.
-        If an array-like object is given, it must have shape ``(ndim, 2)``,
-        where ``ndim`` is the number of dimensions. It defines per axis
-        whether the leftmost (first column) and rightmost (second column)
-        nodes node lie on the boundary.
-        Default: ``False``
+    nodes_on_bdry : bool or `sequence`, optional
+        If a sequence is provided, it determines per axis whether to
+        place the last grid point on the boundary (``True``) or shift it
+        by half a cell size into the interior (``False``). In each axis,
+        an entry may consist in a single bool or a 2-tuple of
+        bool. In the latter case, the first tuple entry decides for
+        the left, the second for the right boundary. The length of the
+        sequence must be ``len(shape)``.
+
+        A single boolean is interpreted as a global choice for all
+        boundaries.
+
+        Default: ``False``.
+
     order : {'C', 'F'}, optional
         Axis ordering in the data storage. Default: 'C'
     dtype : dtype, optional
@@ -977,9 +983,9 @@ def uniform_discr_fromspace(fspace, shape, exponent=2.0, interp='nearest',
     weighting : {'const', 'none'}, optional
         Weighting of the discretized space functions.
 
-            'const' : weight is a constant, the cell volume (default)
+            'const' : Weight is a constant, the cell volume (default).
 
-            'none' : no weighting
+            'none' : No weighting.
 
     Returns
     -------
@@ -1126,15 +1132,14 @@ def uniform_discr_fromintv(interval, shape, exponent=2.0, interp='nearest',
                                    **kwargs)
 
 
-def uniform_discr(min_pt, max_pt, shape,
-                  exponent=2.0, interp='nearest', impl='numpy', **kwargs):
+def uniform_discr(min_pt, max_pt, shape, exponent=2.0, interp='nearest',
+                  impl='numpy', **kwargs):
     """Discretize an Lp function space by uniform sampling.
 
     Parameters
     ----------
     min_pt, max_pt: float or `sequence` of floats
-        Minimum/maximum corners of the domain of the resulting spatial
-        domain.
+        Minimum/maximum corners of the desired function domain.
     shape : int or `sequence` of ints
         Number of samples per axis.
     exponent : positive float, optional
@@ -1157,11 +1162,12 @@ def uniform_discr(min_pt, max_pt, shape,
         an entry may consist in a single bool or a 2-tuple of
         bool. In the latter case, the first tuple entry decides for
         the left, the second for the right boundary. The length of the
-        sequence must be ``array.ndim``.
+        sequence must be ``len(shape)``.
 
         A single boolean is interpreted as a global choice for all
         boundaries.
-        Default: ``False``
+
+        Default: ``False``.
 
     dtype : dtype, optional
         Data type for the discretized space
@@ -1279,8 +1285,7 @@ def uniform_discr_fromdiscr(discr, min_pt=None, max_pt=None,
     discr : `DiscreteLp`
         Uniformly discretized space used as a template.
     min_pt, max_pt: float or `sequence` of floats
-        Minimum/maximum corners of the domain of the resulting spatial
-        domain.
+        Minimum/maximum corners of the desired function domain.
     shape : int or `sequence` of ints
         Number of samples per axis.
     exponent : positive float, optional
@@ -1310,7 +1315,8 @@ def uniform_discr_fromdiscr(discr, min_pt=None, max_pt=None,
 
         A single boolean is interpreted as a global choice for all
         boundaries.
-        Default: ``False``
+
+        Default: ``False``.
 
     dtype : optional
         Data type for the discretized space.

--- a/odl/discr/lp_discr.py
+++ b/odl/discr/lp_discr.py
@@ -165,14 +165,14 @@ class DiscreteLp(DiscretizedSpace):
         return self.__interp_by_axis
 
     @property
-    def min_corner(self):
+    def min_pt(self):
         """Vector of minimal coordinates of the function domain."""
-        return self.partition.begin
+        return self.partition.min_pt
 
     @property
-    def max_corner(self):
+    def max_pt(self):
         """Vector of maximal coordinates of the function domain."""
-        return self.partition.end
+        return self.partition.max_pt
 
     @property
     def order(self):
@@ -773,19 +773,20 @@ class DiscreteLpVector(DiscretizedSpaceVector):
             interv = self.space.uspace.domain
             shape = self.shape
             indices = []
-            for begin, end, n, coord in zip(interv.begin, interv.end,
-                                            shape, coords):
+            for axis, (xmin, xmax, n, coord) in enumerate(
+                    zip(interv.min_pt, interv.max_pt, shape, coords)):
                 if coord is None:
                     indices += [slice(None)]
                 else:
-                    if not begin <= coord <= end:
-                        raise ValueError('coord {} not in range {}'
-                                         ''.format(coord, [begin, end]))
+                    if not xmin <= coord <= xmax:
+                        raise ValueError('in axis {}: coordinate {} not in '
+                                         'the valid range {}'
+                                         ''.format(axis, coord, [xmin, xmax]))
 
-                    if begin == end:
+                    if xmin == xmax:
                         indices += [0]
                     else:
-                        normalized_pos = (float(coord) - begin) / (end - begin)
+                        normalized_pos = (float(coord) - xmin) / (xmax - xmin)
                         indices += [int(n * normalized_pos)]
 
         # Default to showing x-y slice "in the middle"
@@ -933,7 +934,7 @@ def uniform_discr_frompartition(partition, exponent=2.0, interp='nearest',
     return DiscreteLp(fspace, partition, dspace, exponent, interp, order=order)
 
 
-def uniform_discr_fromspace(fspace, nsamples, exponent=2.0, interp='nearest',
+def uniform_discr_fromspace(fspace, shape, exponent=2.0, interp='nearest',
                             impl='numpy', **kwargs):
     """Discretize an Lp function space by uniform partition.
 
@@ -942,9 +943,8 @@ def uniform_discr_fromspace(fspace, nsamples, exponent=2.0, interp='nearest',
     fspace : `FunctionSpace`
         Continuous function space. Its domain must be an
         `IntervalProd` instance.
-    nsamples : int or `sequence` of ints
-        Number of samples per axis. For dimension >= 2, a tuple is
-        required.
+    shape : int or `sequence` of ints
+        Number of samples per axis.
     exponent : positive float, optional
         The parameter ``p`` in ``L^p``. If the exponent is not
         equal to the default 2.0, the space has no inner product.
@@ -1035,14 +1035,14 @@ def uniform_discr_fromspace(fspace, nsamples, exponent=2.0, interp='nearest',
                          ''.format(fspace, dtype))
 
     nodes_on_bdry = kwargs.pop('nodes_on_bdry', False)
-    partition = uniform_partition_fromintv(fspace.domain, nsamples,
+    partition = uniform_partition_fromintv(fspace.domain, shape,
                                            nodes_on_bdry)
 
     return uniform_discr_frompartition(partition, exponent, interp, impl,
                                        dtype=dtype, **kwargs)
 
 
-def uniform_discr_fromintv(interval, nsamples, exponent=2.0, interp='nearest',
+def uniform_discr_fromintv(interval, shape, exponent=2.0, interp='nearest',
                            impl='numpy', **kwargs):
     """Discretize an Lp function space by uniform sampling.
 
@@ -1050,9 +1050,8 @@ def uniform_discr_fromintv(interval, nsamples, exponent=2.0, interp='nearest',
     ----------
     interval : `IntervalProd`
         The domain of the uniformly discretized space.
-    nsamples : int or `sequence` of ints
-        Number of samples per axis. For dimension >= 2, a tuple is
-        required.
+    shape : int or `sequence` of ints
+        Number of samples per axis.
     exponent : positive float, optional
         The parameter :math:`p` in :math:`L^p`. If the exponent is not
         equal to the default 2.0, the space has no inner product.
@@ -1123,22 +1122,21 @@ def uniform_discr_fromintv(interval, nsamples, exponent=2.0, interp='nearest',
         dtype = FN_IMPLS[impl].default_dtype()
 
     fspace = FunctionSpace(interval, out_dtype=dtype)
-    return uniform_discr_fromspace(fspace, nsamples, exponent, interp, impl,
+    return uniform_discr_fromspace(fspace, shape, exponent, interp, impl,
                                    **kwargs)
 
 
-def uniform_discr(min_corner, max_corner, nsamples,
+def uniform_discr(min_pt, max_pt, shape,
                   exponent=2.0, interp='nearest', impl='numpy', **kwargs):
     """Discretize an Lp function space by uniform sampling.
 
     Parameters
     ----------
-    min_corner, max_corner : float or `sequence` of floats
-        Minimum/maximum corners of the domain of the resulting space.
-        For dimension >= 2, sequences are required.
-    nsamples : int or `sequence` of ints
-        Number of samples per axis. For dimension >= 2, a sequence is
-        required.
+    min_pt, max_pt: float or `sequence` of floats
+        Minimum/maximum corners of the domain of the resulting spatial
+        domain.
+    shape : int or `sequence` of ints
+        Number of samples per axis.
     exponent : positive float, optional
         The parameter :math:`p` in :math:`L^p`. If the exponent is not
         equal to the default 2.0, the space has no inner product.
@@ -1210,8 +1208,8 @@ def uniform_discr(min_corner, max_corner, nsamples,
     uniform_discr_fromintv : uniform discretization from an existing
         interval product
     """
-    interval = IntervalProd(min_corner, max_corner)
-    return uniform_discr_fromintv(interval, nsamples, exponent, interp, impl,
+    interval = IntervalProd(min_pt, max_pt)
+    return uniform_discr_fromintv(interval, shape, exponent, interp, impl,
                                   **kwargs)
 
 
@@ -1224,8 +1222,8 @@ def discr_sequence_space(shape, exponent=2.0, impl='numpy', **kwargs):
 
     Parameters
     ----------
-    shape : `sequence` of ints
-        Multi-dimensional size of the elements in this space
+    shape : int or `sequence` of ints
+        Number of element entries per axis.
     exponent : positive float, optional
         The parameter ``p`` in ```L^p``. If the exponent is
         not equal to the default 2.0, the space has no inner
@@ -1267,8 +1265,8 @@ def discr_sequence_space(shape, exponent=2.0, impl='numpy', **kwargs):
                          weighting='none', **kwargs)
 
 
-def uniform_discr_fromdiscr(discr, min_corner=None, max_corner=None,
-                            nsamples=None, cell_sides=None, exponent=2.0,
+def uniform_discr_fromdiscr(discr, min_pt=None, max_pt=None,
+                            shape=None, cell_sides=None, exponent=2.0,
                             interp='nearest', impl='numpy', **kwargs):
     """Return a discretization based on an existing one.
 
@@ -1280,11 +1278,10 @@ def uniform_discr_fromdiscr(discr, min_corner=None, max_corner=None,
     ----------
     discr : `DiscreteLp`
         Uniformly discretized space used as a template.
-    min_corner : float or `sequence` of floats
-        Minimum corner of the resulting spatial domain.
-    max_corner : float or `sequence` of floats
-        Maximum corner of the resulting spatial domain.
-    nsamples : int or `sequence` of ints
+    min_pt, max_pt: float or `sequence` of floats
+        Minimum/maximum corners of the domain of the resulting spatial
+        domain.
+    shape : int or `sequence` of ints
         Number of samples per axis.
     exponent : positive float, optional
         The parameter :math:`p` in :math:`L^p`. If the exponent is not
@@ -1336,7 +1333,7 @@ def uniform_discr_fromdiscr(discr, min_corner=None, max_corner=None,
 
     Notes
     -----
-    The parameters ``min_corner``, ``max_corner``, ``nsamples`` and
+    The parameters ``min_pt``, ``max_pt``, ``shape`` and
     ``cell_sides`` can be combined in the following ways (applies in
     each axis individually):
 
@@ -1344,20 +1341,20 @@ def uniform_discr_fromdiscr(discr, min_corner=None, max_corner=None,
         Return a copy of ``discr``
 
     **1 argument:**
-        [min,max]_corner -> keep sampling but translate domain so it
-        starts/ends at ``[min,max]_corner``
+        [min,max]_pt -> keep sampling but translate domain so it
+        starts/ends at ``[min,max]_pt``
 
-        nsamples/cell_sides -> keep domain but change sampling.
+        shape/cell_sides -> keep domain but change sampling.
         See `uniform_partition` for restrictions.
 
     **2 arguments:**
-        min_corner + max_corner -> translate and resample with the same
+        min_pt + max_pt -> translate and resample with the same
         number of samples
 
-        [min,max]_corner + nsamples/cell_sides -> translate and resample
+        [min,max]_pt + shape/cell_sides -> translate and resample
 
-        nsamples + cell_sides -> error due to ambiguity (keep
-        ``min_corner`` or ``max_corner``?)
+        shape + cell_sides -> error due to ambiguity (keep
+        ``min_pt`` or ``max_pt``?)
 
     **3+ arguments:**
         The underlying partition is uniquely determined by the new
@@ -1381,41 +1378,41 @@ def uniform_discr_fromdiscr(discr, min_corner=None, max_corner=None,
     >>> uniform_discr_fromdiscr(discr) is discr
     False
 
-    Giving ``min_corner`` or ``max_corner`` results in a
+    Giving ``min_pt`` or ``max_pt`` results in a
     translation, while for the other two options, the domain
     is kept but re-partitioned:
 
-    >>> uniform_discr_fromdiscr(discr, min_corner=[1, 1])
+    >>> uniform_discr_fromdiscr(discr, min_pt=[1, 1])
     uniform_discr([1.0, 1.0], [2.0, 3.0], [10, 5])
-    >>> uniform_discr_fromdiscr(discr, max_corner=[0, 0])
+    >>> uniform_discr_fromdiscr(discr, max_pt=[0, 0])
     uniform_discr([-1.0, -2.0], [0.0, 0.0], [10, 5])
     >>> uniform_discr_fromdiscr(discr, cell_sides=[1, 1])
     uniform_discr([0.0, 0.0], [1.0, 2.0], [1, 2])
-    >>> uniform_discr_fromdiscr(discr, nsamples=[5, 5])
+    >>> uniform_discr_fromdiscr(discr, shape=[5, 5])
     uniform_discr([0.0, 0.0], [1.0, 2.0], [5, 5])
-    >>> uniform_discr_fromdiscr(discr, nsamples=[5, 5]).cell_sides
+    >>> uniform_discr_fromdiscr(discr, shape=[5, 5]).cell_sides
     array([ 0.2,  0.4])
 
     The cases with 2 or more additional arguments and the syntax
     for specifying quantities per axis is illustrated in the following:
 
-    # axis 0: translate to match max_corner = 3
-    # axis 1: recompute max_corner using the original nsamples with the
-    # new min_corner and cell_sides
-    >>> new_discr = uniform_discr_fromdiscr(discr, min_corner=[None, 1],
-    ...                                     max_corner=[3, None],
+    # axis 0: translate to match max_pt = 3
+    # axis 1: recompute max_pt using the original shape with the
+    # new min_pt and cell_sides
+    >>> new_discr = uniform_discr_fromdiscr(discr, min_pt=[None, 1],
+    ...                                     max_pt=[3, None],
     ...                                     cell_sides=[None, 0.25])
     >>> new_discr
     uniform_discr([2.0, 1.0], [3.0, 2.25], [10, 5])
     >>> new_discr.cell_sides
     array([ 0.1 ,  0.25])
 
-    # axis 0: recompute min_corner from old cell_sides and new
-    # max_corner and nsamples
-    # axis 1: use new min_corner, nsamples and cell_sides only
-    >>> new_discr = uniform_discr_fromdiscr(discr, min_corner=[None, 1],
-    ...                                     max_corner=[3, None],
-    ...                                     nsamples=[5, 5],
+    # axis 0: recompute min_pt from old cell_sides and new
+    # max_pt and shape
+    # axis 1: use new min_pt, shape and cell_sides only
+    >>> new_discr = uniform_discr_fromdiscr(discr, min_pt=[None, 1],
+    ...                                     max_pt=[3, None],
+    ...                                     shape=[5, 5],
     ...                                     cell_sides=[None, 0.25])
     >>> new_discr
     uniform_discr([2.5, 1.0], [3.0, 2.25], [5, 5])
@@ -1430,68 +1427,68 @@ def uniform_discr_fromdiscr(discr, min_corner=None, max_corner=None,
                          ''.format(discr))
 
     # Normalize partition parameters
-    min_corner = normalized_scalar_param_list(min_corner, discr.ndim,
-                                              param_conv=float, keep_none=True)
-    max_corner = normalized_scalar_param_list(max_corner, discr.ndim,
-                                              param_conv=float, keep_none=True)
-    nsamples = normalized_scalar_param_list(nsamples, discr.ndim,
-                                            param_conv=safe_int_conv,
-                                            keep_none=True)
+    min_pt = normalized_scalar_param_list(min_pt, discr.ndim,
+                                          param_conv=float, keep_none=True)
+    max_pt = normalized_scalar_param_list(max_pt, discr.ndim,
+                                          param_conv=float, keep_none=True)
+    shape = normalized_scalar_param_list(shape, discr.ndim,
+                                         param_conv=safe_int_conv,
+                                         keep_none=True)
     cell_sides = normalized_scalar_param_list(cell_sides, discr.ndim,
                                               param_conv=float, keep_none=True)
 
     nodes_on_bdry = kwargs.pop('nodes_on_bdry', False)
     nodes_on_bdry = normalized_nodes_on_bdry(nodes_on_bdry, discr.ndim)
 
-    new_beg = []
-    new_end = []
+    new_min_pt = []
+    new_max_pt = []
     new_shape = []
     new_csides = []
-    for i, (b, e, n, s, old_b, old_e, old_n, old_s) in enumerate(
-            zip(min_corner, max_corner, nsamples, cell_sides,
-                discr.min_corner, discr.max_corner, discr.shape,
+    for i, (xmin, xmax, n, s, old_xmin, old_xmax, old_n, old_s) in enumerate(
+            zip(min_pt, max_pt, shape, cell_sides,
+                discr.min_pt, discr.max_pt, discr.shape,
                 discr.cell_sides)):
-        num_params = sum(p is not None for p in (b, e, n, s))
+        num_params = sum(p is not None for p in (xmin, xmax, n, s))
 
         if num_params == 0:
-            new_params = [old_b, old_e, old_n, None]
+            new_params = [old_xmin, old_xmax, old_n, None]
 
         elif num_params == 1:
-            if b is not None:
-                new_params = [b, old_e + (b - old_b), old_n, None]
-            elif e is not None:
-                new_params = [old_b + (e - old_e), e, old_n, None]
+            if xmin is not None:
+                new_params = [xmin, old_xmax + (xmin - old_xmin), old_n, None]
+            elif xmax is not None:
+                new_params = [old_xmin + (xmax - old_xmax), xmax, old_n, None]
             elif n is not None:
-                new_params = [old_b, old_e, n, None]
+                new_params = [old_xmin, old_xmax, n, None]
             else:
-                new_params = [old_b, old_e, None, s]
+                new_params = [old_xmin, old_xmax, None, s]
 
         elif num_params == 2:
-            if b is not None and e is not None:
-                new_params = [b, e, old_n, None]
-            elif b is not None and n is not None:
-                new_params = [b, None, n, old_s]
-            elif b is not None and s is not None:
-                new_params = [b, None, old_n, s]
-            elif e is not None and n is not None:
-                new_params = [None, e, n, old_s]
-            elif e is not None and s is not None:
-                new_params = [None, e, old_n, s]
+            if xmin is not None and xmax is not None:
+                new_params = [xmin, xmax, old_n, None]
+            elif xmin is not None and n is not None:
+                new_params = [xmin, None, n, old_s]
+            elif xmin is not None and s is not None:
+                new_params = [xmin, None, old_n, s]
+            elif xmax is not None and n is not None:
+                new_params = [None, xmax, n, old_s]
+            elif xmax is not None and s is not None:
+                new_params = [None, xmax, old_n, s]
             else:
-                raise ValueError('in axis {}: cannot use `nsamples` and '
+                raise ValueError('in axis {}: cannot use `shape` and '
                                  '`cell_size` only due to ambiguous values '
-                                 'for begin and end.'.format(i))
+                                 'for `min_pt` and `max_pt`.'.format(i))
 
         else:
-            new_params = [b, e, n, s]
+            new_params = [xmin, xmax, n, s]
 
-        new_beg.append(new_params[0])
-        new_end.append(new_params[1])
+        new_min_pt.append(new_params[0])
+        new_max_pt.append(new_params[1])
         new_shape.append(new_params[2])
         new_csides.append(new_params[3])
 
-    new_part = uniform_partition(begin=new_beg, end=new_end,
-                                 num_nodes=new_shape,
+    new_part = uniform_partition(min_pt=new_min_pt, max_pt=new_max_pt,
+                                 shape=new_shape,
                                  cell_sides=new_csides,
                                  nodes_on_bdry=nodes_on_bdry)
 

--- a/odl/discr/partition.py
+++ b/odl/discr/partition.py
@@ -578,7 +578,7 @@ def uniform_partition_fromintv(intv_prod, shape, nodes_on_bdry=False):
         an entry may consist in a single bool or a 2-tuple of
         bool. In the latter case, the first tuple entry decides for
         the left, the second for the right boundary. The length of the
-        sequence must be ``array.ndim``.
+        sequence must be ``intv_prod.ndim``.
 
         A single boolean is interpreted as a global choice for all
         boundaries.
@@ -640,12 +640,12 @@ def uniform_partition_fromgrid(grid, min_pt=None, max_pt=None):
     ----------
     grid : `TensorGrid`
         Grid on which the partition is based
-    min_pt, max_pt : `array-like` or dict
-        Spatial points defining the lower and upper limits of the intervals
+    min_pt, max_pt : float, `sequence` of float, or dict
+        Spatial points defining the lower/upper limits of the intervals
         to be partitioned. The points can be specified in two ways:
 
-        array-like: These values are used directly as ``min_pt`` and/or
-        ``max_pt``.
+        float or sequence: The values are used directly as ``min_pt``
+        and/or ``max_pt``.
 
         dict: Index-value pairs specifying an axis and a spatial
         coordinate to be used in that axis. In axes which are not a key
@@ -678,7 +678,7 @@ def uniform_partition_fromgrid(grid, min_pt=None, max_pt=None):
     >>> part.cell_boundary_vecs
     (array([-0.25,  0.25,  0.75,  1.25]),)
 
-    ``min_pt`` and ``max_pt`` can be given explicitly as array-like:
+    ``min_pt`` and ``max_pt`` can be given explicitly:
 
     >>> part = uniform_partition_fromgrid(grid, min_pt=0, max_pt=1)
     >>> part.cell_boundary_vecs
@@ -739,20 +739,20 @@ def uniform_partition_fromgrid(grid, min_pt=None, max_pt=None):
     return RectPartition(IntervalProd(min_pt_vec, max_pt_vec), grid)
 
 
-def uniform_partition(min_pt=None, max_pt=None, shape=None,
-                      cell_sides=None, nodes_on_bdry=False):
+def uniform_partition(min_pt=None, max_pt=None, shape=None, cell_sides=None,
+                      nodes_on_bdry=False):
     """Return a partition with equally sized cells.
 
     Parameters
     ----------
-    min_pt, max_pt : float or array-like, optional
-        Vectors defining the lower and upper limits of intervals in an
+    min_pt, max_pt : float or `sequence` of float, optional
+        Vectors defining the lower/upper limits of the intervals in an
         `IntervalProd` (a rectangular box). ``None`` entries mean
         "compute the value".
     shape : int or `sequence` of ints, optional
         Number of nodes per axis. ``None`` entries mean
         "compute the value".
-    cell_sides : float or `array-like`, optional
+    cell_sides : float or `sequence` of float, optional
         Side length of the partition cells per axis. ``None`` entries mean
         "compute the value".
     nodes_on_bdry : bool or `sequence`, optional

--- a/odl/discr/partition.py
+++ b/odl/discr/partition.py
@@ -39,8 +39,6 @@ from odl.util.normalize import normalized_index_expression
 __all__ = ('RectPartition', 'uniform_partition_fromintv',
            'uniform_partition_fromgrid', 'uniform_partition')
 
-_POINT_POSITIONS = ('center', 'left')
-
 
 class RectPartition(object):
 
@@ -121,14 +119,19 @@ class RectPartition(object):
     # IntervalProd related pass-through methods and derived properties
     # min, max and extent are for duck-typing purposes
     @property
-    def begin(self):
+    def min_pt(self):
         """Minimum coordinates of the partitioned set."""
-        return self.set.begin
+        return self.set.min_pt
 
     @property
-    def end(self):
+    def max_pt(self):
         """Maximum coordinates of the partitioned set."""
-        return self.set.end
+        return self.set.max_pt
+
+    @property
+    def mid_pt(self):
+        """Midpoint of the partitioned set."""
+        return self.set.mid_pt
 
     def min(self):
         """Return the minimum point of the partitioned set.
@@ -256,7 +259,7 @@ class RectPartition(object):
         """
         frac_list = []
         for ax, (cvec, bmin, bmax) in enumerate(zip(
-                self.grid.coord_vectors, self.set.begin, self.set.end)):
+                self.grid.coord_vectors, self.set.min_pt, self.set.max_pt)):
             # Degenerate axes have a value of 1.0 (this is used as weight
             # in integration formulas later)
             if len(cvec) == 1:
@@ -310,7 +313,7 @@ class RectPartition(object):
 
     @property
     def cell_sides(self):
-        """Side lengths of all 'inner' cells of a regular partition.
+        """Side lengths of all 'inner' cells of a uniform partition.
 
         Only defined if ``self.grid`` is a `RegularGrid`.
 
@@ -338,7 +341,7 @@ class RectPartition(object):
 
     @property
     def cell_volume(self):
-        """Volume of the 'inner' cells, regardless of begin and end.
+        """Volume of the 'inner' cells of a uniform partition.
 
         Only defined if ``self.grid`` is a `RegularGrid`.
 
@@ -427,29 +430,29 @@ class RectPartition(object):
         """
         # Special case of index list: slice along first axis
         if isinstance(indices, list):
-            new_begin = [self.cell_boundary_vecs[0][:-1][indices][0]]
-            new_end = [self.cell_boundary_vecs[0][1:][indices][-1]]
+            new_min_pt = [self.cell_boundary_vecs[0][:-1][indices][0]]
+            new_max_pt = [self.cell_boundary_vecs[0][1:][indices][-1]]
             for cvec in self.cell_boundary_vecs[1:]:
-                new_begin.append(cvec[0])
-                new_end.append(cvec[-1])
+                new_min_pt.append(cvec[0])
+                new_max_pt.append(cvec[-1])
 
-            new_intvp = IntervalProd(new_begin, new_end)
+            new_intvp = IntervalProd(new_min_pt, new_max_pt)
             new_grid = self.grid[indices]
             return RectPartition(new_intvp, new_grid)
 
         indices = normalized_index_expression(indices, self.shape,
                                               int_to_slice=True)
         # Build the new partition
-        new_begin, new_end = [], []
+        new_min_pt, new_max_pt = [], []
         for cvec, idx in zip(self.cell_boundary_vecs, indices):
-            # Determine the subinterval begin and end vectors. Take the
-            # first begin as new begin and the last end as new end.
-            sub_begin = cvec[:-1][idx]
-            sub_end = cvec[1:][idx]
-            new_begin.append(sub_begin[0])
-            new_end.append(sub_end[-1])
+            # Determine the subinterval min_pt and max_pt vectors. Take the
+            # first min_pt as new min_pt and the last max_pt as new max_pt.
+            sub_min_pt = cvec[:-1][idx]
+            sub_max_pt = cvec[1:][idx]
+            new_min_pt.append(sub_min_pt[0])
+            new_max_pt.append(sub_max_pt[-1])
 
-        new_intvp = IntervalProd(new_begin, new_end)
+        new_intvp = IntervalProd(new_min_pt, new_max_pt)
         new_grid = self.grid[indices]
         return RectPartition(new_intvp, new_grid)
 
@@ -545,12 +548,12 @@ class RectPartition(object):
         if uniform_partition_fromintv(self.set, self.shape) == self:
 
             if self.ndim == 1:
-                inner_str = '{}, {}, {}'.format(float(self.set.begin),
-                                                float(self.set.end),
+                inner_str = '{}, {}, {}'.format(float(self.set.min_pt),
+                                                float(self.set.max_pt),
                                                 self.size)
             else:
-                inner_str = '{}, {}, {}'.format(list(self.set.begin),
-                                                list(self.set.end),
+                inner_str = '{}, {}, {}'.format(list(self.set.min_pt),
+                                                list(self.set.max_pt),
                                                 list(self.shape))
             return 'uniform_partition({})'.format(inner_str)
         else:
@@ -558,14 +561,14 @@ class RectPartition(object):
             return '{}({})'.format(self.__class__.__name__, inner_str)
 
 
-def uniform_partition_fromintv(intv_prod, num_nodes, nodes_on_bdry=False):
+def uniform_partition_fromintv(intv_prod, shape, nodes_on_bdry=False):
     """Return a partition of an interval product into equally sized cells.
 
     Parameters
     ----------
     intv_prod : `IntervalProd`
         Interval product to be partitioned
-    num_nodes : int or `sequence` of ints
+    shape : int or `sequence` of ints
         Number of nodes per axis. For 1d intervals, a single integer
         can be specified.
     nodes_on_bdry : bool or `sequence`, optional
@@ -620,43 +623,42 @@ def uniform_partition_fromintv(intv_prod, num_nodes, nodes_on_bdry=False):
     array([ 0.2,  0.6,  1. ])
     """
 
-    grid = uniform_sampling_fromintv(intv_prod, num_nodes,
+    grid = uniform_sampling_fromintv(intv_prod, shape,
                                      nodes_on_bdry=nodes_on_bdry)
 
     return RectPartition(intv_prod, grid)
 
 
-def uniform_partition_fromgrid(grid, begin=None, end=None):
+def uniform_partition_fromgrid(grid, min_pt=None, max_pt=None):
     """Return a partition of an interval product based on a given grid.
 
-    This method is complementary to
-    `uniform_partition_fromintv` in that it infers the
-    set to be partitioned from a given grid and optional parameters
-    for the begin and the end of the set.
+    This method is complementary to `uniform_partition_fromintv` in that
+    it infers the set to be partitioned from a given grid and optional
+    parameters for ``min_pt`` and ``max_pt`` of the set.
 
     Parameters
     ----------
     grid : `TensorGrid`
         Grid on which the partition is based
-    begin, end : `array-like` or dict
-        Spatial points defining the begin and end of an interval
-        product to be partitioned. The points can be specified in
-        two ways:
+    min_pt, max_pt : `array-like` or dict
+        Spatial points defining the lower and upper limits of the intervals
+        to be partitioned. The points can be specified in two ways:
 
-        array-like: These values are used directly as begin and/or end.
+        array-like: These values are used directly as ``min_pt`` and/or
+        ``max_pt``.
 
         dict: Index-value pairs specifying an axis and a spatial
         coordinate to be used in that axis. In axes which are not a key
         in the dictionary, the coordinate for the vector is calculated
         as::
 
-            begin = x[0] - (x[1] - x[0]) / 2
-            end = x[-1] + (x[-1] - x[-2]) / 2
+            min_pt = x[0] - (x[1] - x[0]) / 2
+            max_pt = x[-1] + (x[-1] - x[-2]) / 2
 
         See ``Examples`` below.
 
-        In general, ``begin`` may not be larger than ``grid.min_pt``,
-        and ``end`` not smaller than ``grid.max_pt`` in any component.
+        In general, ``min_pt`` may not be larger than ``grid.min_pt``,
+        and ``max_pt`` not smaller than ``grid.max_pt`` in any component.
         ``None`` is equivalent to an empty dictionary, i.e. the values
         are calculated in each dimension.
 
@@ -666,7 +668,8 @@ def uniform_partition_fromgrid(grid, begin=None, end=None):
 
     Examples
     --------
-    Have begin and end of the bounding box automatically calculated:
+    Have ``min_pt`` and ``max_pt`` of the bounding box automatically
+    calculated:
 
     >>> grid = RegularGrid(0, 1, 3)
     >>> grid.coord_vectors
@@ -675,9 +678,9 @@ def uniform_partition_fromgrid(grid, begin=None, end=None):
     >>> part.cell_boundary_vecs
     (array([-0.25,  0.25,  0.75,  1.25]),)
 
-    Begin and end can be given explicitly as array-like:
+    ``min_pt`` and ``max_pt`` can be given explicitly as array-like:
 
-    >>> part = uniform_partition_fromgrid(grid, begin=0, end=1)
+    >>> part = uniform_partition_fromgrid(grid, min_pt=0, max_pt=1)
     >>> part.cell_boundary_vecs
     (array([ 0.  ,  0.25,  0.75,  1.  ]),)
 
@@ -685,73 +688,72 @@ def uniform_partition_fromgrid(grid, begin=None, end=None):
     keys refer to axes, the values to the coordinates to use:
 
     >>> grid = RegularGrid([0, 0], [1, 1], (3, 3))
-    >>> part = uniform_partition_fromgrid(grid, begin={0: -1}, end={-1: 3})
+    >>> part = uniform_partition_fromgrid(grid, min_pt={0: -1}, max_pt={-1: 3})
     >>> part.cell_boundary_vecs[0]
     array([-1.  ,  0.25,  0.75,  1.25])
     >>> part.cell_boundary_vecs[1]
     array([-0.25,  0.25,  0.75,  3.  ])
     """
-    # Make dictionaries from begin and end and fill with None where no value
-    # is given.
-    if begin is None:
-        begin = {i: None for i in range(grid.ndim)}
-    elif not hasattr(begin, 'items'):  # array-like
-        begin = np.atleast_1d(begin)
-        begin = {i: float(v) for i, v in enumerate(begin)}
+    # Make dictionaries from min_pt and max_pt and fill with None where no
+    # value is given.
+    if min_pt is None:
+        min_pt = {i: None for i in range(grid.ndim)}
+    elif not hasattr(min_pt, 'items'):  # array-like
+        min_pt = np.atleast_1d(min_pt)
+        min_pt = {i: float(v) for i, v in enumerate(min_pt)}
     else:
-        begin.update({i: None for i in range(grid.ndim) if i not in begin})
+        min_pt.update({i: None for i in range(grid.ndim) if i not in min_pt})
 
-    if end is None:
-        end = {i: None for i in range(grid.ndim)}
-    elif not hasattr(end, 'items'):
-        end = np.atleast_1d(end)
-        end = {i: float(v) for i, v in enumerate(end)}
+    if max_pt is None:
+        max_pt = {i: None for i in range(grid.ndim)}
+    elif not hasattr(max_pt, 'items'):
+        max_pt = np.atleast_1d(max_pt)
+        max_pt = {i: float(v) for i, v in enumerate(max_pt)}
     else:
-        end.update({i: None for i in range(grid.ndim) if i not in end})
+        max_pt.update({i: None for i in range(grid.ndim) if i not in max_pt})
 
     # Set the values in the vectors by computing (None) or directly from the
     # given vectors (otherwise).
-    begin_vec = np.empty(grid.ndim)
-    for ax, beg_val in begin.items():
-        if beg_val is None:
+    min_pt_vec = np.empty(grid.ndim)
+    for ax, xmin in min_pt.items():
+        if xmin is None:
             cvec = grid.coord_vectors[ax]
             if len(cvec) == 1:
-                raise ValueError('cannot calculate begin in axis {} with '
+                raise ValueError('in axis {}: cannot calculate `min_pt` with '
                                  'only 1 grid point'.format(ax))
-            begin_vec[ax] = cvec[0] - (cvec[1] - cvec[0]) / 2
+            min_pt_vec[ax] = cvec[0] - (cvec[1] - cvec[0]) / 2
         else:
-            begin_vec[ax] = beg_val
+            min_pt_vec[ax] = xmin
 
-    end_vec = np.empty(grid.ndim)
-    for ax, end_val in end.items():
-        if end_val is None:
+    max_pt_vec = np.empty(grid.ndim)
+    for ax, xmax in max_pt.items():
+        if xmax is None:
             cvec = grid.coord_vectors[ax]
             if len(cvec) == 1:
-                raise ValueError('cannot calculate end in axis {} with '
+                raise ValueError('in axis {}: cannot calculate `max_pt` with '
                                  'only 1 grid point'.format(ax))
-            end_vec[ax] = cvec[-1] + (cvec[-1] - cvec[-2]) / 2
+            max_pt_vec[ax] = cvec[-1] + (cvec[-1] - cvec[-2]) / 2
         else:
-            end_vec[ax] = end_val
+            max_pt_vec[ax] = xmax
 
-    return RectPartition(IntervalProd(begin_vec, end_vec), grid)
+    return RectPartition(IntervalProd(min_pt_vec, max_pt_vec), grid)
 
 
-def uniform_partition(begin=None, end=None, num_nodes=None,
+def uniform_partition(min_pt=None, max_pt=None, shape=None,
                       cell_sides=None, nodes_on_bdry=False):
     """Return a partition with equally sized cells.
 
     Parameters
     ----------
-    begin, end : float or `array-like`, optional
-        Vectors defining the begin end end points of an `IntervalProd`
-        (a rectangular box). For one-dimensional partitions, single
-        floats can be provided. ``None`` entries mean "compute the value".
-    num_nodes : int or `sequence` of ints, optional
-        Number of nodes per axis. For 1d intervals, a single integer
-        can be specified. ``None`` entries mean "compute the value".
+    min_pt, max_pt : float or array-like, optional
+        Vectors defining the lower and upper limits of intervals in an
+        `IntervalProd` (a rectangular box). ``None`` entries mean
+        "compute the value".
+    shape : int or `sequence` of ints, optional
+        Number of nodes per axis. ``None`` entries mean
+        "compute the value".
     cell_sides : float or `array-like`, optional
-        Side length of the partition cells per axis. For 1d intervals,
-        a single integer can be specified. ``None`` entries mean
+        Side length of the partition cells per axis. ``None`` entries mean
         "compute the value".
     nodes_on_bdry : bool or `sequence`, optional
         If a sequence is provided, it determines per axis whether to
@@ -767,8 +769,8 @@ def uniform_partition(begin=None, end=None, num_nodes=None,
 
     Notes
     -----
-    In each axis, 3 of the 4 possible parameters ``begin``, ``end``,
-    ``num_nodes`` and ``cell_sides`` must be given. If all four are
+    In each axis, 3 of the 4 possible parameters ``min_pt``, ``max_pt``,
+    ``shape`` and ``cell_sides`` must be given. If all four are
     provided, they are checked for consistency.
 
     See also
@@ -781,34 +783,31 @@ def uniform_partition(begin=None, end=None, num_nodes=None,
     Any combination of three of the four parameters can be used for
     creation of a partition:
 
-    >>> part = uniform_partition(begin=0, end=2, num_nodes=4)
+    >>> part = uniform_partition(min_pt=0, max_pt=2, shape=4)
     >>> part.cell_boundary_vecs
     (array([ 0. ,  0.5,  1. ,  1.5,  2. ]),)
-    >>> part = uniform_partition(begin=0, num_nodes=4, cell_sides=0.5)
+    >>> part = uniform_partition(min_pt=0, shape=4, cell_sides=0.5)
     >>> part.cell_boundary_vecs
     (array([ 0. ,  0.5,  1. ,  1.5,  2. ]),)
-    >>> part = uniform_partition(end=2, num_nodes=4, cell_sides=0.5)
+    >>> part = uniform_partition(max_pt=2, shape=4, cell_sides=0.5)
     >>> part.cell_boundary_vecs
     (array([ 0. ,  0.5,  1. ,  1.5,  2. ]),)
-    >>> part = uniform_partition(begin=0, end=2, cell_sides=0.5)
+    >>> part = uniform_partition(min_pt=0, max_pt=2, cell_sides=0.5)
     >>> part.cell_boundary_vecs
     (array([ 0. ,  0.5,  1. ,  1.5,  2. ]),)
 
     In higher dimensions, the parameters can be given differently in
     each axis. Where ``None`` is given, the value will be computed:
 
-    >>> part = uniform_partition(begin=[0, 0], end=[1, 2],
-    ...                          num_nodes=[4, 2])
+    >>> part = uniform_partition(min_pt=[0, 0], max_pt=[1, 2], shape=[4, 2])
     >>> part.cell_boundary_vecs
     (array([ 0.  ,  0.25,  0.5 ,  0.75,  1.  ]), array([ 0.,  1.,  2.]))
-    >>> part = uniform_partition(begin=[0, 0], end=[1, 2],
-    ...                          num_nodes=[None, 2],
-    ...                          cell_sides=[0.25, None])
+    >>> part = uniform_partition(min_pt=[0, 0], max_pt=[1, 2],
+    ...                          shape=[None, 2], cell_sides=[0.25, None])
     >>> part.cell_boundary_vecs
     (array([ 0.  ,  0.25,  0.5 ,  0.75,  1.  ]), array([ 0.,  1.,  2.]))
-    >>> part = uniform_partition(begin=[0, None], end=[None, 2],
-    ...                          num_nodes=[4, 2],
-    ...                          cell_sides=[0.25, 1])
+    >>> part = uniform_partition(min_pt=[0, None], max_pt=[None, 2],
+    ...                          shape=[4, 2], cell_sides=[0.25, 1])
     >>> part.cell_boundary_vecs
     (array([ 0.  ,  0.25,  0.5 ,  0.75,  1.  ]), array([ 0.,  1.,  2.]))
 
@@ -846,33 +845,33 @@ def uniform_partition(begin=None, end=None, num_nodes=None,
     # Normalize partition parameters
 
     # np.size(None) == 1
-    sizes = [np.size(p) for p in (begin, end, num_nodes, cell_sides)]
+    sizes = [np.size(p) for p in (min_pt, max_pt, shape, cell_sides)]
     ndim = int(np.max(sizes))
 
     if ndim == 1:
-        begin = [begin]
-        end = [end]
-        num_nodes = [num_nodes]
+        min_pt = [min_pt]
+        max_pt = [max_pt]
+        shape = [shape]
         cell_sides = [cell_sides]
     else:
-        if begin is None:
-            begin = [None] * ndim
-        if end is None:
-            end = [None] * ndim
-        if num_nodes is None:
-            num_nodes = [None] * ndim
+        if min_pt is None:
+            min_pt = [None] * ndim
+        if max_pt is None:
+            max_pt = [None] * ndim
+        if shape is None:
+            shape = [None] * ndim
         if cell_sides is None:
             cell_sides = [None] * ndim
 
-        begin = list(begin)
-        end = list(end)
-        num_nodes = list(num_nodes)
+        min_pt = list(min_pt)
+        max_pt = list(max_pt)
+        shape = list(shape)
         cell_sides = list(cell_sides)
-        sizes = [len(p) for p in (begin, end, num_nodes, cell_sides)]
+        sizes = [len(p) for p in (min_pt, max_pt, shape, cell_sides)]
 
         if not all(s == ndim for s in sizes):
             raise ValueError('inconsistent sizes {}, {}, {}, {} of '
-                             'arguments `begin`, `end`, `num_nodes`, '
+                             'arguments `min_pt`, `max_pt`, `shape`, '
                              '`cell_sides`'.format(*sizes))
 
     # Normalize nodes_on_bdry
@@ -884,13 +883,13 @@ def uniform_partition(begin=None, end=None, num_nodes=None,
         raise ValueError('nodes_on_bdry has length {}, expected {}.'
                          ''.format(len(nodes_on_bdry), ndim))
 
-    # Calculate the missing parameters in begin, end, num_nodes
-    for i, (b, e, n, s, on_bdry) in enumerate(zip(begin, end, num_nodes,
-                                                  cell_sides, nodes_on_bdry)):
-        num_params = sum(p is not None for p in (b, e, n, s))
+    # Calculate the missing parameters in min_pt, max_pt, shape
+    for i, (xmin, xmax, n, dx, on_bdry) in enumerate(
+            zip(min_pt, max_pt, shape, cell_sides, nodes_on_bdry)):
+        num_params = sum(p is not None for p in (xmin, xmax, n, dx))
         if num_params < 3:
             raise ValueError('in axis {}: expected at least 3 of the '
-                             'parameters `begin`, `end`, `num_nodes`, '
+                             'parameters `min_pt`, `max_pt`, `shape`, '
                              '`cell_sides`, got {}'
                              ''.format(i, num_params))
 
@@ -901,32 +900,32 @@ def uniform_partition(begin=None, end=None, num_nodes=None,
             bdry_l = bdry_r = on_bdry
 
         # For each node on the boundary, we subtract 1/2 from the number of
-        # full cells between begin and end.
-        if b is None:
-            begin[i] = e - (n - sum([bdry_l, bdry_r]) / 2.0) * s
-        elif e is None:
-            end[i] = b + (n - sum([bdry_l, bdry_r]) / 2.0) * s
+        # full cells between min_pt and max_pt.
+        if xmin is None:
+            min_pt[i] = xmax - (n - sum([bdry_l, bdry_r]) / 2.0) * dx
+        elif xmax is None:
+            max_pt[i] = xmin + (n - sum([bdry_l, bdry_r]) / 2.0) * dx
         elif n is None:
             # Here we add to n since (e-b)/s gives the reduced number of cells.
-            n_calc = (e - b) / s + sum([bdry_l, bdry_r]) / 2.0
+            n_calc = (xmax - xmin) / dx + sum([bdry_l, bdry_r]) / 2.0
             n_round = int(round(n_calc))
             if abs(n_calc - n_round) > 1e-5:
                 raise ValueError('in axis {}: calculated number of nodes '
                                  '{} = ({} - {}) / {} too far from integer'
-                                 ''.format(i, n_calc, e, b, s))
-            num_nodes[i] = n_round
-        elif s is None:
+                                 ''.format(i, n_calc, xmax, xmin, dx))
+            shape[i] = n_round
+        elif dx is None:
             pass
         else:
-            e_calc = b + (n - sum([bdry_l, bdry_r]) / 2.0) * s
-            if not np.isclose(e, e_calc):
+            xmax_calc = xmin + (n - sum([bdry_l, bdry_r]) / 2.0) * dx
+            if not np.isclose(xmax, xmax_calc):
                 raise ValueError('in axis {}: calculated endpoint '
                                  '{} = {} + {} * {} too far from given '
                                  'endpoint {}.'
-                                 ''.format(i, e_calc, b, n, s, e))
+                                 ''.format(i, xmax_calc, xmin, n, dx, xmax))
 
     return uniform_partition_fromintv(
-        IntervalProd(begin, end), num_nodes, nodes_on_bdry)
+        IntervalProd(min_pt, max_pt), shape, nodes_on_bdry)
 
 
 if __name__ == '__main__':

--- a/odl/set/domain.py
+++ b/odl/set/domain.py
@@ -831,11 +831,8 @@ def Interval(min_pt, max_pt):
 
     Parameters
     ----------
-    min_pt : `array-like`, shape ``(1,)``, or `float`
-        The lower ends of the intervals in the product
-    max_pt : `array-like`, shape ``(1,)``, or `float`
-        The upper ends of the intervals in the product
-
+    min_pt, max_pt : float or `array-like`, shape ``(1,)``
+        Lower/upper ends of the interval.
     """
     interval = IntervalProd(min_pt, max_pt)
     if interval.ndim != 1:
@@ -849,10 +846,8 @@ def Rectangle(min_pt, max_pt):
 
     Parameters
     ----------
-    min_pt : `array-like`, shape ``(2,)``
-        The lower ends of the intervals in the product
-    max_pt : `array-like`, shape ``(2,)``
-        The upper ends of the intervals in the product
+    min_pt, max_pt : `array-like`, shape ``(2,)``
+        Lower/upper ends of the intervals in the product.
     """
     rectangle = IntervalProd(min_pt, max_pt)
     if rectangle.ndim != 2:
@@ -866,10 +861,8 @@ def Cuboid(min_pt, max_pt):
 
     Parameters
     ----------
-    min_pt : `array-like`, shape ``(3,)``
-        The lower ends of the intervals in the product
-    max_pt : `array-like`, shape ``(3,)``
-        The upper ends of the intervals in the product
+    min_pt, max_pt : `array-like`, shape ``(3,)``
+        Lower/upper ends of the intervals in the product.
     """
     cuboid = IntervalProd(min_pt, max_pt)
     if cuboid.ndim != 3:

--- a/odl/set/domain.py
+++ b/odl/set/domain.py
@@ -47,61 +47,59 @@ class IntervalProd(Set):
     return a new instance.
     """
 
-    def __init__(self, begin, end):
+    def __init__(self, min_pt, max_pt):
         """Initialize a new instance.
 
         Parameters
         ----------
-        begin : `array-like` or float
-            The lower ends of the intervals. A float can be used in
-            one dimension.
-        end : `array-like` or float
-            The upper ends of the intervals. A float can be used in
-            one dimension.
+        min_pt, max_pt : float or `array-like`
+            Vectors of lower/upper ends of the intervals in the product.
 
         Examples
         --------
-        >>> b, e = [-1, 2.5, 70, 80], [-0.5, 10, 75, 90]
-        >>> rbox = IntervalProd(b, e)
+        >>> import odl
+        >>> min_pt, max_pt = [-1, 2.5, 70, 80], [-0.5, 10, 75, 90]
+        >>> rbox = odl.IntervalProd(min_pt, max_pt)
         >>> rbox
         IntervalProd([-1.0, 2.5, 70.0, 80.0], [-0.5, 10.0, 75.0, 90.0])
         """
-        self.__begin = np.atleast_1d(begin).astype('float64')
-        self.__end = np.atleast_1d(end).astype('float64')
+        self.__min_pt = np.atleast_1d(min_pt).astype('float64')
+        self.__max_pt = np.atleast_1d(max_pt).astype('float64')
 
-        if self.begin.ndim > 1:
-            raise ValueError('`begin` must be 1-dimensional, got an array '
-                             'with {} axes'.format(self.begin.ndim))
-        if self.end.ndim > 1:
-            raise ValueError('`end` must be 1-dimensional, got an array '
-                             'with {} axes'.format(self.begin.ndim))
-        if len(self.begin) != len(self.end):
-            raise ValueError('`begin` and `end` have different lengths '
+        if self.min_pt.ndim > 1:
+            raise ValueError('`min_pt` must be 1-dimensional, got an array '
+                             'with {} axes'.format(self.min_pt.ndim))
+        if self.max_pt.ndim > 1:
+            raise ValueError('`max_pt` must be 1-dimensional, got an array '
+                             'with {} axes'.format(self.max_pt.ndim))
+        if len(self.min_pt) != len(self.max_pt):
+            raise ValueError('`min_pt` and `max_pt` have different lengths '
                              '({} != {})'
-                             ''.format(len(self.begin), len(self.end)))
-        for i, (beg, end) in enumerate(zip(self.begin, self.end)):
-            if beg > end:
-                raise ValueError('in axis {}: `begin` is larger than `end` '
-                                 '({} > {})'.format(i, beg, end))
+                             ''.format(len(self.min_pt), len(self.max_pt)))
 
-        self.__ideg = np.where(self.begin == self.end)[0]
-        self.__inondeg = np.where(self.begin != self.end)[0]
+        for axis, (xmin, xmax) in enumerate(zip(self.min_pt, self.max_pt)):
+            if xmax < xmin:
+                raise ValueError('in axis {}: upper end smaller than lower '
+                                 'end ({} < {})'.format(axis, xmax, xmin))
+
+        self.__ideg = np.where(self.min_pt == self.max_pt)[0]
+        self.__inondeg = np.where(self.min_pt != self.max_pt)[0]
         super().__init__()
 
     @property
-    def begin(self):
-        """Left interval boundary/boundaries."""
-        return self.__begin
+    def min_pt(self):
+        """Left interval boundaries of this interval product."""
+        return self.__min_pt
 
     @property
-    def end(self):
-        """Right interval boundary/boundaries."""
-        return self.__end
+    def max_pt(self):
+        """Right interval boundaries of this interval product."""
+        return self.__max_pt
 
     @property
     def ndim(self):
         """Number of intervals in the product."""
-        return len(self.begin)
+        return len(self.min_pt)
 
     @property
     def true_ndim(self):
@@ -128,10 +126,10 @@ class IntervalProd(Set):
         return self.volume
 
     @property
-    def midpoint(self):
+    def mid_pt(self):
         """Midpoint of this interval product."""
-        midp = (self.end + self.begin) / 2.
-        midp[self.ideg] = self.begin[self.ideg]
+        midp = (self.max_pt + self.min_pt) / 2.
+        midp[self.ideg] = self.min_pt[self.ideg]
         return midp
 
     @property
@@ -146,11 +144,11 @@ class IntervalProd(Set):
 
     def min(self):
         """Return the minimum point of this interval product."""
-        return self.begin
+        return self.min_pt
 
     def max(self):
         """Return the maximum point of this interval product."""
-        return self.end
+        return self.max_pt
 
     def extent(self):
         """Return the vector of interval lengths per axis."""
@@ -167,8 +165,8 @@ class IntervalProd(Set):
         Returns
         -------
         element : `numpy.ndarray` or float
-            Array (ndim > 1) or float version of ``inp`` if provided,
-            otherwise ``self.midpoint``.
+            Array (`ndim` > 1) or float version of ``inp`` if provided,
+            otherwise ``self.mid_pt``.
 
         Examples
         --------
@@ -177,7 +175,7 @@ class IntervalProd(Set):
         0.5
         """
         if inp is None:
-            return self.midpoint
+            return self.mid_pt
         elif inp in self:
             if self.ndim == 1:
                 return float(inp)
@@ -200,9 +198,8 @@ class IntervalProd(Set):
 
         Examples
         --------
-        >>> from math import sqrt
         >>> rbox1 = IntervalProd(0, 0.5)
-        >>> rbox2 = IntervalProd(0, sqrt(0.5)**2)
+        >>> rbox2 = IntervalProd(0, np.sqrt(0.5)**2)
         >>> rbox1.approx_equals(rbox2, atol=0)  # Numerical error
         False
         >>> rbox1.approx_equals(rbox2, atol=1e-15)
@@ -213,8 +210,8 @@ class IntervalProd(Set):
         elif not isinstance(other, IntervalProd):
             return False
 
-        return (np.allclose(self.begin, other.begin, atol=atol, rtol=0.0) and
-                np.allclose(self.end, other.end, atol=atol, rtol=0.0))
+        return (np.allclose(self.min_pt, other.min_pt, atol=atol, rtol=0.0) and
+                np.allclose(self.max_pt, other.max_pt, atol=atol, rtol=0.0))
 
     def __eq__(self, other):
         """Return ``self == other``."""
@@ -234,13 +231,12 @@ class IntervalProd(Set):
 
         Examples
         --------
-        >>> from math import sqrt
-        >>> b, e = [-1, 0, 2], [-0.5, 0, 3]
-        >>> rbox = IntervalProd(b, e)
+        >>> min_pt, max_pt = [-1, 0, 2], [-0.5, 0, 3]
+        >>> rbox = IntervalProd(min_pt, max_pt)
         >>> # Numerical error
-        >>> rbox.approx_contains([-1 + sqrt(0.5)**2, 0., 2.9], atol=0)
+        >>> rbox.approx_contains([-1 + np.sqrt(0.5)**2, 0., 2.9], atol=0)
         False
-        >>> rbox.approx_contains([-1 + sqrt(0.5)**2, 0., 2.9], atol=1e-9)
+        >>> rbox.approx_contains([-1 + np.sqrt(0.5)**2, 0., 2.9], atol=1e-9)
         True
         """
         try:
@@ -275,7 +271,7 @@ class IntervalProd(Set):
 
         if point.shape != (self.ndim,):
             return False
-        return (self.begin <= point).all() and (point <= self.end).all()
+        return (self.min_pt <= point).all() and (point <= self.max_pt).all()
 
     def contains_set(self, other, atol=0.0):
         """Return ``True`` if ``other`` is (almost) contained in this set.
@@ -295,10 +291,10 @@ class IntervalProd(Set):
 
         Examples
         --------
-        >>> b1, e1 = [-1, 0, 2], [-0.5, 0, 3]
-        >>> rbox1 = IntervalProd(b1, e1)
-        >>> b2, e2 = [-0.6, 0, 2.1], [-0.5, 0, 2.5]
-        >>> rbox2 = IntervalProd(b2, e2)
+        >>> min_pt1, max_pt1 = [-1, 0, 2], [-0.5, 0, 3]
+        >>> rbox1 = IntervalProd(min_pt1, max_pt1)
+        >>> min_pt2, max_pt2 = [-0.6, 0, 2.1], [-0.5, 0, 2.5]
+        >>> rbox2 = IntervalProd(min_pt2, max_pt2)
         >>> rbox1.contains_set(rbox2)
         True
         >>> rbox2.contains_set(rbox1)
@@ -336,10 +332,10 @@ class IntervalProd(Set):
         Examples
         --------
         >>> import odl
-        >>> b, e = [-1, 0, 2], [-0.5, 0, 3]
-        >>> rbox = IntervalProd(b, e)
+        >>> min_pt, max_pt = [-1, 0, 2], [-0.5, 0, 3]
+        >>> rbox = IntervalProd(min_pt, max_pt)
 
-        Arrays are expected in (ndim, npoints) shape:
+        Arrays are expected in ``(ndim, npoints)`` shape:
 
         >>> arr = np.array([[-1, 0, 2],   # defining one point at a time
         ...                 [-0.5, 0, 2]])
@@ -363,9 +359,9 @@ class IntervalProd(Set):
         ...                    [2, 2]])
         True
 
-        And with grids:
+        Grids are also accepted as input:
 
-        >>> agrid = odl.uniform_sampling(rbox.begin, rbox.end, [3, 1, 3])
+        >>> agrid = odl.uniform_sampling(rbox.min_pt, rbox.max_pt, [3, 1, 3])
         >>> rbox.contains_all(agrid)
         True
         """
@@ -380,8 +376,8 @@ class IntervalProd(Set):
             vecs = tuple(vec.squeeze() for vec in other)
             mins = np.fromiter((np.min(vec) for vec in vecs), dtype=float)
             maxs = np.fromiter((np.max(vec) for vec in vecs), dtype=float)
-            return (np.all(mins >= self.begin - atol) and
-                    np.all(maxs <= self.end + atol))
+            return (np.all(mins >= self.min_pt - atol) and
+                    np.all(maxs <= self.max_pt + atol))
 
         # Convert to array and check each element
         other = np.asarray(other)
@@ -392,7 +388,7 @@ class IntervalProd(Set):
             else:
                 mins = np.min(other, axis=1)
                 maxs = np.max(other, axis=1)
-            return np.all(mins >= self.begin) and np.all(maxs <= self.end)
+            return np.all(mins >= self.min_pt) and np.all(maxs <= self.max_pt)
         else:
             return False
 
@@ -408,8 +404,8 @@ class IntervalProd(Set):
 
         Examples
         --------
-        >>> b, e = [-1, 2.5, 0], [-0.5, 10, 0]
-        >>> rbox = IntervalProd(b, e)
+        >>> min_pt, max_pt = [-1, 2.5, 0], [-0.5, 10, 0]
+        >>> rbox = IntervalProd(min_pt, max_pt)
         >>> rbox.measure()
         3.75
         >>> rbox.measure(ndim=3)
@@ -431,7 +427,7 @@ class IntervalProd(Set):
         elif ndim > self.true_ndim:
             return 0.0
         else:
-            return np.prod((self.end - self.begin)[self.inondeg])
+            return np.prod((self.max_pt - self.min_pt)[self.inondeg])
 
     def dist(self, point, exponent=2.0):
         """Return the distance of ``point`` to this set.
@@ -457,8 +453,8 @@ class IntervalProd(Set):
 
         Examples
         --------
-        >>> b, e = [-1, 0, 2], [-0.5, 0, 3]
-        >>> rbox = IntervalProd(b, e)
+        >>> min_pt, max_pt = [-1, 0, 2], [-0.5, 0, 3]
+        >>> rbox = IntervalProd(min_pt, max_pt)
         >>> rbox.dist([-5, 3, 2])
         5.0
         >>> rbox.dist([-5, 3, 2], exponent=float('inf'))
@@ -472,16 +468,16 @@ class IntervalProd(Set):
         if np.any(np.isnan(point)):
             return float('inf')
 
-        i_larger = np.where(point > self.end)
-        i_smaller = np.where(point < self.begin)
+        i_larger = np.where(point > self.max_pt)
+        i_smaller = np.where(point < self.min_pt)
 
         # Access [0] since np.where returns a tuple.
         if len(i_larger[0]) == 0 and len(i_smaller[0]) == 0:
             return 0.0
         else:
             proj = np.concatenate((point[i_larger], point[i_smaller]))
-            border = np.concatenate((self.end[i_larger],
-                                     self.begin[i_smaller]))
+            border = np.concatenate((self.max_pt[i_larger],
+                                     self.min_pt[i_smaller]))
             return np.linalg.norm(proj - border, ord=exponent)
 
     def collapse(self, indices, values):
@@ -505,8 +501,8 @@ class IntervalProd(Set):
 
         Examples
         --------
-        >>> b, e = [-1, 0, 2], [-0.5, 1, 3]
-        >>> rbox = IntervalProd(b, e)
+        >>> min_pt, max_pt = [-1, 0, 2], [-0.5, 1, 3]
+        >>> rbox = IntervalProd(min_pt, max_pt)
         >>> rbox.collapse(1, 0)
         Cuboid([-1.0, 0.0, 2.0], [-0.5, 0.0, 3.0])
         >>> rbox.collapse([1, 2], [0, 2.5])
@@ -525,19 +521,19 @@ class IntervalProd(Set):
                 raise IndexError('in axis {}: index {} out of range 0 --> {}'
                                  ''.format(axis, index, self.ndim - 1))
 
-        if np.any(values < self.begin[indices]):
+        if np.any(values < self.min_pt[indices]):
             raise ValueError('values {} not above the lower interval '
                              'boundaries {}'
-                             ''.format(values, self.begin[indices]))
+                             ''.format(values, self.min_pt[indices]))
 
-        if np.any(values > self.end[indices]):
+        if np.any(values > self.max_pt[indices]):
             raise ValueError('values {} not below the upper interval '
                              'boundaries {}'
-                             ''.format(values, self.end[indices]))
+                             ''.format(values, self.max_pt[indices]))
 
-        b_new = self.begin.copy()
+        b_new = self.min_pt.copy()
         b_new[indices] = values
-        e_new = self.end.copy()
+        e_new = self.max_pt.copy()
         e_new[indices] = values
 
         return IntervalProd(b_new, e_new)
@@ -554,8 +550,8 @@ class IntervalProd(Set):
 
         Examples
         --------
-        >>> b, e = [-1, 0, 2], [-0.5, 1, 3]
-        >>> rbox = IntervalProd(b, e)
+        >>> min_pt, max_pt = [-1, 0, 2], [-0.5, 1, 3]
+        >>> rbox = IntervalProd(min_pt, max_pt)
         >>> rbox.collapse(1, 0).squeeze()
         Rectangle([-1.0, 2.0], [-0.5, 3.0])
         >>> rbox.collapse([1, 2], [0, 2.5]).squeeze()
@@ -563,8 +559,8 @@ class IntervalProd(Set):
         >>> rbox.collapse([0, 1, 2], [-1, 0, 2.5]).squeeze()
         IntervalProd([], [])
         """
-        b_new = self.begin[self.inondeg]
-        e_new = self.end[self.inondeg]
+        b_new = self.min_pt[self.inondeg]
+        e_new = self.max_pt[self.inondeg]
         return IntervalProd(b_new, e_new)
 
     def insert(self, index, other):
@@ -607,18 +603,18 @@ class IntervalProd(Set):
         if index < 0:
             index += self.ndim
 
-        new_beg = np.empty(self.ndim + other.ndim)
-        new_end = np.empty(self.ndim + other.ndim)
+        new_min_pt = np.empty(self.ndim + other.ndim)
+        new_max_pt = np.empty(self.ndim + other.ndim)
 
-        new_beg[: index] = self.begin[: index]
-        new_end[: index] = self.end[: index]
-        new_beg[index: index + other.ndim] = other.begin
-        new_end[index: index + other.ndim] = other.end
+        new_min_pt[: index] = self.min_pt[: index]
+        new_max_pt[: index] = self.max_pt[: index]
+        new_min_pt[index: index + other.ndim] = other.min_pt
+        new_max_pt[index: index + other.ndim] = other.max_pt
         if index < self.ndim:  # Avoid IndexError
-            new_beg[index + other.ndim:] = self.begin[index:]
-            new_end[index + other.ndim:] = self.end[index:]
+            new_min_pt[index + other.ndim:] = self.min_pt[index:]
+            new_max_pt[index + other.ndim:] = self.max_pt[index:]
 
-        return IntervalProd(new_beg, new_end)
+        return IntervalProd(new_min_pt, new_max_pt)
 
     def append(self, other):
         """Insert at the end.
@@ -688,9 +684,9 @@ class IntervalProd(Set):
 
         minmax_vecs = [0] * self.ndim
         for axis in self.ideg:
-            minmax_vecs[axis] = self.begin[axis]
+            minmax_vecs[axis] = self.min_pt[axis]
         for axis in self.inondeg:
-            minmax_vecs[axis] = (self.begin[axis], self.end[axis])
+            minmax_vecs[axis] = (self.min_pt[axis], self.max_pt[axis])
 
         minmax_grid = TensorGrid(*minmax_vecs)
         return minmax_grid.points(order=order)
@@ -711,7 +707,7 @@ class IntervalProd(Set):
         Returns
         -------
         subinterval : `IntervalProd`
-            Interval product corresponding to the indices.
+            Interval product corresponding to the given indices.
 
         Examples
         --------
@@ -734,7 +730,7 @@ class IntervalProd(Set):
         >>> rbox[[0, 1, 0]]
         Cuboid([-1.0, 2.0, -1.0], [-0.5, 3.0, -0.5])
         """
-        return IntervalProd(self.begin[indices], self.end[indices])
+        return IntervalProd(self.min_pt[indices], self.max_pt[indices])
 
     def __pos__(self):
         """Return ``+self``."""
@@ -742,7 +738,7 @@ class IntervalProd(Set):
 
     def __neg__(self):
         """Return ``-self``."""
-        return type(self)(-self.end, -self.begin)
+        return type(self)(-self.max_pt, -self.min_pt)
 
     def __add__(self, other):
         """Return ``self + other``."""
@@ -751,9 +747,10 @@ class IntervalProd(Set):
                 raise ValueError('addition not possible for {} and {}: '
                                  'dimension mismatch ({} != {})'
                                  ''.format(self, other, self.ndim, other.ndim))
-            return type(self)(self.begin + other.begin, self.end + other.end)
+            return type(self)(self.min_pt + other.min_pt,
+                              self.max_pt + other.max_pt)
         elif np.isscalar(other):
-            return type(self)(self.begin + other, self.end + other)
+            return type(self)(self.min_pt + other, self.max_pt + other)
         else:
             return NotImplemented
 
@@ -770,16 +767,16 @@ class IntervalProd(Set):
                                  ''.format(self, other, self.ndim, other.ndim))
 
             comp_mat = np.empty([self.ndim, 4])
-            comp_mat[:, 0] = self.begin * other.begin
-            comp_mat[:, 1] = self.begin * other.end
-            comp_mat[:, 2] = self.end * other.begin
-            comp_mat[:, 3] = self.end * other.end
-            new_beg = np.min(comp_mat, axis=1)
-            new_end = np.max(comp_mat, axis=1)
-            return type(self)(new_beg, new_end)
+            comp_mat[:, 0] = self.min_pt * other.min_pt
+            comp_mat[:, 1] = self.min_pt * other.max_pt
+            comp_mat[:, 2] = self.max_pt * other.min_pt
+            comp_mat[:, 3] = self.max_pt * other.max_pt
+            new_min_pt = np.min(comp_mat, axis=1)
+            new_max_pt = np.max(comp_mat, axis=1)
+            return type(self)(new_min_pt, new_max_pt)
         elif np.isscalar(other):
-            vec1 = self.begin * other
-            vec2 = self.end * other
+            vec1 = self.min_pt * other
+            vec2 = self.max_pt * other
             return type(self)(np.minimum(vec1, vec2), np.maximum(vec1, vec2))
         else:
             return NotImplemented
@@ -793,13 +790,14 @@ class IntervalProd(Set):
     def __rdiv__(self, other):
         """Return ``other / self``."""
         if np.isscalar(other):
-            for axis, (b, e) in enumerate(zip(self.begin, self.end)):
-                if b <= 0 and e >= 0:
-                    raise ValueError('division not possible: interval product'
-                                     'contains 0 in axis {}'.format(axis))
+            for axis, (xmin, xmax) in enumerate(zip(self.min_pt, self.max_pt)):
+                if xmin <= 0 and xmax >= 0:
+                    raise ValueError('in axis {}: interval {} contains 0, '
+                                     'division not possible'
+                                     .format(axis, [xmin, xmax]))
 
-            vec1 = other / self.begin
-            vec2 = other / self.end
+            vec1 = other / self.min_pt
+            vec2 = other / self.max_pt
             return type(self)(np.minimum(vec1, vec2), np.maximum(vec1, vec2))
         else:
             return NotImplemented
@@ -809,73 +807,74 @@ class IntervalProd(Set):
     def __repr__(self):
         """Return ``repr(self)``."""
         if self.ndim == 1:
-            return 'Interval({!r}, {!r})'.format(self.begin[0], self.end[0])
+            return 'Interval({!r}, {!r})'.format(self.min_pt[0],
+                                                 self.max_pt[0])
         elif self.ndim == 2:
-            return 'Rectangle({!r}, {!r})'.format(list(self.begin),
-                                                  list(self.end))
+            return 'Rectangle({!r}, {!r})'.format(list(self.min_pt),
+                                                  list(self.max_pt))
         elif self.ndim == 3:
-            return 'Cuboid({!r}, {!r})'.format(list(self.begin),
-                                               list(self.end))
+            return 'Cuboid({!r}, {!r})'.format(list(self.min_pt),
+                                               list(self.max_pt))
         else:
             return '{}({}, {})'.format(self.__class__.__name__,
-                                       array1d_repr(self.begin),
-                                       array1d_repr(self.end))
+                                       array1d_repr(self.min_pt),
+                                       array1d_repr(self.max_pt))
 
     def __str__(self):
         """Return ``str(self)``."""
-        return ' x '.join('[{}, {}]'.format(b, e)
-                          for (b, e) in zip(self.begin, self.end))
+        return ' x '.join('[{}, {}]'.format(xmin, xmax)
+                          for xmin, xmax in zip(self.min_pt, self.max_pt))
 
 
-def Interval(begin, end):
+def Interval(min_pt, max_pt):
     """One-dimensional interval product.
 
     Parameters
     ----------
-    begin : `array-like` with shape ``(1,)`` or float
-        Lower end of the interval.
-    end : `array-like` with shape ``(1,)`` or float
-        Upper end of the interval.
+    min_pt : `array-like`, shape ``(1,)``, or `float`
+        The lower ends of the intervals in the product
+    max_pt : `array-like`, shape ``(1,)``, or `float`
+        The upper ends of the intervals in the product
 
     """
-    interval = IntervalProd(begin, end)
+    interval = IntervalProd(min_pt, max_pt)
     if interval.ndim != 1:
-        raise ValueError('cannot make an interval from `begin` {} and '
-                         '`end` {}'.format(begin, end))
+        raise ValueError('cannot make an interval from `min_pt` {} and '
+                         '`max_pt` {}'.format(min_pt, max_pt))
     return interval
 
 
-def Rectangle(begin, end):
+def Rectangle(min_pt, max_pt):
     """Two-dimensional interval product.
 
     Parameters
     ----------
-    begin : `array-like` with shape ``(2,)``
-        Lower ends of the intervals in the product.
-    end : `array-like` with shape ``(2,)``
-        Upper ends of the intervals in the product.
+    min_pt : `array-like`, shape ``(2,)``
+        The lower ends of the intervals in the product
+    max_pt : `array-like`, shape ``(2,)``
+        The upper ends of the intervals in the product
     """
-    rectangle = IntervalProd(begin, end)
+    rectangle = IntervalProd(min_pt, max_pt)
     if rectangle.ndim != 2:
-        raise ValueError('cannot make a rectangle from `begin` {} and '
-                         '`end` {}'.format(begin, end))
+        raise ValueError('cannot make a rectangle from `min_pt` {} and '
+                         '`max_pt` {}'.format(min_pt, max_pt))
     return rectangle
 
 
-def Cuboid(begin, end):
+def Cuboid(min_pt, max_pt):
     """Three-dimensional interval product.
 
     Parameters
     ----------
-    begin : `array-like` with shape ``(3,)``
-        Lower ends of the intervals in the product.
-    end : `array-like` with shape ``(3,)``
-        Upper ends of the intervals in the product.
+    min_pt : `array-like`, shape ``(3,)``
+        The lower ends of the intervals in the product
+    max_pt : `array-like`, shape ``(3,)``
+        The upper ends of the intervals in the product
     """
-    cuboid = IntervalProd(begin, end)
+    cuboid = IntervalProd(min_pt, max_pt)
     if cuboid.ndim != 3:
-        raise ValueError('cannot make a cuboid from `begin` {} and '
-                         '`end` {}'.format(begin, end))
+        raise ValueError('cannot make a cuboid from `min_pt` {} and '
+                         '`max_pt` {}'.format(min_pt, max_pt))
     return cuboid
 
 

--- a/odl/tomo/backends/astra_setup.py
+++ b/odl/tomo/backends/astra_setup.py
@@ -98,8 +98,8 @@ def astra_volume_geometry(discr_reco):
         raise ValueError('`discr_reco` {} is not uniformly discretized')
 
     vol_shp = discr_reco.partition.shape
-    vol_min = discr_reco.partition.begin
-    vol_max = discr_reco.partition.end
+    vol_min = discr_reco.partition.min_pt
+    vol_max = discr_reco.partition.max_pt
 
     if discr_reco.ndim == 2:
         # ASTRA does in principle support custom minimum and maximum
@@ -187,8 +187,8 @@ def astra_conebeam_3d_geom_to_vec(geometry):
         vectors[ang_idx, 0:3] = geometry.src_position(angle)
 
         # center of detector
-        midp = geometry.det_params.midpoint
-        vectors[ang_idx, 3:6] = geometry.det_point_position(angle, midp)
+        mid_pt = geometry.det_params.mid_pt
+        vectors[ang_idx, 3:6] = geometry.det_point_position(angle, mid_pt)
 
         # vector from detector pixel (0,0) to (0,1)
         unit_vecs = geometry.detector.axes
@@ -242,8 +242,8 @@ def astra_conebeam_2d_geom_to_vec(geometry):
         vectors[ang_idx, 0:2] = geometry.src_position(angle)
 
         # center of detector
-        midp = geometry.det_params.midpoint
-        vectors[ang_idx, 2:4] = geometry.det_point_position(angle, midp)
+        mid_pt = geometry.det_params.mid_pt
+        vectors[ang_idx, 2:4] = geometry.det_point_position(angle, mid_pt)
 
         # vector from detector pixel (0) to (1)
         unit_vec = geometry.detector.axis
@@ -293,13 +293,13 @@ def astra_parallel_3d_geom_to_vec(geometry):
     for ang_idx, angle in enumerate(angles):
         rot_matrix = geometry.rotation_matrix(angle)
 
-        midp = geometry.det_params.midpoint
+        mid_pt = geometry.det_params.mid_pt
 
         # source position
-        vectors[ang_idx, 0:3] = geometry.det_to_src(angle, midp)
+        vectors[ang_idx, 0:3] = geometry.det_to_src(angle, mid_pt)
 
         # center of detector
-        vectors[ang_idx, 3:6] = geometry.det_point_position(angle, midp)
+        vectors[ang_idx, 3:6] = geometry.det_point_position(angle, mid_pt)
 
         # vector from detector pixel (0,0) to (0,1)
         unit_vecs = geometry.detector.axes

--- a/odl/tomo/backends/stir_bindings.py
+++ b/odl/tomo/backends/stir_bindings.py
@@ -295,14 +295,14 @@ def stir_projector_from_file(volume_file, projection_file):
     grid_shape = [volume.get_z_size(),
                   volume.get_y_size(),
                   volume.get_x_size()]
-    min_corner = [origin[1], origin[2], origin[3]]
-    max_corner = [origin[1] + grid_spacing[1] * grid_shape[0],
-                  origin[2] + grid_spacing[2] * grid_shape[1],
-                  origin[3] + grid_spacing[3] * grid_shape[2]]
+    min_pt = [origin[1], origin[2], origin[3]]
+    max_pt = [origin[1] + grid_spacing[1] * grid_shape[0],
+              origin[2] + grid_spacing[2] * grid_shape[1],
+              origin[3] + grid_spacing[3] * grid_shape[2]]
 
     # reverse to handle STIR bug? See:
     # https://github.com/UCL/STIR/issues/7
-    recon_sp = uniform_discr(min_corner, max_corner, grid_shape,
+    recon_sp = uniform_discr(min_pt, max_pt, grid_shape,
                              dtype='float32')
 
     # TODO: set correct projection space. Currently, a default grid with

--- a/odl/tomo/geometry/detector.py
+++ b/odl/tomo/geometry/detector.py
@@ -182,7 +182,7 @@ class FlatDetector(Detector):
         # TODO: apart from being constant, there is no big simplification
         # in this method compared to parent. Consider removing FlatDetector
         # altogether.
-        return super().surface_measure(self.params.begin)
+        return super().surface_measure(self.params.min_pt)
 
 
 class Flat1dDetector(FlatDetector):

--- a/odl/tomo/operators/ray_trafo.py
+++ b/odl/tomo/operators/ray_trafo.py
@@ -105,10 +105,10 @@ class RayTransform(Operator):
                 raise TypeError("'scikit' backend only supports 2d parallel "
                                 'geometries')
 
-            midp = discr_domain.domain.midpoint
-            if not all(midp == [0, 0]):
+            mid_pt = discr_domain.domain.mid_pt
+            if not all(mid_pt == [0, 0]):
                 raise ValueError('`discr_domain.domain` needs to be '
-                                 'centered on [0, 0], got {}'.format(midp))
+                                 'centered on [0, 0], got {}'.format(mid_pt))
 
             shape = discr_domain.shape
             if shape[0] != shape[1]:

--- a/odl/trafos/fourier.py
+++ b/odl/trafos/fourier.py
@@ -1556,8 +1556,8 @@ def reciprocal_space(space, axes=None, halfcomplex=False, shift=True,
     # Make a partition with nodes on the boundary in the last transform axis
     # if `halfcomplex == True`, otherwise a standard partition.
     if halfcomplex:
-        end = {axes[-1]: recip_grid.max_pt[axes[-1]]}
-        part = uniform_partition_fromgrid(recip_grid, end=end)
+        max_pt = {axes[-1]: recip_grid.max_pt[axes[-1]]}
+        part = uniform_partition_fromgrid(recip_grid, max_pt=max_pt)
     else:
         part = uniform_partition_fromgrid(recip_grid)
 

--- a/odl/util/graphics.py
+++ b/odl/util/graphics.py
@@ -62,20 +62,20 @@ def _colorbar_format(minval, maxval):
 def _axes_info(grid, npoints=5):
     result = []
 
-    min_corner = grid.min()
-    max_corner = grid.max()
+    min_pt = grid.min()
+    max_pt = grid.max()
     for axis in range(grid.ndim):
-        minv = min_corner[axis]
-        maxv = max_corner[axis]
+        xmin = min_pt[axis]
+        xmax = max_pt[axis]
 
-        points = np.linspace(minv, maxv, npoints)
+        points = np.linspace(xmin, xmax, npoints)
         indices = np.linspace(0, grid.shape[axis] - 1, npoints, dtype=int)
         tick_values = grid.coord_vectors[axis][indices]
 
         # Do not use corner point in case of a partition, use outer corner
-        tick_values[[0, -1]] = minv, maxv
+        tick_values[[0, -1]] = xmin, xmax
 
-        format_str = '{:.' + str(_digits(minv, maxv)) + 'f}'
+        format_str = '{:.' + str(_digits(xmin, xmax)) + 'f}'
         tick_labels = [format_str.format(f) for f in tick_values]
 
         result += [(points, tick_labels)]

--- a/test/discr/discr_ops_test.py
+++ b/test/discr/discr_ops_test.py
@@ -142,8 +142,8 @@ def test_resizing_op_properties(fn_impl, padding):
         # Implicit range via ran_shp and offset
         res_op = odl.ResizingOperator(space, ran_shp=(20, 15), offset=[0, 5],
                                       pad_mode=pad_mode, pad_const=pad_const)
-        assert np.allclose(res_op.range.min_corner, res_space.min_corner)
-        assert np.allclose(res_op.range.max_corner, res_space.max_corner)
+        assert np.allclose(res_op.range.min_pt, res_space.min_pt)
+        assert np.allclose(res_op.range.max_pt, res_space.max_pt)
         assert np.allclose(res_op.range.cell_sides, res_space.cell_sides)
         assert res_op.range.dtype == res_space.dtype
         assert res_op.offset == (0, 5)

--- a/test/discr/grid_test.py
+++ b/test/discr/grid_test.py
@@ -613,15 +613,15 @@ def test_regulargrid_init_raise():
         RegularGrid(minpt, maxpt, bad_dim_shape)
 
 
-def test_regulargrid_center():
+def test_regulargrid_mid_pt():
     minpt = (0.75, 0, -5)
     maxpt = (1.25, 0, 1)
     shape = (2, 1, 3)
 
-    center = (1, 0, -2)
+    mid_pt = (1, 0, -2)
 
     grid = RegularGrid(minpt, maxpt, shape)
-    assert all_equal(grid.center, center)
+    assert all_equal(grid.mid_pt, mid_pt)
 
 
 def test_regulargrid_stride():

--- a/test/discr/lp_discr_test.py
+++ b/test/discr/lp_discr_test.py
@@ -1016,42 +1016,42 @@ def test_uniform_discr_fromdiscr_one_attr():
     discr = odl.uniform_discr([0, -1], [1, 1], [10, 5])
     # csides = [0.1, 0.4]
 
-    # min_corner -> translate, keep cells
-    new_min_corner = [3, 7]
-    true_new_end = [4, 9]
+    # min_pt -> translate, keep cells
+    new_min_pt = [3, 7]
+    true_new_max_pt = [4, 9]
 
-    new_discr = odl.uniform_discr_fromdiscr(discr, min_corner=new_min_corner)
-    assert all_almost_equal(new_discr.min_corner, new_min_corner)
-    assert all_almost_equal(new_discr.max_corner, true_new_end)
+    new_discr = odl.uniform_discr_fromdiscr(discr, min_pt=new_min_pt)
+    assert all_almost_equal(new_discr.min_pt, new_min_pt)
+    assert all_almost_equal(new_discr.max_pt, true_new_max_pt)
     assert all_equal(new_discr.shape, discr.shape)
     assert all_almost_equal(new_discr.cell_sides, discr.cell_sides)
 
-    # max_corner -> translate, keep cells
-    new_max_corner = [3, 7]
-    true_new_begin = [2, 5]
+    # max_pt -> translate, keep cells
+    new_max_pt = [3, 7]
+    true_new_min_pt = [2, 5]
 
-    new_discr = odl.uniform_discr_fromdiscr(discr, max_corner=new_max_corner)
-    assert all_almost_equal(new_discr.min_corner, true_new_begin)
-    assert all_almost_equal(new_discr.max_corner, new_max_corner)
+    new_discr = odl.uniform_discr_fromdiscr(discr, max_pt=new_max_pt)
+    assert all_almost_equal(new_discr.min_pt, true_new_min_pt)
+    assert all_almost_equal(new_discr.max_pt, new_max_pt)
     assert all_equal(new_discr.shape, discr.shape)
     assert all_almost_equal(new_discr.cell_sides, discr.cell_sides)
 
-    # nsamples -> resize cells, keep corners
-    new_nsamples = (5, 20)
+    # shape -> resize cells, keep corners
+    new_shape = (5, 20)
     true_new_csides = [0.2, 0.1]
-    new_discr = odl.uniform_discr_fromdiscr(discr, nsamples=new_nsamples)
-    assert all_almost_equal(new_discr.min_corner, discr.min_corner)
-    assert all_almost_equal(new_discr.max_corner, discr.max_corner)
-    assert all_equal(new_discr.shape, new_nsamples)
+    new_discr = odl.uniform_discr_fromdiscr(discr, shape=new_shape)
+    assert all_almost_equal(new_discr.min_pt, discr.min_pt)
+    assert all_almost_equal(new_discr.max_pt, discr.max_pt)
+    assert all_equal(new_discr.shape, new_shape)
     assert all_almost_equal(new_discr.cell_sides, true_new_csides)
 
     # cell_sides -> resize cells, keep corners
     new_csides = [0.5, 0.2]
-    true_new_nsamples = (2, 10)
+    true_new_shape = (2, 10)
     new_discr = odl.uniform_discr_fromdiscr(discr, cell_sides=new_csides)
-    assert all_almost_equal(new_discr.min_corner, discr.min_corner)
-    assert all_almost_equal(new_discr.max_corner, discr.max_corner)
-    assert all_equal(new_discr.shape, true_new_nsamples)
+    assert all_almost_equal(new_discr.min_pt, discr.min_pt)
+    assert all_almost_equal(new_discr.max_pt, discr.max_pt)
+    assert all_equal(new_discr.shape, true_new_shape)
     assert all_almost_equal(new_discr.cell_sides, new_csides)
 
 
@@ -1061,53 +1061,53 @@ def test_uniform_discr_fromdiscr_two_attrs():
     discr = odl.uniform_discr([0, -1], [1, 1], [10, 5])
     # csides = [0.1, 0.4]
 
-    new_min_corner = [-2, 1]
-    new_max_corner = [4, 2]
+    new_min_pt = [-2, 1]
+    new_max_pt = [4, 2]
     true_new_csides = [0.6, 0.2]
-    new_discr = odl.uniform_discr_fromdiscr(discr, min_corner=new_min_corner,
-                                            max_corner=new_max_corner)
-    assert all_almost_equal(new_discr.min_corner, new_min_corner)
-    assert all_almost_equal(new_discr.max_corner, new_max_corner)
+    new_discr = odl.uniform_discr_fromdiscr(discr, min_pt=new_min_pt,
+                                            max_pt=new_max_pt)
+    assert all_almost_equal(new_discr.min_pt, new_min_pt)
+    assert all_almost_equal(new_discr.max_pt, new_max_pt)
     assert all_equal(new_discr.shape, discr.shape)
     assert all_almost_equal(new_discr.cell_sides, true_new_csides)
 
-    new_min_corner = [-2, 1]
-    new_nsamples = (5, 20)
-    true_new_max_corner = [-1.5, 9]
-    new_discr = odl.uniform_discr_fromdiscr(discr, min_corner=new_min_corner,
-                                            nsamples=new_nsamples)
-    assert all_almost_equal(new_discr.min_corner, new_min_corner)
-    assert all_almost_equal(new_discr.max_corner, true_new_max_corner)
-    assert all_equal(new_discr.shape, new_nsamples)
+    new_min_pt = [-2, 1]
+    new_shape = (5, 20)
+    true_new_max_pt = [-1.5, 9]
+    new_discr = odl.uniform_discr_fromdiscr(discr, min_pt=new_min_pt,
+                                            shape=new_shape)
+    assert all_almost_equal(new_discr.min_pt, new_min_pt)
+    assert all_almost_equal(new_discr.max_pt, true_new_max_pt)
+    assert all_equal(new_discr.shape, new_shape)
     assert all_almost_equal(new_discr.cell_sides, discr.cell_sides)
 
-    new_min_corner = [-2, 1]
+    new_min_pt = [-2, 1]
     new_csides = [0.6, 0.2]
-    true_new_max_corner = [4, 2]
-    new_discr = odl.uniform_discr_fromdiscr(discr, min_corner=new_min_corner,
+    true_new_max_pt = [4, 2]
+    new_discr = odl.uniform_discr_fromdiscr(discr, min_pt=new_min_pt,
                                             cell_sides=new_csides)
-    assert all_almost_equal(new_discr.min_corner, new_min_corner)
-    assert all_almost_equal(new_discr.max_corner, true_new_max_corner)
+    assert all_almost_equal(new_discr.min_pt, new_min_pt)
+    assert all_almost_equal(new_discr.max_pt, true_new_max_pt)
     assert all_equal(new_discr.shape, discr.shape)
     assert all_almost_equal(new_discr.cell_sides, new_csides)
 
-    new_max_corner = [4, 2]
-    new_nsamples = (5, 20)
-    true_new_min_corner = [3.5, -6]
-    new_discr = odl.uniform_discr_fromdiscr(discr, max_corner=new_max_corner,
-                                            nsamples=new_nsamples)
-    assert all_almost_equal(new_discr.min_corner, true_new_min_corner)
-    assert all_almost_equal(new_discr.max_corner, new_max_corner)
-    assert all_equal(new_discr.shape, new_nsamples)
+    new_max_pt = [4, 2]
+    new_shape = (5, 20)
+    true_new_min_pt = [3.5, -6]
+    new_discr = odl.uniform_discr_fromdiscr(discr, max_pt=new_max_pt,
+                                            shape=new_shape)
+    assert all_almost_equal(new_discr.min_pt, true_new_min_pt)
+    assert all_almost_equal(new_discr.max_pt, new_max_pt)
+    assert all_equal(new_discr.shape, new_shape)
     assert all_almost_equal(new_discr.cell_sides, discr.cell_sides)
 
-    new_max_corner = [4, 2]
+    new_max_pt = [4, 2]
     new_csides = [0.6, 0.2]
-    true_new_min_corner = [-2, 1]
-    new_discr = odl.uniform_discr_fromdiscr(discr, max_corner=new_max_corner,
+    true_new_min_pt = [-2, 1]
+    new_discr = odl.uniform_discr_fromdiscr(discr, max_pt=new_max_pt,
                                             cell_sides=new_csides)
-    assert all_almost_equal(new_discr.min_corner, true_new_min_corner)
-    assert all_almost_equal(new_discr.max_corner, new_max_corner)
+    assert all_almost_equal(new_discr.min_pt, true_new_min_pt)
+    assert all_almost_equal(new_discr.max_pt, new_max_pt)
     assert all_equal(new_discr.shape, discr.shape)
     assert all_almost_equal(new_discr.cell_sides, new_csides)
 
@@ -1117,42 +1117,42 @@ def test_uniform_discr_fromdiscr_per_axis():
     discr = odl.uniform_discr([0, -1], [1, 1], [10, 5])
     # csides = [0.1, 0.4]
 
-    new_min_corner = [-2, None]
-    new_max_corner = [4, 2]
-    new_nsamples = (None, 20)
+    new_min_pt = [-2, None]
+    new_max_pt = [4, 2]
+    new_shape = (None, 20)
     new_csides = [None, None]
 
-    true_new_min_corner = [-2, -6]
-    true_new_max_corner = [4, 2]
-    true_new_nsamples = (10, 20)
+    true_new_min_pt = [-2, -6]
+    true_new_max_pt = [4, 2]
+    true_new_shape = (10, 20)
     true_new_csides = [0.6, 0.4]
 
     new_discr = odl.uniform_discr_fromdiscr(
-        discr, min_corner=new_min_corner, max_corner=new_max_corner,
-        nsamples=new_nsamples, cell_sides=new_csides)
+        discr, min_pt=new_min_pt, max_pt=new_max_pt,
+        shape=new_shape, cell_sides=new_csides)
 
-    assert all_almost_equal(new_discr.min_corner, true_new_min_corner)
-    assert all_almost_equal(new_discr.max_corner, true_new_max_corner)
-    assert all_equal(new_discr.shape, true_new_nsamples)
+    assert all_almost_equal(new_discr.min_pt, true_new_min_pt)
+    assert all_almost_equal(new_discr.max_pt, true_new_max_pt)
+    assert all_equal(new_discr.shape, true_new_shape)
     assert all_almost_equal(new_discr.cell_sides, true_new_csides)
 
-    new_min_corner = None
-    new_max_corner = [None, 2]
-    new_nsamples = (5, None)
+    new_min_pt = None
+    new_max_pt = [None, 2]
+    new_shape = (5, None)
     new_csides = [None, 0.2]
 
-    true_new_min_corner = [0, 1]
-    true_new_max_corner = [1, 2]
-    true_new_nsamples = (5, 5)
+    true_new_min_pt = [0, 1]
+    true_new_max_pt = [1, 2]
+    true_new_shape = (5, 5)
     true_new_csides = [0.2, 0.2]
 
     new_discr = odl.uniform_discr_fromdiscr(
-        discr, min_corner=new_min_corner, max_corner=new_max_corner,
-        nsamples=new_nsamples, cell_sides=new_csides)
+        discr, min_pt=new_min_pt, max_pt=new_max_pt,
+        shape=new_shape, cell_sides=new_csides)
 
-    assert all_almost_equal(new_discr.min_corner, true_new_min_corner)
-    assert all_almost_equal(new_discr.max_corner, true_new_max_corner)
-    assert all_equal(new_discr.shape, true_new_nsamples)
+    assert all_almost_equal(new_discr.min_pt, true_new_min_pt)
+    assert all_almost_equal(new_discr.max_pt, true_new_max_pt)
+    assert all_equal(new_discr.shape, true_new_shape)
     assert all_almost_equal(new_discr.cell_sides, true_new_csides)
 
 

--- a/test/discr/partition_test.py
+++ b/test/discr/partition_test.py
@@ -36,16 +36,19 @@ from odl.util.testutils import all_equal, all_almost_equal
 def test_partition_init():
     vec1 = np.array([2, 4, 5, 7])
     vec2 = np.array([-4, -3, 0, 1, 4])
-    begin = [2, -5]
-    end = [10, 4]
+    min_pt = [2, -5]
+    max_pt = [10, 4]
 
     # Simply test if code runs
-    odl.RectPartition(odl.Rectangle(begin, end), odl.TensorGrid(vec1, vec2))
-    odl.RectPartition(odl.Interval(begin[0], end[0]), odl.TensorGrid(vec1))
+    odl.RectPartition(odl.Rectangle(min_pt, max_pt),
+                      odl.TensorGrid(vec1, vec2))
+    odl.RectPartition(odl.Interval(min_pt[0], max_pt[0]),
+                      odl.TensorGrid(vec1))
 
     # Degenerate dimensions should work, too
     vec2 = np.array([1.0])
-    odl.RectPartition(odl.Rectangle(begin, end), odl.TensorGrid(vec1, vec2))
+    odl.RectPartition(odl.Rectangle(min_pt, max_pt),
+                      odl.TensorGrid(vec1, vec2))
 
 
 def test_partition_init_raise():
@@ -53,28 +56,29 @@ def test_partition_init_raise():
     vec1 = np.array([2, 4, 5, 7])
     vec2 = np.array([-4, -3, 0, 1, 4])
     grid = odl.TensorGrid(vec1, vec2)
-    begin = [2, -5]
-    end = [10, 4]
+    min_pt = [2, -5]
+    max_pt = [10, 4]
 
-    beg_toolarge = (2, -3.5)
-    end_toosmall = (7, 1)
-    beg_badshape = (-1, 2, 0)
-    end_badshape = (2,)
-
-    with pytest.raises(ValueError):
-        odl.RectPartition(odl.IntervalProd(beg_toolarge, end), grid)
+    min_pt_toolarge = (2, -3.5)
+    max_pt_toosmall = (7, 1)
+    min_pt_badshape = (-1, 2, 0)
+    max_pt_badshape = (2,)
 
     with pytest.raises(ValueError):
-        odl.RectPartition(odl.IntervalProd(begin, end_toosmall), grid)
+        odl.RectPartition(odl.IntervalProd(min_pt_toolarge, max_pt), grid)
 
     with pytest.raises(ValueError):
-        odl.RectPartition(odl.IntervalProd(beg_badshape, end_badshape), grid)
+        odl.RectPartition(odl.IntervalProd(min_pt, max_pt_toosmall), grid)
+
+    with pytest.raises(ValueError):
+        odl.RectPartition(odl.IntervalProd(min_pt_badshape, max_pt_badshape),
+                          grid)
 
     with pytest.raises(TypeError):
         odl.RectPartition(None, grid)
 
     with pytest.raises(TypeError):
-        odl.RectPartition(odl.IntervalProd(beg_toolarge, end), None)
+        odl.RectPartition(odl.IntervalProd(min_pt_toolarge, max_pt), None)
 
 
 def test_partition_set():
@@ -82,16 +86,16 @@ def test_partition_set():
     vec2 = np.array([-4, -3, 0, 1, 4])
     grid = odl.TensorGrid(vec1, vec2)
 
-    begin = [1, -4]
-    end = [10, 5]
-    intv = odl.IntervalProd(begin, end)
+    min_pt = [1, -4]
+    max_pt = [10, 5]
+    intv = odl.IntervalProd(min_pt, max_pt)
 
     part = odl.RectPartition(intv, grid)
-    assert part.set == odl.IntervalProd(begin, end)
-    assert all_equal(part.begin, begin)
-    assert all_equal(part.min(), begin)
-    assert all_equal(part.end, end)
-    assert all_equal(part.max(), end)
+    assert part.set == odl.IntervalProd(min_pt, max_pt)
+    assert all_equal(part.min_pt, min_pt)
+    assert all_equal(part.min(), min_pt)
+    assert all_equal(part.max_pt, max_pt)
+    assert all_equal(part.max(), max_pt)
 
 
 def test_partition_cell_boundary_vecs():
@@ -102,9 +106,9 @@ def test_partition_cell_boundary_vecs():
     midpts1 = [3, 4.5, 6]
     midpts2 = [-3.5, -1.5, 0.5, 2.5]
 
-    begin = [2, -6]
-    end = [10, 4]
-    intv = odl.IntervalProd(begin, end)
+    min_pt = [2, -6]
+    max_pt = [10, 4]
+    intv = odl.IntervalProd(min_pt, max_pt)
 
     true_bvec1 = [2] + midpts1 + [10]
     true_bvec2 = [-6] + midpts2 + [4]
@@ -121,9 +125,9 @@ def test_partition_cell_sizes_vecs():
     midpts1 = [3, 4.5, 6]
     midpts2 = [-3.5, -1.5, 0.5, 2.5]
 
-    begin = [2, -6]
-    end = [10, 4]
-    intv = odl.IntervalProd(begin, end)
+    min_pt = [2, -6]
+    max_pt = [10, 4]
+    intv = odl.IntervalProd(min_pt, max_pt)
 
     bvec1 = np.array([2] + midpts1 + [10])
     bvec2 = np.array([-6] + midpts2 + [4])
@@ -153,29 +157,29 @@ def test_partition_cell_volume():
 def test_partition_insert():
     vec11 = [2, 4, 5, 7]
     vec12 = [-4, -3, 0, 1, 4]
-    begin1 = [1, -4]
-    end1 = [7, 5]
+    min_pt1 = [1, -4]
+    max_pt1 = [7, 5]
     grid1 = odl.TensorGrid(vec11, vec12)
-    intv1 = odl.IntervalProd(begin1, end1)
+    intv1 = odl.IntervalProd(min_pt1, max_pt1)
     part1 = odl.RectPartition(intv1, grid1)
 
     vec21 = [-2, 0, 3]
     vec22 = [0]
-    begin2 = [-2, -2]
-    end2 = [4, 0]
+    min_pt2 = [-2, -2]
+    max_pt2 = [4, 0]
     grid2 = odl.TensorGrid(vec21, vec22)
-    intv2 = odl.IntervalProd(begin2, end2)
+    intv2 = odl.IntervalProd(min_pt2, max_pt2)
     part2 = odl.RectPartition(intv2, grid2)
 
     part = part1.insert(0, part2)
-    assert all_equal(part.begin, [-2, -2, 1, -4])
-    assert all_equal(part.end, [4, 0, 7, 5])
+    assert all_equal(part.min_pt, [-2, -2, 1, -4])
+    assert all_equal(part.max_pt, [4, 0, 7, 5])
     assert all_equal(part.grid.min_pt, [-2, 0, 2, -4])
     assert all_equal(part.grid.max_pt, [3, 0, 7, 4])
 
     part = part1.insert(1, part2)
-    assert all_equal(part.begin, [1, -2, -2, -4])
-    assert all_equal(part.end, [7, 4, 0, 5])
+    assert all_equal(part.min_pt, [1, -2, -2, -4])
+    assert all_equal(part.max_pt, [7, 4, 0, 5])
     assert all_equal(part.grid.min_pt, [2, -2, 0, -4])
     assert all_equal(part.grid.max_pt, [7, 3, 0, 4])
 
@@ -186,10 +190,10 @@ def test_partition_getitem():
     vec3 = [-2, 0, 3]
     vec4 = [0]
     vecs = [vec1, vec2, vec3, vec4]
-    begin = [1, -4, -2, -2]
-    end = [7, 5, 4, 0]
+    min_pt = [1, -4, -2, -2]
+    max_pt = [7, 5, 4, 0]
     grid = odl.TensorGrid(*vecs)
-    intv = odl.IntervalProd(begin, end)
+    intv = odl.IntervalProd(min_pt, max_pt)
     part = odl.RectPartition(intv, grid)
 
     # Test a couple of slices
@@ -197,17 +201,17 @@ def test_partition_getitem():
     slc_vecs = [v[i] for i, v in zip(slc, vecs)]
     slc_part = part[slc]
     assert slc_part.grid == odl.TensorGrid(*slc_vecs)
-    slc_beg = [3, 0.5, 1.5, -2]
-    slc_end = [4.5, 2.5, 4, 0]
-    assert slc_part.set == odl.IntervalProd(slc_beg, slc_end)
+    slc_min_pt = [3, 0.5, 1.5, -2]
+    slc_max_pt = [4.5, 2.5, 4, 0]
+    assert slc_part.set == odl.IntervalProd(slc_min_pt, slc_max_pt)
 
     slc = (slice(None), slice(None, None, 2), slice(None, 2), 0)
     slc_vecs = [v[i] for i, v in zip(slc, vecs)]
     slc_part = part[slc]
     assert slc_part.grid == odl.TensorGrid(*slc_vecs)
-    slc_beg = [1, -4, -2, -2]
-    slc_end = [7, 5, 1.5, 0]
-    assert slc_part.set == odl.IntervalProd(slc_beg, slc_end)
+    slc_min_pt = [1, -4, -2, -2]
+    slc_max_pt = [7, 5, 1.5, 0]
+    assert slc_part.set == odl.IntervalProd(slc_min_pt, slc_max_pt)
 
     # Fewer indices
     assert part[1] == part[1, :, :, :] == part[1, ...]
@@ -215,9 +219,9 @@ def test_partition_getitem():
     assert part[1, 2:, ::2] == part[1, 2:, ::2, :] == part[1, 2:, ::2, ...]
 
     # Index list using indices 0 and 2
-    lst_beg = [1, -4, -2, -2]
-    lst_end = [6, 5, 4, 0]
-    lst_intv = odl.IntervalProd(lst_beg, lst_end)
+    lst_min_pt = [1, -4, -2, -2]
+    lst_max_pt = [6, 5, 4, 0]
+    lst_intv = odl.IntervalProd(lst_min_pt, lst_max_pt)
     lst_vec1 = [2, 5]
     lst_grid = odl.TensorGrid(lst_vec1, vec2, vec3, vec4)
     lst_part = odl.RectPartition(lst_intv, lst_grid)
@@ -229,14 +233,14 @@ def test_partition_getitem():
 
 def test_uniform_partition_fromintv():
     intvp = odl.IntervalProd([0, 0], [1, 2])
-    nsamp = (4, 10)
+    shape = (4, 10)
 
     # All nodes at the boundary
-    part = odl.uniform_partition_fromintv(intvp, nsamp, nodes_on_bdry=True)
-    assert all_equal(part.begin, intvp.begin)
-    assert all_equal(part.end, intvp.end)
-    assert all_equal(part.grid.min_pt, intvp.begin)
-    assert all_equal(part.grid.max_pt, intvp.end)
+    part = odl.uniform_partition_fromintv(intvp, shape, nodes_on_bdry=True)
+    assert all_equal(part.min_pt, intvp.min_pt)
+    assert all_equal(part.max_pt, intvp.max_pt)
+    assert all_equal(part.grid.min_pt, intvp.min_pt)
+    assert all_equal(part.grid.max_pt, intvp.max_pt)
     for cs in part.cell_sizes_vecs:
         # Check that all cell sizes are equal (except first and last which
         # are halved)
@@ -245,30 +249,30 @@ def test_uniform_partition_fromintv():
         assert all_almost_equal(cs[-1], cs[-2] / 2)
 
     # All nodes not the boundary
-    part = odl.uniform_partition_fromintv(intvp, nsamp, nodes_on_bdry=False)
-    assert all_equal(part.begin, intvp.begin)
-    assert all_equal(part.end, intvp.end)
+    part = odl.uniform_partition_fromintv(intvp, shape, nodes_on_bdry=False)
+    assert all_equal(part.min_pt, intvp.min_pt)
+    assert all_equal(part.max_pt, intvp.max_pt)
     for cs in part.cell_sizes_vecs:
         # Check that all cell sizes are equal
         assert np.allclose(np.diff(cs), 0)
 
     # Only left nodes at the boundary
-    part = odl.uniform_partition_fromintv(intvp, nsamp,
+    part = odl.uniform_partition_fromintv(intvp, shape,
                                           nodes_on_bdry=[[True, False]] * 2)
-    assert all_equal(part.begin, intvp.begin)
-    assert all_equal(part.end, intvp.end)
-    assert all_equal(part.grid.min_pt, intvp.begin)
+    assert all_equal(part.min_pt, intvp.min_pt)
+    assert all_equal(part.max_pt, intvp.max_pt)
+    assert all_equal(part.grid.min_pt, intvp.min_pt)
     for cs in part.cell_sizes_vecs:
         # Check that all cell sizes are equal (except first)
         assert np.allclose(np.diff(cs[1:]), 0)
         assert all_almost_equal(cs[0], cs[1] / 2)
 
     # Only right nodes at the boundary
-    part = odl.uniform_partition_fromintv(intvp, nsamp,
+    part = odl.uniform_partition_fromintv(intvp, shape,
                                           nodes_on_bdry=[[False, True]] * 2)
-    assert all_equal(part.begin, intvp.begin)
-    assert all_equal(part.end, intvp.end)
-    assert all_equal(part.grid.max_pt, intvp.end)
+    assert all_equal(part.min_pt, intvp.min_pt)
+    assert all_equal(part.max_pt, intvp.max_pt)
+    assert all_equal(part.grid.max_pt, intvp.max_pt)
     for cs in part.cell_sizes_vecs:
         # Check that all cell sizes are equal (except last)
         assert np.allclose(np.diff(cs[:-1]), 0)
@@ -278,54 +282,55 @@ def test_uniform_partition_fromintv():
 def test_uniform_partition_fromgrid():
     vec1 = np.array([2, 4, 5, 7])
     vec2 = np.array([-4, -3, 0, 1, 4])
-    begin = [0, -4]
-    end = [7, 8]
-    beg_calc = [2 - (4 - 2) / 2, -4 - (-3 + 4) / 2]
-    end_calc = [7 + (7 - 5) / 2, 4 + (4 - 1) / 2]
+    min_pt = [0, -4]
+    max_pt = [7, 8]
+    min_pt_calc = [2 - (4 - 2) / 2, -4 - (-3 + 4) / 2]
+    max_pt_calc = [7 + (7 - 5) / 2, 4 + (4 - 1) / 2]
 
     # Default case
     grid = odl.TensorGrid(vec1, vec2)
     part = odl.uniform_partition_fromgrid(grid)
-    assert part.set == odl.IntervalProd(beg_calc, end_calc)
+    assert part.set == odl.IntervalProd(min_pt_calc, max_pt_calc)
 
-    # Explicit begin / end, full vectors
-    part = odl.uniform_partition_fromgrid(grid, begin=begin)
-    assert part.set == odl.IntervalProd(begin, end_calc)
-    part = odl.uniform_partition_fromgrid(grid, end=end)
-    assert part.set == odl.IntervalProd(beg_calc, end)
+    # Explicit min_pt / max_pt, full vectors
+    part = odl.uniform_partition_fromgrid(grid, min_pt=min_pt)
+    assert part.set == odl.IntervalProd(min_pt, max_pt_calc)
+    part = odl.uniform_partition_fromgrid(grid, max_pt=max_pt)
+    assert part.set == odl.IntervalProd(min_pt_calc, max_pt)
 
-    # begin / end as dictionaries
-    beg_dict = {0: 0.5}
-    end_dict = {-1: 8}
-    part = odl.uniform_partition_fromgrid(grid, begin=beg_dict, end=end_dict)
-    true_beg = [0.5, beg_calc[1]]
-    true_end = [end_calc[0], 8]
-    assert part.set == odl.IntervalProd(true_beg, true_end)
+    # min_pt / max_pt as dictionaries
+    min_pt_dict = {0: 0.5}
+    max_pt_dict = {-1: 8}
+    part = odl.uniform_partition_fromgrid(
+        grid, min_pt=min_pt_dict, max_pt=max_pt_dict)
+    true_min_pt = [0.5, min_pt_calc[1]]
+    true_max_pt = [max_pt_calc[0], 8]
+    assert part.set == odl.IntervalProd(true_min_pt, true_max_pt)
 
-    # Degenerate dimension, needs both explicit begin and end
+    # Degenerate dimension, needs both explicit min_pt and max_pt
     grid = odl.TensorGrid(vec1, [1.0])
     with pytest.raises(ValueError):
         odl.uniform_partition_fromgrid(grid)
     with pytest.raises(ValueError):
-        odl.uniform_partition_fromgrid(grid, begin=begin)
+        odl.uniform_partition_fromgrid(grid, min_pt=min_pt)
     with pytest.raises(ValueError):
-        odl.uniform_partition_fromgrid(grid, end=end)
+        odl.uniform_partition_fromgrid(grid, max_pt=max_pt)
 
 
 def test_uniform_partition():
 
-    begin = [0, 0]
-    end = [1, 2]
-    nsamp = (4, 10)
+    min_pt = [0, 0]
+    max_pt = [1, 2]
+    shape = (4, 10)
     csides = [0.25, 0.2]
 
     # Test standard case
-    part = odl.uniform_partition(begin, end, nsamp, nodes_on_bdry=True)
+    part = odl.uniform_partition(min_pt, max_pt, shape, nodes_on_bdry=True)
 
-    assert all_equal(part.begin, begin)
-    assert all_equal(part.end, end)
-    assert all_equal(part.grid.min_pt, begin)
-    assert all_equal(part.grid.max_pt, end)
+    assert all_equal(part.min_pt, min_pt)
+    assert all_equal(part.max_pt, max_pt)
+    assert all_equal(part.grid.min_pt, min_pt)
+    assert all_equal(part.grid.max_pt, max_pt)
     for cs in part.cell_sizes_vecs:
         # Check that all cell sizes are equal (except first and last which
         # are halved)
@@ -337,54 +342,56 @@ def test_uniform_partition():
     assert part[1:, ::3].is_uniform
 
     # Test combinations of parameters
-    true_part = odl.uniform_partition(begin, end, nsamp, nodes_on_bdry=False)
-    part = odl.uniform_partition(begin=begin, end=end, num_nodes=nsamp,
+    true_part = odl.uniform_partition(min_pt, max_pt, shape,
+                                      nodes_on_bdry=False)
+    part = odl.uniform_partition(min_pt=min_pt, max_pt=max_pt, shape=shape,
                                  cell_sides=None)
     assert part == true_part
-    part = odl.uniform_partition(begin=begin, end=end, num_nodes=None,
+    part = odl.uniform_partition(min_pt=min_pt, max_pt=max_pt, shape=None,
                                  cell_sides=csides)
     assert part == true_part
-    part = odl.uniform_partition(begin=begin, end=None,
-                                 num_nodes=nsamp, cell_sides=csides)
+    part = odl.uniform_partition(min_pt=min_pt, max_pt=None,
+                                 shape=shape, cell_sides=csides)
     assert part == true_part
-    part = odl.uniform_partition(begin=None, end=end, num_nodes=nsamp,
+    part = odl.uniform_partition(min_pt=None, max_pt=max_pt, shape=shape,
                                  cell_sides=csides)
     assert part == true_part
-    part = odl.uniform_partition(begin=begin, end=end, num_nodes=nsamp,
+    part = odl.uniform_partition(min_pt=min_pt, max_pt=max_pt, shape=shape,
                                  cell_sides=csides)
     assert part == true_part
 
     # Test parameters per axis
     part = odl.uniform_partition(
-        begin=[0, None], end=[None, 2], num_nodes=nsamp, cell_sides=csides)
+        min_pt=[0, None], max_pt=[None, 2], shape=shape, cell_sides=csides)
     assert part == true_part
     part = odl.uniform_partition(
-        begin=begin, end=[None, 2], num_nodes=(4, None), cell_sides=csides)
+        min_pt=min_pt, max_pt=[None, 2], shape=(4, None), cell_sides=csides)
     assert part == true_part
     part = odl.uniform_partition(
-        begin=begin, end=end, num_nodes=(None, 4), cell_sides=[0.25, None])
+        min_pt=min_pt, max_pt=max_pt, shape=(None, 4), cell_sides=[0.25, None])
 
     # Test robustness against numerical error
     part = odl.uniform_partition(
-        begin=begin, end=[None, np.sqrt(2) ** 2], num_nodes=nsamp,
+        min_pt=min_pt, max_pt=[None, np.sqrt(2) ** 2], shape=shape,
         cell_sides=[0.25, np.log(np.exp(0.2))])
     assert part.approx_equals(true_part, atol=1e-8)
 
     # Test nodes_on_bdry
     # Here we compute stuff, so we can only expect approximate equality
     csides = [1 / 3., 2 / 9.5]
-    true_part = odl.uniform_partition(begin, end, nsamp,
+    true_part = odl.uniform_partition(min_pt, max_pt, shape,
                                       nodes_on_bdry=(True, (False, True)))
     part = odl.uniform_partition(
-        begin=[0, None], end=[None, 2], num_nodes=nsamp,
+        min_pt=[0, None], max_pt=[None, 2], shape=shape,
         cell_sides=csides, nodes_on_bdry=(True, (False, True)))
     assert part.approx_equals(true_part, atol=1e-8)
     part = odl.uniform_partition(
-        begin=begin, end=[None, 2], num_nodes=(4, None), cell_sides=csides,
+        min_pt=min_pt, max_pt=[None, 2], shape=(4, None), cell_sides=csides,
         nodes_on_bdry=(True, (False, True)))
     assert part.approx_equals(true_part, atol=1e-8)
     part = odl.uniform_partition(
-        begin=begin, end=end, num_nodes=(None, 10), cell_sides=[1 / 3., None],
+        min_pt=min_pt, max_pt=max_pt, shape=(None, 10),
+        cell_sides=[1 / 3., None],
         nodes_on_bdry=(True, (False, True)))
     assert part.approx_equals(true_part, atol=1e-8)
 
@@ -395,30 +402,33 @@ def test_uniform_partition():
         odl.uniform_partition()
 
     with pytest.raises(ValueError):
-        odl.uniform_partition(begin, end)
+        odl.uniform_partition(min_pt, max_pt)
 
     with pytest.raises(ValueError):
         part = odl.uniform_partition(
-            begin=[0, None], end=[1, None], num_nodes=nsamp, cell_sides=csides)
+            min_pt=[0, None], max_pt=[1, None], shape=shape,
+            cell_sides=csides)
 
     with pytest.raises(ValueError):
         part = odl.uniform_partition(
-            begin=begin, end=[1, None], num_nodes=(4, None), cell_sides=csides)
+            min_pt=min_pt, max_pt=[1, None], shape=(4, None),
+            cell_sides=csides)
 
     # Parameters with inconsistent sizes
     with pytest.raises(ValueError):
         part = odl.uniform_partition(
-            begin=begin, end=[1, None, None], num_nodes=nsamp)
+            min_pt=min_pt, max_pt=[1, None, None], shape=shape)
 
-    # Too large rounding error in computing num_nodes
+    # Too large rounding error in computing shape
     with pytest.raises(ValueError):
         part = odl.uniform_partition(
-            begin=begin, end=end, cell_sides=[0.25, 0.2001])
+            min_pt=min_pt, max_pt=max_pt, cell_sides=[0.25, 0.2001])
 
     # Inconsistent values
     with pytest.raises(ValueError):
         part = odl.uniform_partition(
-            begin=begin, end=end, num_nodes=nsamp, cell_sides=[0.25, 0.2001])
+            min_pt=min_pt, max_pt=max_pt, shape=shape,
+            cell_sides=[0.25, 0.2001])
 
 if __name__ == '__main__':
     pytest.main(str(__file__.replace('\\', '/')) + ' -v')

--- a/test/set/domain_test.py
+++ b/test/set/domain_test.py
@@ -33,7 +33,8 @@ from odl.util.testutils import almost_equal, all_equal
 
 def random_point(set_):
     if isinstance(set_, IntervalProd):
-        return np.random.rand(set_.ndim) * (set_.end - set_.begin) + set_.begin
+        return (set_.min_pt +
+                np.random.rand(set_.ndim) * (set_.max_pt - set_.min_pt))
     else:
         raise NotImplementedError("unknown type")
 
@@ -57,32 +58,32 @@ def test_init():
         IntervalProd((1, 2, 3), (1, 2, 0))
 
 
-def test_begin():
+def test_min_pt():
     set_ = IntervalProd(1, 2)
-    assert almost_equal(set_.begin, 1)
+    assert almost_equal(set_.min_pt, 1)
 
     set_ = IntervalProd(-np.inf, 0)
-    assert almost_equal(set_.begin, -np.inf)
+    assert almost_equal(set_.min_pt, -np.inf)
 
     set_ = IntervalProd([1], [2])
-    assert almost_equal(set_.begin, 1)
+    assert almost_equal(set_.min_pt, 1)
 
     set_ = IntervalProd([1, 2, 3], [5, 6, 7])
-    assert all_equal(set_.begin, [1, 2, 3])
+    assert all_equal(set_.min_pt, [1, 2, 3])
 
 
-def test_end():
+def test_max_pt():
     set_ = IntervalProd(1, 2)
-    assert almost_equal(set_.end, 2)
+    assert almost_equal(set_.max_pt, 2)
 
     set_ = IntervalProd(0, np.inf)
-    assert almost_equal(set_.end, np.inf)
+    assert almost_equal(set_.max_pt, np.inf)
 
     set_ = IntervalProd([1], [2])
-    assert almost_equal(set_.end, 2)
+    assert almost_equal(set_.max_pt, 2)
 
     set_ = IntervalProd([1, 2, 3], [5, 6, 7])
-    assert all_equal(set_.end, [5, 6, 7])
+    assert all_equal(set_.max_pt, [5, 6, 7])
 
 
 def test_ndim():
@@ -156,15 +157,15 @@ def test_volume():
     assert almost_equal(set_.volume, (5 - 1) * (6 - 2) * (7 - 3))
 
 
-def test_modpoint():
+def test_mid_pt():
     set_ = IntervalProd(1, 2)
-    assert set_.midpoint == 1.5
+    assert set_.mid_pt == 1.5
 
     set_ = IntervalProd(0, np.inf)
-    assert set_.midpoint == np.inf
+    assert set_.mid_pt == np.inf
 
     set_ = IntervalProd([1, 2, 3], [5, 6, 7])
-    assert all_equal(set_.midpoint, [3, 4, 5])
+    assert all_equal(set_.mid_pt, [3, 4, 5])
 
 
 def test_element():
@@ -294,24 +295,24 @@ def test_insert():
     intvp2 = IntervalProd(1, 3)
 
     intvp = intvp1.insert(0, intvp2)
-    true_begin = [1, 0, 0]
-    true_end = [3, 1, 2]
-    assert intvp == IntervalProd(true_begin, true_end)
+    true_min_pt = [1, 0, 0]
+    true_max_pt = [3, 1, 2]
+    assert intvp == IntervalProd(true_min_pt, true_max_pt)
 
     intvp = intvp1.insert(1, intvp2)
-    true_begin = [0, 1, 0]
-    true_end = [1, 3, 2]
-    assert intvp == IntervalProd(true_begin, true_end)
+    true_min_pt = [0, 1, 0]
+    true_max_pt = [1, 3, 2]
+    assert intvp == IntervalProd(true_min_pt, true_max_pt)
 
     intvp = intvp1.insert(2, intvp2)
-    true_begin = [0, 0, 1]
-    true_end = [1, 2, 3]
-    assert intvp == IntervalProd(true_begin, true_end)
+    true_min_pt = [0, 0, 1]
+    true_max_pt = [1, 2, 3]
+    assert intvp == IntervalProd(true_min_pt, true_max_pt)
 
     intvp = intvp1.insert(-1, intvp2)  # same as 1
-    true_begin = [0, 1, 0]
-    true_end = [1, 3, 2]
-    assert intvp == IntervalProd(true_begin, true_end)
+    true_min_pt = [0, 1, 0]
+    true_max_pt = [1, 3, 2]
+    assert intvp == IntervalProd(true_min_pt, true_max_pt)
 
     with pytest.raises(IndexError):
         intvp1.insert(3, intvp2)
@@ -326,8 +327,8 @@ def test_dist():
         assert set_.dist(interior) == 0.0
 
     for exterior in [0.0, 2.0, np.inf]:
-        assert set_.dist(exterior) == min(abs(set_.begin - exterior),
-                                          abs(exterior - set_.end))
+        assert set_.dist(exterior) == min(abs(set_.min_pt - exterior),
+                                          abs(exterior - set_.max_pt))
 
     assert set_.dist(np.NaN) == np.inf
 

--- a/test/space/fspace_test.py
+++ b/test/space/fspace_test.py
@@ -87,22 +87,22 @@ def test_fspace_equality():
 
 
 def _points(domain, num):
-    beg = domain.begin
-    end = domain.end
+    min_pt = domain.min_pt
+    max_pt = domain.max_pt
     ndim = domain.ndim
     points = np.random.uniform(low=0, high=1, size=(ndim, num))
     for i in range(ndim):
-        points[i, :] = beg[i] + (end[i] - beg[i]) * points[i]
+        points[i, :] = min_pt[i] + (max_pt[i] - min_pt[i]) * points[i]
     return points
 
 
 def _meshgrid(domain, shape):
-    beg = domain.begin
-    end = domain.end
+    min_pt = domain.min_pt
+    max_pt = domain.max_pt
     ndim = domain.ndim
     coord_vecs = []
     for i in range(ndim):
-        vec = np.random.uniform(low=beg[i], high=end[i], size=shape[i])
+        vec = np.random.uniform(low=min_pt[i], high=max_pt[i], size=shape[i])
         vec.sort()
         coord_vecs.append(vec)
     return sparse_meshgrid(*coord_vecs)

--- a/test/tomo/backends/astra_cpu_test.py
+++ b/test/tomo/backends/astra_cpu_test.py
@@ -43,7 +43,7 @@ def test_astra_cpu_projector_parallel2d():
 
     # Create reco space and a phantom
     reco_space = odl.uniform_discr([-4, -5], [4, 5], (4, 5), dtype='float32')
-    phantom = odl.phantom.cuboid(reco_space, begin=[0, 0], end=[4, 5])
+    phantom = odl.phantom.cuboid(reco_space, min_pt=[0, 0], max_pt=[4, 5])
 
     # Create parallel geometry
     angle_part = odl.uniform_partition(0, 2 * np.pi, 8)
@@ -71,7 +71,7 @@ def test_astra_cpu_projector_fanflat():
 
     # Create reco space and a phantom
     reco_space = odl.uniform_discr([-4, -5], [4, 5], (4, 5), dtype='float32')
-    phantom = odl.phantom.cuboid(reco_space, begin=[0, 0], end=[4, 5])
+    phantom = odl.phantom.cuboid(reco_space, min_pt=[0, 0], max_pt=[4, 5])
 
     # Create fan beam geometry with flat detector
     angle_part = odl.uniform_partition(0, 2 * np.pi, 8)

--- a/test/tomo/backends/astra_cuda_test.py
+++ b/test/tomo/backends/astra_cuda_test.py
@@ -43,7 +43,7 @@ def test_astra_cuda_projector_parallel2d():
 
     # Create reco space and a phantom
     reco_space = odl.uniform_discr([-4, -5], [4, 5], (4, 5), dtype='float32')
-    phantom = odl.phantom.cuboid(reco_space, begin=[0, 0], end=[4, 5])
+    phantom = odl.phantom.cuboid(reco_space, min_pt=[0, 0], max_pt=[4, 5])
 
     # Create parallel geometry
     angle_part = odl.uniform_partition(0, 2 * np.pi, 8)
@@ -71,7 +71,7 @@ def test_astra_cuda_projector_fanflat():
 
     # Create reco space and a phantom
     reco_space = odl.uniform_discr([-4, -5], [4, 5], (4, 5), dtype='float32')
-    phantom = odl.phantom.cuboid(reco_space, begin=[0, 0], end=[4, 5])
+    phantom = odl.phantom.cuboid(reco_space, min_pt=[0, 0], max_pt=[4, 5])
 
     # Create fan beam geometry with flat detector
     angle_part = odl.uniform_partition(0, 2 * np.pi, 8)
@@ -104,7 +104,8 @@ def test_astra_cuda_projector_parallel3d():
     # Create reco space and a phantom
     reco_space = odl.uniform_discr([-4, -5, -6], [4, 5, 6], (4, 5, 6),
                                    dtype='float32')
-    phantom = odl.phantom.cuboid(reco_space, begin=[0, 0, 0], end=[4, 5, 6])
+    phantom = odl.phantom.cuboid(reco_space, min_pt=[0, 0, 0],
+                                 max_pt=[4, 5, 6])
 
     # Create parallel geometry
     angle_part = odl.uniform_partition(0, 2 * np.pi, 8)
@@ -133,7 +134,8 @@ def test_astra_gpu_projector_circular_conebeam():
     # Create reco space and a phantom
     reco_space = odl.uniform_discr([-4, -5, -6], [4, 5, 6], (4, 5, 6),
                                    dtype='float32')
-    phantom = odl.phantom.cuboid(reco_space, begin=[0, 0, 0], end=[4, 5, 6])
+    phantom = odl.phantom.cuboid(reco_space, min_pt=[0, 0, 0],
+                                 max_pt=[4, 5, 6])
 
     # Create circular cone beam geometry with flat detector
     angle_part = odl.uniform_partition(0, 2 * np.pi, 8)
@@ -165,7 +167,8 @@ def test_astra_cuda_projector_helical_conebeam():
     # Create reco space and a phantom
     reco_space = odl.uniform_discr([-4, -5, -6], [4, 5, 6], (4, 5, 6),
                                    dtype='float32')
-    phantom = odl.phantom.cuboid(reco_space, begin=[0, 0, 0], end=[4, 5, 6])
+    phantom = odl.phantom.cuboid(reco_space, min_pt=[0, 0, 0],
+                                 max_pt=[4, 5, 6])
 
     # Create circular cone beam geometry with flat detector
     angle_part = odl.uniform_partition(0, 2 * np.pi, 8)

--- a/test/tomo/backends/astra_setup_test.py
+++ b/test/tomo/backends/astra_setup_test.py
@@ -54,9 +54,9 @@ def _discrete_domain(ndim, interp):
     """
     max_pt = np.arange(1, ndim + 1)
     min_pt = - max_pt
-    nsamples = np.arange(1, ndim + 1) * 10
+    shape = np.arange(1, ndim + 1) * 10
 
-    return odl.uniform_discr(min_pt, max_pt, nsamples=nsamples, interp=interp,
+    return odl.uniform_discr(min_pt, max_pt, shape=shape, interp=interp,
                              dtype='float32')
 
 
@@ -77,9 +77,9 @@ def _discrete_domain_anisotropic(ndim, interp):
     """
     min_pt = [-1] * ndim
     max_pt = [1] * ndim
-    nsamples = np.arange(1, ndim + 1) * 10
+    shape = np.arange(1, ndim + 1) * 10
 
-    return odl.uniform_discr(min_pt, max_pt, nsamples=nsamples, interp=interp,
+    return odl.uniform_discr(min_pt, max_pt, shape=shape, interp=interp,
                              dtype='float32')
 
 

--- a/test/tomo/backends/scikit_test.py
+++ b/test/tomo/backends/scikit_test.py
@@ -39,7 +39,7 @@ def test_scikit_radon_projector_parallel2d():
 
     # Create reco space and a phantom
     reco_space = odl.uniform_discr([-5, -5], [5, 5], (5, 5), dtype='float32')
-    phantom = odl.phantom.cuboid(reco_space, begin=[0, 0], end=[5, 5])
+    phantom = odl.phantom.cuboid(reco_space, min_pt=[0, 0], max_pt=[5, 5])
 
     # Create parallel geometry
     angle_part = odl.uniform_partition(0, 2 * np.pi, 8)

--- a/test/trafos/fourier_test.py
+++ b/test/trafos/fourier_test.py
@@ -102,7 +102,7 @@ def direction(request):
 
 def test_reciprocal_1d_odd():
 
-    grid = odl.uniform_sampling(0, 1, num_nodes=11)
+    grid = odl.uniform_sampling(0, 1, shape=11)
     s = grid.stride
     n = np.array(grid.shape)
 
@@ -116,7 +116,7 @@ def test_reciprocal_1d_odd():
     assert all_almost_equal(rgrid.stride, true_recip_stride)
     # Should be symmetric
     assert all_almost_equal(rgrid.min_pt, -rgrid.max_pt)
-    assert all_almost_equal(rgrid.center, 0)
+    assert all_almost_equal(rgrid.mid_pt, 0)
     # Zero should be at index n // 2
     assert all_almost_equal(rgrid[n // 2], 0)
 
@@ -137,7 +137,7 @@ def test_reciprocal_1d_odd():
 
 def test_reciprocal_1d_odd_halfcomplex():
 
-    grid = odl.uniform_sampling(0, 1, num_nodes=11)
+    grid = odl.uniform_sampling(0, 1, shape=11)
     s = grid.stride
     n = np.array(grid.shape)
 
@@ -169,7 +169,7 @@ def test_reciprocal_1d_odd_halfcomplex():
 
 def test_reciprocal_1d_even():
 
-    grid = odl.uniform_sampling(0, 1, num_nodes=10)
+    grid = odl.uniform_sampling(0, 1, shape=10)
     s = grid.stride
     n = np.array(grid.shape)
 
@@ -183,7 +183,7 @@ def test_reciprocal_1d_even():
     assert all_almost_equal(rgrid.stride, true_recip_stride)
     # Should be symmetric
     assert all_almost_equal(rgrid.min_pt, -rgrid.max_pt)
-    assert all_almost_equal(rgrid.center, 0)
+    assert all_almost_equal(rgrid.mid_pt, 0)
     # No point should be closer to 0 than half a recip stride
     atol = 0.999 * true_recip_stride / 2
     assert not rgrid.approx_contains(0, atol=atol)
@@ -204,7 +204,7 @@ def test_reciprocal_1d_even():
 
 def test_reciprocal_1d_even_halfcomplex():
 
-    grid = odl.uniform_sampling(0, 1, num_nodes=10)
+    grid = odl.uniform_sampling(0, 1, shape=10)
     s = grid.stride
     n = np.array(grid.shape)
 
@@ -236,7 +236,7 @@ def test_reciprocal_1d_even_halfcomplex():
 
 def test_reciprocal_nd():
 
-    grid = odl.uniform_sampling([0] * 3, [1] * 3, num_nodes=(3, 4, 5))
+    grid = odl.uniform_sampling([0] * 3, [1] * 3, shape=(3, 4, 5))
     s = grid.stride
     n = np.array(grid.shape)
 
@@ -256,7 +256,7 @@ def test_reciprocal_nd():
 
 def test_reciprocal_nd_shift_list():
 
-    grid = odl.uniform_sampling([0] * 3, [1] * 3, num_nodes=(3, 4, 5))
+    grid = odl.uniform_sampling([0] * 3, [1] * 3, shape=(3, 4, 5))
     s = grid.stride
     n = np.array(grid.shape)
     shift = [False, True, False]
@@ -279,7 +279,7 @@ def test_reciprocal_nd_shift_list():
 
 def test_reciprocal_nd_axes():
 
-    grid = odl.uniform_sampling([0] * 3, [1] * 3, num_nodes=(3, 4, 5))
+    grid = odl.uniform_sampling([0] * 3, [1] * 3, shape=(3, 4, 5))
     s = grid.stride
     n = np.array(grid.shape)
     axes_list = [[1, -1], [0], 0, [0, 2, 1], [2, 0]]
@@ -310,7 +310,7 @@ def test_reciprocal_nd_axes():
 
 def test_reciprocal_nd_halfcomplex():
 
-    grid = odl.uniform_sampling([0] * 3, [1] * 3, num_nodes=(3, 4, 5))
+    grid = odl.uniform_sampling([0] * 3, [1] * 3, shape=(3, 4, 5))
     s = grid.stride
     n = np.array(grid.shape)
     stride_last = 2 * pi / (s[-1] * n[-1])


### PR DESCRIPTION
The following substitutions were made:

- `begin` -> `min_pt` (in grid.py and partition.py)
- `end` -> `max_pt` (in grid.py and partition.py)
- `num_nodes` -> `shape` (in grid.py and partition.py)
- `center` -> `mid_pt` (in grid.py)
- `midpoint` -> `mid_pt` (in domain.py)
- `min_corner` -> `min_pt` (in lp_discr.py)
- `max_corner` -> `max_pt` (in lp_discr.py)
- `nsamples` -> `shape` (in lp_discr.py)