### PR TITLE
MAINT: rename testutils example_ methods to noise_, improve doc, closes #557

### DIFF
--- a/test/discr/discr_ops_test.py
+++ b/test/discr/discr_ops_test.py
@@ -27,7 +27,7 @@ import numpy as np
 
 import odl
 from odl.discr.discr_ops import _SUPPORTED_RESIZE_PAD_MODES
-from odl.util.testutils import almost_equal, example_element, dtype_places
+from odl.util.testutils import almost_equal, noise_element, dtype_places
 from odl.util.utility import is_scalar_dtype, is_real_floating_dtype
 
 
@@ -222,7 +222,7 @@ def test_resizing_op_inverse(padding, fn_impl):
                                       pad_const=pad_const)
 
         # Only left inverse if the operator extentds in all axes
-        x = example_element(space)
+        x = noise_element(space)
         assert res_op.inverse(res_op(x)) == x
 
 
@@ -245,8 +245,8 @@ def test_resizing_op_adjoint(padding, fn_impl):
                 res_op.adjoint
             return
 
-        elem = example_element(space)
-        res_elem = example_element(res_space)
+        elem = noise_element(space)
+        res_elem = noise_element(res_space)
         inner1 = res_op(elem).inner(res_elem)
         inner2 = elem.inner(res_op.adjoint(res_elem))
         assert almost_equal(inner1, inner2, places=dtype_places(dtype))

--- a/test/discr/lp_discr_test.py
+++ b/test/discr/lp_discr_test.py
@@ -30,7 +30,7 @@ import odl
 from odl.discr.lp_discr import DiscreteLp
 from odl.space.base_ntuples import FnBase
 from odl.util.testutils import (almost_equal, all_equal, all_almost_equal,
-                                example_vectors)
+                                noise_vectors)
 
 # Pytest fixture
 
@@ -350,7 +350,7 @@ def test_zero():
 def _test_unary_operator(discr, function):
     # Verify that the statement y=function(x) gives equivalent results
     # to NumPy
-    x_arr, x = example_vectors(discr)
+    x_arr, x = noise_vectors(discr)
 
     y_arr = function(x_arr)
 
@@ -362,7 +362,7 @@ def _test_unary_operator(discr, function):
 def _test_binary_operator(discr, function):
     # Verify that the statement z=function(x,y) gives equivalent results
     # to NumPy
-    [x_arr, y_arr], [x, y] = example_vectors(discr, 2)
+    [x_arr, y_arr], [x, y] = noise_vectors(discr, 2)
 
     z_arr = function(x_arr, y_arr)
     z = function(x, y)
@@ -752,7 +752,7 @@ def test_ufunc(fn_impl, ufunc):
     ufunc = getattr(np, name)
 
     # Create some data
-    arrays, vectors = example_vectors(space, n_args + n_out)
+    arrays, vectors = noise_vectors(space, n_args + n_out)
     in_arrays = arrays[:n_args]
     out_arrays = arrays[n_args:]
     data_vector = vectors[0]
@@ -863,7 +863,7 @@ def test_reduction(fn_impl, reduction):
     ufunc = getattr(np, name)
 
     # Create some data
-    x_arr, x = example_vectors(space, 1)
+    x_arr, x = noise_vectors(space, 1)
     assert almost_equal(ufunc(x_arr), getattr(x.ufunc, name)())
 
 
@@ -879,7 +879,7 @@ def power(request):
 def test_power(fn_impl, power):
     space = odl.uniform_discr([0, 0], [1, 1], [2, 2], impl=fn_impl)
 
-    x_arr, x = example_vectors(space, 1)
+    x_arr, x = noise_vectors(space, 1)
     x_pos_arr = np.abs(x_arr)
     x_neg_arr = -x_pos_arr
     x_pos = np.abs(x)

--- a/test/largescale/solvers/advanced/proximal_operator_slow_test.py
+++ b/test/largescale/solvers/advanced/proximal_operator_slow_test.py
@@ -32,7 +32,7 @@ from odl.solvers.advanced.proximal_operators import (
     proximal_l1, proximal_cconj_l1,
     proximal_l2, proximal_cconj_l2,
     proximal_l2_squared, proximal_cconj_l2_squared)
-from odl.util.testutils import example_element
+from odl.util.testutils import noise_element
 
 
 pytestmark = odl.util.skip_if_no_largescale
@@ -86,7 +86,7 @@ def proximal_and_function(request, stepsize, offset):
     space = odl.uniform_discr(0, 1, 2)
 
     if offset:
-        g = example_element(space)
+        g = noise_element(space)
     else:
         g = None
 
@@ -170,7 +170,7 @@ def test_proximal_defintion(proximal_and_function):
 
     assert proximal.domain == proximal.range
 
-    x = example_element(proximal.domain) * 10
+    x = noise_element(proximal.domain) * 10
     f_x = proximal_objective(function, x, x)
     prox_x = proximal(x)
     f_prox_x = proximal_objective(function, x, prox_x)
@@ -178,7 +178,7 @@ def test_proximal_defintion(proximal_and_function):
     assert f_prox_x <= f_x
 
     for i in range(100):
-        y = example_element(proximal.domain)
+        y = noise_element(proximal.domain)
         f_y = proximal_objective(function, x, y)
 
         assert f_prox_x <= f_y

--- a/test/largescale/space/fn_base_slow_test.py
+++ b/test/largescale/space/fn_base_slow_test.py
@@ -28,7 +28,7 @@ import numpy as np
 
 # ODL imports
 import odl
-from odl.util.testutils import all_almost_equal, almost_equal, example_vectors
+from odl.util.testutils import all_almost_equal, almost_equal, noise_vectors
 
 pytestmark = odl.util.skip_if_no_largescale
 
@@ -116,7 +116,7 @@ def fn_weighting(fn):
 def test_inner(fn):
     weighting = fn_weighting(fn)
 
-    [xarr, yarr], [x, y] = example_vectors(fn, 2)
+    [xarr, yarr], [x, y] = noise_vectors(fn, 2)
 
     correct_inner = np.vdot(yarr, xarr) * weighting
 
@@ -127,7 +127,7 @@ def test_inner(fn):
 def test_norm(fn):
     weighting = np.sqrt(fn_weighting(fn))
 
-    xarr, x = example_vectors(fn)
+    xarr, x = noise_vectors(fn)
 
     correct_norm = np.linalg.norm(xarr) * weighting
 
@@ -138,7 +138,7 @@ def test_norm(fn):
 def test_dist(fn):
     weighting = np.sqrt(fn_weighting(fn))
 
-    [xarr, yarr], [x, y] = example_vectors(fn, 2)
+    [xarr, yarr], [x, y] = noise_vectors(fn, 2)
 
     correct_dist = np.linalg.norm(xarr - yarr) * weighting
 
@@ -151,7 +151,7 @@ def _test_lincomb(fn, a, b):
     # data and given a,b
 
     # Unaliased arguments
-    [x_arr, y_arr, z_arr], [x, y, z] = example_vectors(fn, 3)
+    [x_arr, y_arr, z_arr], [x, y, z] = noise_vectors(fn, 3)
 
     z_arr[:] = a * x_arr + b * y_arr
     z.lincomb(a, x, b, y)
@@ -171,7 +171,7 @@ def _test_member_lincomb(spc, a):
     # Validates vector member lincomb against the result on host
 
     # Generate vectors
-    [x_host, y_host], [x_device, y_device] = example_vectors(spc, 2)
+    [x_host, y_host], [x_device, y_device] = noise_vectors(spc, 2)
 
     # Host side calculation
     y_host[:] = a * x_host
@@ -192,7 +192,7 @@ def test_member_lincomb(fn):
 def _test_unary_operator(spc, function):
     # Verify that the statement y=function(x) gives equivalent
     # results to Numpy.
-    x_arr, x = example_vectors(spc)
+    x_arr, x = noise_vectors(spc)
 
     y_arr = function(x_arr)
     y = function(x)
@@ -204,7 +204,7 @@ def _test_unary_operator(spc, function):
 def _test_binary_operator(spc, function):
     # Verify that the statement z=function(x,y) gives equivalent
     # results to Numpy.
-    [x_arr, y_arr], [x, y] = example_vectors(spc, 2)
+    [x_arr, y_arr], [x, y] = noise_vectors(spc, 2)
 
     z_arr = function(x_arr, y_arr)
     z = function(x, y)

--- a/test/solvers/advanced/douglas_rachford_test.py
+++ b/test/solvers/advanced/douglas_rachford_test.py
@@ -26,7 +26,7 @@ import pytest
 import odl
 from odl.solvers import douglas_rachford_pd
 
-from odl.util.testutils import all_almost_equal, example_element
+from odl.util.testutils import all_almost_equal, noise_element
 
 
 # Places for the accepted error when comparing results
@@ -46,7 +46,7 @@ def test_primal_dual_input_handling():
 
     # Check that the algorithm runs. With the above operators, the algorithm
     # returns the input.
-    x0 = example_element(space1)
+    x0 = noise_element(space1)
     x = x0.copy()
     niter = 3
 
@@ -71,7 +71,7 @@ def test_primal_dual_input_handling():
 
     # Test for correct space
     space2 = odl.uniform_discr(1, 2, 10)
-    x = example_element(space2)
+    x = noise_element(space2)
     with pytest.raises(ValueError):
         douglas_rachford_pd(x, prox_f, prox_cc_g, lin_ops, tau=1.0,
                             sigma=[1.0, 1.0], niter=niter)
@@ -94,8 +94,8 @@ def test_primal_dual_l1():
     L = [odl.IdentityOperator(space)]
 
     # Data
-    data_1 = odl.util.testutils.example_element(space)
-    data_2 = odl.util.testutils.example_element(space)
+    data_1 = odl.util.testutils.noise_element(space)
+    data_2 = odl.util.testutils.noise_element(space)
 
     # Proximals
     prox_f = odl.solvers.proximal_l1(space, g=data_1)

--- a/test/solvers/advanced/forward_backward_test.py
+++ b/test/solvers/advanced/forward_backward_test.py
@@ -28,7 +28,7 @@ import pytest
 # Internal
 import odl
 from odl.solvers import forward_backward_pd
-from odl.util.testutils import all_almost_equal, almost_equal, example_element
+from odl.util.testutils import all_almost_equal, almost_equal, noise_element
 
 # Places for the accepted error when comparing results
 HIGH_ACCURACY = 8
@@ -48,7 +48,7 @@ def test_forward_backward_input_handling():
 
     # Check that the algorithm runs. With the above operators, the algorithm
     # returns the input.
-    x0 = example_element(space1)
+    x0 = noise_element(space1)
     x = x0.copy()
     niter = 3
 
@@ -73,7 +73,7 @@ def test_forward_backward_input_handling():
 
     # Test for correct space
     space2 = odl.uniform_discr(1, 2, 10)
-    x = example_element(space2)
+    x = noise_element(space2)
     with pytest.raises(ValueError):
         forward_backward_pd(x, prox_f, prox_cc_g, lin_ops, grad_h, tau=1.0,
                             sigma=[1.0, 1.0], niter=niter)
@@ -97,7 +97,7 @@ def test_forward_backward_basic():
     prox_f = odl.solvers.proximal_zero(space)
     grad_h = 2.0 * odl.IdentityOperator(space)  # Gradient of two-norm square
 
-    x = example_element(space)
+    x = noise_element(space)
     x_global_min = space.zero()
 
     forward_backward_pd(x, prox_f, prox_cc_g, lin_ops, grad_h, tau=0.5,
@@ -120,7 +120,7 @@ def test_forward_backward_with_lin_ops():
 
     space = odl.rn(10)
     alpha = 0.1
-    b = example_element(space)
+    b = noise_element(space)
 
     lin_op = alpha * odl.IdentityOperator(space)
     lin_ops = [lin_op]
@@ -130,7 +130,7 @@ def test_forward_backward_with_lin_ops():
     # Gradient of two-norm square
     grad_h = 2.0 * (odl.IdentityOperator(space) - odl.ConstantOperator(b))
 
-    x = example_element(space)
+    x = noise_element(space)
 
     # Explicit solution: x_hat = (I^T * I + (alpha*I)^T * (alpha*I))^-1 * (I*b)
     x_global_min = b / (1 + alpha**2)

--- a/test/solvers/advanced/proximal_utils_test.py
+++ b/test/solvers/advanced/proximal_utils_test.py
@@ -31,7 +31,7 @@ import pytest
 import odl
 import odl.solvers as odls
 
-from odl.util.testutils import all_almost_equal, example_element
+from odl.util.testutils import all_almost_equal, noise_element
 
 # Places for the accepted error when comparing results
 PLACES = 8
@@ -44,7 +44,7 @@ def test_proximal_translation():
     space = odl.uniform_discr(0, 1, 10)
 
     # Element in the image space where the proximal operator is evaluated
-    translation = example_element(space)
+    translation = noise_element(space)
 
     # Factory function returning the proximal operators
     lam = float(np.random.randn(1))
@@ -55,7 +55,7 @@ def test_proximal_translation():
     prox = odls.proximal_translation(prox_factory, translation)(step_size)
 
     # Create an element in the space, in which to evaluate the proximals
-    x = example_element(space)
+    x = noise_element(space)
 
     # Explicit computation:
     expected_result = ((x + 2 * step_size * lam * translation) /
@@ -80,7 +80,7 @@ def test_proximal_arg_scaling():
     prox = odls.proximal_arg_scaling(prox_factory, scaling_param)(step_size)
 
     # Create an element in the space, in which to evaluate the proximals
-    x = example_element(space)
+    x = noise_element(space)
 
     # Explicit computation:
     expected_result = x / (2 * step_size * lam * scaling_param ** 2 + 1)
@@ -103,7 +103,7 @@ def test_proximal_arg_scaling_zero():
     prox = odls.proximal_arg_scaling(prox_factory, scaling_param)(step_size)
 
     # Create an element in the space, in which to evaluate the proximals
-    x = example_element(space)
+    x = noise_element(space)
 
     # Check that the scaling with zero returns proximal facotry for the
     # proximal_zero, which ersults in the identity operator
@@ -132,7 +132,7 @@ def test_proximal_quadratic_perturbation_quadratic():
     prox = odls.proximal_quadratic_perturbation(prox_factory, a)(step_size)
 
     # Create an element in the space, in which to evaluate the proximals
-    x = example_element(space)
+    x = noise_element(space)
 
     # Explicit computation:
     expected_result = x / (2 * step_size * (lam + a) + 1)
@@ -148,7 +148,7 @@ def test_proximal_quadratic_perturbation_linear_and_quadratic():
 
     # The parameter for the quadratic perturbation
     a = float(np.random.rand(1))  # This needs to be non-negative
-    u = example_element(space)
+    u = noise_element(space)
     lam = float(np.random.randn(1))
 
     # Factory function returning the proximal operators
@@ -160,7 +160,7 @@ def test_proximal_quadratic_perturbation_linear_and_quadratic():
                                                 a, u)(step_size)
 
     # Create an element in the space, in which to evaluate the proximals
-    x = example_element(space)
+    x = noise_element(space)
 
     # Explicit computation:
     expected_result = (x - step_size * u) / (2 * step_size * (lam + a) + 1)

--- a/test/space/ntuples_test.py
+++ b/test/space/ntuples_test.py
@@ -39,8 +39,8 @@ from odl.space.npy_ntuples import (
     npy_weighted_inner, npy_weighted_norm, npy_weighted_dist,
     MatVecOperator)
 from odl.util.testutils import (almost_equal, all_almost_equal, all_equal,
-                                example_array, example_element,
-                                example_vectors)
+                                noise_array, noise_element,
+                                noise_vectors)
 from odl.util.ufuncs import UFUNCS, REDUCTIONS
 
 # Check for python3
@@ -51,7 +51,7 @@ PYTHON2 = version_info < (3, 0)
 # Helpers to generate data
 def _pos_array(fn):
     """Create an array with positive real entries as weight in `fn`."""
-    return np.abs(example_array(fn)) + 0.1
+    return np.abs(noise_array(fn)) + 0.1
 
 
 def _dense_matrix(fn):
@@ -205,7 +205,7 @@ def test_astype():
 
 def test_vector_class_init(fn):
     # Test that code runs
-    arr = example_array(fn)
+    arr = noise_array(fn)
 
     NumpyFnVector(fn, arr)
     # Space has to be an actual space
@@ -227,31 +227,31 @@ def _test_lincomb(fn, a, b):
     # data and given a,b, contiguous and non-contiguous
 
     # Unaliased arguments
-    [xarr, yarr, zarr], [x, y, z] = example_vectors(fn, 3)
+    [xarr, yarr, zarr], [x, y, z] = noise_vectors(fn, 3)
     zarr[:] = a * xarr + b * yarr
     fn.lincomb(a, x, b, y, out=z)
     assert all_almost_equal([x, y, z], [xarr, yarr, zarr])
 
     # First argument aliased with output
-    [xarr, yarr, zarr], [x, y, z] = example_vectors(fn, 3)
+    [xarr, yarr, zarr], [x, y, z] = noise_vectors(fn, 3)
     zarr[:] = a * zarr + b * yarr
     fn.lincomb(a, z, b, y, out=z)
     assert all_almost_equal([x, y, z], [xarr, yarr, zarr])
 
     # Second argument aliased with output
-    [xarr, yarr, zarr], [x, y, z] = example_vectors(fn, 3)
+    [xarr, yarr, zarr], [x, y, z] = noise_vectors(fn, 3)
     zarr[:] = a * xarr + b * zarr
     fn.lincomb(a, x, b, z, out=z)
     assert all_almost_equal([x, y, z], [xarr, yarr, zarr])
 
     # Both arguments aliased with each other
-    [xarr, yarr, zarr], [x, y, z] = example_vectors(fn, 3)
+    [xarr, yarr, zarr], [x, y, z] = noise_vectors(fn, 3)
     zarr[:] = a * xarr + b * xarr
     fn.lincomb(a, x, b, x, out=z)
     assert all_almost_equal([x, y, z], [xarr, yarr, zarr])
 
     # All aliased
-    [xarr, yarr, zarr], [x, y, z] = example_vectors(fn, 3)
+    [xarr, yarr, zarr], [x, y, z] = noise_vectors(fn, 3)
     zarr[:] = a * zarr + b * zarr
     fn.lincomb(a, z, b, z, out=z)
     assert all_almost_equal([x, y, z], [xarr, yarr, zarr])
@@ -289,14 +289,14 @@ def test_lincomb_exceptions(fn):
 
 def test_multiply(fn):
     # space method
-    [x_arr, y_arr, out_arr], [x, y, out] = example_vectors(fn, 3)
+    [x_arr, y_arr, out_arr], [x, y, out] = noise_vectors(fn, 3)
     out_arr = x_arr * y_arr
 
     fn.multiply(x, y, out)
     assert all_almost_equal([x_arr, y_arr, out_arr], [x, y, out])
 
     # member method
-    [x_arr, y_arr, out_arr], [x, y, out] = example_vectors(fn, 3)
+    [x_arr, y_arr, out_arr], [x, y, out] = noise_vectors(fn, 3)
     out_arr = x_arr * y_arr
 
     x.multiply(y, out=out)
@@ -322,7 +322,7 @@ def test_multiply_exceptions(fn):
 
 def test_power(fn):
 
-    [x_arr, y_arr], [x, y] = example_vectors(fn, n=2)
+    [x_arr, y_arr], [x, y] = noise_vectors(fn, n=2)
     y_pos = fn.element(np.abs(y) + 0.1)
     y_pos_arr = np.abs(y_arr) + 0.1
 
@@ -349,7 +349,7 @@ def test_power(fn):
 def _test_unary_operator(fn, function):
     # Verify that the statement y=function(x) gives equivalent results
     # to NumPy
-    x_arr, x = example_vectors(fn)
+    x_arr, x = noise_vectors(fn)
 
     y_arr = function(x_arr)
 
@@ -361,7 +361,7 @@ def _test_unary_operator(fn, function):
 def _test_binary_operator(fn, function):
     # Verify that the statement z=function(x,y) gives equivalent results
     # to NumPy
-    [x_arr, y_arr], [x, y] = example_vectors(fn, 2)
+    [x_arr, y_arr], [x, y] = noise_vectors(fn, 2)
 
     z_arr = function(x_arr, y_arr)
     z = function(x, y)
@@ -455,8 +455,8 @@ def test_operators(fn):
 
 
 def test_assign(fn):
-    x = example_element(fn)
-    y = example_element(fn)
+    x = noise_element(fn)
+    y = noise_element(fn)
 
     y.assign(x)
 
@@ -469,8 +469,8 @@ def test_assign(fn):
 
 
 def test_inner(fn):
-    xd = example_element(fn)
-    yd = example_element(fn)
+    xd = noise_element(fn)
+    yd = noise_element(fn)
 
     correct_inner = np.vdot(yd, xd)
     assert almost_equal(fn.inner(xd, yd), correct_inner)
@@ -492,7 +492,7 @@ def test_inner_exceptions(fn):
 
 
 def test_norm(fn):
-    xarr, x = example_vectors(fn)
+    xarr, x = noise_vectors(fn)
 
     correct_norm = np.linalg.norm(xarr)
 
@@ -512,7 +512,7 @@ def test_norm_exceptions(fn):
 
 def test_pnorm(exponent):
     for fn in (odl.rn(3, exponent=exponent), odl.cn(3, exponent=exponent)):
-        xarr, x = example_vectors(fn)
+        xarr, x = noise_vectors(fn)
         correct_norm = np.linalg.norm(xarr, ord=exponent)
 
         assert almost_equal(fn.norm(x), correct_norm)
@@ -520,7 +520,7 @@ def test_pnorm(exponent):
 
 
 def test_dist(fn):
-    [xarr, yarr], [x, y] = example_vectors(fn, n=2)
+    [xarr, yarr], [x, y] = noise_vectors(fn, n=2)
 
     correct_dist = np.linalg.norm(xarr - yarr)
 
@@ -544,7 +544,7 @@ def test_dist_exceptions(fn):
 
 def test_pdist(exponent):
     for fn in (odl.rn(3, exponent=exponent), odl.cn(3, exponent=exponent)):
-        [xarr, yarr], [x, y] = example_vectors(fn, n=2)
+        [xarr, yarr], [x, y] = noise_vectors(fn, n=2)
 
         correct_dist = np.linalg.norm(xarr - yarr, ord=exponent)
 
@@ -553,7 +553,7 @@ def test_pdist(exponent):
 
 
 def test_setitem(fn):
-    x = example_element(fn)
+    x = noise_element(fn)
 
     for index in [0, 1, 2, -1, -2, -3]:
         x[index] = index
@@ -561,7 +561,7 @@ def test_setitem(fn):
 
 
 def test_setitem_index_error(fn):
-    x = example_element(fn)
+    x = noise_element(fn)
 
     with pytest.raises(IndexError):
         x[-fn.size - 1] = 0
@@ -616,8 +616,8 @@ def test_setslice():
 
 
 def test_transpose(fn):
-    x = example_element(fn)
-    y = example_element(fn)
+    x = noise_element(fn)
+    y = noise_element(fn)
 
     # Assert linear operator
     assert isinstance(x.T, Operator)
@@ -661,7 +661,7 @@ def test_multiply_by_scalar(fn):
 
 
 def test_member_copy(fn):
-    x = example_element(fn)
+    x = noise_element(fn)
 
     y = x.copy()
 
@@ -676,7 +676,7 @@ def test_member_copy(fn):
 def test_python_copy(fn):
     import copy
 
-    x = example_element(fn)
+    x = noise_element(fn)
 
     y = copy.copy(x)
 
@@ -784,7 +784,7 @@ def test_array_method(fn):
 def test_array_wrap_method(fn):
     # Verify that the __array_wrap__ method works. This enables numpy ufuncs
     # on vectors
-    x_h, x = example_vectors(fn)
+    x_h, x = noise_vectors(fn)
     y_h = np.sin(x_h)
     y = np.sin(x)
 
@@ -793,7 +793,7 @@ def test_array_wrap_method(fn):
 
 
 def test_conj(fn):
-    xarr, x = example_vectors(fn)
+    xarr, x = noise_vectors(fn)
     xconj = x.conj()
     assert all_equal(xconj, xarr.conj())
     y = x.copy()
@@ -927,7 +927,7 @@ def test_matvec_call(fn):
     # Square cases
     sparse_mat = _sparse_matrix(fn)
     dense_mat = _dense_matrix(fn)
-    xarr, x = example_vectors(fn)
+    xarr, x = noise_vectors(fn)
 
     op_sparse = MatVecOperator(sparse_mat, fn, fn)
     op_dense = MatVecOperator(dense_mat, fn, fn)
@@ -1113,7 +1113,7 @@ def test_matrix_equiv():
 
 
 def test_matrix_inner(fn):
-    [xarr, yarr], [x, y] = example_vectors(fn, 2)
+    [xarr, yarr], [x, y] = noise_vectors(fn, 2)
     sparse_mat = _sparse_matrix(fn)
     sparse_mat_as_dense = np.asarray(sparse_mat.todense())
     dense_mat = _dense_matrix(fn)
@@ -1139,7 +1139,7 @@ def test_matrix_inner(fn):
 
 
 def test_matrix_norm(fn, exponent):
-    xarr, x = example_vectors(fn)
+    xarr, x = noise_vectors(fn)
     sparse_mat = _sparse_matrix(fn)
     sparse_mat_as_dense = np.asarray(sparse_mat.todense())
     dense_mat = _dense_matrix(fn)
@@ -1186,7 +1186,7 @@ def test_matrix_norm(fn, exponent):
 
 
 def test_matrix_dist(fn, exponent):
-    [xarr, yarr], [x, y] = example_vectors(fn, n=2)
+    [xarr, yarr], [x, y] = noise_vectors(fn, n=2)
     sparse_mat = _sparse_matrix(fn)
     sparse_mat_as_dense = np.asarray(sparse_mat.todense())
     dense_mat = _dense_matrix(fn)
@@ -1231,7 +1231,7 @@ def test_matrix_dist(fn, exponent):
 
 
 def test_matrix_dist_using_inner(fn):
-    [xarr, yarr], [x, y] = example_vectors(fn, 2)
+    [xarr, yarr], [x, y] = noise_vectors(fn, 2)
     mat = _dense_matrix(fn)
 
     w = NumpyFnMatrixWeighting(mat, dist_using_inner=True)
@@ -1341,7 +1341,7 @@ def test_vector_equiv():
 
 
 def test_vector_inner(fn):
-    [xarr, yarr], [x, y] = example_vectors(fn, 2)
+    [xarr, yarr], [x, y] = noise_vectors(fn, 2)
 
     weight_vec = _pos_array(fn)
     weighting_vec = NumpyFnVectorWeighting(weight_vec)
@@ -1361,7 +1361,7 @@ def test_vector_inner(fn):
 
 
 def test_vector_norm(fn, exponent):
-    xarr, x = example_vectors(fn)
+    xarr, x = noise_vectors(fn)
 
     weight_vec = _pos_array(fn)
     weighting_vec = NumpyFnVectorWeighting(weight_vec, exponent=exponent)
@@ -1380,7 +1380,7 @@ def test_vector_norm(fn, exponent):
 
 
 def test_vector_dist(fn, exponent):
-    [xarr, yarr], [x, y] = example_vectors(fn, n=2)
+    [xarr, yarr], [x, y] = noise_vectors(fn, n=2)
 
     weight_vec = _pos_array(fn)
     weighting_vec = NumpyFnVectorWeighting(weight_vec, exponent=exponent)
@@ -1400,7 +1400,7 @@ def test_vector_dist(fn, exponent):
 
 
 def test_vector_dist_using_inner(fn):
-    [xarr, yarr], [x, y] = example_vectors(fn, 2)
+    [xarr, yarr], [x, y] = noise_vectors(fn, 2)
 
     weight_vec = _pos_array(fn)
     w = NumpyFnVectorWeighting(weight_vec)
@@ -1490,7 +1490,7 @@ def test_constant_equiv():
 
 
 def test_constant_inner(fn):
-    [xarr, yarr], [x, y] = example_vectors(fn, 2)
+    [xarr, yarr], [x, y] = noise_vectors(fn, 2)
 
     constant = 1.5
     true_result_const = constant * np.vdot(yarr, xarr)
@@ -1505,7 +1505,7 @@ def test_constant_inner(fn):
 
 
 def test_constant_norm(fn, exponent):
-    xarr, x = example_vectors(fn)
+    xarr, x = noise_vectors(fn)
 
     constant = 1.5
     if exponent == float('inf'):
@@ -1523,7 +1523,7 @@ def test_constant_norm(fn, exponent):
 
 
 def test_constant_dist(fn, exponent):
-    [xarr, yarr], [x, y] = example_vectors(fn, 2)
+    [xarr, yarr], [x, y] = noise_vectors(fn, 2)
 
     constant = 1.5
     if exponent == float('inf'):
@@ -1541,7 +1541,7 @@ def test_constant_dist(fn, exponent):
 
 
 def test_const_dist_using_inner(fn):
-    [xarr, yarr], [x, y] = example_vectors(fn, 2)
+    [xarr, yarr], [x, y] = noise_vectors(fn, 2)
 
     constant = 1.5
     w = NumpyFnConstWeighting(constant)
@@ -1582,7 +1582,7 @@ def test_noweight():
 
 
 def test_custom_inner(fn):
-    [xarr, yarr], [x, y] = example_vectors(fn, 2)
+    [xarr, yarr], [x, y] = noise_vectors(fn, 2)
 
     def inner(x, y):
         return np.vdot(y, x)
@@ -1614,7 +1614,7 @@ def test_custom_inner(fn):
 
 
 def test_custom_norm(fn):
-    [xarr, yarr], [x, y] = example_vectors(fn, 2)
+    [xarr, yarr], [x, y] = noise_vectors(fn, 2)
 
     norm = np.linalg.norm
 
@@ -1643,7 +1643,7 @@ def test_custom_norm(fn):
 
 
 def test_custom_dist(fn):
-    [xarr, yarr], [x, y] = example_vectors(fn, 2)
+    [xarr, yarr], [x, y] = noise_vectors(fn, 2)
 
     def dist(x, y):
         return np.linalg.norm(x - y)
@@ -1711,7 +1711,7 @@ def test_ufuncs(fn, ufunc):
     npufunc = getattr(np, name)
 
     # Create some data
-    arrays, vectors = example_vectors(fn, n_args + n_out)
+    arrays, vectors = noise_vectors(fn, n_args + n_out)
     in_arrays = arrays[:n_args]
     out_arrays = arrays[n_args:]
     data_vector = vectors[0]
@@ -1749,7 +1749,7 @@ def _impl_test_reduction(fn, name):
     ufunc = getattr(np, name)
 
     # Create some data
-    x_arr, x = example_vectors(fn, 1)
+    x_arr, x = noise_vectors(fn, 1)
 
     assert ufunc(x_arr) == getattr(x.ufunc, name)()
 


### PR DESCRIPTION
Branch name obviously outdated.

Improved doc of these methods and made it more clear they are for tests, also wrote out what they actually do.