### PR TITLE
Issue 474  broadcast pspace arithmetic

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -79,17 +79,15 @@ def reduction(request):
     return request.param
 
 arithmetic_op_par = [operator.add,
-                     operator.div,
                      operator.truediv,
                      operator.mul,
                      operator.sub,
                      operator.iadd,
-                     operator.idiv,
                      operator.itruediv,
                      operator.imul,
                      operator.isub]
-arithmetic_op_ids = [' + ', ' // ', ' / ', ' * ', ' - ',
-                     ' += ', ' //= ', ' /= ', ' *= ', ' -= ']
+arithmetic_op_ids = [' + ', ' / ', ' * ', ' - ',
+                     ' += ', ' /= ', ' *= ', ' -= ']
 
 
 @pytest.fixture(ids=arithmetic_op_ids, params=arithmetic_op_par)

--- a/conftest.py
+++ b/conftest.py
@@ -22,6 +22,7 @@ from future import standard_library
 standard_library.install_aliases()
 
 import pytest
+import operator
 import odl
 from odl.trafos.wavelet import PYWAVELETS_AVAILABLE
 
@@ -75,4 +76,23 @@ reduction_ids = [' reduction={} '.format(p[0]) for p in reduction_params]
 
 @pytest.fixture(scope="module", ids=reduction_ids, params=reduction_params)
 def reduction(request):
+    return request.param
+
+arithmetic_op_par = [operator.add,
+                     operator.div,
+                     operator.truediv,
+                     operator.mul,
+                     operator.sub,
+                     operator.iadd,
+                     operator.idiv,
+                     operator.itruediv,
+                     operator.imul,
+                     operator.isub]
+arithmetic_op_ids = [' + ', ' // ', ' / ', ' * ', ' - ',
+                     ' += ', ' //= ', ' /= ', ' *= ', ' -= ']
+
+
+@pytest.fixture(ids=arithmetic_op_ids, params=arithmetic_op_par)
+def arithmetic_op(request):
+    """An arithmetic operator, e.g. +, -, // etc."""
     return request.param

--- a/odl/set/space.py
+++ b/odl/set/space.py
@@ -457,9 +457,9 @@ class LinearSpaceElement(object):
                 # other --> other * space.one()
                 return self.space.lincomb(1, self, other, one(), out=self)
         else:
-            # We do not raise here since we don't want a fallback for inplace.
-            # Otherwise python attempts self = self / other which does not
-            # modify self.
+            # We do not `return NotImplemented` here since we don't want a
+            # fallback for inplace. Otherwise python attempts
+            # `self = self + other` which does not modify self.
             raise TypeError('cannot add {!r} and {!r} in place'
                             ''.format(self, other))
 
@@ -492,9 +492,9 @@ class LinearSpaceElement(object):
             else:
                 return self.space.lincomb(1, self, -other, one(), out=self)
         else:
-            # We do not raise here since we don't want a fallback for inplace.
-            # Otherwise python attempts self = self - other which does not
-            # modify self.
+            # We do not `return NotImplemented` here since we don't want a
+            # fallback for inplace. Otherwise python attempts
+            # `self = self - other` which does not modify self.
             raise TypeError('cannot subtract {!r} and {!r} in place'
                             ''.format(self, other))
 
@@ -538,9 +538,9 @@ class LinearSpaceElement(object):
         elif other in self.space:
             return self.space.multiply(other, self, out=self)
         else:
-            # We do not raise here since we don't want a fallback for inplace.
-            # Otherwise python attempts self = self * other which does not
-            # modify self.
+            # We do not `return NotImplemented` here since we don't want a
+            # fallback for inplace. Otherwise python attempts
+            # `self = self * other` which does not modify self.
             raise TypeError('cannot multiply {!r} and {!r} in place'
                             ''.format(self, other))
 
@@ -565,9 +565,9 @@ class LinearSpaceElement(object):
         elif other in self.space:
             return self.space.divide(self, other, out=self)
         else:
-            # We do not raise here since we don't want a fallback for inplace.
-            # Otherwise python attempts self = self / other which does not
-            # modify self.
+            # We do not `return NotImplemented` here since we don't want a
+            # fallback for inplace. Otherwise python attempts
+            # `self = self + other` which does not modify self.
             raise TypeError('cannot divide {!r} and {!r} in place'
                             ''.format(self, other))
 

--- a/odl/set/space.py
+++ b/odl/set/space.py
@@ -458,7 +458,7 @@ class LinearSpaceElement(object):
                 return self.space.lincomb(1, self, other, one(), out=self)
         else:
             # We do not `return NotImplemented` here since we don't want a
-            # fallback for inplace. Otherwise python attempts
+            # fallback for in-place. Otherwise python attempts
             # `self = self + other` which does not modify self.
             raise TypeError('cannot add {!r} and {!r} in place'
                             ''.format(self, other))
@@ -493,7 +493,7 @@ class LinearSpaceElement(object):
                 return self.space.lincomb(1, self, -other, one(), out=self)
         else:
             # We do not `return NotImplemented` here since we don't want a
-            # fallback for inplace. Otherwise python attempts
+            # fallback for in-place. Otherwise python attempts
             # `self = self - other` which does not modify self.
             raise TypeError('cannot subtract {!r} and {!r} in place'
                             ''.format(self, other))
@@ -539,7 +539,7 @@ class LinearSpaceElement(object):
             return self.space.multiply(other, self, out=self)
         else:
             # We do not `return NotImplemented` here since we don't want a
-            # fallback for inplace. Otherwise python attempts
+            # fallback for in-place. Otherwise python attempts
             # `self = self * other` which does not modify self.
             raise TypeError('cannot multiply {!r} and {!r} in place'
                             ''.format(self, other))
@@ -566,8 +566,8 @@ class LinearSpaceElement(object):
             return self.space.divide(self, other, out=self)
         else:
             # We do not `return NotImplemented` here since we don't want a
-            # fallback for inplace. Otherwise python attempts
-            # `self = self + other` which does not modify self.
+            # fallback for in-place. Otherwise python attempts
+            # `self = self / other` which does not modify self.
             raise TypeError('cannot divide {!r} and {!r} in place'
                             ''.format(self, other))
 

--- a/odl/set/space.py
+++ b/odl/set/space.py
@@ -457,7 +457,11 @@ class LinearSpaceElement(object):
                 # other --> other * space.one()
                 return self.space.lincomb(1, self, other, one(), out=self)
         else:
-            return NotImplemented
+            # We do not raise here since we don't want a fallback for inplace.
+            # Otherwise python attempts self = self / other which does not
+            # modify self.
+            raise TypeError('cannot add {!r} and {!r} in place'
+                            ''.format(self, other))
 
     def __add__(self, other):
         """Return ``self + other``."""
@@ -488,7 +492,11 @@ class LinearSpaceElement(object):
             else:
                 return self.space.lincomb(1, self, -other, one(), out=self)
         else:
-            return NotImplemented
+            # We do not raise here since we don't want a fallback for inplace.
+            # Otherwise python attempts self = self - other which does not
+            # modify self.
+            raise TypeError('cannot subtract {!r} and {!r} in place'
+                            ''.format(self, other))
 
     def __sub__(self, other):
         """Return ``self - other``."""
@@ -508,6 +516,9 @@ class LinearSpaceElement(object):
 
     def __rsub__(self, other):
         """Return ``other - self``."""
+        if other in self.space:
+            tmp = self.space.element()
+            return self.space.lincomb(1, other, -1, self, out=tmp)
         if other in self.space.field:
             one = getattr(self.space, 'one', None)
             if one is None:
@@ -518,7 +529,6 @@ class LinearSpaceElement(object):
                 self.space.lincomb(other, tmp, out=tmp)
                 return self.space.lincomb(1, tmp, -1, self, out=tmp)
         else:
-            # Case `other in self.space` handled by `other`
             return NotImplemented
 
     def __imul__(self, other):
@@ -528,7 +538,11 @@ class LinearSpaceElement(object):
         elif other in self.space:
             return self.space.multiply(other, self, out=self)
         else:
-            return NotImplemented
+            # We do not raise here since we don't want a fallback for inplace.
+            # Otherwise python attempts self = self * other which does not
+            # modify self.
+            raise TypeError('cannot multiply {!r} and {!r} in place'
+                            ''.format(self, other))
 
     def __mul__(self, other):
         """Return ``self * other``."""
@@ -542,9 +556,7 @@ class LinearSpaceElement(object):
         else:
             return NotImplemented
 
-    def __rmul__(self, other):
-        """Return ``other * self``."""
-        return self.__mul__(other)
+    __rmul__ = __mul__
 
     def __itruediv__(self, other):
         """Implement ``self /= other``."""
@@ -553,7 +565,11 @@ class LinearSpaceElement(object):
         elif other in self.space:
             return self.space.divide(self, other, out=self)
         else:
-            return NotImplemented
+            # We do not raise here since we don't want a fallback for inplace.
+            # Otherwise python attempts self = self / other which does not
+            # modify self.
+            raise TypeError('cannot divide {!r} and {!r} in place'
+                            ''.format(self, other))
 
     __idiv__ = __itruediv__
 
@@ -581,8 +597,10 @@ class LinearSpaceElement(object):
                 tmp = one()
                 self.space.lincomb(other, tmp, out=tmp)
                 return self.space.divide(tmp, self, out=tmp)
+        elif other in self.space:
+            tmp = self.space.element()
+            return self.space.divide(other, self, out=tmp)
         else:
-            # Case `other in self.space` handled by `other`
             return NotImplemented
 
     __rdiv__ = __rtruediv__

--- a/odl/space/pspace.py
+++ b/odl/space/pspace.py
@@ -838,19 +838,19 @@ def _broadcast_arithmetic(op):
     -------
     broadcast_arithmetic_op : function
         Function intended to be used as a method for `ProductSpaceVector`
-        which tries to perform broadcasting if possible.
+        which performs broadcasting if possible.
 
     Notes
     -----
-    Broadcasting is the operation of "applying a operator multiple times" in
+    Broadcasting is the operation of "applying an operator multiple times" in
     some sense. For example:
 
     .. math::
-        [1, 2] + 1 = [2, 3]
+        (1, 2) + 1 = (2, 3)
 
     is a form of broadcasting. In this implementation, we only allow "single
-    layer" broadcasting. I.e., we do not support broadcasting over several
-    productspaces at once.
+    layer" broadcasting, i.e., we do not support broadcasting over several
+    product spaces at once.
     """
     def _broadcast_arithmetic_impl(self, other):
         if (self.space.is_power_space and other in self.space[0]):

--- a/test/solvers/advanced/proximal_operator_test.py
+++ b/test/solvers/advanced/proximal_operator_test.py
@@ -496,7 +496,7 @@ def test_proximal_convconj_kl_cross_entropy():
 
     assert all_almost_equal(prox_val, x_verify, HIGH_ACC)
 
-    # Test inplace evaluation
+    # Test in-place evaluation
     x_inplace = space.element()
     prox(x, out=x_inplace)
 

--- a/test/space/ntuples_test.py
+++ b/test/space/ntuples_test.py
@@ -369,9 +369,7 @@ def _test_scalar_operator(fn, function):
     for scalar in [-31.2, -1, 0, 1, 2.13]:
         x_arr, x = noise_elements(fn)
 
-        if scalar == 0 and function in [operator.div,
-                                        operator.idiv,
-                                        operator.truediv,
+        if scalar == 0 and function in [operator.truediv,
                                         operator.itruediv]:
             # Check for correct zero division behaviour
             with pytest.raises(ZeroDivisionError):

--- a/test/space/ntuples_test.py
+++ b/test/space/ntuples_test.py
@@ -375,7 +375,6 @@ def _test_scalar_operator(fn, function):
                                         operator.itruediv]:
             # Check for correct zero division behaviour
             with pytest.raises(ZeroDivisionError):
-                y_arr = function(x_arr, scalar)
                 y = function(x, scalar)
         else:
             y_arr = function(x_arr, scalar)

--- a/test/space/ntuples_test.py
+++ b/test/space/ntuples_test.py
@@ -347,11 +347,8 @@ def test_power(fn):
     assert all_almost_equal(y_pos, y_pos_arr)
 
 
-def _test_unary_operator(fn, function):
-    # Verify that the statement y=function(x) gives equivalent results
-    # to NumPy
-    x_arr, x = noise_elements(fn)
-
+def test_unary_ops(fn):
+    """Verify that the unary operators (`+x` and `-x`) work as expected."""
     for op in [operator.pos, operator.neg]:
         x_arr, x = noise_elements(fn)
 
@@ -361,65 +358,61 @@ def _test_unary_operator(fn, function):
         assert all_almost_equal([x, y], [x_arr, y_arr])
 
 
-def _test_scalar_operator(fn, function):
-    # Verify that the statement y=op(x, scalar) gives equivalent results
-    # to NumPy
-    [x_arr, y_arr], [x, y] = noise_elements(fn, 2)
+def test_scalar_operator(fn, arithmetic_op):
+    """Verify binary operations with scalars.
+
+    Verifies that the statement y=op(x, scalar) gives equivalent results
+    to NumPy.
+    """
 
     for scalar in [-31.2, -1, 0, 1, 2.13]:
         x_arr, x = noise_elements(fn)
 
-        if scalar == 0 and function in [operator.truediv,
-                                        operator.itruediv]:
+        # Left op
+        if scalar == 0 and arithmetic_op in [operator.truediv,
+                                             operator.itruediv]:
             # Check for correct zero division behaviour
             with pytest.raises(ZeroDivisionError):
-                y = function(x, scalar)
+                y = arithmetic_op(x, scalar)
         else:
-            y_arr = function(x_arr, scalar)
-            y = function(x, scalar)
+            y_arr = arithmetic_op(x_arr, scalar)
+            y = arithmetic_op(x, scalar)
 
             assert all_almost_equal([x, y], [x_arr, y_arr])
 
         # right op
         x_arr, x = noise_elements(fn)
 
-        y_arr = function(scalar, x_arr)
-        y = function(scalar, x)
+        y_arr = arithmetic_op(scalar, x_arr)
+        y = arithmetic_op(scalar, x)
 
         assert all_almost_equal([x, y], [x_arr, y_arr])
 
 
-def _test_binary_operator(fn, op):
-    # Verify that the statement z=op(x,y) gives equivalent results to NumPy
+def test_binary_operator(fn, arithmetic_op):
+    """Verify binary operations with vectors.
+
+    Verifies that the statement z=op(x, y) gives equivalent results to NumPy.
+    """
     [x_arr, y_arr], [x, y] = noise_elements(fn, 2)
 
     # non-aliased left
-    z_arr = op(x_arr, y_arr)
-    z = op(x, y)
+    z_arr = arithmetic_op(x_arr, y_arr)
+    z = arithmetic_op(x, y)
 
     assert all_almost_equal([x, y, z], [x_arr, y_arr, z_arr])
 
     # non-aliased right
-    z_arr = op(y_arr, x_arr)
-    z = op(y, x)
+    z_arr = arithmetic_op(y_arr, x_arr)
+    z = arithmetic_op(y, x)
 
     assert all_almost_equal([x, y, z], [x_arr, y_arr, z_arr])
 
     # aliased operation
-    z_arr = op(x_arr, x_arr)
-    z = op(x, x)
+    z_arr = arithmetic_op(x_arr, x_arr)
+    z = arithmetic_op(x, x)
 
     assert all_almost_equal([x, y, z], [x_arr, y_arr, z_arr])
-
-
-def test_operators(fn, arithmetic_op):
-    # Test of the operators `+`, `-`, etc work as expected
-
-    # Interactions with scalars
-    _test_scalar_operator(fn, arithmetic_op)
-
-    # Interactions with vectors
-    _test_binary_operator(fn, arithmetic_op)
 
 
 def test_assign(fn):

--- a/test/space/pspace_test.py
+++ b/test/space/pspace_test.py
@@ -623,7 +623,7 @@ def test_operators(arithmetic_op):
                          operator.isub,
                          operator.itruediv,
                          operator.imul]:
-        # Check for correct error since inplace op is not possible here
+        # Check for correct error since in-place op is not possible here
         with pytest.raises(TypeError):
             z = arithmetic_op(x, y)
     else:

--- a/test/space/pspace_test.py
+++ b/test/space/pspace_test.py
@@ -23,9 +23,11 @@ standard_library.install_aliases()
 
 import numpy as np
 import pytest
+import operator
 
 import odl
-from odl.util.testutils import all_equal, all_almost_equal, almost_equal
+from odl.util.testutils import (all_equal, all_almost_equal, almost_equal,
+                                example_vectors)
 
 
 exp_params = [2.0, 1.0, float('inf'), 0.5, 1.5]
@@ -566,6 +568,86 @@ def test_element_setitem_fancy():
     assert x[[0, 2]][1] is x3_new
 
 
+def test_unary_ops():
+    # Verify that the unary operators (`+x` and `-x`) work as expected
+
+    space = odl.rn(3)
+    pspace = odl.ProductSpace(space, 2)
+
+    for op in [operator.pos, operator.neg]:
+        x_arr, x = example_vectors(pspace)
+
+        y_arr = op(x_arr)
+        y = op(x)
+
+        assert all_almost_equal([x, y], [x_arr, y_arr])
+
+
+def test_operators(arithmetic_op):
+    # Test of the operators `+`, `-`, etc work as expected by numpy
+
+    space = odl.rn(3)
+    pspace = odl.ProductSpace(space, 2)
+
+    # Interactions with scalars
+
+    for scalar in [-31.2, -1, 0, 1, 2.13]:
+
+        # Left op
+        x_arr, x = example_vectors(pspace)
+        if scalar == 0 and arithmetic_op in [operator.div,
+                                             operator.idiv,
+                                             operator.truediv,
+                                             operator.itruediv]:
+            # Check for correct zero division behaviour
+            with pytest.raises(ZeroDivisionError):
+                y = arithmetic_op(x, scalar)
+        else:
+            y_arr = arithmetic_op(x_arr, scalar)
+            y = arithmetic_op(x, scalar)
+
+            assert all_almost_equal([x, y], [x_arr, y_arr])
+
+        # Right op
+        x_arr, x = example_vectors(pspace)
+
+        y_arr = arithmetic_op(scalar, x_arr)
+        y = arithmetic_op(scalar, x)
+
+        assert all_almost_equal([x, y], [x_arr, y_arr])
+
+    # Verify that the statement z=op(x,y) gives equivalent results to NumPy
+    x_arr, x = example_vectors(space, 1)
+    y_arr, y = example_vectors(pspace, 1)
+
+    # non-aliased left
+    if arithmetic_op in [operator.iadd,
+                         operator.isub,
+                         operator.idiv,
+                         operator.itruediv,
+                         operator.imul]:
+        # Check for correct error since inplace op is not possible here
+        with pytest.raises(TypeError):
+            z = arithmetic_op(x, y)
+    else:
+        z_arr = arithmetic_op(x_arr, y_arr)
+        z = arithmetic_op(x, y)
+
+        assert all_almost_equal([x, y, z], [x_arr, y_arr, z_arr])
+
+    # non-aliased right
+    z_arr = arithmetic_op(y_arr, x_arr)
+    z = arithmetic_op(y, x)
+
+    assert all_almost_equal([x, y, z], [x_arr, y_arr, z_arr])
+
+    # aliased operation
+    z_arr = arithmetic_op(y_arr, y_arr)
+    z = arithmetic_op(y, y)
+
+    assert all_almost_equal([x, y, z], [x_arr, y_arr, z_arr])
+
+
 def test_ufuncs():
     # Cannot use fixture due to bug in pytest
     H = odl.ProductSpace(odl.rn(1), odl.rn(2))
@@ -612,4 +694,4 @@ def test_reductions():
 
 
 if __name__ == '__main__':
-    pytest.main(str(__file__.replace('\\', '/') + ' -v'))
+    pytest.main([str(__file__.replace('\\', '/')), '-v'])

--- a/test/space/pspace_test.py
+++ b/test/space/pspace_test.py
@@ -27,7 +27,7 @@ import operator
 
 import odl
 from odl.util.testutils import (all_equal, all_almost_equal, almost_equal,
-                                example_vectors)
+                                noise_elements)
 
 
 exp_params = [2.0, 1.0, float('inf'), 0.5, 1.5]
@@ -575,7 +575,7 @@ def test_unary_ops():
     pspace = odl.ProductSpace(space, 2)
 
     for op in [operator.pos, operator.neg]:
-        x_arr, x = example_vectors(pspace)
+        x_arr, x = noise_elements(pspace)
 
         y_arr = op(x_arr)
         y = op(x)
@@ -594,7 +594,7 @@ def test_operators(arithmetic_op):
     for scalar in [-31.2, -1, 0, 1, 2.13]:
 
         # Left op
-        x_arr, x = example_vectors(pspace)
+        x_arr, x = noise_elements(pspace)
         if scalar == 0 and arithmetic_op in [operator.div,
                                              operator.idiv,
                                              operator.truediv,
@@ -609,16 +609,16 @@ def test_operators(arithmetic_op):
             assert all_almost_equal([x, y], [x_arr, y_arr])
 
         # Right op
-        x_arr, x = example_vectors(pspace)
+        x_arr, x = noise_elements(pspace)
 
         y_arr = arithmetic_op(scalar, x_arr)
         y = arithmetic_op(scalar, x)
 
         assert all_almost_equal([x, y], [x_arr, y_arr])
 
-    # Verify that the statement z=op(x,y) gives equivalent results to NumPy
-    x_arr, x = example_vectors(space, 1)
-    y_arr, y = example_vectors(pspace, 1)
+    # Verify that the statement z=op(x, y) gives equivalent results to NumPy
+    x_arr, x = noise_elements(space, 1)
+    y_arr, y = noise_elements(pspace, 1)
 
     # non-aliased left
     if arithmetic_op in [operator.iadd,

--- a/test/space/pspace_test.py
+++ b/test/space/pspace_test.py
@@ -595,9 +595,7 @@ def test_operators(arithmetic_op):
 
         # Left op
         x_arr, x = noise_elements(pspace)
-        if scalar == 0 and arithmetic_op in [operator.div,
-                                             operator.idiv,
-                                             operator.truediv,
+        if scalar == 0 and arithmetic_op in [operator.truediv,
                                              operator.itruediv]:
             # Check for correct zero division behaviour
             with pytest.raises(ZeroDivisionError):
@@ -623,7 +621,6 @@ def test_operators(arithmetic_op):
     # non-aliased left
     if arithmetic_op in [operator.iadd,
                          operator.isub,
-                         operator.idiv,
                          operator.itruediv,
                          operator.imul]:
         # Check for correct error since inplace op is not possible here


### PR DESCRIPTION
Quite well needed support for broadcasting, currently only supports "single power spaces", i.e.

```
ProductSpace(ProductSpace(space, 2), 2)
```

will still fail to multiply with `space`. I guess we are fine with that for now, but it should be added.

Also did some other general fixes.