### PR TITLE
MAINT: style fixes to WaveletTransform

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -112,7 +112,8 @@ if not on_rtd:
         'python': ('http://python.readthedocs.org/en/latest/', None),
         'numpy': ('http://numpy.readthedocs.org/en/latest/', None),
         'scipy': ('http://docs.scipy.org/doc/scipy/reference/', None),
-        'matplotlib': ('http://matplotlib.sourceforge.net/', None)}
+        'matplotlib': ('http://matplotlib.sourceforge.net/', None),
+        'pywt': ('https://pywavelets.readthedocs.io/en/latest/', None)}
 
 # Stop autodoc from skipping __init__
 

--- a/doc/source/release_notes.rst
+++ b/doc/source/release_notes.rst
@@ -12,7 +12,6 @@ Next release
 New features
 ------------
 - Add ``ResizingOperator`` for shrinking and extending (padding) of discretized functions, including a variety of padding methods. (:pull:`499`)
-<<<<<<< HEAD
 - Add ``as_writable_array`` that allows casting arbitrary array-likes to a numpy array and then storing the results later on. This is
   intended to be used with odl vectors that may not be stored in numpy format (like cuda vectors), but can be used with other types like lists.
   (:pull:`524`)
@@ -20,11 +19,10 @@ New features
 
 Improvements
 ------------
+- Change ``pad_mode`` style in ``WaveletTransform`` to follow the ODL standard nomenclature instead of PyWavelet style.
 - Add intelligence to ``power_method_opnorm`` so it can terminate early by checking if consecutive iterates are close. (:pull:`527`)
-=======
 - Add ``BroadcastOperator(op, n)``, ``ReductionOperator(op, n)`` and ``DiagonalOperator(op, n)`` syntax.
   This is equivalent to ``BroadcastOperator(*([op] * n))`` etc, i.e. create ``n`` copies of the operator.
->>>>>>> ENH: allow syntax (op, n) in the ProductSpaceOperators, closes #517
 
 Changes
 --------

--- a/examples/trafos/wavelet_trafo.py
+++ b/examples/trafos/wavelet_trafo.py
@@ -1,0 +1,45 @@
+# Copyright 2014-2016 The ODL development group
+#
+# This file is part of ODL.
+#
+# ODL is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# ODL is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with ODL.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Simple example on the usage of the Wavelet Transform."""
+
+import odl
+
+# Discretized space: discretized functions on the rectangle [-1, 1] x [-1, 1]
+# with 512 samples per dimension.
+space = odl.uniform_discr([-1, -1], [1, 1], (256, 256))
+
+# Make the Wavelet transform operator on this space. The range is calculated
+# automatically. The default backend is PyWavelets (pywt).
+wavelet_op = odl.trafos.WaveletTransform(space, nscales=2, wbasis='Haar')
+
+# Create a phantom and its wavelet transfrom and display them.
+phantom = odl.phantom.shepp_logan(space, modified=True)
+phantom.show(title='Shepp-Logan phantom')
+
+# Note that the wavelet transform is a vector in rn.
+phantom_wt = wavelet_op(phantom)
+phantom_wt.show(title='wavelet transform')
+
+# It may however (for some choices of wbasis) be interpreted as a vector in the
+# domain of the transformation
+phantom_wt_2d = space.element(phantom_wt)
+phantom_wt_2d.show('wavelet transform in 2d')
+
+# Calculate the inverse transform.
+phantom_wt_inv = wavelet_op.inverse(phantom_wt)
+phantom_wt_inv.show(title='wavelet transform inverted')

--- a/test/trafos/wavelet_test.py
+++ b/test/trafos/wavelet_test.py
@@ -44,8 +44,8 @@ def test_coeff_size_list():
     # Verify that the helper function does indeed work as expected
     shape = (16,)
     nscale = 3
-    wbasis = pywt.Wavelet('db1')
-    mode = 'per'
+    wbasis = 'db1'
+    mode = 'periodic'
     size_list1d = coeff_size_list(shape, nscale, wbasis, mode)
     S1d = [(2,), (2,), (4,), (8,), (16,)]
     shape = (16, 16)
@@ -64,8 +64,8 @@ def test_wavelet_decomposition3d_and_reconstruction3d():
     # Test 3D wavelet decomposition and reconstruction and verify that
     # they perform as expected
     x = np.random.rand(16, 16, 16)
-    mode = 'sym'
-    wbasis = pywt.Wavelet('db5')
+    mode = 'symmetric'
+    wbasis = 'db5'
     nscales = 1
     wavelet_coeffs = wavelet_decomposition3d(x, wbasis, mode, nscales)
     aaa = wavelet_coeffs[0]
@@ -80,7 +80,7 @@ def test_wavelet_decomposition3d_and_reconstruction3d():
     assert all_almost_equal(reconstruction, x)
     assert all_almost_equal(reconstruction_reference, x)
 
-    wbasis = pywt.Wavelet('db1')
+    wbasis = 'db1'
     nscales = 3
     wavelet_coeffs = wavelet_decomposition3d(x, wbasis, mode, nscales)
     shape_true = (nscales + 1, )
@@ -94,8 +94,8 @@ def test_wavelet_decomposition3d_and_reconstruction3d():
 @skip_if_no_pywavelets
 def test_pywt_coeff_to_array_and_array_to_pywt_coeff():
     # Verify that the helper function does indeed work as expected
-    wbasis = pywt.Wavelet('db1')
-    mode = 'zpd'
+    wbasis = 'db1'
+    mode = 'constant'
     nscales = 2
     n = 16
     # 1D test
@@ -152,9 +152,9 @@ def test_dwt():
     n = 16
     x = np.zeros(n)
     x[5:10] = 1
-    wbasis = pywt.Wavelet('db1')
+    wbasis = 'db1'
     nscales = 2
-    mode = 'sym'
+    mode = 'symmetric'
     size_list = coeff_size_list((n,), nscales, wbasis, mode)
 
     # Define a discretized domain
@@ -196,9 +196,9 @@ def test_dwt():
     n = 16
     x = np.zeros((n, n))
     x[5:10, 5:10] = 1
-    wbasis = pywt.Wavelet('db1')
+    wbasis = 'db1'
     nscales = 2
-    mode = 'sym'
+    mode = 'symmetric'
     size_list = coeff_size_list((n, n), nscales, wbasis, mode)
 
     # Define a discretized domain
@@ -240,9 +240,9 @@ def test_dwt():
     n = 16
     x = np.zeros((n, n, n))
     x[5:10, 5:10, 5:10] = 1
-    wbasis = pywt.Wavelet('db2')
+    wbasis = 'db2'
     nscales = 1
-    mode = 'per'
+    mode = 'periodic'
     size_list = coeff_size_list((n, n, n), nscales, wbasis, mode)
 
     # Define a discretized domain


### PR DESCRIPTION
Done so far:

* Change boundary conditions to follow ODL style.
* Made the distinction between ODL and pywt more clear in general.
* Updated tests according to the above.
* Add PyWavelets to intersphinx.

TODO:

Add the actual example.