### PR TITLE
MAINT: replace numerous "vector" occurences by "element"

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ where FOO, BAR, etc are the dependencies. Others require more complicated instal
 | [scikit-image](http://scikit-image.org/)    | 2D parallel beam forward/backward projectors in [RayTransform](http://odl.readthedocs.io/generated/odl.tomo.operators.ray_trafo.RayTransform.html) | scikit |
 | [FFTW](https://github.com/pyFFTW/pyFFTW)   | Accelerated [FourierTransform](http://odl.readthedocs.io/generated/odl.trafos.fourier.FourierTransform.html) | fftw |
 | [PyWavelets](https://github.com/PyWavelets/pywt)   | Computation of the  [WaveletTransform](http://odl.readthedocs.io/generated/odl.trafos.wavelet.WaveletTransform.html) | pywavelets |
-| [matplotlib](http://matplotlib.org/)   | Visualization through the [show](http://odl.readthedocs.io/generated/odl.discr.lp_discr.DiscreteLpVector.show.html) command | show |
+| [matplotlib](http://matplotlib.org/)   | Visualization through the [show](http://odl.readthedocs.io/generated/odl.discr.lp_discr.DiscreteLpElement.show.html) command | show |
 | [proximal](http://github.com/comp-imaging/ProxImaL)   | Solution of some convex optimization problems | proximal |
 | [pytest](http://pytest.org/latest/)   | Unit tests | testing |
 

--- a/doc/source/guide/faq.rst
+++ b/doc/source/guide/faq.rst
@@ -16,7 +16,7 @@ General errors
         from . import diagnostics
 
         ImportError: cannot import diagnostics
-        
+
    However, I did not change anything in ``diagnostics``? Where does the error come from?
 
    **P:** Usually, this error originates from invalid code in a completely different place. You
@@ -30,47 +30,47 @@ General errors
    sometimes interfere with changes to your codebase.
 
    **S:** Here are two things you can do to find the error more quickly.
-   
+
    1. Delete the bytecode files. In a standard GNU/Linux shell, you can simply invoke (in your
       ``odl`` working directory)
 
       .. code-block:: bash
 
          find . -name *.pyc | xargs rm
-   
+
    2. Execute the modules you changed since the last working (importable) state. In most IDEs, you
       have the possibility to run a currently opened file. Alternatively, you can run on the
       command line
-      
+
       .. code-block:: bash
-      
+
          python path/to/your/module.py
-      
+
       This will yield a specific error message for an erroneous module that helps you debugging your
       changes.
 
-#. **Q:** When adding two vectors, the following error is shown::
+#. **Q:** When adding two space elements, the following error is shown::
 
-      TypeError: unsupported operand type(s) for +: 'DiscreteLpVector' and 'DiscreteLpVector'
-      
+      TypeError: unsupported operand type(s) for +: 'DiscreteLpElement' and 'DiscreteLpElement'
+
    This seems completely illogical since it works in other situations and clearly must be supported.
    Why is this error shown?
 
-   **P:** The vectors you are trying to add are not in the same space,
-   for example the following code gives the error
+   **P:** The elements you are trying to add are not in the same space.
+   For example, the following code triggers the same error:
 
       >>> x = odl.uniform_discr(0, 1, 10).one()
       >>> y = odl.uniform_discr(0, 1, 11).one()
       >>> x - y
 
-   In this case, the problem is that the vectors have a different number of elements.
+   In this case, the problem is that the elements have a different number of entries.
    Other possible issues include that they are discretizations of different sets,
-   have different data types (:term:`dtype`), or implementation (for example cuda/cpu).
+   have different data types (:term:`dtype`), or implementation (for example CUDA/CPU).
 
-   **S:** The vectors need to somehow be cast to the same space.
-   How to do this depends on the problem at hand. To find what the issue is,
-   inspect the ``space`` properties of both vectors. For example in the above
-   we see that the issue lies in the number of discretization points
+   **S:** The elements need to somehow be cast to the same space.
+   How to do this depends on the problem at hand.
+   To find what the issue is, inspect the ``space`` properties of both elements.
+   For the above example, we see that the issue lies in the number of discretization points:
 
       >>> x.space
       odl.uniform_discr(0, 1, 10)
@@ -83,7 +83,7 @@ General errors
      for example a "we identify X with Y" step has been omitted.
 
    * If the ``dtype`` or ``impl`` do not match, they need to be cast to each one of the others.
-     The most simple way to do this is by using the `DiscreteLpVector.astype` method.
+     The most simple way to do this is by using the `DiscreteLpElement.astype` method.
 
 #. **Q:** I have installed ODL with the ``pip install --editable`` option, but I still get an
    ``AttributeError`` when I try to use a function/class I just implemented. The use-without-reinstall

--- a/doc/source/guide/glossary.rst
+++ b/doc/source/guide/glossary.rst
@@ -31,7 +31,7 @@ Glossary
         Saying that ``x`` is an element of a given `Set` ``my_set`` means that ``x in my_set``
         evaluates to `True`. The term is typically used as "element of <set>" or "<set>" element.
         When referring to a `LinearSpace` like, e.g., `DiscreteLp`, an element is of the
-        corresponding type `LinearSpaceVector`, i.e. `DiscreteLpVector` in the above example.
+        corresponding type `LinearSpaceElement`, i.e. `DiscreteLpElement` in the above example.
         Elements of a set can be created by the `Set.element` method.
 
     element-like
@@ -40,7 +40,7 @@ Glossary
         object with 3 real entries.
 
         Example: ```DiscreteLp` element-like`` means that
-        `DiscreteLp.element` can create a `DiscreteLpVector` from the input.
+        `DiscreteLp.element` can create a `DiscreteLpElement` from the input.
 
     in-place evaluation
         Operator evaluation method which uses an existing data container to store

--- a/doc/source/guide/in_depth/linearspace_guide.rst
+++ b/doc/source/guide/in_depth/linearspace_guide.rst
@@ -24,27 +24,27 @@ Abstract methods
 ----------------
 In the following, the abstract methods are explained in detail.
 
-Element creation 
+Element creation
 ~~~~~~~~~~~~~~~~
 
 ``element(inp=None)``
 
 This public method is the factory for the inner
-`LinearSpaceVector` class. It creates a new element of the space,
+`LinearSpaceElement` class. It creates a new element of the space,
 either from scratch or from an existing data container. In the
 simplest possible case, it just delegates the construction to the
-`LinearSpaceVector` class.
+`LinearSpaceElement` class.
 
 If no data is provided, the new element is **merely allocated, not
 initialized**, thus it can contain *any* value.
 
 **Parameters:**
     inp : `object`, optional
-        A container for values for the element initialization
+        A container for values for the element initialization.
 
 **Returns:**
-    element : `LinearSpaceVector`
-        The new vector
+    element : `LinearSpaceElement`
+        The new element.
 
 Linear combination
 ~~~~~~~~~~~~~~~~~~
@@ -59,19 +59,19 @@ functions, see below.
 
 **Parameters:**
     a, b : scalars, must be members of the space's ``field``
-        Multiplicative scalar factors for input vector ``x1`` or ``x2``,
-        respectively
-    x1, x2 : `LinearSpaceVector`
-        Input vectors
-    out : `LinearSpaceVector`
-        Element to which the result of the computation is written
+        Multiplicative scalar factors for input element ``x1`` or ``x2``,
+        respectively.
+    x1, x2 : `LinearSpaceElement`
+        Input elements.
+    out : `LinearSpaceElement`
+        Element to which the result of the computation is written.
 
 **Returns:** `None`
 
 **Requirements:**
  * Aliasing of ``x1``, ``x2`` and ``out`` **must** be allowed.
- * The input vectors ``x1`` and ``x2`` **must not** be modified.
- * The initial state of the output vector ``out`` **must not**
+ * The input elements ``x1`` and ``x2`` **must not** be modified.
+ * The initial state of the output element ``out`` **must not**
    influence the result.
 
 Underlying scalar field
@@ -86,7 +86,7 @@ underlie the space. Can be instances of either `RealNumbers` or
 Should be implemented as a ``@property`` to make it immutable.
 
 Equality check
-~~~~~~~~~~~~~~ 
+~~~~~~~~~~~~~~
 
 ``__eq__(other)``
 
@@ -95,12 +95,12 @@ purpose is to check two `LinearSpace` instances for equality.
 
 **Parameters:**
     other : `object`
-        The object to compare to
+        The object to compare to.
 
 **Returns:**
     equals : `bool`
         `True` if ``other`` is the same `LinearSpace`, `False`
-        otherwise
+        otherwise.
 
 
 Distance (optional)
@@ -109,13 +109,13 @@ Distance (optional)
 ``_dist(x1, x2)``
 
 A raw (not type-checking) private method measuring the distance
-between two vectors ``x1`` and ``x2``.
+between two elements ``x1`` and ``x2``.
 
 A space with a distance is called a **metric space**.
 
 **Parameters:**
-    x1,x2 : `LinearSpaceVector`
-        Vectors whose mutual distance to calculate
+    x1,x2 : `LinearSpaceElement`
+        Elements whose mutual distance to calculate.
 
 **Returns:**
     distance : `float`
@@ -139,12 +139,12 @@ space element ``x``.
 A space with a norm is called a **normed space**.
 
 **Parameters:**
-    x : `LinearSpaceVector`
-        The vector to measure
+    x : `LinearSpaceElement`
+        The element to measure.
 
 **Returns:**
     norm : `float`
-        The length of ``x`` as measured in the space's norm
+        The length of ``x`` as measured in the space's norm.
 
 **Requirements:**
  * ``_norm(s * x) = |s| * _norm(x)`` for any scalar ``s``
@@ -161,8 +161,8 @@ A raw (not type-checking) private method calculating the inner
 product of two space elements ``x`` and ``y``.
 
 **Parameters:**
-    x,y : `LinearSpaceVector`
-        Vectors whose inner product to calculate
+    x,y : `LinearSpaceElement`
+        Elements whose inner product to calculate.
 
 **Returns:**
     inner : `float` or `complex`
@@ -181,14 +181,14 @@ Pointwise multiplication (optional)
 
 ``_multiply(x1, x2, out)``
 
-A raw (not type-checking) private method multiplying two vectors
+A raw (not type-checking) private method multiplying two elements
 ``x1`` and ``x2`` element-wise and storing the result in ``out``.
 
 **Parameters:**
-    x1, x2 : `LinearSpaceVector`
-        Vectors whose element-wise product to calculate
-    out : `LinearSpaceVector`
-        Vector to store the result
+    x1, x2 : `LinearSpaceElement`
+        Elements whose element-wise product to calculate.
+    out : `LinearSpaceElement`
+        Element to store the result.
 
 **Returns:** `None`
 

--- a/doc/source/guide/in_depth/linearspace_guide.rst
+++ b/doc/source/guide/in_depth/linearspace_guide.rst
@@ -182,11 +182,11 @@ Pointwise multiplication (optional)
 ``_multiply(x1, x2, out)``
 
 A raw (not type-checking) private method multiplying two elements
-``x1`` and ``x2`` element-wise and storing the result in ``out``.
+``x1`` and ``x2`` point-wise and storing the result in ``out``.
 
 **Parameters:**
     x1, x2 : `LinearSpaceElement`
-        Elements whose element-wise product to calculate.
+        Elements whose point-wise product to calculate.
     out : `LinearSpaceElement`
         Element to store the result.
 

--- a/doc/source/guide/in_depth/numpy_guide.rst
+++ b/doc/source/guide/in_depth/numpy_guide.rst
@@ -17,13 +17,13 @@ Casting vectors to and from arrays
 ==================================
 ODL vectors are stored in an abstract way, enabling storage on the CPU, GPU, or perhaps on a cluster on the other side of the world. This allows algorithms to be written in a generalized and storage-agnostic manner. Still, it is often convenient to be able to access the data and look at it, perhaps to initialize a vector, or to call an external function.
 
-To cast a NumPy array to an ODL vector, you simply need to call the `LinearSpace.element` method in an appropriate space::
+To cast a NumPy array to an element of an ODL vector space, you simply need to call the `LinearSpace.element` method in an appropriate space::
 
    >>> r3 = odl.rn(3)
    >>> arr = np.array([1, 2, 3])
    >>> x = r3.element(arr)
 
-If the data type and storage methods allow it, the vector simply wraps the underlying array using a `view
+If the data type and storage methods allow it, the element simply wraps the underlying array using a `view
 <http://docs.scipy.org/doc/numpy/glossary.html#term-view>`_::
 
    >>> float_arr = np.array([1.0, 2.0, 3.0])
@@ -31,20 +31,20 @@ If the data type and storage methods allow it, the vector simply wraps the under
    >>> x.data is float_arr
    True
 
-Casting ODL vectors to NumPy arrays can be done in two ways, either through the member function `NtuplesBaseVector.asarray`, or using `numpy.asarray`. These are both optimized and if possible return a view::
+Casting ODL vector space elements to NumPy arrays can be done in two ways, either through the member function `NtuplesBaseVector.asarray`, or using `numpy.asarray`. These are both optimized and if possible return a view::
 
    >>> x.asarray()
    array([1.0, 2.0, 3.0])
    >>> np.asarray(x)
    array([1.0, 2.0, 3.0])
 
-These methods work with any ODL vector represented by an array. For example, in discretizations, a two-dimensional array can be used::
+These methods work with any ODL object represented by an array. For example, in discretizations, a two-dimensional array can be used::
 
-   >>> X = odl.uniform_discr([0, 0], [1, 1], [3, 3])
+   >>> space = odl.uniform_discr([0, 0], [1, 1], [3, 3])
    >>> arr = np.array([[1, 2, 3],
    ...                 [4, 5, 6],
    ...                 [7, 8, 9]])
-   >>> x = X.element(arr)
+   >>> x = space.element(arr)
    >>> x.asarray()
    array([[1.0, 2.0, 3.0],
           [4.0, 5.0, 6.0],
@@ -53,19 +53,19 @@ These methods work with any ODL vector represented by an array. For example, in 
 Using ODL vectors with NumPy functions
 ======================================
 A very convenient feature of ODL is its seamless interaction with NumPy functions. For universal functions (`ufuncs
-<http://docs.scipy.org/doc/numpy/reference/ufuncs.html>`_) this is supported both via method of the ODL vector and by direct application of the NumPy functions. For example, using NumPy::
+<http://docs.scipy.org/doc/numpy/reference/ufuncs.html>`_) this is supported both via method of the ODL object and by direct application of the NumPy functions. For example, using NumPy::
 
    >>> r3 = odl.rn(3)
    >>> x = r3.element([1, 2, 3])
    >>> np.negative(x)
    rn(3).element([-1.0, -2.0, -3.0])
 
-This method of using NumPy always uses the NumPy implementation, which can involve overhead in case the data is not stored in a CPU space. To always enable optimized code, users can call the member `NtuplesBaseVector.ufunc`::
+This method always uses the NumPy implementation, which can involve overhead in case the data is not stored in a CPU space. To always enable optimized code, users can call the member `NtuplesBaseVector.ufunc`::
 
    >>> x.ufunc.negative()
    rn(3).element([-1.0, -2.0, -3.0])
 
-For other arbitrary functions, ODL vectors are generally accepted as input, but the output is often of `numpy.ndarray` type::
+For other arbitrary functions, ODL vector space elements are generally accepted as input, but the output is often of `numpy.ndarray` type::
 
    >>> np.convolve(x, x, mode='same')
    array([  4.,  10.,  12.])
@@ -80,7 +80,7 @@ NumPy functions as Operators
 To solve the above issue, it is often useful to write an `Operator` wrapping NumPy functions, thus allowing full access to the ODL ecosystem. To wrap the convolution operation, you could write a new class::
 
    class MyConvolution(odl.Operator):
-       """Operator for convolving with given vector."""
+       """Operator for convolving with a given vector."""
 
        def __init__(self, vector):
            """Initialize the convolution."""

--- a/doc/source/guide/in_depth/vectorization_guide.rst
+++ b/doc/source/guide/in_depth/vectorization_guide.rst
@@ -6,7 +6,7 @@ Vectorized functions
 
 
 This section is intended as a small guideline on how to write functions which work with the
-vectorization machinery by Numpy which is used internally in ODL. 
+vectorization machinery by Numpy which is used internally in ODL.
 
 
 What is vectorization?
@@ -50,7 +50,7 @@ want to discretize a two-dimensional Gaussian function::
 
     def gaussian2(x):
         return np.exp(-(x[0] ** 2 + x[1] ** 2) / 2)
-    
+
 on the rectangle [-5, 5] x [-5, 5] with 100 pixels in each
 dimension. The code for this is simply::
 
@@ -70,7 +70,7 @@ To make this process fast, ``element`` assumes that the function is written in a
 supports vectorization, but also guarantees that the output has the correct shape. The function
 receives a :term:`meshgrid` tuple as input, in the above case consisting of two vectors::
 
-    >>> mesh = discr.meshgrid()
+    >>> mesh = discr.meshgrid
     >>> mesh[0].shape
     (100, 1)
     >>> mesh[1].shape
@@ -81,26 +81,16 @@ When inserted into the function, the final shape of the output is determined by 
 be ``(100, 100)`` since the arrays in ``mesh`` are added after squaring. This size is the same
 as expected by the discretization.
 
-If, however, the function does not use all components of its input, the shape will be different::
+If a function does not use all components of the input, ODL tries to broadcast the result to the shape of the discretized space::
 
-    >>> def gaussian_const_x0_bad(x):
-    ...     return np.exp(-x[1] ** 2 / 2)  # no x[0] -> no broadcasting
+    >>> def gaussian_const_x0(x):
+    ...     return np.exp(-x[1] ** 2 / 2)  # no x[0] -> broadcasting
 
-    >>> gaussian_const_x0_bad(mesh).shape
+    >>> gaussian_const_x0(mesh).shape
     (1, 100)
 
-This array is too small for the discretization, and an exception will be raised, stating that this
-function cannot be discretized.
-
-The solution to this issue is rather simple: just make sure that all components are used such that
-the broadcasting rules are triggered::
-
-    >>> def gaussian_const_x0_good(x):
-    ...     return np.exp(-x[1] ** 2 / 2) + 0 * x[0]  # broadcasting
-
-    >>> gaussian_const_x0_good(mesh).shape
+    >>> discr.element(gaussian_const_x0).shape
     (100, 100)
-
 
 
 Further reading

--- a/doc/source/guide/introduction/about_odl.rst
+++ b/doc/source/guide/introduction/about_odl.rst
@@ -130,7 +130,7 @@ sampling of continuously defined functions. If we, for example, want to discreti
 
     >>> exp_discr = l2_discr.element(lambda x: np.exp(-x))
     >>> type(exp_discr)
-    odl.discr.lp_discr.DiscreteLpVector
+    odl.discr.lp_discr.DiscreteLpElement
     >>> exp_discr.shape
     (5,)
 

--- a/doc/source/math/linear_spaces.rst
+++ b/doc/source/math/linear_spaces.rst
@@ -11,11 +11,11 @@ Definition and basic properties
 A linear space over a `field`_ :math:`\mathbb{F}` is a set :math:`\mathcal{X}`, endorsed with the
 operations of `vector addition`_ ":math:`+`" and `scalar multiplication`_ ":math:`\cdot`" which
 are required to fullfill certain properties, usually called axioms. To emphasize the importance of
-all ingredients, vector spaces are often written as tuples 
+all ingredients, vector spaces are often written as tuples
 :math:`(\mathcal{X}, \mathbb{F}, +, \cdot)`. We always assume that :math:`\mathbb{F} = \mathbb{R}` or
 :math:`\mathbb{C}`.
 
-In the following, we list the axioms, which are required to hold for arbitrary 
+In the following, we list the axioms, which are required to hold for arbitrary
 :math:`x, y, z \in \mathcal{X}` and :math:`a, b \in \mathbb{F}`.
 
 +--------------------------------+--------------------------------------------------------------+
@@ -54,7 +54,7 @@ with the following properties for all :math:`x, y, z \in \mathcal{X}`:
 
 .. math::
     :nowrap:
-    
+
     \begin{align*}
       & d(x, y) = 0 \quad \Leftrightarrow \quad x = y && \text{(identity of indiscernibles)} \\
       & d(x, y) = d(y, x)  && \text{(symmetry)} \\
@@ -74,7 +74,7 @@ if it fulfills the following conditions for all :math:`x, y \in \mathcal{X}` and
 
 .. math::
     :nowrap:
-    
+
     \begin{align*}
       & \lVert x \rVert = 0 \Leftrightarrow x = 0 && \text{(positive definiteness)} \\
       & \lVert a \cdot x \rVert = \lvert a \rvert\, \lVert x \rVert && \text{(positive homegeneity)}
@@ -88,7 +88,7 @@ is called `Normed vector space`_. Note that a norm induces a natural metric via
 
 Inner product spaces
 --------------------
-Measure angles and defining notions like orthogonality requires the existence of an `inner product`_ 
+Measure angles and defining notions like orthogonality requires the existence of an `inner product`_
 
 .. math:: \langle \cdot, \cdot \rangle : \mathcal{X} \times \mathcal{X} \to \mathbb{F}
 
@@ -96,16 +96,16 @@ with the following properties for all :math:`x, y, z \in \mathcal{X}` and :math:
 
 .. math::
     :nowrap:
-    
+
     \begin{align*}
       & \langle x, x \rangle \geq 0 \quad \text{and} \quad \langle x, x \rangle = 0 \Leftrightarrow
       x = 0 && \text{(positive definiteness)} \\
       & \langle a \cdot x + y, z \rangle = a \, \langle x, z \rangle + a \, \langle y, z \rangle &&
       \text{(linearity in the first argument)} \\
-      & \langle x, y \rangle = \overline{\langle x, y \rangle} && \text{(conjugate symmetry)} 
+      & \langle x, y \rangle = \overline{\langle x, y \rangle} && \text{(conjugate symmetry)}
     \end{align*}
 
-The tuple :math:`(\mathcal{X}, \mathbb{F}, +, \cdot, \langle \cdot \rangle)` is then called an 
+The tuple :math:`(\mathcal{X}, \mathbb{F}, +, \cdot, \langle \cdot \rangle)` is then called an
 `Inner product space`_. Note that the inner product induces the norm
 :math:`\lVert x \rVert = \sqrt{\langle x, x \rangle}`.
 
@@ -115,7 +115,7 @@ Cartesian spaces
 We refer to the space :math:`\mathbb{F}^n` as the :math:`n`-dimensional `Cartesian space`_ over the
 field :math:`\mathbb{F}`. We choose this notion since Euclidean spaces are usually associated with
 the `Euclidean norm and distance`_, which are just (important) special cases. Vector addition and
-scalar multiplication in :math:`\mathbb{F}^n` are, of course, realized with element-wise addition
+scalar multiplication in :math:`\mathbb{F}^n` are, of course, realized with entry-wise addition
 and scalar multiplication.
 
 The natural inner product in :math:`\mathbb{F}^n` is defined as
@@ -125,7 +125,7 @@ The natural inner product in :math:`\mathbb{F}^n` is defined as
 and reduces to the well-known `dot product`_ if :math:`\mathbb{F} = \mathbb{R}`. For the norm, the
 most common choices are from the family of `p-norms`_
 
-.. math:: 
+.. math::
     \lVert x \rVert_p &:= \left( \sum_{i=1}^n \lvert x_i \rvert^p \right)^{\frac{1}{p}}
     \quad \text{if } p \in [1, \infty) \\[1ex]
     \lVert x \rVert_\infty &:= \max\big\{\lvert x_i \rvert\,|\, i \in \{1, \dots, n\} \big\}
@@ -161,9 +161,9 @@ since :math:`\langle Ax, x \rangle = \langle A^{1/2} x, A^{1/2} x \rangle =
 
 Remark on matrices as operators
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-A matrix :math:`M \in \mathbb{F}^{m \times n}` can be regarded as a `linear operator`_ 
+A matrix :math:`M \in \mathbb{F}^{m \times n}` can be regarded as a `linear operator`_
 
-.. math:: 
+.. math::
     \mathcal{M} &: \mathbb{F}^n \to \mathbb{F}^m \\
     \mathcal{M}(x) &:= M x
 
@@ -173,22 +173,22 @@ defined with the conjugate transposed matrix:
 .. math::
     \mathcal{M}^* &: \mathbb{F}^m \to \mathbb{F}^n \\
     \mathcal{M}^*(y) &:= M^* y
-    
+
 However if the spaces :math:`\mathbb{F}^n` and :math:`\mathbb{F}^m` have weighted inner products,
 this identification is no longer valid. If :math:`\mathbb{F}^{n \times n} \ni A = A^* \succeq 0`
-and :math:`\mathbb{F}^{m \times m} \ni B = B^* \succeq 0` are the weighting matrices of the 
+and :math:`\mathbb{F}^{m \times m} \ni B = B^* \succeq 0` are the weighting matrices of the
 inner products, we get
 
 .. math::
     \langle \mathcal{M}(x), y \rangle_B
-    &= \langle B\mathcal{M}(x), y \rangle_{\mathbb{F}^m} 
+    &= \langle B\mathcal{M}(x), y \rangle_{\mathbb{F}^m}
     = \langle M x, B y \rangle_{\mathbb{F}^m}
     = \langle x, M^* B y \rangle_{\mathbb{F}^n} \\
     &= \langle A^{-1} A x, M^* B y \rangle_{\mathbb{F}^n}
     = \langle A x, A^{-1} M^* B y \rangle_{\mathbb{F}^n} \\
     &= \langle x, A^{-1} M^* B y \rangle_A
 
-Thus, the adjoint of the matrix operator between the weighted spaces is rather given as 
+Thus, the adjoint of the matrix operator between the weighted spaces is rather given as
 :math:`\mathcal{M}^*(y) = A^{-1} M^* B y`.
 
 Useful Wikipedia articles

--- a/doc/source/release_notes.rst
+++ b/doc/source/release_notes.rst
@@ -35,8 +35,16 @@ Changes
 - Unify the names of minimum (``min_pt``), maximum (``max_pt``) and middle (``mid_pt``) points as well as number of points (``shape``) in grids, interval products and factory functions for discretized spaces. (:pull:`541`)
 - Removed ``simple_operator`` since it was never used and did not follow the ODL style. (:pull:`543`)
   The parameter ``padding_value`` is now called ``pad_const``.
-- Removed ``Interval``, ``Rectangle`` and ``Cuboid`` since they were confusing (Capitalized name but not a Cunction) and
-  barely ever used. Users should instead use ``IntervalProd`` in all cases. (:pull:`537`)
+- Removed ``Interval``, ``Rectangle`` and ``Cuboid`` since they were confusing (Capitalized name but not a Cunction) and barely ever used.
+  Users should instead use ``IntervalProd`` in all cases. (:pull:`537`)
+- The following classes have been renamed:
+  * `LinearSpaceVector` -> `LinearSpaceElement`
+  * `DiscreteLpVector` -> `DiscreteLpElement`
+  * `ProductSpaceVector` -> `ProductSpaceElement`
+  * `DiscretizedSetVector` -> `DiscretizedSetElement`
+  * `DiscretizedSpaceVector` -> `DiscretizedSpaceElement`
+  * `FunctionSetVector` -> `FunctionSetElement`
+  * `FunctionSpaceVector` -> `FunctionSpaceElement`
 
 Bugfixes
 --------

--- a/examples/solvers/chambolle_pock_deconvolve.py
+++ b/examples/solvers/chambolle_pock_deconvolve.py
@@ -54,7 +54,7 @@ convolution = ft.inverse * gaussian * ft
 # Create phantom
 phantom = odl.phantom.shepp_logan(space, modified=True)
 
-# Create vector of convolved phantom
+# Create the convolved version of the phantom
 data = convolution(phantom)
 data.show('Convolved data')
 

--- a/examples/solvers/denoising_with_entropy_type_regularization.py
+++ b/examples/solvers/denoising_with_entropy_type_regularization.py
@@ -40,7 +40,7 @@ image *= 100 / image.max()
 # Add noise
 noisy_image = np.random.poisson(1 + image)
 
-# Discretized spaces and vectors
+# Discretized spaces and elements
 space = odl.uniform_discr([0, 0], shape, shape)
 orig = space.element(image)
 noisy = space.element(noisy_image)

--- a/examples/solvers/douglas_rachford_primal_dual_mri.py
+++ b/examples/solvers/douglas_rachford_primal_dual_mri.py
@@ -38,8 +38,8 @@ space = odl.uniform_discr([0, 0], [n, n], [n, n])
 # Create MRI operator. First fourier transform, then subsample
 ft = odl.trafos.FourierTransform(space)
 sampling_points = np.random.rand(*ft.range.shape) < subsampling
-sampling_vector = ft.range.element(sampling_points)
-mri_op = sampling_vector * ft
+sampling_mask = ft.range.element(sampling_points)
+mri_op = sampling_mask * ft
 
 # Create noisy MRI data
 phantom = odl.phantom.shepp_logan(space, modified=True)

--- a/examples/space/simple_r.py
+++ b/examples/space/simple_r.py
@@ -43,13 +43,13 @@ class Reals(odl.LinearSpace):
         return RealNumber(self, value)
 
 
-class RealNumber(odl.LinearSpaceVector):
+class RealNumber(odl.LinearSpaceElement):
     """Real vectors are floats."""
 
     __val__ = None
 
     def __init__(self, space, v):
-        odl.LinearSpaceVector.__init__(self, space=space)
+        odl.LinearSpaceElement.__init__(self, space=space)
         self.__val__ = v
 
     def __float__(self):

--- a/examples/space/vectorization.py
+++ b/examples/space/vectorization.py
@@ -15,7 +15,7 @@
 # You should have received a copy of the GNU General Public License
 # along with ODL.  If not, see <http://www.gnu.org/licenses/>.
 
-"""Example showing how to use vectorization of FunctionSpaceVector's."""
+"""Example showing how to use vectorization of ``FunctionSpaceElement``'s."""
 
 import numpy as np
 import odl

--- a/examples/space/vectorization.py
+++ b/examples/space/vectorization.py
@@ -15,7 +15,7 @@
 # You should have received a copy of the GNU General Public License
 # along with ODL.  If not, see <http://www.gnu.org/licenses/>.
 
-"""Example showing how to use vectorization of ``FunctionSpaceElement``'s."""
+"""Example showing how to use vectorization of `FunctionSpaceElement`'s."""
 
 import numpy as np
 import odl

--- a/examples/visualization/show_1d.py
+++ b/examples/visualization/show_1d.py
@@ -15,28 +15,28 @@
 # You should have received a copy of the GNU General Public License
 # along with ODL.  If not, see <http://www.gnu.org/licenses/>.
 
-"""Examples on using the vector.show() syntax
+"""Example for DiscreteLpElement.show() in 1D.
 
-NOTES
+Notes
 -----
 The behaviour of blocking shows etc in matplotlib is experimental and can cause
-issues with these examples.
+issues with this example.
 """
 
 import matplotlib.pyplot as plt
 import odl
 import numpy as np
 
-spc = odl.uniform_discr(0, 5, 100)
-vec = spc.element(np.sin)
+space = odl.uniform_discr(0, 5, 100)
+elem = space.element(np.sin)
 
 # Get figure object
-fig = vec.show(title='Sine functions')
+fig = elem.show(title='Sine functions')
 # Plot into the same figure
-fig = (vec / 2).show(fig=fig)
+fig = (elem / 2).show(fig=fig)
 
 # Plotting is deferred until show() is called
 plt.show()
 
-# Can also force "instant" plotting
-vec.show(show=True)
+# "Instant" plotting can be forced
+elem.show(show=True)

--- a/examples/visualization/show_1d.py
+++ b/examples/visualization/show_1d.py
@@ -15,7 +15,7 @@
 # You should have received a copy of the GNU General Public License
 # along with ODL.  If not, see <http://www.gnu.org/licenses/>.
 
-"""Example for DiscreteLpElement.show() in 1D.
+"""Example for `DiscreteLpElement.show` in 1D.
 
 Notes
 -----

--- a/examples/visualization/show_2d.py
+++ b/examples/visualization/show_2d.py
@@ -15,24 +15,24 @@
 # You should have received a copy of the GNU General Public License
 # along with ODL.  If not, see <http://www.gnu.org/licenses/>.
 
-"""Examples on using the vector.show() syntax
+"""Example for DiscreteLpElement.show() in 2D.
 
-NOTES
+Notes
 -----
 The behaviour of blocking shows etc in matplotlib is experimental and can cause
-issues with these examples.
+issues with this example.
 """
 
 import odl
 
-spc = odl.uniform_discr([0, 0], [1, 1], [100, 100])
-vec = odl.phantom.shepp_logan(spc, modified=True)
+space = odl.uniform_discr([0, 0], [1, 1], [100, 100])
+phantom = odl.phantom.shepp_logan(space, modified=True)
 
 # Show all data
-vec.show(show=True)
+phantom.show(show=True)
 
-# We can show subsets by index:
-vec.show(indices=[slice(None), 50])
+# We can show subsets by index
+phantom.show(indices=[slice(None), 50])
 
 # Or we can show by coordinate
-vec.show(coords=[None, 0.5])
+phantom.show(coords=[None, 0.5])

--- a/examples/visualization/show_2d.py
+++ b/examples/visualization/show_2d.py
@@ -15,7 +15,7 @@
 # You should have received a copy of the GNU General Public License
 # along with ODL.  If not, see <http://www.gnu.org/licenses/>.
 
-"""Example for DiscreteLpElement.show() in 2D.
+"""Example for `DiscreteLpElement.show` in 2D.
 
 Notes
 -----

--- a/examples/visualization/show_2d_complex.py
+++ b/examples/visualization/show_2d_complex.py
@@ -15,7 +15,7 @@
 # You should have received a copy of the GNU General Public License
 # along with ODL.  If not, see <http://www.gnu.org/licenses/>.
 
-"""Example for DiscreteLpElement.show() in 2D with complex data.
+"""Example for `DiscreteLpElement.show` in 2D with complex data.
 
 Notes
 -----

--- a/examples/visualization/show_2d_complex.py
+++ b/examples/visualization/show_2d_complex.py
@@ -15,18 +15,16 @@
 # You should have received a copy of the GNU General Public License
 # along with ODL.  If not, see <http://www.gnu.org/licenses/>.
 
-"""Examples on using the vector.show() syntax
+"""Example for DiscreteLpElement.show() in 2D with complex data.
 
-NOTES
+Notes
 -----
 The behaviour of blocking shows etc in matplotlib is experimental and can cause
-issues with these examples.
+issues with this example.
 """
 
 import odl
 
-spc = odl.uniform_discr([0, 0], [1, 1], [100, 100], dtype='complex')
-vec = odl.phantom.shepp_logan(spc, modified=True) * (1 + 0.5j)
-
-# Can also force "instant" plotting
-vec.show(show=True)
+space = odl.uniform_discr([0, 0], [1, 1], [100, 100], dtype='complex')
+phantom = odl.phantom.shepp_logan(space, modified=True) * (1 + 0.5j)
+phantom.show(show=True)

--- a/examples/visualization/show_ntuple.py
+++ b/examples/visualization/show_ntuple.py
@@ -15,11 +15,10 @@
 # You should have received a copy of the GNU General Public License
 # along with ODL.  If not, see <http://www.gnu.org/licenses/>.
 
-"""Example on the usage of the vector.show() syntax for n-tuples"""
+"""Example for displaying n-tuples using show()."""
 
 import odl
 
-spc = odl.rn(5)
-vec = spc.element([1, 2, 3, 4, 5])
-
-vec.show(show=True)
+space = odl.rn(5)
+vector = space.element([1, 2, 3, 4, 5])
+vector.show(show=True)

--- a/examples/visualization/show_ntuple.py
+++ b/examples/visualization/show_ntuple.py
@@ -15,7 +15,11 @@
 # You should have received a copy of the GNU General Public License
 # along with ODL.  If not, see <http://www.gnu.org/licenses/>.
 
-"""Example for displaying n-tuples using show()."""
+"""Example for using `FnBaseVector.show`.
+
+The ``show`` method is implemented for all types of n-tuples and displays
+the data as a scatter plot.
+"""
 
 import odl
 

--- a/examples/visualization/show_productspace.py
+++ b/examples/visualization/show_productspace.py
@@ -15,7 +15,7 @@
 # You should have received a copy of the GNU General Public License
 # along with ODL.  If not, see <http://www.gnu.org/licenses/>.
 
-"""Example on using show with ProductSpace's."""
+"""Example on using `ProductSpaceElement.show`."""
 
 import odl
 import numpy as np

--- a/examples/visualization/show_productspace.py
+++ b/examples/visualization/show_productspace.py
@@ -22,29 +22,29 @@ import numpy as np
 
 n = 100
 m = 7
-spc = odl.uniform_discr([0, 0], [1, 1], [n, n])
-pspace = odl.ProductSpace(spc, m)
+space = odl.uniform_discr([0, 0], [1, 1], [n, n])
+pspace = odl.ProductSpace(space, m)
 
 # Making a product space element where each component consists of a
 # Shepp-Logan phantom multiplied by the constant i, where i is the
 # index of the product space component.
-vec = pspace.element([odl.phantom.shepp_logan(spc, modified=True) * i
-                      for i in range(m)])
+elem = pspace.element([odl.phantom.shepp_logan(space, modified=True) * i
+                       for i in range(m)])
 
 # By default 4 uniformly spaced elements are shown. Since there are 7 in
 # total, the shown components are 0, 2, 4 and 6
-vec.show(title='Default')
+elem.show(title='Default')
 
 # One can also use indexing by a list of indices or a slice.
-vec.show(indices=[0, 1], show=True,
-         title='Show first 2 elements')
+elem.show(indices=[0, 1], show=True,
+          title='Show first 2 elements')
 
-vec.show(indices=np.s_[::3], show=True,
-         title='Show every third element')
+elem.show(indices=np.s_[::3], show=True,
+          title='Show every third element')
 
 # Slices propagate (as in numpy): the first index in the slice applies to
 # the product space components, the other dimensions are applied to each
-# component. Here we take the second vector component and slice in the
+# component. Here we take the second component and slice in the
 # middle along the second axis.
-vec.show(indices=np.s_[2, :, n // 2], show=True,
-         title='Show second element, then slice by [:, n//2]')
+elem.show(indices=np.s_[2, :, n // 2], show=True,
+          title='Show second element, then slice by [:, n//2]')

--- a/examples/visualization/show_update_1d.py
+++ b/examples/visualization/show_update_1d.py
@@ -23,8 +23,8 @@ import numpy as np
 
 n = 100
 m = 20
-spc = odl.uniform_discr(0, 5, n)
-vec = spc.element(np.sin(spc.points()))
+space = odl.uniform_discr(0, 5, n)
+elem = space.element(np.sin)
 
 # Pre-create a plot and set some property, here the plot limits in the y axis.
 fig = plt.figure()
@@ -32,7 +32,7 @@ plt.ylim(-m, m)
 
 # Reuse the figure indefinitely
 for i in range(m):
-    fig = (vec * i).show(fig=fig)
+    fig = (elem * i).show(fig=fig)
     plt.pause(0.1)
 
 plt.show()

--- a/examples/visualization/show_update_2d.py
+++ b/examples/visualization/show_update_2d.py
@@ -22,15 +22,15 @@ import matplotlib.pyplot as plt
 
 n = 100
 m = 20
-spc = odl.uniform_discr([0, 0], [1, 1], [n, n])
-vec = odl.phantom.shepp_logan(spc, modified=True)
+space = odl.uniform_discr([0, 0], [1, 1], [n, n])
+phantom = odl.phantom.shepp_logan(space, modified=True)
 
 # Create a figure by saving the result of show
 fig = None
 
 # Reuse the figure indefinitely, values are overwritten.
 for i in range(m):
-    fig = (vec * i).show(fig=fig, clim=[0, m])
+    fig = (phantom * i).show(fig=fig, clim=[0, m])
     plt.pause(0.1)
 
 plt.show()

--- a/examples/visualization/visualize_vector_examples.py
+++ b/examples/visualization/visualize_vector_examples.py
@@ -19,12 +19,12 @@
 
 import odl
 
-disc = odl.uniform_discr(0, 1, 100)
+space_1d = odl.uniform_discr(0, 1, 100)
 
-for name, vec in disc.examples:
-    vec.show(name)
+for name, elem in space_1d.examples:
+    elem.show(name)
 
-disc = odl.uniform_discr([0, 0], [1, 1], [100, 100])
+space_2d = odl.uniform_discr([0, 0], [1, 1], [100, 100])
 
-for name, vec in disc.examples:
-    vec.show(name)
+for name, elem in space_2d.examples:
+    elem.show(name)

--- a/odl/deform/linearized.py
+++ b/odl/deform/linearized.py
@@ -25,10 +25,10 @@ from builtins import super
 
 import numpy as np
 
-from odl.discr import (DiscreteLp, DiscreteLpVector, Gradient, Divergence,
+from odl.discr import (DiscreteLp, DiscreteLpElement, Gradient, Divergence,
                        PointwiseInner)
 from odl.operator.operator import Operator
-from odl.space import ProductSpaceVector
+from odl.space import ProductSpaceElement
 
 
 __all__ = ('LinDeformFixedTempl', 'LinDeformFixedDisp')
@@ -42,7 +42,7 @@ def _linear_deform(template, displacement, out=None):
 
     Parameters
     ----------
-    template : `DiscreteLpVector`
+    template : `DiscreteLpElement`
         Template to be deformed by a displacement field.
     displacement : element of power space of ``template.space``
         Vector field (displacement field) used to deform the
@@ -142,7 +142,7 @@ class LinDeformFixedTempl(Operator):
 
         Parameters
         ----------
-        template : `DiscreteLpVector`
+        template : `DiscreteLpElement`
             Fixed template that is to be deformed.
 
         Examples
@@ -172,8 +172,8 @@ class LinDeformFixedTempl(Operator):
         >>> print(op(disp_field))
         [0.0, 0.0, 1.0, 0.5, 0.0]
         """
-        if not isinstance(template, DiscreteLpVector):
-            raise TypeError('`template` must be a `DiscreteLpVector`'
+        if not isinstance(template, DiscreteLpElement):
+            raise TypeError('`template` must be a `DiscreteLpElement`'
                             'instance, got {!r}'.format(template))
 
         self.__template = template
@@ -301,8 +301,8 @@ class LinDeformFixedDisp(Operator):
         >>> print(op(template))
         [0.0, 0.0, 1.0, 0.5, 0.0]
         """
-        if not isinstance(displacement, ProductSpaceVector):
-            raise TypeError('`displacement must be a `ProductSpaceVector` '
+        if not isinstance(displacement, ProductSpaceElement):
+            raise TypeError('`displacement must be a `ProductSpaceElement` '
                             'instance, got {!r}'.format(displacement))
         if not displacement.space.is_power_space:
             raise TypeError('`displacement.space` must be a power space, '

--- a/odl/diagnostics/space.py
+++ b/odl/diagnostics/space.py
@@ -34,7 +34,7 @@ __all__ = ('SpaceTest',)
 
 
 def _approx_equal(x, y, eps):
-    """Test if vectors ``x`` and ``y`` are approximately equal.
+    """Test if elements ``x`` and ``y`` are approximately equal.
 
     ``eps`` is a given absolute tolerance.
     """
@@ -85,7 +85,7 @@ class SpaceTest(object):
         if self.verbose:
             print(message)
 
-    def element(self):
+    def element_method(self):
         """Verify `LinearSpace.element`."""
         with FailCounter(test_name='Verifying element method',
                          logger=self.log) as counter:
@@ -272,9 +272,9 @@ class SpaceTest(object):
                                  ''.format(n_x, a, b))
 
     def _subtraction(self):
-        """Verify vector subtraction as addition of additive inverse."""
+        """Verify element subtraction as addition of additive inverse."""
         with FailCounter(
-                test_name='Verifying vector subtraction',
+                test_name='Verifying element subtraction',
                 err_msg='error = dist(x - y, x + (-1 * y))',
                 logger=self.log) as counter:
 
@@ -760,7 +760,7 @@ class SpaceTest(object):
                     counter.fail('failed with x={:25s} y={:25s} a={}'
                                  ''.format(n_x, n_y, a))
 
-    def _multiply_distributive_vec(self):
+    def _multiply_distributive_vector(self):
         """Verify distributivity of vector multiplication."""
         with FailCounter(
                 test_name='Verifying distributivity of vector multiplication '
@@ -817,7 +817,7 @@ class SpaceTest(object):
         self._multiply_commutative()
         self._multiply_associative()
         self._multiply_distributive_scalar()
-        self._multiply_distributive_vec()
+        self._multiply_distributive_vector()
 
     def equals(self):
         """Verify `LinearSpace.__eq__`."""
@@ -874,10 +874,10 @@ class SpaceTest(object):
                     counter.fail('not obj not in space,  with obj={}'
                                  ''.format(obj))
 
-    def vector_assign(self):
-        """Verify `LinearSpaceVector.assign`."""
+    def element_assign(self):
+        """Verify `LinearSpaceElement.assign`."""
         with FailCounter(
-                test_name='Verify behavior of ``LinearSpaceVector.assign()``',
+                test_name='Verify behavior of ``LinearSpaceElement.assign()``',
                 logger=self.log) as counter:
 
             for [n_x, x], [n_y, y] in samples(self.space,
@@ -888,10 +888,10 @@ class SpaceTest(object):
                     counter.fail('failed with x={:25s} y={:25s}'
                                  ''.format(n_x, n_y))
 
-    def vector_copy(self):
-        """Verify `LinearSpaceVector.copy`."""
+    def element_copy(self):
+        """Verify `LinearSpaceElement.copy`."""
         with FailCounter(
-                test_name='Verify behavior of ``LinearSpaceVector.copy()``',
+                test_name='Verify behavior of ``LinearSpaceElement.copy()``',
                 logger=self.log) as counter:
 
             for [n_x, x] in samples(self.space):
@@ -909,8 +909,8 @@ class SpaceTest(object):
                     counter.fail('modified y, x changed with x={:25s}'
                                  ''.format(n_x))
 
-    def vector_set_zero(self):
-        """Verify `LinearSpaceVector.set_zero`."""
+    def element_set_zero(self):
+        """Verify `LinearSpaceElement.set_zero`."""
         try:
             zero = self.space.zero()
         except NotImplementedError:
@@ -919,7 +919,7 @@ class SpaceTest(object):
 
         with FailCounter(
                 test_name='Verify behavior of '
-                          '``LinearSpaceVector.set_zero()``',
+                          '``LinearSpaceElement.set_zero()``',
                 logger=self.log) as counter:
 
             for [n_x, x] in samples(self.space):
@@ -929,8 +929,8 @@ class SpaceTest(object):
                     counter.fail('failed with x={:25s}'
                                  ''.format(n_x))
 
-    def vector_equals(self):
-        """Verify `LinearSpaceVector.__eq__`."""
+    def element_equals(self):
+        """Verify `LinearSpaceElement.__eq__`."""
         try:
             zero = self.space.zero()
         except NotImplementedError:
@@ -944,7 +944,7 @@ class SpaceTest(object):
             return
 
         with FailCounter(
-                test_name='Verify behavior of ``vector1 == vector2``',
+                test_name='Verify behavior of ``element1 == element2``',
                 logger=self.log) as counter:
 
             for [n_x, x], [n_y, y] in samples(self.space,
@@ -966,41 +966,40 @@ class SpaceTest(object):
                         counter.fail('failed x != y with x={:25s}, x={:25s}'
                                      ''.format(n_x, n_y))
 
-    def vector_space(self):
-        """Verify `LinearSpaceVector.space`."""
+    def element_space(self):
+        """Verify `LinearSpaceElement.space`."""
         with FailCounter(
-                test_name='Verify ``LinearSpaceVector.space``',
+                test_name='Verify ``LinearSpaceElement.space``',
                 logger=self.log) as counter:
 
             for [n_x, x] in samples(self.space):
                 if x.space != self.space:
                     counter.fail('failed with x={:25s}'.format(n_x))
 
-    def vector(self):
-        """Verify `LinearSpaceVector`."""
+    def element(self):
+        """Verify `LinearSpaceElement`."""
 
-        self.log('\n== Verifying Vector ==\n')
-        self.vector_assign()
-        self.vector_copy()
-        self.vector_set_zero()
-        self.vector_equals()
-        self.vector_space()
+        self.log('\n== Verifying element attributes ==\n')
+        self.element_assign()
+        self.element_copy()
+        self.element_set_zero()
+        self.element_equals()
+        self.element_space()
 
     def run_tests(self):
         """Run all tests on this space."""
         self.log('\n== RUNNING ALL TESTS ==\n')
         self.log('Space = {}'.format(self.space))
         self.field()
-        self.element()
+        self.element_method()
         self.linearity()
-        self.element()
         self.inner()
         self.norm()
         self.dist()
         self.multiply()
         self.equals()
         self.contains()
-        self.vector()
+        self.element()
 
     def __str__(self):
         """Return ``str(self)``."""

--- a/odl/diagnostics/space.py
+++ b/odl/diagnostics/space.py
@@ -57,9 +57,8 @@ class SpaceTest(object):
 
     """Automated tests for `LinearSpace` instances.
 
-    This class allows users to automatically test various
-    features of an ``LinearSpace`` such as linearity and the
-    various operators.
+    This class allows users to automatically test various features of a
+    `LinearSpace` such as linearity and vector space operations.
     """
 
     def __init__(self, space, verbose=True, tol=1e-5):
@@ -333,11 +332,11 @@ class SpaceTest(object):
 
         These properties include things such as associativity
 
-        ``x + y = y + x``
+            ``x + y = y + x``
 
         and identity of the `LinearSpace.zero` element
 
-        ``x + 0 = x``
+            ``x + 0 = x``
 
         References
         ----------
@@ -837,7 +836,7 @@ class SpaceTest(object):
             print('** space == deepcopy(space) failed***')
 
         with FailCounter(
-                test_name='Verify behavior of ``space == obj`` when ``obj`` '
+                test_name='Verify behavior of `space == obj` when `obj` '
                           'is not a space',
                 logger=self.log) as counter:
 
@@ -853,7 +852,7 @@ class SpaceTest(object):
     def contains(self):
         """Verify `LinearSpace.__contains__`."""
         with FailCounter(
-                test_name='Verify behavior of ``obj in space``',
+                test_name='Verify behavior of `obj in space`',
                 logger=self.log) as counter:
 
             for [n_x, x] in samples(self.space):
@@ -877,7 +876,7 @@ class SpaceTest(object):
     def element_assign(self):
         """Verify `LinearSpaceElement.assign`."""
         with FailCounter(
-                test_name='Verify behavior of ``LinearSpaceElement.assign()``',
+                test_name='Verify behavior of `LinearSpaceElement.assign`',
                 logger=self.log) as counter:
 
             for [n_x, x], [n_y, y] in samples(self.space,
@@ -891,7 +890,7 @@ class SpaceTest(object):
     def element_copy(self):
         """Verify `LinearSpaceElement.copy`."""
         with FailCounter(
-                test_name='Verify behavior of ``LinearSpaceElement.copy()``',
+                test_name='Verify behavior of `LinearSpaceElement.copy`',
                 logger=self.log) as counter:
 
             for [n_x, x] in samples(self.space):
@@ -918,8 +917,7 @@ class SpaceTest(object):
             return
 
         with FailCounter(
-                test_name='Verify behavior of '
-                          '``LinearSpaceElement.set_zero()``',
+                test_name='Verify behavior of `LinearSpaceElement.set_zero`',
                 logger=self.log) as counter:
 
             for [n_x, x] in samples(self.space):
@@ -944,7 +942,7 @@ class SpaceTest(object):
             return
 
         with FailCounter(
-                test_name='Verify behavior of ``element1 == element2``',
+                test_name='Verify behavior of `element1 == element2`',
                 logger=self.log) as counter:
 
             for [n_x, x], [n_y, y] in samples(self.space,
@@ -969,7 +967,7 @@ class SpaceTest(object):
     def element_space(self):
         """Verify `LinearSpaceElement.space`."""
         with FailCounter(
-                test_name='Verify ``LinearSpaceElement.space``',
+                test_name='Verify `LinearSpaceElement.space`',
                 logger=self.log) as counter:
 
             for [n_x, x] in samples(self.space):
@@ -1016,6 +1014,7 @@ class SpaceTest(object):
 
 
 if __name__ == '__main__':
+    # pylint: disable=wrong-import-position
     from odl import rn, uniform_discr
     SpaceTest(rn(10), verbose=False).run_tests()
     SpaceTest(uniform_discr([0, 0], [1, 1], [5, 5])).run_tests()

--- a/odl/discr/diff_ops.py
+++ b/odl/discr/diff_ops.py
@@ -66,14 +66,16 @@ class PartialDerivative(PointwiseTensorFieldOperator):
             Finite difference method which is used in the interior of the
             domain of ``f``.
         pad_mode : {'constant', 'symmetric', 'periodic', ``None``}, optional
+            Method to be used to fill in missing values in an enlarged array.
 
-            'constant' : Pads values outside the domain of ``f`` with a
-            constant value given by ``pad_const``.
+            ``'constant'``: Fill with ``pad_const``.
 
-            'symmetric' : Pads with the reflection of the vector mirrored
-            along the edge of the array.
+            ``'symmetric'``: Reflect at the boundaries, not doubling the
+            outmost values. This requires at least two entries along
+            ``axis``.
 
-            'periodic' : Pads with the values from the other side of the array.
+            ``'periodic'``: Fill in values from the other side, keeping
+            the order.
 
             ``None`` : Use one-sided forward or backward differences at
             the boundary.
@@ -118,9 +120,9 @@ class PartialDerivative(PointwiseTensorFieldOperator):
         Parameters
         ----------
         x : `domain` element
-            Input vector to which the operator is applied.
+            Input element to which the operator is applied.
         out : `range` element, optional
-            Output vector to which the result is written.
+            Output element to which the result is written.
 
         Returns
         -------
@@ -180,7 +182,7 @@ class Gradient(PointwiseTensorFieldOperator):
     """Spatial gradient operator for `DiscreteLp` spaces.
 
     Calls helper function `finite_diff` to calculate each component of the
-    resulting product space vector. For the adjoint of the `Gradient`
+    resulting product space element. For the adjoint of the `Gradient`
     operator, zero padding is assumed to match the negative `Divergence`
     operator
     """
@@ -203,14 +205,15 @@ class Gradient(PointwiseTensorFieldOperator):
         method : {'central', 'forward', 'backward'}, optional
             Finite difference method to be used
         pad_mode : {'constant', 'symmetric', 'periodic'}, optional
+            Method to be used to fill in missing values in an enlarged array.
 
-            'constant' : Pads values outside the domain of ``f`` with a
-            constant value given by ``pad_const``.
+            ``'constant'``: Fill with ``pad_const``.
 
-            'symmetric' : Pads with the reflection of the vector mirrored
-            along the edge of the array.
+            ``'symmetric'``: Reflect at the boundaries, not doubling the
+            outmost values..
 
-            'periodic' : Pads with the values from the other side of the array.
+            ``'periodic'``: Fill in values from the other side, keeping
+            the order.
 
         pad_const : float, optional
             For ``pad_mode == 'constant'``, ``f`` assumes
@@ -381,14 +384,15 @@ class Divergence(PointwiseTensorFieldOperator):
         method : {'central', 'forward', 'backward'}, optional
             Finite difference method to be used
         pad_mode : {'constant', 'symmetric', 'periodic'}, optional
+            Method to be used to fill in missing values in an enlarged array.
 
-            'constant' : Pads values outside the domain of ``f`` with a
-            constant value given by ``pad_const``.
+            ``'constant'``: Fill with ``pad_const``.
 
-            'symmetric' : Pads with the reflection of the vector mirrored
-            along the edge of the array.
+            ``'symmetric'``: Reflect at the boundaries, not doubling the
+            outmost values..
 
-            'periodic' : Pads with the values from the other side of the array.
+            ``'periodic'``: Fill in values from the other side, keeping
+            the order.
 
         pad_const : float, optional
             For ``pad_mode == 'constant'``, ``f`` assumes
@@ -457,7 +461,7 @@ class Divergence(PointwiseTensorFieldOperator):
         Parameters
         ----------
         x : `domain` element
-            `ProductSpaceVector` to which the divergence operator
+            `ProductSpaceElement` to which the divergence operator
             is applied.
         out : `range` element, optional
             Output vector to which the result is written.
@@ -545,14 +549,18 @@ class Laplacian(PointwiseTensorFieldOperator):
         space : `DiscreteLp`
             Space of elements which the operator is acting on.
         pad_mode : {'constant', 'symmetric', 'periodic'}, optional
+            Method to be used to fill in missing values in an enlarged array.
 
-            'constant' : Pads values outside the domain of ``f`` with a
-            constant value given by ``pad_const``.
+            ``'constant'``: Fill with ``pad_const``.
 
-            'symmetric' : Pads with the reflection of the vector mirrored
-            along the edge of the array.
+            ``'symmetric'``: Reflect at the boundaries, not doubling the
+            outmost values..
 
-            'periodic' : Pads with the values from the other side of the array.
+            ``'periodic'``: Fill in values from the other side, keeping
+            the order.
+
+            ``None`` : Use one-sided forward or backward differences at
+            the boundary.
 
         pad_const : float, optional
             For ``pad_mode == 'constant'``, ``f`` assumes
@@ -693,14 +701,16 @@ def finite_diff(f, axis=0, dx=1.0, method='forward', out=None, **kwargs):
          the same shape as the input array ``f``.
 
     pad_mode : {'constant', 'symmetric', 'periodic', ``None``}, optional
+        Method to be used to fill in missing values in an enlarged array.
 
-        'constant' : Pads values outside the domain of ``f`` with a constant
-        value given by ``pad_const``.
+        ``'constant'``: Fill with ``pad_const``.
 
-        'symmetric' : Pads with the reflection of the vector mirrored
-        along the edge of the array.
+        ``'symmetric'``: Reflect at the boundaries, not doubling the
+        outmost values. This requires at least two entries along
+        ``axis``.
 
-        'periodic' : Pads with the values from the other side of the array.
+        ``'periodic'``: Fill in values from the other side, keeping
+        the order.
 
         ``None`` : Use one-sided forward or backward differences at
         the boundary.

--- a/odl/discr/discr_mappings.py
+++ b/odl/discr/discr_mappings.py
@@ -243,7 +243,7 @@ class PointCollocation(FunctionSetMapping):
 
         Parameters
         ----------
-        func : `FunctionSetVector`
+        func : `FunctionSetElement`
             The function to be evaluated
         out : `NtuplesBaseVector`, optional
             Array to which the values are written. Its shape must be
@@ -409,12 +409,12 @@ class NearestInterpolation(FunctionSetMapping):
         ----------
         x : `NtuplesBaseVector`
             The array of values to be interpolated
-        out : `FunctionSetVector`, optional
-            Vector in which to store the interpolator
+        out : `FunctionSetElement`, optional
+            Element in which to store the interpolator
 
         Returns
         -------
-        out : `FunctionSetVector`
+        out : `FunctionSetElement`
             Nearest-neighbor interpolator for the grid of this
             operator. If ``out`` was provided, the returned object
             is a reference to it.
@@ -507,12 +507,12 @@ class LinearInterpolation(FunctionSetMapping):
         ----------
         x : `FnBaseVector`
             The array of values to be interpolated
-        out : `FunctionSpaceVector`, optional
-            Vector in which to store the interpolator
+        out : `FunctionSpaceElement`, optional
+            Element in which to store the interpolator
 
         Returns
         -------
-        out : `FunctionSpaceVector`
+        out : `FunctionSpaceElement`
             Linear interpolator for the grid of this operator. If
             ``out`` was provided, the returned object is a reference
             to it.
@@ -642,12 +642,12 @@ class PerAxisInterpolation(FunctionSetMapping):
         ----------
         x : `FnBaseVector`
             The array of values to be interpolated
-        out : `FunctionSpaceVector`, optional
-            Vector in which to store the interpolator
+        out : `FunctionSpaceElement`, optional
+            Element in which to store the interpolator
 
         Returns
         -------
-        out : `FunctionSpaceVector`
+        out : `FunctionSpaceElement`
             Per-axis interpolator for the grid of this operator. If
             ``out`` was provided, the returned object is a reference
             to it.

--- a/odl/discr/discr_ops.py
+++ b/odl/discr/discr_ops.py
@@ -94,7 +94,7 @@ class Resampling(Operator):
     def _call(self, x, out=None):
         """Apply resampling operator.
 
-        The vector ``x`` is resampled using the sampling and interpolation
+        The element ``x`` is resampled using the sampling and interpolation
         operators of the underlying spaces.
         """
         if out is None:

--- a/odl/discr/discretization.py
+++ b/odl/discr/discretization.py
@@ -33,8 +33,8 @@ from odl.util.utility import (
     is_real_floating_dtype, is_complex_floating_dtype, is_scalar_dtype)
 
 
-__all__ = ('DiscretizedSet', 'DiscretizedSetVector',
-           'DiscretizedSpace', 'DiscretizedSpaceVector')
+__all__ = ('DiscretizedSet', 'DiscretizedSetElement',
+           'DiscretizedSpace', 'DiscretizedSpaceElement')
 
 
 class DiscretizedSet(NtuplesBase):
@@ -138,7 +138,7 @@ class DiscretizedSet(NtuplesBase):
 
     @property
     def dspace(self):
-        """Space for the coefficients of the vectors in this space.
+        """Space for the coefficients of the elements of this space.
 
         Returns
         -------
@@ -183,7 +183,7 @@ class DiscretizedSet(NtuplesBase):
 
         Returns
         -------
-        element : `DiscretizedSetVector`
+        element : `DiscretizedSetElement`
             The discretized element, calculated as ``sampling(inp)`` or
             ``dspace.element(inp)``, tried in this order.
 
@@ -236,15 +236,15 @@ class DiscretizedSet(NtuplesBase):
 
     @property
     def element_type(self):
-        """`DiscretizedSetVector`"""
-        return DiscretizedSetVector
+        """`DiscretizedSetElement`"""
+        return DiscretizedSetElement
 
 
-class DiscretizedSetVector(NtuplesBaseVector):
+class DiscretizedSetElement(NtuplesBaseVector):
 
     """Representation of a `DiscretizedSet` element.
 
-    Basically only a wrapper class for dspace's vector class."""
+    Basically only a wrapper class for dspace's element class."""
 
     def __init__(self, space, ntuple):
         """Initialize a new instance."""
@@ -277,7 +277,7 @@ class DiscretizedSetVector(NtuplesBaseVector):
         return self.size
 
     def copy(self):
-        """Create an identical (deep) copy of this vector."""
+        """Create an identical (deep) copy of this element."""
         return self.space.element(self.ntuple.copy())
 
     def asarray(self, out=None):
@@ -292,13 +292,13 @@ class DiscretizedSetVector(NtuplesBaseVector):
         return self.ntuple.asarray(out=out)
 
     def __eq__(self, other):
-        """Return ``vec == other``.
+        """Return ``self == other``.
 
         Returns
         -------
         equals : bool
             ``True`` if all entries of ``other`` are equal to this
-            vector's entries, ``False`` otherwise.
+            element's entries, ``False`` otherwise.
         """
         return (other in self.space and
                 self.ntuple == other.ntuple)
@@ -338,7 +338,7 @@ class DiscretizedSetVector(NtuplesBaseVector):
         self.ntuple.__setitem__(indices, input_data)
 
     def sampling(self, ufunc, **kwargs):
-        """Restrict a continuous function and assign to this vector
+        """Restrict a continuous function and assign to this element.
 
         Parameters
         ----------
@@ -351,13 +351,10 @@ class DiscretizedSetVector(NtuplesBaseVector):
         --------
         >>> import odl
         >>> import numpy as np
-
-        Create discretization
-
         >>> X = odl.uniform_discr(0, 1, 5)
         >>> x = X.element()
 
-        Assign x according to continuous vector
+        Assign x according to a continuous function:
 
         >>> x.sampling(lambda x: x)
         >>> print(x)  # Print values at grid points (which are centered)
@@ -371,13 +368,13 @@ class DiscretizedSetVector(NtuplesBaseVector):
 
     @property
     def interpolation(self):
-        """Interpolation operator associated with this vector.
+        """Interpolation operator associated with this element.
 
         Returns
         -------
         interpolation_op : `FunctionSetMapping`
             Operatior representing a continuous interpolation of this
-            vector
+            element.
 
         Examples
         --------
@@ -478,11 +475,11 @@ class DiscretizedSpace(DiscretizedSet, FnBase):
 
     # Pass-through attributes of the wrapped ``dspace``
     def zero(self):
-        """Create a vector of zeros."""
+        """Return the element of all zeros."""
         return self.element_type(self, self.dspace.zero())
 
     def one(self):
-        """Create a vector of ones."""
+        """Return the element of all ones."""
         return self.element_type(self, self.dspace.one())
 
     @property
@@ -500,56 +497,57 @@ class DiscretizedSpace(DiscretizedSet, FnBase):
         self.dspace._lincomb(a, x1.ntuple, b, x2.ntuple, out.ntuple)
 
     def _dist(self, x1, x2):
-        """Raw distance between two vectors."""
+        """Raw distance between two elements."""
         return self.dspace._dist(x1.ntuple, x2.ntuple)
 
     def _norm(self, x):
-        """Raw norm of a vector."""
+        """Raw norm of an element."""
         return self.dspace._norm(x.ntuple)
 
     def _inner(self, x1, x2):
-        """Raw inner product of two vectors."""
+        """Raw inner product of two elements."""
         return self.dspace._inner(x1.ntuple, x2.ntuple)
 
     def _multiply(self, x1, x2, out):
-        """Raw pointwise multiplication of two vectors."""
+        """Raw pointwise multiplication of two elements."""
         self.dspace._multiply(x1.ntuple, x2.ntuple, out.ntuple)
 
     def _divide(self, x1, x2, out):
-        """Raw pointwise multiplication of two vectors."""
+        """Raw pointwise multiplication of two elements."""
         self.dspace._divide(x1.ntuple, x2.ntuple, out.ntuple)
 
     @property
     def examples(self):
         """Return example functions in the space.
 
-        These are created by discretizing the examples in the underlying uspace
+        These are created by discretizing the examples in the underlying
+        `uspace`.
 
         See Also
         --------
         FunctionSpace.examples
         """
-        for name, vector in self.uspace.examples:
-            yield (name, self.element(vector))
+        for name, elem in self.uspace.examples:
+            yield (name, self.element(elem))
 
     @property
     def element_type(self):
-        """`DiscretizedSpaceVector`"""
-        return DiscretizedSpaceVector
+        """`DiscretizedSpaceElement`"""
+        return DiscretizedSpaceElement
 
 
-class DiscretizedSpaceVector(DiscretizedSetVector, FnBaseVector):
+class DiscretizedSpaceElement(DiscretizedSetElement, FnBaseVector):
 
     """Representation of a `DiscretizedSpace` element."""
 
     def __init__(self, space, data):
         """Initialize a new instance."""
         assert isinstance(space, DiscretizedSpace)
-        DiscretizedSetVector.__init__(self, space, data)
+        DiscretizedSetElement.__init__(self, space, data)
 
     def __ipow__(self, p):
         """Implement ``self **= p``."""
-        # Falls back to `LinearSpaceVector.__ipow__` if `self.ntuple`
+        # Falls back to `LinearSpaceElement.__ipow__` if `self.ntuple`
         # has no own `__ipow__`. The fallback only works for integer `p`.
         self.ntuple.__ipow__(p)
         return self

--- a/odl/discr/grid.py
+++ b/odl/discr/grid.py
@@ -44,12 +44,12 @@ def sparse_meshgrid(*x):
     Parameters
     ----------
     x1,...,xN : `array-like`
-        Input arrays to turn into sparse meshgrid vectors
+        Input arrays to turn into sparse meshgrid vectors.
 
     Returns
     -------
     meshgrid : tuple of `numpy.ndarray`'s
-        Sparse coordinate vectors representing an N-dimensional grid
+        Sparse coordinate vectors representing an N-dimensional grid.
 
     See Also
     --------

--- a/odl/discr/lp_discr.py
+++ b/odl/discr/lp_discr.py
@@ -27,7 +27,7 @@ import numpy as np
 from numbers import Integral
 
 from odl.discr.discretization import (
-    DiscretizedSpace, DiscretizedSpaceVector, dspace_type)
+    DiscretizedSpace, DiscretizedSpaceElement, dspace_type)
 from odl.discr.discr_mappings import (
     PointCollocation, NearestInterpolation, LinearInterpolation,
     PerAxisInterpolation)
@@ -43,7 +43,7 @@ from odl.util.ufuncs import DiscreteLpUFuncs
 from odl.util.utility import (
     is_real_dtype, is_complex_floating_dtype, dtype_repr)
 
-__all__ = ('DiscreteLp', 'DiscreteLpVector',
+__all__ = ('DiscreteLp', 'DiscreteLpElement',
            'uniform_discr_frompartition', 'uniform_discr_fromspace',
            'uniform_discr_fromintv', 'uniform_discr',
            'uniform_discr_fromdiscr', 'discr_sequence_space')
@@ -266,7 +266,7 @@ class DiscreteLp(DiscretizedSpace):
 
         Returns
         -------
-        element : `DiscreteLpVector`
+        element : `DiscreteLpElement`
             The discretized element, calculated as ``sampling(inp)`` or
             ``dspace.element(inp)``, tried in this order.
 
@@ -478,11 +478,11 @@ class DiscreteLp(DiscretizedSpace):
 
     @property
     def element_type(self):
-        """`DiscreteLpVector`"""
-        return DiscreteLpVector
+        """`DiscreteLpElement`"""
+        return DiscreteLpElement
 
 
-class DiscreteLpVector(DiscretizedSpaceVector):
+class DiscreteLpElement(DiscretizedSpaceElement):
 
     """Representation of a `DiscreteLp` element."""
 
@@ -497,7 +497,7 @@ class DiscreteLpVector(DiscretizedSpaceVector):
             shape.
         """
         if out is None:
-            return DiscretizedSpaceVector.asarray(self).reshape(
+            return DiscretizedSpaceElement.asarray(self).reshape(
                 self.shape, order=self.space.order)
         else:
             if out.shape not in (self.space.shape, (self.space.size,)):
@@ -579,14 +579,14 @@ class DiscreteLpVector(DiscretizedSpaceVector):
 
         Parameters
         ----------
-        out : `DiscreteLpVector`, optional
+        out : `DiscreteLpElement`, optional
             Element to which the complex conjugate is written.
-            Must be an element of this vector's space.
+            Must be an element of this element's space.
 
         Returns
         -------
-        out : `DiscreteLpVector`
-            The complex conjugate vector. If ``out`` is provided,
+        out : `DiscreteLpElement`
+            The complex conjugate element. If ``out`` is provided,
             the returned object is a reference to it.
 
         Examples
@@ -618,7 +618,7 @@ class DiscreteLpVector(DiscretizedSpaceVector):
             return out
 
     def __setitem__(self, indices, values):
-        """Set values of this vector.
+        """Set values of this element.
 
         Parameters
         ----------
@@ -636,7 +636,7 @@ class DiscreteLpVector(DiscretizedSpaceVector):
             shape is allowed as ``values``.
         """
         if values in self.space:
-            # For DiscretizedSetVector of the same type, use ntuple directly
+            # For DiscretizedSetElement of the same type, use ntuple directly
             self.ntuple[indices] = values.ntuple
         else:
             # Other sequence types are piped through a Numpy array. Equivalent

--- a/odl/operator/default_ops.py
+++ b/odl/operator/default_ops.py
@@ -36,7 +36,10 @@ __all__ = ('ScalingOperator', 'ZeroOperator', 'IdentityOperator',
 
 class ScalingOperator(Operator):
 
-    """Operator of multiplication with a scalar."""
+    """Operator of multiplication with a scalar.
+
+        ``ScalingOperator(s)(x) == s * x``
+    """
 
     def __init__(self, space, scalar):
         """Initialize a new instance.
@@ -119,7 +122,8 @@ class ScalingOperator(Operator):
 
     def __repr__(self):
         """Return ``repr(self)``."""
-        return 'ScalingOperator({!r}, {!r})'.format(self.domain, self.scalar)
+        return '{}({!r}, {!r})'.format(self.__class__.__name__,
+                                       self.domain, self.scalar)
 
     def __str__(self):
         """Return ``str(self)``."""
@@ -128,7 +132,10 @@ class ScalingOperator(Operator):
 
 class ZeroOperator(ScalingOperator):
 
-    """Operator mapping each element to the zero element."""
+    """Operator mapping each element to the zero element.
+
+        ``ZeroOperator()(x) == 0``
+    """
 
     def __init__(self, space):
         """Initialize a new instance.
@@ -142,7 +149,7 @@ class ZeroOperator(ScalingOperator):
 
     def __repr__(self):
         """Return ``repr(self)``."""
-        return 'ZeroOperator({!r})'.format(self.domain)
+        return '{}({!r})'.format(self.__class__.__name__, self.domain)
 
     def __str__(self):
         """Return ``str(self)``."""
@@ -151,7 +158,10 @@ class ZeroOperator(ScalingOperator):
 
 class IdentityOperator(ScalingOperator):
 
-    """Operator mapping each element to itself."""
+    """Operator mapping each element to itself.
+
+        ``IdentityOperator()(x) == x``
+    """
 
     def __init__(self, space):
         """Initialize a new instance.
@@ -176,9 +186,7 @@ class LinCombOperator(Operator):
 
     """Operator mapping two space elements to a linear combination.
 
-    This opertor calculates:
-
-    ``out = a*x[0] + b*x[1]``
+        ``LinCombOperator(a, b)(x, y) == a * x + b * y``
     """
 
     def __init__(self, space, a, b):
@@ -228,9 +236,9 @@ class LinCombOperator(Operator):
 
 class MultiplyOperator(Operator):
 
-    """Operator multiplying two elements.
+    """Operator multiplying by a fixed space or field element.
 
-    ``MultiplyOperator(y)(x) <==> x * y``
+        ``MultiplyOperator(y)(x) == x * y``
 
     Here, ``y`` is a `LinearSpaceElement` or `Field` element and
     ``x`` is a `LinearSpaceElement`.
@@ -342,7 +350,7 @@ class MultiplyOperator(Operator):
 
     def __repr__(self):
         """Return ``repr(self)``."""
-        return 'MultiplyOperator({!r})'.format(self.y)
+        return '{}({!r})'.format(self.__class__.__name__, self.multiplicand)
 
     def __str__(self):
         """Return ``str(self)``."""
@@ -351,9 +359,9 @@ class MultiplyOperator(Operator):
 
 class PowerOperator(Operator):
 
-    """Power of a space element or a scalar.
+    """Operator taking a fixed power of a space or field element.
 
-    ``PowerOperator(p)(x) <==> x ** p``
+        ``PowerOperator(p)(x) == x ** p``
 
     Here, ``x`` is a `LinearSpaceElement` or `Field` element and ``p`` is
     a number. Hence, this operator can be defined either on a
@@ -408,7 +416,7 @@ class PowerOperator(Operator):
     def derivative(self, point):
         """Derivative of this operator.
 
-        ``MultiplyOperator(n).derivative(x)(y) <==> n * x ** (n - 1) * y``
+            ``PowerOperator(p).derivative(y)(x) == p * y ** (p - 1) * x``
 
         Parameters
         ----------
@@ -455,7 +463,7 @@ class PowerOperator(Operator):
 class InnerProductOperator(Operator):
     """Operator taking the inner product with a fixed space element.
 
-    ``InnerProductOperator(vec)(x) <==> x.inner(vec)``
+        ``InnerProductOperator(y)(x) <==> y.inner(x)``
 
     This is only applicable in inner product spaces.
 
@@ -548,7 +556,7 @@ class NormOperator(Operator):
 
     """Vector space norm as an operator.
 
-    ``NormOperator(space)(x) <==> space.norm(x)``
+        ``NormOperator()(x) <==> x.norm()``
 
     This is only applicable in normed spaces.
 
@@ -583,6 +591,8 @@ class NormOperator(Operator):
     def derivative(self, point):
         """Derivative of this operator in ``point``.
 
+            ``NormOperator().derivative(y)(x) == (y / y.norm()).inner(x)``
+
         This is only applicable in inner product spaces.
 
         Parameters
@@ -607,7 +617,7 @@ class NormOperator(Operator):
 
         .. math::
 
-            (D ||.||)(x)(y) = < x / ||x||, y >
+            (D \|\cdot\|)(y)(x) = \langle y / \|y\|, x \\rangle
 
         Examples
         --------
@@ -638,7 +648,7 @@ class DistOperator(Operator):
 
     """Operator taking the distance to a fixed space element.
 
-    ``DistOperator(y)(x) <==> y.dist(x)``
+        ``DistOperator(y)(x) == y.dist(x)``
 
     This is only applicable in metric spaces.
 
@@ -680,6 +690,9 @@ class DistOperator(Operator):
     def derivative(self, point):
         """The derivative operator.
 
+            ``DistOperator(y).derivative(z)(x) ==
+            ((y - z) / y.dist(z)).inner(x)``
+
         This is only applicable in inner product spaces.
 
         Parameters
@@ -704,7 +717,7 @@ class DistOperator(Operator):
 
         .. math::
 
-            (D d(x, y))(y)(z) = < (x-y) / d(x, y), y >
+            (D d(\cdot, y))(z)(x) = \\langle (y-z) / d(y, z), x \\rangle
 
         Examples
         --------
@@ -738,7 +751,7 @@ class ConstantOperator(Operator):
 
     """Operator that always returns the same value.
 
-    ``ConstantOperator(y)(x) <==> (x --> y)``
+        ``ConstantOperator(y)(x) == y``
     """
 
     def __init__(self, vector, domain=None):
@@ -814,7 +827,7 @@ class ResidualOperator(Operator):
 
     """Operator that calculates the residual ``op(x) - y``.
 
-    ``ResidualOperator(op, y)(x) <==> (x --> op(x) - y)``
+        ``ResidualOperator(op, y)(x) == op(x) - y``
     """
 
     def __init__(self, operator, vector):
@@ -832,11 +845,11 @@ class ResidualOperator(Operator):
         --------
         >>> import odl
         >>> r3 = odl.rn(3)
-        >>> vec = r3.element([1, 2, 3])
-        >>> op = IdentityOperator(r3)
-        >>> res = ResidualOperator(op, vec)
+        >>> y = r3.element([1, 2, 3])
+        >>> ident_op = odl.IdentityOperator(r3)
+        >>> res_op = odl.ResidualOperator(ident_op, y)
         >>> x = r3.element([4, 5, 6])
-        >>> res(x, out=r3.element())
+        >>> res_op(x)
         rn(3).element([3.0, 3.0, 3.0])
         """
         if not isinstance(operator, Operator):
@@ -876,7 +889,7 @@ class ResidualOperator(Operator):
 
         It is equal to the derivative of the "inner" operator:
 
-        ``ResidualOperator(op, vec).derivative(x) <==> op.derivative(x)``
+            ``ResidualOperator(op, y).derivative(z) == op.derivative(z)``
 
         Parameters
         ----------

--- a/odl/operator/operator.py
+++ b/odl/operator/operator.py
@@ -717,17 +717,17 @@ class Operator(object):
         If ``other`` is an operator, this corresponds to
         operator composition:
 
-            ``left * right <==> (x --> left(right(x))``
+            ``(left * right)(x) == left(right(x))``
 
         If ``other`` is a scalar, this corresponds to scalar multiplication
         with the operator argument:
 
-            ``op * scalar <==> (x --> op(scalar * x))``
+            ``(op * scalar)(x) == op(scalar * x)``
 
         If ``other`` is an ``op.domain`` element, this corresponds to
         vector multiplication with the operator argument:
 
-            ``op * y <==> (x --> op(y * x))``
+            ``(op * y)(x) == op(y * x)``
 
         Note that left and right multiplications are generally
         different.
@@ -802,17 +802,17 @@ class Operator(object):
         If ``other`` is an `Operator`, this corresponds to
         operator composition:
 
-        ``left * right <==> (x --> left(right(x)))``
+            ``(left * right)(x) == left(right(x))``
 
         If ``other`` is a scalar, this corresponds to scalar multiplication
         with the operator evaluation result:
 
-        ``scalar * op <==> (x --> scalar * op(x))``
+            ``(scalar * op)(x) == scalar * op(x)``
 
         If ``other`` is an ``op.domain`` element, this corresponds to
         vector multiplication with the operator evaluation result:
 
-        ``y * op <==> (x --> y * op(x))``
+            ``(y * op)(x) == y * op(x)``
 
         Note that left and right multiplications are generally
         different.
@@ -878,14 +878,14 @@ class Operator(object):
         return self.__rmul__(other)
 
     def __pow__(self, n):
-        """Return ``op**s``.
+        """Return ``op ** n``.
 
         This corresponds to the power of an operator:
 
-        ``op ** 1 <==> (x --> op(x))``
-        ``op ** 2 <==> (x --> op(op(x)))``
-        ``op ** 3 <==> (x --> op(op(op(x))))``
-        ...
+            ``(op ** 1)(x) == op(x)``
+            ``(op ** 2)(x) == op(op(x))``
+            ``(op ** 3)(x) == op(op(op(x)))``
+            ...
 
         Parameters
         ----------
@@ -896,7 +896,7 @@ class Operator(object):
         -------
         pow : `Operator`
             The power of this operator. If ``n == 1``, ``pow`` is
-            this operator, for ``n > 1``, a `OperatorComp`
+            this operator, for ``n > 1``, an `OperatorComp`
 
         Examples
         --------
@@ -928,7 +928,7 @@ class Operator(object):
         If ``other`` is a scalar, this corresponds to right
         division of operators with scalars:
 
-        ``op / scalar <==> (x --> op(x / scalar))``
+            ``(op / scalar)(x) == op(x / scalar)``
 
         Parameters
         ----------
@@ -1000,7 +1000,7 @@ class OperatorSum(Operator):
 
     """Expression type for the sum of operators.
 
-    ``OperatorSum(left, right) <==> (x --> left(x) + right(x))``
+        ``OperatorSum(left, right)(x) == left(x) + right(x)``
 
     The sum is only well-defined for `Operator` instances where
     `Operator.range` is a `LinearSpace`.
@@ -1105,8 +1105,8 @@ class OperatorSum(Operator):
         The adjoint of the operator sum is the sum of the operator
         adjoints:
 
-        ``OperatorSum(left, right).adjoint ==
-        OperatorSum(left.adjoint, right.adjoint)``
+            ``OperatorSum(left, right).adjoint ==
+            OperatorSum(left.adjoint, right.adjoint)``
 
         Returns
         -------
@@ -1137,10 +1137,9 @@ class OperatorComp(Operator):
 
     """Expression type for the composition of operators.
 
-    ``OperatorComp(left, right) <==> (x --> left(right(x)))``
+        ``OperatorComp(left, right)(x) == left(right(x))``
 
-    The composition is only well-defined if
-    ``left.domain == right.range``.
+    The composition is only well-defined if ``left.domain == right.range``.
     """
 
     def __init__(self, left, right, tmp=None):
@@ -1200,8 +1199,8 @@ class OperatorComp(Operator):
         The inverse of the operator composition is the composition of
         the inverses in reverse order:
 
-        ``OperatorComp(left, right).inverse ==``
-        ``OperatorComp(right.inverse, left.inverse)``
+            ``OperatorComp(left, right).inverse ==``
+            ``OperatorComp(right.inverse, left.inverse)``
         """
         return OperatorComp(self.right.inverse, self.left.inverse,
                             self.__tmp)
@@ -1212,8 +1211,8 @@ class OperatorComp(Operator):
         The derivative of the operator composition follows the chain
         rule:
 
-        ``OperatorComp(left, right).derivative(x) ==
-        OperatorComp(left.derivative(right(x)), right.derivative(x))``
+            ``OperatorComp(left, right).derivative(y) ==
+            OperatorComp(left.derivative(right(y)), right.derivative(y))``
 
         Parameters
         ----------
@@ -1234,8 +1233,8 @@ class OperatorComp(Operator):
         The adjoint of the operator composition is the composition of
         the operator adjoints in reverse order:
 
-        ``OperatorComp(left, right).adjoint ==
-        OperatorComp(right.adjoint, left.adjoint)``
+            ``OperatorComp(left, right).adjoint ==
+            OperatorComp(right.adjoint, left.adjoint)``
 
         Returns
         -------
@@ -1266,7 +1265,7 @@ class OperatorPointwiseProduct(Operator):
 
     """Expression type for the pointwise operator mulitplication.
 
-    ``OperatorPointwiseProduct(left, right) <==> (x --> left(x) * right(x))``
+        ``OperatorPointwiseProduct(left, right)(x) == left(x) * right(x)``
     """
 
     def __init__(self, left, right):
@@ -1328,7 +1327,7 @@ class OperatorLeftScalarMult(Operator):
 
     """Expression type for the operator left scalar multiplication.
 
-    ``OperatorLeftScalarMult(op, scalar) <==> (x --> scalar * op(x))``
+        ``OperatorLeftScalarMult(op, s)(x) == s * op(x)``
 
     The scalar multiplication is well-defined only if ``op.range`` is
     a `LinearSpace`.
@@ -1408,8 +1407,8 @@ class OperatorLeftScalarMult(Operator):
         ``op.inverse * 1/scalar`` if ``scalar != 0``. If ``scalar == 0``,
         the inverse is not defined.
 
-        ``OperatorLeftScalarMult(op, scalar).inverse <==>``
-        ``OperatorRightScalarMult(op.inverse, 1.0/scalar)``
+            ``OperatorLeftScalarMult(op, s).inverse ==
+            OperatorRightScalarMult(op.inverse, 1/s)``
 
         Examples
         --------
@@ -1430,8 +1429,8 @@ class OperatorLeftScalarMult(Operator):
 
         Left scalar multiplication and derivative are commutative:
 
-        ``OperatorLeftScalarMult(op, scalar).derivative(x) <==>``
-        ``OperatorLeftScalarMult(op.derivative(x), scalar)``
+            ``OperatorLeftScalarMult(op, s).derivative(y) ==
+            OperatorLeftScalarMult(op.derivative(y), s)``
 
         Parameters
         ----------
@@ -1465,8 +1464,8 @@ class OperatorLeftScalarMult(Operator):
         The adjoint of the operator scalar multiplication is the
         scalar multiplication of the operator adjoint:
 
-        ``OperatorLeftScalarMult(op, scalar).adjoint ==``
-        ``OperatorLeftScalarMult(op.adjoint, scalar)``
+            ``OperatorLeftScalarMult(op, s).adjoint ==
+            OperatorLeftScalarMult(op.adjoint, s)``
 
         Raises
         ------
@@ -1502,7 +1501,7 @@ class OperatorRightScalarMult(Operator):
 
     """Expression type for the operator right scalar multiplication.
 
-    ``OperatorRightScalarMult(op, scalar) <==> (x --> op(scalar * x))``
+        ``OperatorRightScalarMult(op, s) == op(s * x)``
 
     The scalar multiplication is well-defined only if ``op.domain`` is
     a `LinearSpace`.
@@ -1594,8 +1593,8 @@ class OperatorRightScalarMult(Operator):
         ``1/scalar * op.inverse`` if ``scalar != 0``. If ``scalar == 0``,
         the inverse is not defined.
 
-        ``OperatorRightScalarMult(op, scalar).inverse <==>``
-        ``OperatorLeftScalarMult(op.inverse, 1.0/scalar)``
+            ``OperatorRightScalarMult(op, s).inverse ==
+            OperatorLeftScalarMult(op.inverse, 1/s)``
 
         Examples
         --------
@@ -1617,8 +1616,8 @@ class OperatorRightScalarMult(Operator):
         The derivative of the right scalar operator multiplication
         follows the chain rule:
 
-        ``OperatorRightScalarMult(op, scalar).derivative(x) <==>``
-        ``OperatorLeftScalarMult(op.derivative(scalar * x), scalar)``
+            ``OperatorRightScalarMult(op, s).derivative(y) ==
+            OperatorLeftScalarMult(op.derivative(s * y), s)``
 
         Parameters
         ----------
@@ -1645,8 +1644,8 @@ class OperatorRightScalarMult(Operator):
         The adjoint of the operator scalar multiplication is the
         scalar multiplication of the operator adjoint:
 
-        ``OperatorLeftScalarMult(op, scalar).adjoint ==``
-        ``OperatorLeftScalarMult(op.adjoint, scalar)``
+        ``OperatorLeftScalarMult(op, s).adjoint ==
+        OperatorLeftScalarMult(op.adjoint, s)``
 
         Raises
         ------
@@ -1687,7 +1686,7 @@ class FunctionalLeftVectorMult(Operator):
     resulting in an operator mapping from the `Operator.domain` to the
     element's `LinearSpaceElement.space`.
 
-    ``FunctionalLeftVectorMult(op, y)(x) <==> y * op(x)``
+        ``FunctionalLeftVectorMult(op, y)(x) == y * op(x)``
     """
 
     def __init__(self, functional, vector):
@@ -1704,13 +1703,13 @@ class FunctionalLeftVectorMult(Operator):
 
         Examples
         --------
-        Create the operator ``(x * x^T)(y) = x * <x, y>``
+        Create the operator ``(y * y^T)(x) = y * <x, y>``
 
         >>> import odl
         >>> space = odl.rn(3)
-        >>> x = space.element([1, 2, 3])
-        >>> functional = odl.InnerProductOperator(x)
-        >>> left_mul_op = FunctionalLeftVectorMult(functional, x)
+        >>> y = space.element([1, 2, 3])
+        >>> functional = odl.InnerProductOperator(y)
+        >>> left_mul_op = FunctionalLeftVectorMult(functional, y)
         >>> left_mul_op([1, 2, 3])
         rn(3).element([14.0, 28.0, 42.0])
         """
@@ -1750,8 +1749,8 @@ class FunctionalLeftVectorMult(Operator):
 
         Left scalar multiplication and derivative are commutative:
 
-        ``FunctionalLeftVectorMult(op, y).derivative(x) <==>``
-        ``FunctionalLeftVectorMult(op.derivative(x), y)``
+            ``FunctionalLeftVectorMult(op, y).derivative(z) ==
+            FunctionalLeftVectorMult(op.derivative(z), y)``
 
         Returns
         -------
@@ -1764,13 +1763,8 @@ class FunctionalLeftVectorMult(Operator):
     def adjoint(self):
         """Adjoint of this operator.
 
-        The adjoint of the operator scalar multiplication is the
-        scalar multiplication of the operator adjoint:
-
-        ``FunctionalLeftVectorMult(op, y).adjoint <==>
-        OperatorComp(op.adjoint, y.T)``
-
-        ``(x * A)^T = A^T * x^T``
+            ``FunctionalLeftVectorMult(op, y).adjoint ==
+            OperatorComp(op.adjoint, y.T)``
 
         Returns
         -------
@@ -1798,16 +1792,14 @@ class FunctionalLeftVectorMult(Operator):
 
 
 class OperatorLeftVectorMult(Operator):
+
     """Expression type for the operator left vector multiplication.
 
-    ``OperatorLeftVectorMult(op, y)(x) <==> y * op(x)``
-
-    The scalar multiplication is well-defined only if ``op.range`` is
-    a ``vector.space.field``.
+        ``OperatorLeftVectorMult(op, y)(x) <==> y * op(x)``
     """
 
     def __init__(self, operator, vector):
-        """Initialize a new Instance.
+        """Initialize a new instance.
 
         Parameters
         ----------
@@ -1850,8 +1842,8 @@ class OperatorLeftVectorMult(Operator):
         The inverse of ``y * op`` is given by
         ``op.inverse / y``.
 
-        ``OperatorLeftVectorMult(op, y).inverse <==>``
-        ``OperatorRightVectorMult(op.inverse, 1.0 / y)``
+        ``OperatorLeftVectorMult(op, y).inverse ==
+        OperatorRightVectorMult(op.inverse, 1/y)``
         """
 
         return self.operator.inverse * (1.0 / self.vector)
@@ -1861,8 +1853,8 @@ class OperatorLeftVectorMult(Operator):
 
         Left scalar multiplication and derivative are commutative:
 
-        ``OperatorLeftVectorMult(op, y).derivative(x) <==>``
-        ``OperatorLeftVectorMult(op.derivative(x), y)``
+            ``OperatorLeftVectorMult(op, y).derivative(z) ==
+            OperatorLeftVectorMult(op.derivative(z), y)``
 
         See Also
         --------
@@ -1877,10 +1869,8 @@ class OperatorLeftVectorMult(Operator):
         The adjoint of the operator vector multiplication is the
         vector multiplication of the operator adjoint:
 
-        ``OperatorLeftVectorMult(op, y).adjoint ==``
-        ``OperatorRightVectorMult(op.adjoint, y)``
-
-        ``(x * A)^T = A^T * x``
+            ``OperatorLeftVectorMult(op, y).adjoint ==
+            OperatorRightVectorMult(op.adjoint, y)``
 
         Returns
         -------
@@ -1911,7 +1901,7 @@ class OperatorRightVectorMult(Operator):
 
     """Expression type for the operator right vector multiplication.
 
-    ``OperatorRightVectorMult(op, y)(x) <==> op(y * x)``
+        ``OperatorRightVectorMult(op, y)(x) == op(y * x)``
 
     The scalar multiplication is well-defined only if ``y`` is in
     ``op.domain``.
@@ -1964,10 +1954,10 @@ class OperatorRightVectorMult(Operator):
         """Inverse of this operator.
 
         The inverse of ``op * y`` is given by
-        ``(1.0 / y) * op.inverse``.
+        ``(1/y) * op.inverse``.
 
-        ``OperatorRightVectorMult(op, y).inverse <==>``
-        ``OperatorLeftVectorMult(op.inverse, 1.0 / y)``
+            ``OperatorRightVectorMult(op, y).inverse ==
+            OperatorLeftVectorMult(op.inverse, 1/y)``
         """
         return (1.0 / self.vector) * self.operator.inverse
 
@@ -1992,10 +1982,8 @@ class OperatorRightVectorMult(Operator):
         The adjoint of the operator vector multiplication is the
         vector multiplication of the operator adjoint:
 
-        ``OperatorRightVectorMult(op, y).adjoint ==``
-        ``OperatorLeftVectorMult(op.adjoint, y)``
-
-        ``(A x)^T = x * A^T``
+            ``OperatorRightVectorMult(op, y).adjoint ==
+            OperatorLeftVectorMult(op.adjoint, y)``
 
         Returns
         -------

--- a/odl/operator/operator.py
+++ b/odl/operator/operator.py
@@ -28,7 +28,7 @@ import inspect
 from numbers import Number, Integral
 import sys
 
-from odl.set import (LinearSpace, LinearSpaceVector, UniversalSpace,
+from odl.set import (LinearSpace, LinearSpaceElement, UniversalSpace,
                      Set, UniversalSet, Field)
 
 
@@ -719,27 +719,27 @@ class Operator(object):
 
             ``left * right <==> (x --> left(right(x))``
 
-        If ``other`` is a scalar, this corresponds to right
-        multiplication of scalars with operators:
+        If ``other`` is a scalar, this corresponds to scalar multiplication
+        with the operator argument:
 
             ``op * scalar <==> (x --> op(scalar * x))``
 
-        If ``other`` is a vector, this corresponds to right
-        multiplication of vectors with operators:
+        If ``other`` is an ``op.domain`` element, this corresponds to
+        vector multiplication with the operator argument:
 
-            ``op * vector <==> (x --> op(vector * x))``
+            ``op * y <==> (x --> op(y * x))``
 
         Note that left and right multiplications are generally
         different.
 
         Parameters
         ----------
-        other : `Operator`, `LinearSpaceVector` or scalar
+        other : `Operator`, `LinearSpaceElement` or scalar
             `Operator`:
                 The `Operator.domain` of ``other`` must match this
                 operator's `Operator.range`.
 
-            `LinearSpaceVector`:
+            `LinearSpaceElement`:
                 ``other`` must be an element of this operator's
                 `Operator.domain`.
 
@@ -760,7 +760,7 @@ class Operator(object):
             If ``other`` is a scalar, ``mul`` is an
             `OperatorRightScalarMult`.
 
-            If ``other`` is a vector, ``mul`` is an
+            If ``other`` is an ``op.domain`` element, ``mul`` is an
             `OperatorRightVectorMult`.
 
         Examples
@@ -784,7 +784,7 @@ class Operator(object):
                 return OperatorLeftScalarMult(self, other)
             else:
                 return OperatorRightScalarMult(self, other)
-        elif isinstance(other, LinearSpaceVector) and other in self.domain:
+        elif isinstance(other, LinearSpaceElement) and other in self.domain:
             return OperatorRightVectorMult(self, other.copy())
         else:
             return NotImplemented
@@ -804,27 +804,27 @@ class Operator(object):
 
         ``left * right <==> (x --> left(right(x)))``
 
-        If ``other`` is a scalar, this corresponds to left
-        multiplication of scalars with operators:
+        If ``other`` is a scalar, this corresponds to scalar multiplication
+        with the operator evaluation result:
 
         ``scalar * op <==> (x --> scalar * op(x))``
 
-        If ``other`` is a vector, this corresponds to left
-        multiplication of vector with operators:
+        If ``other`` is an ``op.domain`` element, this corresponds to
+        vector multiplication with the operator evaluation result:
 
-        ``vector * op <==> (x --> vector * op(x))``
+        ``y * op <==> (x --> y * op(x))``
 
         Note that left and right multiplications are generally
         different.
 
         Parameters
         ----------
-        other : {`Operator`, `LinearSpaceVector`, scalar}
+        other : {`Operator`, `LinearSpaceElement`, scalar}
             `Operator`:
                 The `Operator.range` of ``other`` must match this
                 operator's `Operator.domain`
 
-            `LinearSpaceVector`:
+            `LinearSpaceElement`:
                 ``other`` must be an element of `Operator.range`.
 
             scalar:
@@ -843,7 +843,7 @@ class Operator(object):
             If ``other`` is a scalar, ``mul`` is an
             `OperatorLeftScalarMult`.
 
-            If ``other`` is a vector, ``mul`` is an
+            If ``other`` is an ``op.range`` element, ``mul`` is an
             `OperatorLeftVectorMult`.
 
         Examples
@@ -864,7 +864,7 @@ class Operator(object):
             return OperatorLeftScalarMult(self, other)
         elif other in self.range:
             return OperatorLeftVectorMult(self, other.copy())
-        elif (isinstance(other, LinearSpaceVector) and
+        elif (isinstance(other, LinearSpaceElement) and
               other.space.field == self.range):
             return FunctionalLeftVectorMult(self, other.copy())
         else:
@@ -991,8 +991,8 @@ class Operator(object):
     # Give a `Operator` a higher priority than any NumPy array type. This
     # forces the usage of `__op__` of `Operator` if the other operand
     # is a NumPy object (applies also to scalars!).
-    # Set higher than LinearSpaceVector.__array_priority__ to handle mult with
-    # vector properly
+    # Set higher than LinearSpaceElement.__array_priority__ to handle
+    # vector multiplication properly
     __array_priority__ = 2000000.0
 
 
@@ -1682,12 +1682,12 @@ class FunctionalLeftVectorMult(Operator):
 
     """Expression type for the functional left vector multiplication.
 
-    A functional is a `Operator` whose `Operator.range` is
-    a `Field`. It is multiplied from left with a vector, resulting in
-    an operator mapping from the `Operator.domain` to the vector's
-    `LinearSpaceVector.space`.
+    A functional is an `Operator` whose `Operator.range` is
+    a `Field`. It is multiplied from left with a `LinearSpaceElement`,
+    resulting in an operator mapping from the `Operator.domain` to the
+    element's `LinearSpaceElement.space`.
 
-    ``FunctionalLeftVectorMult(op, vector)(x) <==> vector * op(x)``
+    ``FunctionalLeftVectorMult(op, y)(x) <==> y * op(x)``
     """
 
     def __init__(self, functional, vector):
@@ -1699,8 +1699,8 @@ class FunctionalLeftVectorMult(Operator):
             Functional in the vector multiplication. Its `range` must
             be a `Field`.
         vector : ``functional.range`` `element-like`
-            The vector to multiply by. Its space's `LinearSpace.field` must be
-            the same as ``functional.range``.
+            The element to multiply with. Its space's `LinearSpace.field`
+            must be the same as ``functional.range``.
 
         Examples
         --------
@@ -1714,8 +1714,8 @@ class FunctionalLeftVectorMult(Operator):
         >>> left_mul_op([1, 2, 3])
         rn(3).element([14.0, 28.0, 42.0])
         """
-        if not isinstance(vector, LinearSpaceVector):
-            raise TypeError('`vector` {!r} not is not a LinearSpaceVector'
+        if not isinstance(vector, LinearSpaceElement):
+            raise TypeError('`vector` {!r} not is not a LinearSpaceElement'
                             ''.format(vector))
 
         if functional.range != vector.space.field:
@@ -1734,7 +1734,7 @@ class FunctionalLeftVectorMult(Operator):
 
     @property
     def vector(self):
-        """The vector part of this multiplication."""
+        """The element part of this multiplication."""
         return self.__vector
 
     def _call(self, x, out=None):
@@ -1750,8 +1750,8 @@ class FunctionalLeftVectorMult(Operator):
 
         Left scalar multiplication and derivative are commutative:
 
-        ``FunctionalLeftVectorMult(op, vector).derivative(x) <==>``
-        ``FunctionalLeftVectorMult(op.derivative(x), vector)``
+        ``FunctionalLeftVectorMult(op, y).derivative(x) <==>``
+        ``FunctionalLeftVectorMult(op.derivative(x), y)``
 
         Returns
         -------
@@ -1767,8 +1767,8 @@ class FunctionalLeftVectorMult(Operator):
         The adjoint of the operator scalar multiplication is the
         scalar multiplication of the operator adjoint:
 
-        ``FunctionalLeftVectorMult(op, vector).adjoint ==
-        OperatorComp(op.adjoint, vector.T)``
+        ``FunctionalLeftVectorMult(op, y).adjoint <==>
+        OperatorComp(op.adjoint, y.T)``
 
         ``(x * A)^T = A^T * x^T``
 
@@ -1800,7 +1800,7 @@ class FunctionalLeftVectorMult(Operator):
 class OperatorLeftVectorMult(Operator):
     """Expression type for the operator left vector multiplication.
 
-    ``OperatorLeftVectorMult(op, vector)(x) <==> vector * op(x)``
+    ``OperatorLeftVectorMult(op, y)(x) <==> y * op(x)``
 
     The scalar multiplication is well-defined only if ``op.range`` is
     a ``vector.space.field``.
@@ -1813,7 +1813,7 @@ class OperatorLeftVectorMult(Operator):
         ----------
         operator : `Operator`
             The range of ``op`` must be a `LinearSpace`.
-        vector : `LinearSpaceVector` in ``op.range``
+        vector : `LinearSpaceElement` in ``op.range``
             The vector to multiply by
         """
         if vector not in operator.range:
@@ -1832,7 +1832,7 @@ class OperatorLeftVectorMult(Operator):
 
     @property
     def vector(self):
-        """The vector part of this multiplication."""
+        """The fixed element to multiply with."""
         return self.__vector
 
     def _call(self, x, out=None):
@@ -1847,11 +1847,11 @@ class OperatorLeftVectorMult(Operator):
     def inverse(self):
         """Inverse of this operator.
 
-        The inverse of ``vector * op`` is given by
-        ``op.inverse / vector``.
+        The inverse of ``y * op`` is given by
+        ``op.inverse / y``.
 
-        ``OperatorLeftVectorMult(op, vector).inverse <==>``
-        ``OperatorRightVectorMult(op.inverse, 1.0/vector)``
+        ``OperatorLeftVectorMult(op, y).inverse <==>``
+        ``OperatorRightVectorMult(op.inverse, 1.0 / y)``
         """
 
         return self.operator.inverse * (1.0 / self.vector)
@@ -1861,8 +1861,8 @@ class OperatorLeftVectorMult(Operator):
 
         Left scalar multiplication and derivative are commutative:
 
-        ``OperatorLeftVectorMult(op, vector).derivative(x) <==>``
-        ``OperatorLeftVectorMult(op.derivative(x), vector)``
+        ``OperatorLeftVectorMult(op, y).derivative(x) <==>``
+        ``OperatorLeftVectorMult(op.derivative(x), y)``
 
         See Also
         --------
@@ -1877,8 +1877,8 @@ class OperatorLeftVectorMult(Operator):
         The adjoint of the operator vector multiplication is the
         vector multiplication of the operator adjoint:
 
-        ``OperatorLeftVectorMult(op, vector).adjoint ==``
-        ``OperatorRightVectorMult(op.adjoint, vector)``
+        ``OperatorLeftVectorMult(op, y).adjoint ==``
+        ``OperatorRightVectorMult(op.adjoint, y)``
 
         ``(x * A)^T = A^T * x``
 
@@ -1911,10 +1911,10 @@ class OperatorRightVectorMult(Operator):
 
     """Expression type for the operator right vector multiplication.
 
-    ``OperatorRightVectorMult(op, vector)(x) <==> op(vector * x)``
+    ``OperatorRightVectorMult(op, y)(x) <==> op(y * x)``
 
-    The scalar multiplication is well-defined only if
-    ``vector in op.domain == True``.
+    The scalar multiplication is well-defined only if ``y`` is in
+    ``op.domain``.
     """
 
     def __init__(self, operator, vector):
@@ -1924,8 +1924,8 @@ class OperatorRightVectorMult(Operator):
         ----------
         op : `Operator`
             The domain of ``op`` must be a ``vector.space``.
-        vector : `LinearSpaceVector` in ``op.domain``
-            The vector to multiply by
+        vector : ``op.domain`` element
+            The fixed element to multiply with.
         """
         if not isinstance(operator, Operator):
             raise TypeError('`operator` {!r} not an `Operator` instance'
@@ -1947,7 +1947,7 @@ class OperatorRightVectorMult(Operator):
 
     @property
     def vector(self):
-        """The vector part of this multiplication."""
+        """The fixed element to multiply with."""
         return self.__vector
 
     def _call(self, x, out=None):
@@ -1963,13 +1963,12 @@ class OperatorRightVectorMult(Operator):
     def inverse(self):
         """Inverse of this operator.
 
-        The inverse of ``op * vector`` is given by
-        ``(1.0 / vector) * op.inverse``.
+        The inverse of ``op * y`` is given by
+        ``(1.0 / y) * op.inverse``.
 
-        ``OperatorRightVectorMult(op, vector).inverse <==>``
-        ``OperatorLeftVectorMult(op.inverse, 1.0/vector)``
+        ``OperatorRightVectorMult(op, y).inverse <==>``
+        ``OperatorLeftVectorMult(op.inverse, 1.0 / y)``
         """
-
         return (1.0 / self.vector) * self.operator.inverse
 
     def derivative(self, x):
@@ -1977,8 +1976,8 @@ class OperatorRightVectorMult(Operator):
 
         Left vector multiplication and derivative are commutative:
 
-        ``OperatorRightVectorMult(op, vector).derivative(x) <==>
-        OperatorRightVectorMult(op.derivative(x), vector)``
+        ``OperatorRightVectorMult(op, y).derivative(x) <==>
+        OperatorRightVectorMult(op.derivative(x), y)``
 
         See Also
         --------
@@ -1993,8 +1992,8 @@ class OperatorRightVectorMult(Operator):
         The adjoint of the operator vector multiplication is the
         vector multiplication of the operator adjoint:
 
-        ``OperatorRightVectorMult(op, vector).adjoint ==``
-        ``OperatorLeftVectorMult(op.adjoint, vector)``
+        ``OperatorRightVectorMult(op, y).adjoint ==``
+        ``OperatorLeftVectorMult(op.adjoint, y)``
 
         ``(A x)^T = x * A^T``
 

--- a/odl/operator/oputils.py
+++ b/odl/operator/oputils.py
@@ -49,7 +49,6 @@ def matrix_representation(op):
     ----------
     The algorithm works by letting the operator act on all unit vectors, and
     stacking the output as a matrix.
-
     """
 
     if not op.is_linear:

--- a/odl/operator/pspace_ops.py
+++ b/odl/operator/pspace_ops.py
@@ -40,16 +40,19 @@ class ProductSpaceOperator(Operator):
 
     """A "matrix of operators" on product spaces.
 
-    For example a matrix of operators can act on a vector by::
+    For example a matrix of operators can act on a vector by
 
-    ProductSpaceOperator([[A, B], [C, D]])([x, y]) = [A(x) + B(y), C(x) + D(y)]
+        ``ProductSpaceOperator([[A, B], [C, D]])([x, y]) =
+        [A(x) + B(y), C(x) + D(y)]``
 
     Notes
     -----
     This is intended for the case where an operator can be decomposed
     as a linear combination of "sub-operators", e.g.
 
-        :math:`\\left(
+    .. math::
+
+        \\left(
         \\begin{array}{ccc}
         A & B & 0 \\\\
         0 & C & 0 \\\\
@@ -67,7 +70,7 @@ class ProductSpaceOperator(Operator):
         A(x) + B(y) \\\\
         C(y) \\\\
         D(z)
-        \end{array}\\right)`
+        \end{array}\\right)
 
     Mathematically, a `ProductSpaceOperator` is an operator
 
@@ -221,21 +224,7 @@ class ProductSpaceOperator(Operator):
         super().__init__(domain=domain, range=range, linear=linear)
 
     def _call(self, x, out=None):
-        """Call the ProductSpace operators.
-
-        Parameters
-        ----------
-        x : `domain` element
-            Input vector to be evaluated.
-        out : `range` element, optional
-            Output vector to write the result to.
-
-        Returns
-        -------
-        out : `range` element
-            Result of the evaluation. If ``out`` was provided, the
-            returned object is a reference to it.
-        """
+        """Call the operators on the parts of ``x``."""
         # TODO: add optimization in case an operator appears repeatedly in a
         # row
         if out is None:
@@ -440,21 +429,7 @@ class ComponentProjection(Operator):
         return self.__index
 
     def _call(self, x, out=None):
-        """Project x onto subspace.
-
-        Parameters
-        ----------
-        x : `domain` element
-            Input vector to be projected.
-        out : `range` element, optional
-            Output vector to write the result to.
-
-        Returns
-        -------
-        out : `range` element
-            Projection of ``x`` onto the subspace. If ``out`` was provided,
-            the returned object is a reference to it.
-        """
+        """Project ``x`` onto the subspace."""
         if out is None:
             out = x[self.index].copy()
         else:
@@ -507,7 +482,7 @@ class ComponentProjectionAdjoint(Operator):
         >>> X = odl.ProductSpace(r1, r2, r3)
         >>> x = X.element([[1], [2, 3], [4, 5, 6]])
 
-        Projection on n-th component
+        Projection on the 0-th component:
 
         >>> proj = odl.ComponentProjectionAdjoint(X, 0)
         >>> proj(x[0])
@@ -517,7 +492,7 @@ class ComponentProjectionAdjoint(Operator):
             [0.0, 0.0, 0.0]
         ])
 
-        Projection on sub-space
+        Projection on a sub-space corresponding to indices 0 and 2:
 
         >>> proj = odl.ComponentProjectionAdjoint(X, [0, 2])
         >>> proj(x[0, 2])
@@ -536,21 +511,7 @@ class ComponentProjectionAdjoint(Operator):
         return self.__index
 
     def _call(self, x, out=None):
-        """Extend ``x`` from the subspace.
-
-        Parameters
-        ----------
-        x : `domain` element
-            Input vector to be extended.
-        out : `range` element, optional
-            Output vector to write the result to.
-
-        Returns
-        -------
-        out : `range` element
-            Extension of ``x`` to the superspace. If ``out`` was provided,
-            the returned object is a reference to it.
-        """
+        """Extend ``x`` from the subspace."""
         if out is None:
             out = self.range.zero()
         else:
@@ -651,20 +612,7 @@ class BroadcastOperator(Operator):
         return self.operators[index]
 
     def _call(self, x, out=None):
-        """Apply operators to ``x``.
-
-        Parameters
-        ----------
-        x : `domain` element
-            Input vector to be evaluated by operators.
-        out : `range` element, optional
-            Output vector to write the result to.
-
-        Returns
-        -------
-        out : `range` element
-            Values of operators evaluated in point
-        """
+        """Evaluate all operators in ``x`` and broadcast."""
         wrapped_x = self.prod_op.domain.element([x], cast=False)
         return self.prod_op(wrapped_x, out=out)
 
@@ -683,15 +631,14 @@ class BroadcastOperator(Operator):
 
         Examples
         --------
-
-        Example with affine operator
+        Example with an affine operator:
 
         >>> import odl
         >>> I = odl.IdentityOperator(odl.rn(3))
         >>> residual_op = odl.ResidualOperator(I, I.domain.element([1, 1, 1]))
         >>> op = BroadcastOperator(residual_op, 2 * residual_op)
 
-        Calling operator gives offset by [1, 1, 1]
+        Calling operator offsets by ``[1, 1, 1]``:
 
         >>> x = [1, 2, 3]
         >>> op(x)
@@ -700,7 +647,7 @@ class BroadcastOperator(Operator):
             [0.0, 2.0, 4.0]
         ])
 
-        Derivative of affine operator does not have this offset
+        The derivative of this affine operator does not have an offset:
 
         >>> op.derivative(x)(x)
         ProductSpace(rn(3), 2).element([
@@ -803,28 +750,7 @@ class ReductionOperator(Operator):
         return self.operators[index]
 
     def _call(self, x, out=None):
-        """Apply operators to ``x`` and sum.
-
-        Parameters
-        ----------
-        x : `domain` element
-            Input vector that should be used in the reduction.
-        out : `range` element, optional
-            Output vector to write the result to.
-
-
-        Parameters
-        ----------
-        x : `domain` element
-            Input vector to be evaluated by operators.
-        out : `range` element, optional
-            Output vector to write the result to.
-
-        Returns
-        -------
-        out : `range` element
-            Sum of operators evaluated in ``x``.
-        """
+        """Apply operators to ``x`` and sum."""
         if out is None:
             return self.prod_op(x)[0]
         else:

--- a/odl/phantom/geometric.py
+++ b/odl/phantom/geometric.py
@@ -43,7 +43,7 @@ def cuboid(space, min_pt=None, max_pt=None):
 
     Returns
     -------
-    phantom : `LinearSpaceVector`
+    phantom : `DiscretizedSpaceElement`
         The generated cuboid phantom in ``space``.
 
     Examples

--- a/odl/set/space.py
+++ b/odl/set/space.py
@@ -29,7 +29,7 @@ import numpy as np
 from odl.set.sets import Field, Set, UniversalSet
 
 
-__all__ = ('LinearSpace', 'LinearSpaceVector', 'UniversalSpace',
+__all__ = ('LinearSpace', 'LinearSpaceElement', 'UniversalSpace',
            'LinearSpaceTypeError', 'LinearSpaceTypeError')
 
 
@@ -37,7 +37,7 @@ class LinearSpace(Set):
     """Abstract linear vector space.
 
     Its elements are represented as instances of the
-    `LinearSpaceVector` class.
+    `LinearSpaceElement` class.
     """
 
     def __init__(self, field):
@@ -62,7 +62,7 @@ class LinearSpace(Set):
 
     @abstractmethod
     def element(self, inp=None, **kwargs):
-        """Create a `LinearSpaceVector` from ``inp`` or from scratch.
+        """Create a `LinearSpaceElement` from ``inp`` or from scratch.
 
         If called without ``inp`` argument, an arbitrary element of the
         space is generated without guarantee of its state.
@@ -79,8 +79,8 @@ class LinearSpace(Set):
 
         Returns
         -------
-        element : `LinearSpaceVector`
-            A vector in this space.
+        element : `LinearSpaceElement`
+            A new element of this space.
         """
 
     @property
@@ -159,7 +159,7 @@ class LinearSpace(Set):
         Returns
         -------
         contains : bool
-            ``True`` if ``other`` is a `LinearSpaceVector` instance and
+            ``True`` if ``other`` is a `LinearSpaceElement` instance and
             ``other.space`` is equal to this space, ``False`` otherwise.
 
         Notes
@@ -179,33 +179,31 @@ class LinearSpace(Set):
 
         or, if ``b`` and ``y`` are given,
 
-            ``out = a * x1 + b * x2``
-
-        with error checking of types.
+            ``out = a * x1 + b * x2``.
 
         Parameters
         ----------
         a : `field` element
             Scalar to multiply ``x1`` with.
-        x1 : `LinearSpaceVector`
-            First vector in the linear combination.
+        x1 : `LinearSpaceElement`
+            First space element in the linear combination.
         b : `field` element, optional
             Scalar to multiply ``x2`` with. Required if ``x2`` is
             provided.
-        x2 : `LinearSpaceVector`, optional
-            Second vector in the linear combination.
-        out : `LinearSpaceVector`, optional
+        x2 : `LinearSpaceElement`, optional
+            Second space element in the linear combination.
+        out : `LinearSpaceElement`, optional
             Element to which the result is written.
 
         Returns
         -------
-        out : `LinearSpaceVector`
+        out : `LinearSpaceElement`
             Result of the linear combination. If ``out`` was provided,
             the returned object is a reference to it.
 
         Notes
         -----
-        The vectors ``out``, ``x1`` and ``x2`` may be aligned, thus a call
+        The elements ``out``, ``x1`` and ``x2`` may be aligned, thus a call
 
             ``space.lincomb(x, 2, x, 3.14, out=x)``
 
@@ -227,13 +225,13 @@ class LinearSpace(Set):
             raise LinearSpaceTypeError('`x1` {!r} is not an element of {!r}'
                                        ''.format(x1, self))
 
-        if b is None:  # Single vector
+        if b is None:  # Single element
             if x2 is not None:
                 raise ValueError('`x2` provided but not `b`')
             self._lincomb(a, x1, 0, x1, out)
             return out
 
-        else:  # Two vectors
+        else:  # Two elements
             if b not in self.field:
                 raise LinearSpaceTypeError('`b` {!r} not an element of the '
                                            'field {!r} of {!r}'
@@ -251,7 +249,7 @@ class LinearSpace(Set):
 
         Parameters
         ----------
-        x1, x2 : `LinearSpaceVector`
+        x1, x2 : `LinearSpaceElement`
             Elements whose distance to compute.
 
         Returns
@@ -273,7 +271,7 @@ class LinearSpace(Set):
 
         Parameters
         ----------
-        x : `LinearSpaceVector`
+        x : `LinearSpaceElement`
             Element whose norm to compute.
 
         Returns
@@ -292,7 +290,7 @@ class LinearSpace(Set):
 
         Parameters
         ----------
-        x1, x2 : `LinearSpaceVector`
+        x1, x2 : `LinearSpaceElement`
             Elements whose inner product to compute.
 
         Returns
@@ -314,14 +312,14 @@ class LinearSpace(Set):
 
         Parameters
         ----------
-        x1, x2 : `LinearSpaceVector`
+        x1, x2 : `LinearSpaceElement`
             Multiplicands in the product.
-        out : `LinearSpaceVector`, optional
+        out : `LinearSpaceElement`, optional
             Element to which the result is written.
 
         Returns
         -------
-        out : `LinearSpaceVector`
+        out : `LinearSpaceElement`
             Product of the elements. If ``out`` was provided, the
             returned object is a reference to it.
         """
@@ -346,16 +344,16 @@ class LinearSpace(Set):
 
         Parameters
         ----------
-        x1 : `LinearSpaceVector`
+        x1 : `LinearSpaceElement`
             Dividend in the quotient.
-        x2 : `LinearSpaceVector`
+        x2 : `LinearSpaceElement`
             Divisor in the quotient.
-        out : `LinearSpaceVector`, optional
+        out : `LinearSpaceElement`, optional
             Element to which the result is written.
 
         Returns
         -------
-        out : `LinearSpaceVector`
+        out : `LinearSpaceElement`
             Quotient of the elements. If ``out`` was provided, the
             returned object is a reference to it.
         """
@@ -377,11 +375,11 @@ class LinearSpace(Set):
 
     @property
     def element_type(self):
-        """Type of elements of this space (`LinearSpaceVector`)."""
-        return LinearSpaceVector
+        """Type of elements of this space (`LinearSpaceElement`)."""
+        return LinearSpaceElement
 
 
-class LinearSpaceVector(object):
+class LinearSpaceElement(object):
 
     """Abstract class for `LinearSpace` elements.
 
@@ -402,7 +400,7 @@ class LinearSpaceVector(object):
 
     @property
     def space(self):
-        """Space to which this vector belongs."""
+        """Space to which this element belongs."""
         return self.__space
 
     # Convenience functions
@@ -423,13 +421,13 @@ class LinearSpaceVector(object):
         ----------
         a : element of ``space.field``
             Scalar to multiply ``x1`` with.
-        x1 : `LinearSpaceVector`
-            First vector in the linear combination.
+        x1 : `LinearSpaceElement`
+            First space element in the linear combination.
         b : element of ``space.field``, optional
             Scalar to multiply ``x2`` with. Required if ``x2`` is
             provided.
-        x2 : `LinearSpaceVector`, optional
-            Second vector in the linear combination.
+        x2 : `LinearSpaceElement`, optional
+            Second space element in the linear combination.
 
         See Also
         --------
@@ -438,7 +436,7 @@ class LinearSpaceVector(object):
         return self.space.lincomb(a, x1, b, x2, out=self)
 
     def set_zero(self):
-        """Set this vector to zero.
+        """Set this element to zero.
 
         See Also
         --------
@@ -638,13 +636,13 @@ class LinearSpaceVector(object):
 
         Parameters
         ----------
-        other : `LinearSpaceVector`
+        other : `LinearSpaceElement`
             Element of this space.
 
         Returns
         -------
         equals : bool
-            ``True`` if the vectors are equal ``False`` otherwise.
+            ``True`` if the elements are equal ``False`` otherwise.
 
         See Also
         --------
@@ -673,8 +671,8 @@ class LinearSpaceVector(object):
         if other is self:
             # Optimization for a common case
             return True
-        elif (not isinstance(other, LinearSpaceVector) or
-                other.space != self.space):
+        elif (not isinstance(other, LinearSpaceElement) or
+              other.space != self.space):
             # Cannot use (if other not in self.space) since this is not
             # reflexive.
             return False
@@ -691,7 +689,7 @@ class LinearSpaceVector(object):
         This is a default implementation that does not print any
         information about the contents of the element.
         """
-        return str(self.space) + "Vector"
+        return str(self.space) + 'Element'
 
     def __repr__(self):
         """Return ``repr(self)``.
@@ -699,10 +697,10 @@ class LinearSpaceVector(object):
         This is a default implementation that does not print any
         information about the contents of the element.
         """
-        return repr(self.space) + "Vector"
+        return repr(self.space) + 'Element'
 
     def __copy__(self):
-        """Return a copy of this vector.
+        """Return a copy of this element.
 
         See Also
         --------
@@ -711,7 +709,7 @@ class LinearSpaceVector(object):
         return self.copy()
 
     def __deepcopy__(self, memo):
-        """Return a deep copy of this vector.
+        """Return a deep copy of this element.
 
         See Also
         --------
@@ -720,7 +718,7 @@ class LinearSpaceVector(object):
         return self.copy()
 
     def norm(self):
-        """Return the norm of this vector.
+        """Return the norm of this element.
 
         See Also
         --------
@@ -770,7 +768,7 @@ class LinearSpaceVector(object):
 
     @property
     def T(self):
-        """This vector's transpose, i.e. the functional ``<. , self>``.
+        """This element's transpose, i.e. the functional ``<. , self>``.
 
         Returns
         -------
@@ -796,8 +794,8 @@ class LinearSpaceVector(object):
         from odl.operator import InnerProductOperator
         return InnerProductOperator(self.copy())
 
-    # Give a `Vector` a higher priority than any NumPy array type. This
-    # forces the usage of `__op__` of `Vector` if the other operand
+    # Give an `Element` a higher priority than any NumPy array type. This
+    # forces the usage of `__op__` of `Element` if the other operand
     # is a NumPy object (applies also to scalars!).
     __array_priority__ = 1000000.0
 
@@ -871,9 +869,9 @@ class UniversalSpace(LinearSpace):
     def __contains__(self, other):
         """Return ``other in self``.
 
-        Dummy membership check, ``True`` for any `LinearSpaceVector`.
+        Dummy membership check, ``True`` for any `LinearSpaceElement`.
         """
-        return isinstance(other, LinearSpaceVector)
+        return isinstance(other, LinearSpaceElement)
 
 
 class LinearSpaceTypeError(TypeError):

--- a/odl/solvers/advanced/douglas_rachford.py
+++ b/odl/solvers/advanced/douglas_rachford.py
@@ -49,7 +49,7 @@ def douglas_rachford_pd(x, prox_f, prox_cc_g, L, tau, sigma, niter,
 
     Parameters
     ----------
-    x : `LinearSpaceVector`
+    x : `LinearSpaceElement`
         Initial point, updated in-place.
     prox_f : `callable`
         `proximal factory` for the function ``f``.

--- a/odl/solvers/advanced/forward_backward.py
+++ b/odl/solvers/advanced/forward_backward.py
@@ -56,7 +56,7 @@ def forward_backward_pd(x, prox_f, prox_cc_g, L, grad_h, tau, sigma, niter,
 
     Parameters
     ----------
-    x : `LinearSpaceVector`
+    x : `LinearSpaceElement`
         Initial point, updated in-place.
     prox_f : `callable`
         `Proximal factory` for the functional ``f``.

--- a/odl/solvers/advanced/proximal_operators.py
+++ b/odl/solvers/advanced/proximal_operators.py
@@ -35,7 +35,7 @@ import numpy as np
 from odl.operator import (Operator, IdentityOperator, ScalingOperator,
                           ConstantOperator, ResidualOperator, DiagonalOperator)
 from odl.space import ProductSpace
-from odl.set import LinearSpaceVector
+from odl.set import LinearSpaceElement
 
 
 __all__ = ('combine_proximals', 'proximal_cconj', 'proximal_translation',
@@ -248,8 +248,8 @@ def proximal_quadratic_perturbation(prox_factory, a, u=None):
         c prox[s*f( . * c)]((x - s*u)*c)
 
     where ``c`` is the constant c = 1/sqrt(s*2*a + 1), ``a`` is the scaling
-    parameter belonging to the quadratic term, ``u`` is the vector defining the
-    linear functional, and ``s`` is the step size.
+    parameter belonging to the quadratic term, ``u`` is the space
+    element defining the linear functional, and ``s`` is the step size.
 
     Parameters
     ----------
@@ -259,8 +259,8 @@ def proximal_quadratic_perturbation(prox_factory, a, u=None):
     a : non-negative float
         Scaling of the quadratic term
     u : Element in domain of F, optional
-        Defines the linear functional
-        Default: Treated as zero vector
+        Defines the linear functional. For ``None``, the zero element
+        is taken.
 
     Returns
     -------
@@ -279,8 +279,8 @@ def proximal_quadratic_perturbation(prox_factory, a, u=None):
         raise ValueError('scaling parameter muts be non-negative, got {}'
                          ''.format(a))
 
-    if u is not None and not isinstance(u, LinearSpaceVector):
-        raise TypeError('`u` must be `None` or a `LinearSpaceVector` '
+    if u is not None and not isinstance(u, LinearSpaceElement):
+        raise TypeError('`u` must be `None` or a `LinearSpaceElement` '
                         'instance, got {!r}.'.format(u))
 
     def quadratic_perturbation_prox_factory(step_size):
@@ -825,7 +825,7 @@ def proximal_cconj_l1(space, lam=1, g=None, isotropic=False):
             lam (y - sigma g) / (max(lam, ||y - sigma g||_2)
 
     where max(.,.) thresholds the lower bound of ||y||_2 point-wise and
-    1 is a vector in the space of ||y||_2 with all components set
+    1 is a element of the space of ||y||_2 with all components set
     to 1.
 
     Parameters
@@ -993,15 +993,15 @@ def proximal_cconj_kl(space, lam=1, g=None):
 
         F^*(p) = sum_i (-g ln(pos(1_X - p))_i + ind_P(1_X - p)
 
-    where p is the variable dual to x, and 1_X is a vector in the space X with
-    all components set to 1.
+    where p is the variable dual to x, and 1_X is an element of the space
+    X with all components set to 1.
 
     The proximal operator of the convex conjugate of F is
 
         prox[sigma * F^*](x) =
             1/2 (lam + x - sqrt((x - lam)^2 + 4 lam sigma g)
 
-    with the step size parameter sigma and lam_X is a vector in the space X
+    with the step size parameter sigma and lam_X is an element of the space X
     with all components set to lam.
 
     Parameters

--- a/odl/solvers/iterative/iterative.py
+++ b/odl/solvers/iterative/iterative.py
@@ -80,7 +80,7 @@ def landweber(op, x, rhs, niter=1, omega=1, projection=None, callback=None):
         `Operator.adjoint` property, i.e. ``op.derivative(x).adjoint`` must be
         well-defined for ``x`` in the operator domain.
     x : ``op.domain`` element
-        Vector to which the result is written. Its initial value is
+        Element to which the result is written. Its initial value is
         used as starting point of the iteration, and its values are
         updated in each iteration step.
     rhs : ``op.range`` element
@@ -146,7 +146,7 @@ def conjugate_gradient(op, x, rhs, niter=1, callback=None):
         self-adjoint. This implies in particular that its domain and
         range are equal.
     x : ``op.domain`` element
-        Vector to which the result is written. Its initial value is
+        Element to which the result is written. Its initial value is
         used as starting point of the iteration, and its values are
         updated in each iteration step.
     rhs : ``op.range`` element
@@ -237,7 +237,7 @@ Conjugate_gradient_on_the_normal_equations>`_.
         in turn must implement `Operator.adjoint`, i.e.
         the call ``op.derivative(x).adjoint`` must be valid.
     x : ``op.domain`` element
-        Vector to which the result is written. Its initial value is
+        Element to which the result is written. Its initial value is
         used as starting point of the iteration, and its values are
         updated in each iteration step.
     rhs : ``op.range`` element
@@ -346,7 +346,7 @@ def gauss_newton(op, x, rhs, niter=1, zero_seq=exp_zero_seq(2.0),
         in turn must implement `Operator.adjoint`, i.e.
         the call ``op.derivative(x).adjoint`` must be valid.
     x : ``op.domain`` element
-        Vector to which the result is written. Its initial value is
+        Element to which the result is written. Its initial value is
         used as starting point of the iteration, and its values are
         updated in each iteration step.
     rhs : ``op.range`` element

--- a/odl/solvers/scalar/steplen.py
+++ b/odl/solvers/scalar/steplen.py
@@ -45,9 +45,9 @@ class StepLength(with_metaclass(ABCMeta, object)):
 
         Parameters
         ----------
-        x : `LinearSpaceVector`
+        x : `LinearSpaceElement`
             The current point
-        direction : `LinearSpaceVector`
+        direction : `LinearSpaceElement`
             Search direction in which the line search should be computed
         dir_derivative : float
             Directional derivative along the ``direction``
@@ -69,9 +69,9 @@ class LineSearch(with_metaclass(ABCMeta, object)):
 
         Parameters
         ----------
-        x : `LinearSpaceVector`
+        x : `LinearSpaceElement`
             The current point
-        direction : `LinearSpaceVector`
+        direction : `LinearSpaceElement`
             Search direction in which the line search should be computed
         dir_derivative : float
             Directional derivative along the ``direction``
@@ -134,9 +134,9 @@ class BacktrackingLineSearch(LineSearch):
 
         Parameters
         ----------
-        x : `LinearSpaceVector`
+        x : `LinearSpaceElement`
             The current point
-        direction : `LinearSpaceVector`
+        direction : `LinearSpaceElement`
             Search direction in which the line search should be computed
         dir_derivative : float
             Directional derivative along the ``direction``
@@ -199,9 +199,9 @@ class ConstantLineSearch(LineSearch):
 
         Parameters
         ----------
-        x : `LinearSpaceVector`
+        x : `LinearSpaceElement`
             The current point
-        direction : `LinearSpaceVector`
+        direction : `LinearSpaceElement`
             Search direction in which the line search should be computed
         dir_derivative : float
             Directional derivative along the ``direction``
@@ -242,9 +242,9 @@ class BarzilaiBorweinStep(object):
 
         Parameters
         ----------
-        x : `LinearSpaceVector`
+        x : `LinearSpaceElement`
             The current point
-        x0 : `LinearSpaceVector`
+        x0 : `LinearSpaceElement`
             The previous point
 
         Returns

--- a/odl/solvers/util/callback.py
+++ b/odl/solvers/util/callback.py
@@ -39,7 +39,7 @@ class SolverCallback(object):
 
         Parameters
         ----------
-        result : `LinearSpaceVector`
+        result : `LinearSpaceElement`
             Partial result after n iterations
 
         Returns
@@ -302,15 +302,14 @@ class CallbackShow(SolverCallback):
 
     See Also
     --------
-    DiscreteLpVector.show
+    DiscreteLpElement.show
     NtuplesBaseVector.show
     """
 
     def __init__(self, *args, **kwargs):
         """Initialize a new instance.
 
-        Parameters are passed through to the vectors show method. Additional
-        parameters included.
+        Additional parameters are passed through to the ``show`` method.
 
         Parameters
         ----------

--- a/odl/space/base_ntuples.py
+++ b/odl/space/base_ntuples.py
@@ -27,7 +27,7 @@ from abc import ABCMeta, abstractmethod
 import numpy as np
 
 from odl.set import (Set, RealNumbers, ComplexNumbers, LinearSpace,
-                     LinearSpaceVector)
+                     LinearSpaceElement)
 from odl.util.ufuncs import NtuplesBaseUFuncs
 from odl.util.utility import (
     array1d_repr, array1d_str, dtype_repr, with_metaclass,
@@ -628,7 +628,7 @@ class FnBase(NtuplesBase, LinearSpace):
         raise NotImplementedError('abstract method')
 
 
-class FnBaseVector(NtuplesBaseVector, LinearSpaceVector):
+class FnBaseVector(NtuplesBaseVector, LinearSpaceElement):
 
     """Abstract class for `NtuplesBase` elements.
 
@@ -636,8 +636,8 @@ class FnBaseVector(NtuplesBaseVector, LinearSpaceVector):
     space, call the space's `LinearSpace.element` method instead.
     """
 
-    __eq__ = LinearSpaceVector.__eq__
-    copy = LinearSpaceVector.copy
+    __eq__ = LinearSpaceElement.__eq__
+    copy = LinearSpaceElement.copy
 
 
 if __name__ == '__main__':

--- a/odl/space/npy_ntuples.py
+++ b/odl/space/npy_ntuples.py
@@ -1727,7 +1727,7 @@ class NumpyFnVectorWeighting(VectorWeightingBase):
         <a, b>_w := <w * a, b> = b^H (w * a)
 
     with ``b^H`` standing for transposed complex conjugate and
-    ``w * a`` for element-wise multiplication.
+    ``w * a`` for entry-wise multiplication.
 
     For other exponents, only norm and dist are defined. In the case of
     exponent ``inf``, the weighted norm is

--- a/odl/space/pspace.py
+++ b/odl/space/pspace.py
@@ -830,7 +830,7 @@ class ProductSpaceElementWeighting(VectorWeightingBase):
 
         <x, y>_w = <w * x, y>
 
-    with element-wise multiplication ``w * x``. For other exponents,
+    with component-wise multiplication ``w * x``. For other exponents,
     only ``norm`` and ```dist`` are defined. In the case of exponent
     ``inf``, the weighted norm is::
 

--- a/odl/space/weighting.py
+++ b/odl/space/weighting.py
@@ -111,7 +111,7 @@ class WeightingBase(object):
         Notes
         -----
         This operation must be computationally cheap, i.e. no large
-        arrays may be compared element-wise. That is the task of the
+        arrays may be compared entry-wise. That is the task of the
         `equiv` method.
         """
         return (isinstance(other, WeightingBase) and

--- a/odl/space/weighting.py
+++ b/odl/space/weighting.py
@@ -15,12 +15,7 @@
 # You should have received a copy of the GNU General Public License
 # along with ODL.  If not, see <http://www.gnu.org/licenses/>.
 
-"""CPU implementations of ``n``-dimensional Cartesian spaces.
-
-This is a default implementation of :math:`A^n` for an arbitrary set
-:math:`A` as well as the real and complex spaces :math:`R^n` and
-:math:`C^n`. The data is represented by NumPy arrays.
-"""
+"""Weightings for finite-dimensional spaces."""
 
 # Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
@@ -29,12 +24,10 @@ from future import standard_library
 standard_library.install_aliases()
 from builtins import super
 
-# External module imports
 import numpy as np
 import scipy.linalg as linalg
 from scipy.sparse.base import isspmatrix
 
-# ODL imports
 from odl.space.base_ntuples import FnBaseVector
 from odl.util.utility import array1d_repr, arraynd_repr
 
@@ -141,53 +134,53 @@ class WeightingBase(object):
         return self == other
 
     def inner(self, x1, x2):
-        """Calculate the inner product of two vectors.
+        """Return the inner product of two elements.
 
         Parameters
         ----------
-        x1, x2 : `LinearSpaceVector`
-            Vectors whose inner product is calculated
+        x1, x2 : `LinearSpaceElement`
+            Elements whose inner product is calculated.
 
         Returns
         -------
         inner : float or complex
-            The inner product of the two provided vectors
+            The inner product of the two provided elements.
         """
         raise NotImplementedError
 
     def norm(self, x):
-        """Calculate the norm of a vector.
+        """Calculate the norm of an element.
 
         This is the standard implementation using `inner`.
         Subclasses should override it for optimization purposes.
 
         Parameters
         ----------
-        x1 : `LinearSpaceVector`
-            Vector whose norm is calculated
+        x1 : `LinearSpaceElement`
+            Element whose norm is calculated.
 
         Returns
         -------
         norm : float
-            The norm of the vector
+            The norm of the element.
         """
         return float(np.sqrt(self.inner(x, x).real))
 
     def dist(self, x1, x2):
-        """Calculate the distance between two vectors.
+        """Calculate the distance between two elements.
 
         This is the standard implementation using `norm`.
         Subclasses should override it for optimization purposes.
 
         Parameters
         ----------
-        x1, x2 : `LinearSpaceVector`
-            Vectors whose mutual distance is calculated
+        x1, x2 : `LinearSpaceElement`
+            Elements whose mutual distance is calculated.
 
         Returns
         -------
         dist : float
-            The distance between the vectors
+            The distance between the elements.
         """
         if self.dist_using_inner:
             dist_squared = (self.norm(x1) ** 2 + self.norm(x2) ** 2 -
@@ -534,9 +527,9 @@ class VectorWeightingBase(WeightingBase):
         Parameters
         ----------
         vector : 1-dim. `array-like`
-            Weighting vector of the inner product
+            Weighting vector of the inner product.
         impl : string
-            Specifier for the implementation backend
+            Specifier for the implementation backend.
         exponent : positive float
             Exponent of the norm. For values other than 2.0, the inner
             product is not defined.
@@ -545,7 +538,7 @@ class VectorWeightingBase(WeightingBase):
         dist_using_inner : bool, optional
             Calculate `dist` using the formula
 
-                ``||x - y||^2 = ||x||^2 + ||y||^2 - 2 * Re <x, y>``
+                ``||x - y||^2 = ||x||^2 + ||y||^2 - 2 * Re <x, y>``.
 
             This avoids the creation of new arrays and is thus faster
             for large arrays. On the downside, it will not evaluate to
@@ -622,7 +615,7 @@ class VectorWeightingBase(WeightingBase):
 
     @property
     def repr_part(self):
-        """Return a string usable in a space's ``__repr__`` method."""
+        """String usable in a space's ``__repr__`` method."""
         part = 'weight={}'.format(array1d_repr(self.vector, nprint=10))
         if self.exponent != 2.0:
             part += ', exponent={}'.format(self.exponent)
@@ -664,14 +657,14 @@ class ConstWeightingBase(WeightingBase):
         constant : positive float
             Weighting constant of the inner product.
         impl : string
-            Specifier for the implementation backend
+            Specifier for the implementation backend.
         exponent : positive float, optional
             Exponent of the norm. For values other than 2.0, the inner
             product is not defined.
         dist_using_inner : bool, optional
             Calculate `dist` using the formula
 
-                ``||x - y||^2 = ||x||^2 + ||y||^2 - 2 * Re <x, y>``
+                ``||x - y||^2 = ||x||^2 + ||y||^2 - 2 * Re <x, y>``.
 
             This avoids the creation of new arrays and is thus faster
             for large arrays. On the downside, it will not evaluate to
@@ -728,7 +721,7 @@ class ConstWeightingBase(WeightingBase):
 
     @property
     def repr_part(self):
-        """Return a string usable in a space's ``__repr__`` method."""
+        """String usable in a space's ``__repr__`` method."""
         sep = ''
         if self.const != 1.0:
             part = 'weight={:.4}'.format(self.const)
@@ -776,11 +769,11 @@ class NoWeightingBase(ConstWeightingBase):
             Exponent of the norm. For values other than 2.0, the inner
             product is not defined.
         impl : string
-            Specifier for the implementation backend
+            Specifier for the implementation backend.
         dist_using_inner : bool, optional
             Calculate `dist` using the formula
 
-                ``||x - y||^2 = ||x||^2 + ||y||^2 - 2 * Re <x, y>``
+                ``||x - y||^2 = ||x||^2 + ||y||^2 - 2 * Re <x, y>``.
 
             This avoids the creation of new arrays and is thus faster
             for large arrays. On the downside, it will not evaluate to
@@ -825,9 +818,9 @@ class CustomInnerProductBase(WeightingBase):
         ----------
         inner : `callable`
             The inner product implementation. It must accept two
-            `LinearSpaceVector` arguments, return an element from
+            `LinearSpaceElement` arguments, return an element from
             their space's field (real or complex number) and
-            satisfy the following conditions for all vectors
+            satisfy the following conditions for all space elements
             ``x, y, z`` and scalars ``s``:
 
             - ``<x, y> = conj(<y, x>)``
@@ -835,11 +828,11 @@ class CustomInnerProductBase(WeightingBase):
             - ``<x, x> = 0``  if and only if  ``x = 0``
 
         impl : string
-            Specifier for the implementation backend
+            Specifier for the implementation backend.
         dist_using_inner : bool, optional
             Calculate `dist` using the formula
 
-                ``||x - y||^2 = ||x||^2 + ||y||^2 - 2 * Re <x, y>``
+                ``||x - y||^2 = ||x||^2 + ||y||^2 - 2 * Re <x, y>``.
 
             This avoids the creation of new arrays and is thus faster
             for large arrays. On the downside, it will not evaluate to
@@ -873,7 +866,7 @@ class CustomInnerProductBase(WeightingBase):
 
     @property
     def repr_part(self):
-        """Return a string usable in a space's ``__repr__`` method."""
+        """String usable in a space's ``__repr__`` method."""
         part = 'inner={}'.format(self.inner)
         if self.exponent != 2.0:
             part += ', exponent={}'.format(self.exponent)
@@ -905,8 +898,8 @@ class CustomNormBase(WeightingBase):
         ----------
         norm : `callable`
             The norm implementation. It must accept a
-            `LinearSpaceVector` argument, return a float and satisfy
-            the following conditions for all vectors
+            `LinearSpaceElement` argument, return a float and satisfy
+            the following conditions for all space elements
             ``x, y`` and scalars ``s``:
 
             - ``||x|| >= 0``
@@ -974,9 +967,9 @@ class CustomDistBase(WeightingBase):
         ----------
         dist : `callable`
             The distance function defining a metric on a `LinearSpace`.
-            It must accept two `LinearSpaceVector` arguments, return a
+            It must accept two `LinearSpaceElement` arguments, return a
             float and and fulfill the following mathematical conditions
-            for any three vectors ``x, y, z``:
+            for any three space elements ``x, y, z``:
 
             - ``dist(x, y) >= 0``
             - ``dist(x, y) = 0``  if and only if  ``x = y``

--- a/odl/tomo/backends/astra_cpu.py
+++ b/odl/tomo/backends/astra_cpu.py
@@ -27,7 +27,7 @@ try:
 except ImportError:
     pass
 
-from odl.discr import DiscreteLp, DiscreteLpVector
+from odl.discr import DiscreteLp, DiscreteLpElement
 from odl.tomo.backends.astra_setup import (
     astra_projection_geometry, astra_volume_geometry, astra_data,
     astra_projector, astra_algorithm)
@@ -46,14 +46,14 @@ def astra_cpu_forward_projector(vol_data, geometry, proj_space, out=None):
 
     Parameters
     ----------
-    vol_data : `DiscreteLpVector`
+    vol_data : `DiscreteLpElement`
         Volume data to which the forward projector is applied
     geometry : `Geometry`
         Geometry defining the tomographic setup
     proj_space : `DiscreteLp`
         Space to which the calling operator maps
     out : ``proj_space`` element, optional
-        Vector in the projection space to which the result is written. If
+        Element of the projection space to which the result is written. If
         ``None``, an element in ``proj_space`` is created.
 
     Returns
@@ -62,8 +62,8 @@ def astra_cpu_forward_projector(vol_data, geometry, proj_space, out=None):
         Projection data resulting from the application of the projector.
         If ``out`` was provided, the returned object is a reference to it.
     """
-    if not isinstance(vol_data, DiscreteLpVector):
-        raise TypeError('volume data {!r} is not a `DiscreteLpVector` '
+    if not isinstance(vol_data, DiscreteLpElement):
+        raise TypeError('volume data {!r} is not a `DiscreteLpElement` '
                         'instance.'.format(vol_data))
     if vol_data.space.impl != 'numpy':
         raise TypeError('dspace {!r} of the volume is not an '
@@ -87,7 +87,7 @@ def astra_cpu_forward_projector(vol_data, geometry, proj_space, out=None):
     else:
         if out not in proj_space:
             raise TypeError('`out` {} is neither None nor a '
-                            'DiscreteLpVector instance'.format(out))
+                            'DiscreteLpElement instance'.format(out))
 
     ndim = vol_data.ndim
 
@@ -132,14 +132,14 @@ def astra_cpu_back_projector(proj_data, geometry, reco_space, out=None):
 
     Parameters
     ----------
-    proj_data : `DiscreteLpVector`
+    proj_data : `DiscreteLpElement`
         Projection data to which the backward projector is applied
     geometry : `Geometry`
         Geometry defining the tomographic setup
     reco_space : `DiscreteLp`
         Space to which the calling operator maps
     out : ``reco_space`` element, optional
-        Vector in the reconstruction space to which the result is written.
+        Element of the reconstruction space to which the result is written.
         If ``None``, an element in ``reco_space`` is created.
 
     Returns
@@ -149,8 +149,8 @@ def astra_cpu_back_projector(proj_data, geometry, reco_space, out=None):
         projector. If ``out`` was provided, the returned object is a
         reference to it.
     """
-    if not isinstance(proj_data, DiscreteLpVector):
-        raise TypeError('projection data {!r} is not a DiscreteLpVector '
+    if not isinstance(proj_data, DiscreteLpElement):
+        raise TypeError('projection data {!r} is not a DiscreteLpElement '
                         'instance'.format(proj_data))
     if proj_data.space.impl != 'numpy':
         raise TypeError('data type {!r} of the projection space is not an '
@@ -174,7 +174,7 @@ def astra_cpu_back_projector(proj_data, geometry, reco_space, out=None):
     else:
         if out not in reco_space:
             raise TypeError('`out` {} is neither None nor a '
-                            'DiscreteLpVector instance'.format(out))
+                            'DiscreteLpElement instance'.format(out))
 
     ndim = proj_data.ndim
 

--- a/odl/tomo/backends/astra_cuda.py
+++ b/odl/tomo/backends/astra_cuda.py
@@ -29,7 +29,7 @@ try:
 except ImportError:
     ASTRA_CUDA_AVAILABLE = False
 
-from odl.discr import DiscreteLp, DiscreteLpVector
+from odl.discr import DiscreteLp, DiscreteLpElement
 from odl.tomo.backends.astra_setup import (
     astra_projection_geometry, astra_volume_geometry, astra_projector,
     astra_data, astra_algorithm)
@@ -51,14 +51,14 @@ def astra_cuda_forward_projector(vol_data, geometry, proj_space, out=None):
 
     Parameters
     ----------
-    vol_data : `DiscreteLpVector`
+    vol_data : `DiscreteLpElement`
         Volume data to which the projector is applied
     geometry : `Geometry`
         Geometry defining the tomographic setup
     proj_space : `DiscreteLp`
         Space to which the calling operator maps
     out : ``proj_space`` element, optional
-        Vector in the projection space to which the result is written. If
+        Element of the projection space to which the result is written. If
         ``None``, an element in ``proj_space`` is created.
 
     Returns
@@ -67,8 +67,8 @@ def astra_cuda_forward_projector(vol_data, geometry, proj_space, out=None):
         Projection data resulting from the application of the projector.
         If ``out`` was provided, the returned object is a reference to it.
     """
-    if not isinstance(vol_data, DiscreteLpVector):
-        raise TypeError('volume data {!r} is not a DiscreteLpVector '
+    if not isinstance(vol_data, DiscreteLpElement):
+        raise TypeError('volume data {!r} is not a DiscreteLpElement '
                         'instance'.format(vol_data))
     if not isinstance(geometry, Geometry):
         raise TypeError('geometry  {!r} is not a Geometry instance'
@@ -81,9 +81,9 @@ def astra_cuda_forward_projector(vol_data, geometry, proj_space, out=None):
         raise TypeError('projection space {!r} is not a DiscreteLp '
                         'instance'.format(proj_space))
     if out is not None:
-        if not isinstance(out, DiscreteLpVector):
+        if not isinstance(out, DiscreteLpElement):
             raise TypeError('`out` {} is neither None nor a '
-                            'DiscreteLpVector instance'.format(out))
+                            'DiscreteLpElement instance'.format(out))
 
     ndim = vol_data.ndim
 
@@ -164,7 +164,7 @@ def astra_cuda_back_projector(proj_data, geometry, reco_space, out=None):
     reco_space : `DiscreteLp`
         Space to which the calling operator maps
     out : ``reco_space`` element, optional
-        Vector in the reconstruction space to which the result is written.
+        Element of the reconstruction space to which the result is written.
         If ``None``, an element in ``reco_space`` is created.
 
     Returns
@@ -174,8 +174,8 @@ def astra_cuda_back_projector(proj_data, geometry, reco_space, out=None):
         projector. If ``out`` was provided, the returned object is a
         reference to it.
         """
-    if not isinstance(proj_data, DiscreteLpVector):
-        raise TypeError('projection data {!r} is not a DiscreteLpVector '
+    if not isinstance(proj_data, DiscreteLpElement):
+        raise TypeError('projection data {!r} is not a DiscreteLpElement '
                         'instance'.format(proj_data))
     if not isinstance(geometry, Geometry):
         raise TypeError('geometry  {!r} is not a Geometry instance'
@@ -188,9 +188,9 @@ def astra_cuda_back_projector(proj_data, geometry, reco_space, out=None):
                          'geometry do not match'.format(reco_space.ndim,
                                                         geometry.ndim))
     if out is not None:
-        if not isinstance(out, DiscreteLpVector):
+        if not isinstance(out, DiscreteLpElement):
             raise TypeError('`out` {} is neither None nor a '
-                            'DiscreteLpVector instance'.format(out))
+                            'DiscreteLpElement instance'.format(out))
 
     ndim = proj_data.ndim
 

--- a/odl/tomo/backends/astra_setup.py
+++ b/odl/tomo/backends/astra_setup.py
@@ -46,7 +46,7 @@ except ImportError:
     ASTRA_AVAILABLE = False
 import numpy as np
 
-from odl.discr import DiscreteLp, DiscreteLpVector
+from odl.discr import DiscreteLp, DiscreteLpElement
 from odl.tomo.geometry import (
     Geometry, Parallel2dGeometry, DivergentBeamGeometry, ParallelGeometry,
     FlatDetector)
@@ -403,7 +403,7 @@ def astra_data(astra_geom, datatype, data=None, ndim=2, allow_copy=False):
         given data type
     datatype : {'volume', 'projection'}
         Type of the data container
-    data : `DiscreteLpVector`, optional
+    data : `DiscreteLpElement`, optional
         Data for the initialization of the data structure. If ``None``,
         an ASTRA data object filled with zeros is created.
     ndim : {2, 3}, optional
@@ -420,12 +420,12 @@ def astra_data(astra_geom, datatype, data=None, ndim=2, allow_copy=False):
         ASTRA internal ID for the new data structure
     """
     if data is not None:
-        if isinstance(data, DiscreteLpVector):
+        if isinstance(data, DiscreteLpElement):
             ndim = data.space.ndim
         elif isinstance(data, np.ndarray):
             ndim = data.ndim
         else:
-            raise TypeError('`data` {!r} is neither DiscreteLp.Vector '
+            raise TypeError('`data` {!r} is neither DiscreteLpElement '
                             'instance nor a `numpy.ndarray`'.format(data))
     else:
         ndim = int(ndim)

--- a/odl/tomo/backends/scikit_radon.py
+++ b/odl/tomo/backends/scikit_radon.py
@@ -74,7 +74,7 @@ def scikit_radon_forward(volume, geometry, range, out=None):
 
     Parameters
     ----------
-    volume : `DiscreteLpVector`
+    volume : `DiscreteLpElement`
         The volume to project
     geometry : `Geometry`
         The projection geometry to use
@@ -114,7 +114,7 @@ def scikit_radon_back_projector(sinogram, geometry, range, out=None):
 
     Parameters
     ----------
-    sinogram : `DiscreteLpVector`
+    sinogram : `DiscreteLpElement`
         Sinogram (projections) to backproject.
     geometry : `Geometry`
         The projection geometry to use.

--- a/odl/tomo/operators/ray_trafo.py
+++ b/odl/tomo/operators/ray_trafo.py
@@ -172,21 +172,7 @@ class RayTransform(Operator):
         return self.__geometry
 
     def _call(self, x, out=None):
-        """Apply the operator to ``x`` and store the result in ``out``.
-
-        Parameters
-        ----------
-        x : `domain` element
-           Element in the domain of the operator to be forward projected.
-        out : `range` element, optional
-            Vector in the projection space to which the result is written.
-
-        Returns
-        -------
-        out : `range` element
-            Element in the projection space holding the result. If ``out``
-            was provided, the returned object is a reference to it.
-        """
+        """Forward project ``x`` and store the result in ``out`` if given."""
         if self.impl.startswith('astra'):
             backend, data_impl = self.impl.split('_')
             if data_impl == 'cpu':
@@ -306,22 +292,7 @@ class RayBackProjection(Operator):
         return self.__geometry
 
     def _call(self, x, out=None):
-        """Apply the operator to ``x`` and store the result in ``out``.
-
-        Parameters
-        ----------
-        x : `domain` element
-           Element in the domain of the operator which is back-projected.
-        out : `range` element, optional
-            Element in the reconstruction space to which the result is
-            written.
-
-        Returns
-        -------
-        out : `range` element
-            Element in the projection space holding the result. If ``out``
-            was provided, the returned object is a reference to it.
-        """
+        """Back-project ``x`` and store the result in ``out`` if given."""
 
         if self.impl.startswith('astra'):
             backend, data_impl = self.impl.split('_')

--- a/odl/tomo/util/utility.py
+++ b/odl/tomo/util/utility.py
@@ -252,7 +252,7 @@ def perpendicular_vector(vec):
     Parameters
     ----------
     vec : `array-like`
-        Vector of arbitrary length
+        Vector of arbitrary length.
 
     Returns
     -------

--- a/odl/trafos/fourier.py
+++ b/odl/trafos/fourier.py
@@ -1105,9 +1105,9 @@ class DiscreteFourierTransformInverse(DiscreteFourierTransformBase):
         Parameters
         ----------
         x : `domain` element
-            Input vector to be transformed.
+            Input element to be transformed.
         out : `range` element
-            Output vector storing the result.
+            Output element storing the result.
         flags : `sequence` of strings, optional
             Flags for the transform. ``'FFTW_UNALIGNED'`` is not
             supported, and ``'FFTW_DESTROY_INPUT'`` is enabled by
@@ -1637,13 +1637,13 @@ class FourierTransformBase(Operator):
 
         Other Parameters
         ----------------
-        tmp_r : `DiscreteLpVector` or `numpy.ndarray`
+        tmp_r : `DiscreteLpElement` or `numpy.ndarray`
             Temporary for calculations in the real space (domain of
             this transform). It is shared with the inverse.
 
             Variants using this: R2C, R2HC, C2R (inverse)
 
-        tmp_f : `DiscreteLpVector` or `numpy.ndarray`
+        tmp_f : `DiscreteLpElement` or `numpy.ndarray`
             Temporary for calculations in the frequency (reciprocal)
             space. It is shared with the inverse.
 
@@ -2082,13 +2082,13 @@ class FourierTransform(FourierTransformBase):
 
         Other Parameters
         ----------------
-        tmp_r : `DiscreteLpVector` or `numpy.ndarray`
+        tmp_r : `DiscreteLpElement` or `numpy.ndarray`
             Temporary for calculations in the real space (domain of
             this transform). It is shared with the inverse.
 
             Variants using this: R2C, R2HC, C2R (inverse)
 
-        tmp_f : `DiscreteLpVector` or `numpy.ndarray`
+        tmp_f : `DiscreteLpElement` or `numpy.ndarray`
             Temporary for calculations in the frequency (reciprocal)
             space. It is shared with the inverse.
 
@@ -2317,13 +2317,13 @@ class FourierTransformInverse(FourierTransformBase):
 
         Other Parameters
         ----------------
-        tmp_r : `DiscreteLpVector` or `numpy.ndarray`
+        tmp_r : `DiscreteLpElement` or `numpy.ndarray`
             Temporary for calculations in the real space (range of
             this transform). It is shared with the inverse.
 
             Variants using this: C2R, R2C (forward), R2HC (forward)
 
-        tmp_f : `DiscreteLpVector` or `numpy.ndarray`
+        tmp_f : `DiscreteLpElement` or `numpy.ndarray`
             Temporary for calculations in the frequency (reciprocal)
             space. It is shared with the inverse.
 

--- a/odl/trafos/wavelet.py
+++ b/odl/trafos/wavelet.py
@@ -251,7 +251,7 @@ def array_to_pywt_coeff(coeff, size_list):
 
     Parameters
     ----------
-    coeff : `DiscreteLpVector`
+    coeff : `DiscreteLpElement`
         A flat coefficient vector containing the approximation,
         and detail coefficients in the following order
         [aaaN, aadN, adaN, addN, daaN, dadN, ddaN, dddN, ...
@@ -358,7 +358,7 @@ def wavelet_decomposition3d(x, wbasis, pad_mode, nscales):
 
     Parameters
     ----------
-    x : `DiscreteLpVector`
+    x : `DiscreteLpElement`
 
     wbasis : ``pywt.Wavelet``
         Selected wavelet basis. For more information see the

--- a/odl/util/testutils.py
+++ b/odl/util/testutils.py
@@ -143,7 +143,7 @@ def all_equal(iter1, iter2):
 
 
 def all_almost_equal_array(v1, v2, places):
-    # Ravel if has order, only DiscreteLpVector has an order
+    # Ravel if has order, only DiscreteLpElement has an order
     if hasattr(v1, 'order'):
         v1 = v1.__array__().ravel(v1.order)
     else:
@@ -261,31 +261,30 @@ def noise_array(space):
     Notes
     -----
     This method is intended for internal testing purposes, for more explicit
-    example elements see `phantoms` and `LinearSpaceVector.examples`.
+    example elements see `phantoms` and `LinearSpaceElement.examples`.
 
     Parameters
     ----------
     space : `LinearSpace`
-        The space to create vectors in. The `LinearSpace.element` method of the
-        space needs to accept input of `numpy.ndarray` type.
+        Space from which to derive the array data type and size.
 
     Returns
     -------
     noise_array : `numpy.ndarray` element
-        Array with white noise osuch that ``space.element``'s can be created
+        Array with white noise such that ``space.element``'s can be created
         from it.
 
     See Also
     --------
     noise_element
-    noise_vectors
-    LinearSpaceVector.examples : Examples of vectors typical to the space.
+    noise_elements
+    LinearSpaceElement.examples : Examples of elements typical to the space.
     """
     from odl.space import ProductSpace
     if isinstance(space, ProductSpace):
         return np.array([noise_array(si) for si in space])
     else:
-        # Generate numpy vectors, real or complex or int
+        # Generate numpy space elements, real or complex or int
         if np.issubdtype(space.dtype, np.floating):
             arr = np.random.randn(space.size)
         elif np.issubdtype(space.dtype, np.integer):
@@ -298,7 +297,7 @@ def noise_array(space):
 
 
 def noise_element(space):
-    """Creata a white noise element in ``space``
+    """Create a white noise element in ``space``.
 
     The element contains white noise with standard deviation 1 in the case of
     floating point dtypes and uniformly spaced values between -10 and 10 in
@@ -309,13 +308,13 @@ def noise_element(space):
     Notes
     -----
     This method is intended for internal testing purposes, for more explicit
-    example elements see `phantoms` and `LinearSpaceVector.examples`.
+    example elements see `phantoms` and `LinearSpaceElement.examples`.
 
     Parameters
     ----------
     space : `LinearSpace`
-        The space to create vectors in. The `LinearSpace.element` method of the
-        space needs to accept input of `numpy.ndarray` type.
+        Space in which to create an element. The `LinearSpace.element`
+        method of the space needs to accept input of `numpy.ndarray` type.
 
     Returns
     -------
@@ -324,20 +323,20 @@ def noise_element(space):
     See Also
     --------
     noise_array
-    noise_vectors
-    LinearSpaceVector.examples : Examples of vectors typical to the space.
+    noise_elements
+    LinearSpaceElement.examples : Examples of elements typical to the space.
     """
     return space.element(noise_array(space))
 
 
-def noise_vectors(space, n=1):
-    """Create a list of ``n`` arrays and vectors in ``space``.
+def noise_elements(space, n=1):
+    """Create a list of ``n`` noise arrays and elements in ``space``.
 
     The arrays contain white noise with standard deviation 1 in the case of
     floating point dtypes and uniformly spaced values between -10 and 10 in
     the case of integer dtypes.
 
-    The returned vectors wrap the arrays.
+    The returned elements wrap the arrays.
 
     For product spaces the method is called recursively for all sub-spaces.
 
@@ -349,17 +348,17 @@ def noise_vectors(space, n=1):
     Parameters
     ----------
     space : `LinearSpace`
-        The space to create vectors in. The `LinearSpace.element` method of the
-        space needs to accept input of `numpy.ndarray` type.
+        Space to create elements in. The `LinearSpace.element` method
+        of the space needs to accept input of `numpy.ndarray` type.
     n : int
-        The number of vectors to create.
+        Number of elements to create.
 
     Returns
     -------
     arrays : `numpy.ndarray`(s)
         A single array if ``n == 1``, otherwise a tuple of arrays.
-    vectors : ``space`` element(s)
-        A single vector if ``n == 1``, otherwise a tuple of vector.
+    elements : ``space`` element(s)
+        A single element if ``n == 1``, otherwise a tuple of elements.
 
     See Also
     --------
@@ -368,13 +367,13 @@ def noise_vectors(space, n=1):
     """
     arrs = tuple(noise_array(space) for _ in range(n))
 
-    # Make Fn vectors
-    vecs = tuple(space.element(arr.copy()) for arr in arrs)
+    # Make space elements from arrays
+    elems = tuple(space.element(arr.copy()) for arr in arrs)
 
     if n == 1:
-        return arrs + vecs
+        return tuple(arrs + elems)
     else:
-        return arrs, vecs
+        return arrs, elems
 
 
 class FailCounter(object):

--- a/odl/util/ufuncs.py
+++ b/odl/util/ufuncs.py
@@ -324,9 +324,9 @@ def wrap_reduction_discretelp(name, doc):
 
 class DiscreteLpUFuncs(NtuplesBaseUFuncs):
 
-    """UFuncs for `DiscreteLpVector` objects.
+    """UFuncs for `DiscreteLpElement` objects.
 
-    Internal object, should not be created except in `DiscreteLpVector`.
+    Internal object, should not be created except in `DiscreteLpElement`.
     """
 
 
@@ -340,9 +340,9 @@ for name, doc in REDUCTIONS:
     setattr(DiscreteLpUFuncs, name, method)
 
 
-# Ufuncs for productspace vectors
+# Ufuncs for product space elements
 def wrap_ufunc_productspace(name, n_in, n_out, doc):
-    """Add ufunc methods to `ProductSpaceVector`."""
+    """Add ufunc methods to `ProductSpaceElement`."""
 
     if n_in == 1:
         if n_out == 0:
@@ -406,7 +406,7 @@ def wrap_ufunc_productspace(name, n_in, n_out, doc):
 
 
 def wrap_reduction_productspace(name, doc):
-    """Add reduction methods to `ProductSpaceVector`."""
+    """Add reduction methods to `ProductSpaceElement`."""
     def wrapper(self):
         results = [getattr(x.ufunc, name)() for x in self.vector]
         return getattr(np, name)(results)
@@ -418,9 +418,9 @@ def wrap_reduction_productspace(name, doc):
 
 class ProductSpaceUFuncs(object):
 
-    """UFuncs for `ProductSpaceVector` objects.
+    """UFuncs for `ProductSpaceElement` objects.
 
-    Internal object, should not be created except in `ProductSpaceVector`.
+    Internal object, should not be created except in `ProductSpaceElement`.
     """
     def __init__(self, vector):
         """Create ufunc wrapper for vector."""

--- a/odl/util/vectorization.py
+++ b/odl/util/vectorization.py
@@ -43,7 +43,7 @@ def is_valid_input_array(x, ndim=None):
 
 def is_valid_input_meshgrid(x, ndim):
     """Test if ``x`` is a `meshgrid` sequence for points in R^d."""
-    # This case is triggered in FunctionSetVector.__call__ if the
+    # This case is triggered in FunctionSetElement.__call__ if the
     # domain does not have an 'ndim' attribute. We return False and
     # continue.
     if ndim is None:

--- a/test/deform/linearized_deform_test.py
+++ b/test/deform/linearized_deform_test.py
@@ -186,7 +186,7 @@ def test_fixed_templ_init():
 
     # Invalid input
     with pytest.raises(TypeError):
-        # template not a DiscreteLpVector
+        # template not a DiscreteLpElement
         LinDeformFixedTempl(template_function)
 
 
@@ -244,7 +244,7 @@ def test_fixed_disp_init():
     print(LinDeformFixedDisp(disp_field, templ_space=space))
 
     # Non-valid input
-    with pytest.raises(TypeError):  # displacement not ProductSpaceVector
+    with pytest.raises(TypeError):  # displacement not ProductSpaceElement
         LinDeformFixedDisp(space.one())
     with pytest.raises(TypeError):  # templ_space not DiscreteLp
         LinDeformFixedDisp(disp_field, space.vector_field_space)

--- a/test/discr/diff_ops_test.py
+++ b/test/discr/diff_ops_test.py
@@ -290,7 +290,7 @@ def test_gradient(method, fn_impl, padding):
     else:
         pad_mode, pad_const = padding, None
 
-    # DiscreteLp Vector
+    # DiscreteLpElement
     space = odl.uniform_discr([0, 0], [1, 1], DATA_2D.shape, impl=fn_impl)
     dom_vec = space.element(DATA_2D)
 
@@ -328,7 +328,7 @@ def test_gradient(method, fn_impl, padding):
     lin_size = 3
     for ndim in [1, 3, 6]:
 
-        # DiscreteLp Vector
+        # DiscreteLpElement
         space = odl.uniform_discr([0.] * ndim, [1.] * ndim, [lin_size] * ndim)
         dom_vec = odl.phantom.cuboid(space, [0.2] * ndim, [0.8] * ndim)
 
@@ -393,7 +393,7 @@ def test_divergence(method, fn_impl, padding):
 
     # Higher dimensional arrays
     for ndim in range(1, 6):
-        # DiscreteLp Vector
+        # DiscreteLpElement
         lin_size = 3
         space = odl.uniform_discr([0.] * ndim, [1.] * ndim, [lin_size] * ndim)
 

--- a/test/discr/lp_discr_test.py
+++ b/test/discr/lp_discr_test.py
@@ -30,7 +30,7 @@ import odl
 from odl.discr.lp_discr import DiscreteLp
 from odl.space.base_ntuples import FnBase
 from odl.util.testutils import (almost_equal, all_equal, all_almost_equal,
-                                noise_vectors)
+                                noise_elements)
 
 # Pytest fixture
 
@@ -154,9 +154,9 @@ def test_element_1d(exponent):
     discr = odl.uniform_discr(0, 1, 3, impl='numpy', exponent=exponent)
     weight = 1.0 if exponent == float('inf') else discr.cell_volume
     dspace = odl.rn(3, exponent=exponent, weight=weight)
-    vec = discr.element()
-    assert isinstance(vec, odl.DiscreteLpVector)
-    assert vec.ntuple in dspace
+    elem = discr.element()
+    assert isinstance(elem, odl.DiscreteLpElement)
+    assert elem.ntuple in dspace
 
 
 def test_element_2d(exponent):
@@ -164,58 +164,58 @@ def test_element_2d(exponent):
                               impl='numpy', exponent=exponent)
     weight = 1.0 if exponent == float('inf') else discr.cell_volume
     dspace = odl.rn(9, exponent=exponent, weight=weight)
-    vec = discr.element()
-    assert isinstance(vec, odl.DiscreteLpVector)
-    assert vec.ntuple in dspace
+    elem = discr.element()
+    assert isinstance(elem, odl.DiscreteLpElement)
+    assert elem.ntuple in dspace
 
 
 def test_element_from_array_1d():
     discr = odl.uniform_discr(0, 1, 3, impl='numpy')
-    vec = discr.element([1, 2, 3])
+    elem = discr.element([1, 2, 3])
 
-    assert isinstance(vec, odl.DiscreteLpVector)
-    assert isinstance(vec.ntuple, odl.NumpyFnVector)
-    assert all_equal(vec.ntuple, [1, 2, 3])
+    assert isinstance(elem, odl.DiscreteLpElement)
+    assert isinstance(elem.ntuple, odl.NumpyFnVector)
+    assert all_equal(elem.ntuple, [1, 2, 3])
 
 
 def test_element_from_array_2d():
     # assert orderings work properly with 2d
     discr = odl.uniform_discr([0, 0], [1, 1], [2, 2], impl='numpy', order='C')
-    vec = discr.element([[1, 2],
+    elem = discr.element([[1, 2],
                          [3, 4]])
 
-    assert isinstance(vec, odl.DiscreteLpVector)
-    assert isinstance(vec.ntuple, odl.NumpyFnVector)
+    assert isinstance(elem, odl.DiscreteLpElement)
+    assert isinstance(elem.ntuple, odl.NumpyFnVector)
 
     # Check ordering
-    assert all_equal(vec.ntuple, [1, 2, 3, 4])
+    assert all_equal(elem.ntuple, [1, 2, 3, 4])
 
     # Linear creation works as well
-    linear_vec = discr.element([1, 2, 3, 4])
-    assert all_equal(vec.ntuple, [1, 2, 3, 4])
+    linear_elem = discr.element([1, 2, 3, 4])
+    assert all_equal(linear_elem.ntuple, [1, 2, 3, 4])
 
     # Fortran order
     discr = odl.uniform_discr([0, 0], [1, 1], (2, 2), impl='numpy', order='F')
-    vec = discr.element([[1, 2],
+    elem = discr.element([[1, 2],
                          [3, 4]])
 
     # Check ordering
-    assert all_equal(vec.ntuple, [1, 3, 2, 4])
+    assert all_equal(elem.ntuple, [1, 3, 2, 4])
 
     # Linear creation works aswell
-    linear_vec = discr.element([1, 2, 3, 4])
-    assert all_equal(linear_vec.ntuple, [1, 2, 3, 4])
+    linear_elem = discr.element([1, 2, 3, 4])
+    assert all_equal(linear_elem.ntuple, [1, 2, 3, 4])
 
     # Using broadcasting
-    broadcast_vec = discr.element([[1, 2]])
+    broadcast_elem = discr.element([[1, 2]])
     broadcast_expected = discr.element([[1, 2],
                                         [1, 2]])
-    assert all_equal(broadcast_vec, broadcast_expected)
+    assert all_equal(broadcast_elem, broadcast_expected)
 
-    broadcast_vec = discr.element([[1], [2]])
+    broadcast_elem = discr.element([[1], [2]])
     broadcast_expected = discr.element([[1, 1],
                                         [2, 2]])
-    assert all_equal(broadcast_vec, broadcast_expected)
+    assert all_equal(broadcast_elem, broadcast_expected)
 
 
 def test_element_from_array_2d_shape():
@@ -340,17 +340,17 @@ def test_element_from_function_2d():
 
 def test_zero():
     discr = odl.uniform_discr(0, 1, 3)
-    vec = discr.zero()
+    zero = discr.zero()
 
-    assert isinstance(vec, odl.DiscreteLpVector)
-    assert isinstance(vec.ntuple, odl.NumpyFnVector)
-    assert all_equal(vec, [0, 0, 0])
+    assert isinstance(zero, odl.DiscreteLpElement)
+    assert isinstance(zero.ntuple, odl.NumpyFnVector)
+    assert all_equal(zero, [0, 0, 0])
 
 
 def _test_unary_operator(discr, function):
     # Verify that the statement y=function(x) gives equivalent results
     # to NumPy
-    x_arr, x = noise_vectors(discr)
+    x_arr, x = noise_elements(discr)
 
     y_arr = function(x_arr)
 
@@ -362,7 +362,7 @@ def _test_unary_operator(discr, function):
 def _test_binary_operator(discr, function):
     # Verify that the statement z=function(x,y) gives equivalent results
     # to NumPy
-    [x_arr, y_arr], [x, y] = noise_vectors(discr, 2)
+    [x_arr, y_arr], [x, y] = noise_elements(discr, 2)
 
     z_arr = function(x_arr, y_arr)
     z = function(x, y)
@@ -480,138 +480,138 @@ def test_interp():
 
 def test_getitem():
     discr = odl.uniform_discr(0, 1, 3)
-    vec = discr.element([1, 2, 3])
+    elem = discr.element([1, 2, 3])
 
-    assert all_equal(vec, [1, 2, 3])
+    assert all_equal(elem, [1, 2, 3])
 
 
 def test_getslice():
     discr = odl.uniform_discr(0, 1, 3)
-    vec = discr.element([1, 2, 3])
+    elem = discr.element([1, 2, 3])
 
-    assert isinstance(vec[:], odl.NumpyFnVector)
-    assert all_equal(vec[:], [1, 2, 3])
+    assert isinstance(elem[:], odl.NumpyFnVector)
+    assert all_equal(elem[:], [1, 2, 3])
 
     discr = odl.uniform_discr(0, 1, 3, dtype='complex')
-    vec = discr.element([1 + 2j, 2 - 2j, 3])
+    elem = discr.element([1 + 2j, 2 - 2j, 3])
 
-    assert isinstance(vec[:], odl.NumpyFnVector)
-    assert all_equal(vec[:], [1 + 2j, 2 - 2j, 3])
+    assert isinstance(elem[:], odl.NumpyFnVector)
+    assert all_equal(elem[:], [1 + 2j, 2 - 2j, 3])
 
 
 def test_setitem():
     discr = odl.uniform_discr(0, 1, 3)
-    vec = discr.element([1, 2, 3])
-    vec[0] = 4
-    vec[1] = 5
-    vec[2] = 6
+    elem = discr.element([1, 2, 3])
+    elem[0] = 4
+    elem[1] = 5
+    elem[2] = 6
 
-    assert all_equal(vec, [4, 5, 6])
+    assert all_equal(elem, [4, 5, 6])
 
 
 def test_setitem_nd():
 
     # 1D
     discr = odl.uniform_discr(0, 1, 3)
-    vec = discr.element([1, 2, 3])
+    elem = discr.element([1, 2, 3])
 
-    vec[:] = [4, 5, 6]
-    assert all_equal(vec, [4, 5, 6])
+    elem[:] = [4, 5, 6]
+    assert all_equal(elem, [4, 5, 6])
 
-    vec[:] = np.array([3, 2, 1])
-    assert all_equal(vec, [3, 2, 1])
+    elem[:] = np.array([3, 2, 1])
+    assert all_equal(elem, [3, 2, 1])
 
-    vec[:] = 0
-    assert all_equal(vec, [0, 0, 0])
+    elem[:] = 0
+    assert all_equal(elem, [0, 0, 0])
 
-    vec[:] = [1]
-    assert all_equal(vec, [1, 1, 1])
-
-    with pytest.raises(ValueError):
-        vec[:] = [0, 0]  # bad shape
+    elem[:] = [1]
+    assert all_equal(elem, [1, 1, 1])
 
     with pytest.raises(ValueError):
-        vec[:] = [0, 0, 1, 2]  # bad shape
+        elem[:] = [0, 0]  # bad shape
+
+    with pytest.raises(ValueError):
+        elem[:] = [0, 0, 1, 2]  # bad shape
 
     # 2D
     discr = odl.uniform_discr([0, 0], [1, 1], [3, 2])
 
-    vec = discr.element([[1, 2],
+    elem = discr.element([[1, 2],
                          [3, 4],
                          [5, 6]])
 
-    vec[:] = [[-1, -2],
-              [-3, -4],
-              [-5, -6]]
-    assert all_equal(vec, [-1, -2, -3, -4, -5, -6])
+    elem[:] = [[-1, -2],
+               [-3, -4],
+               [-5, -6]]
+    assert all_equal(elem, [-1, -2, -3, -4, -5, -6])
 
     arr = np.arange(6, 12).reshape([3, 2])
-    vec[:] = arr
-    assert all_equal(vec, np.arange(6, 12))
+    elem[:] = arr
+    assert all_equal(elem, np.arange(6, 12))
 
-    vec[:] = 0
-    assert all_equal(vec, [0] * 6)
+    elem[:] = 0
+    assert all_equal(elem, [0] * 6)
 
-    vec[:] = [1]
-    assert all_equal(vec, [1] * 6)
-
-    with pytest.raises(ValueError):
-        vec[:] = [0, 0]  # bad shape
+    elem[:] = [1]
+    assert all_equal(elem, [1] * 6)
 
     with pytest.raises(ValueError):
-        vec[:] = [0, 0, 0]  # bad shape
+        elem[:] = [0, 0]  # bad shape
 
     with pytest.raises(ValueError):
-        vec[:] = np.arange(6)[:, np.newaxis]  # bad shape (6, 1)
+        elem[:] = [0, 0, 0]  # bad shape
+
+    with pytest.raises(ValueError):
+        elem[:] = np.arange(6)[:, np.newaxis]  # bad shape (6, 1)
 
     with pytest.raises(ValueError):
         arr = np.arange(6, 12).reshape([3, 2])
-        vec[:] = arr.T  # bad shape (2, 3)
+        elem[:] = arr.T  # bad shape (2, 3)
 
     # nD
     shape = (3,) * 3 + (4,) * 3
     discr = odl.uniform_discr([0] * 6, [1] * 6, shape)
     size = np.prod(shape)
-    vec = discr.element(np.zeros(shape))
+    elem = discr.element(np.zeros(shape))
 
     arr = np.arange(size).reshape(shape)
 
-    vec[:] = arr
-    assert all_equal(vec, np.arange(size))
+    elem[:] = arr
+    assert all_equal(elem, np.arange(size))
 
-    vec[:] = 0
-    assert all_equal(vec, np.zeros(size))
+    elem[:] = 0
+    assert all_equal(elem, np.zeros(size))
 
-    vec[:] = [1]
-    assert all_equal(vec, np.ones(size))
+    elem[:] = [1]
+    assert all_equal(elem, np.ones(size))
 
     with pytest.raises(ValueError):
         # Reversed shape -> bad
-        vec[:] = np.arange(size).reshape((4,) * 3 + (3,) * 3)
+        elem[:] = np.arange(size).reshape((4,) * 3 + (3,) * 3)
 
 
 def test_setslice():
     discr = odl.uniform_discr(0, 1, 3)
-    vec = discr.element([1, 2, 3])
+    elem = discr.element([1, 2, 3])
 
-    vec[:] = [4, 5, 6]
-    assert all_equal(vec, [4, 5, 6])
+    elem[:] = [4, 5, 6]
+    assert all_equal(elem, [4, 5, 6])
 
 
 def test_asarray_2d():
     discr_F = odl.uniform_discr([0, 0], [1, 1], [2, 2], order='F')
-    vec_F = discr_F.element([[1, 2],
+    elem_F = discr_F.element([[1, 2],
                              [3, 4]])
 
     # Verify that returned array equals input data
-    assert all_equal(vec_F.asarray(), [[1, 2],
-                                       [3, 4]])
+    assert all_equal(elem_F.asarray(), [[1, 2],
+                                        [3, 4]])
     # Check order of out array
-    assert vec_F.asarray().flags['F_CONTIGUOUS']
+    assert elem_F.asarray().flags['F_CONTIGUOUS']
 
     # test out parameter
     out_F = np.asfortranarray(np.empty([2, 2]))
-    result_F = vec_F.asarray(out=out_F)
+    result_F = elem_F.asarray(out=out_F)
     assert result_F is out_F
     assert all_equal(out_F, [[1, 2],
                              [3, 4]])
@@ -619,33 +619,33 @@ def test_asarray_2d():
     # Try discontinuous
     out_F_wrong = np.asfortranarray(np.empty([2, 2]))[::2, :]
     with pytest.raises(ValueError):
-        result_F = vec_F.asarray(out=out_F_wrong)
+        result_F = elem_F.asarray(out=out_F_wrong)
 
     # Try wrong shape
     out_F_wrong = np.asfortranarray(np.empty([2, 3]))
     with pytest.raises(ValueError):
-        result_F = vec_F.asarray(out=out_F_wrong)
+        result_F = elem_F.asarray(out=out_F_wrong)
 
     # Try wrong order
     out_F_wrong = np.empty([2, 2])
     with pytest.raises(ValueError):
-        vec_F.asarray(out=out_F_wrong)
+        elem_F.asarray(out=out_F_wrong)
 
     # Also check with C ordering
     discr_C = odl.uniform_discr([0, 0], [1, 1], (2, 2), order='C')
-    vec_C = discr_C.element([[1, 2],
+    elem_C = discr_C.element([[1, 2],
                              [3, 4]])
 
     # Verify that returned array equals input data
-    assert all_equal(vec_C.asarray(), [[1, 2],
-                                       [3, 4]])
+    assert all_equal(elem_C.asarray(), [[1, 2],
+                                        [3, 4]])
 
     # Check order of out array
-    assert vec_C.asarray().flags['C_CONTIGUOUS']
+    assert elem_C.asarray().flags['C_CONTIGUOUS']
 
     # test out parameter
     out_C = np.empty([2, 2])
-    result_C = vec_C.asarray(out=out_C)
+    result_C = elem_C.asarray(out=out_C)
     assert result_C is out_C
     assert all_equal(out_C, [[1, 2],
                              [3, 4]])
@@ -653,17 +653,17 @@ def test_asarray_2d():
     # Try discontinuous
     out_C_wrong = np.empty([4, 2])[::2, :]
     with pytest.raises(ValueError):
-        result_C = vec_C.asarray(out=out_C_wrong)
+        result_C = elem_C.asarray(out=out_C_wrong)
 
     # Try wrong shape
     out_C_wrong = np.empty([2, 3])
     with pytest.raises(ValueError):
-        result_C = vec_C.asarray(out=out_C_wrong)
+        result_C = elem_C.asarray(out=out_C_wrong)
 
     # Try wrong order
     out_C_wrong = np.asfortranarray(np.empty([2, 2]))
     with pytest.raises(ValueError):
-        vec_C.asarray(out=out_C_wrong)
+        elem_C.asarray(out=out_C_wrong)
 
 
 def test_transpose():
@@ -682,33 +682,33 @@ def test_transpose():
 def test_cell_sides():
     # Non-degenerated case, should be same as cell size
     discr = odl.uniform_discr([0, 0], [1, 1], [2, 2])
-    vec = discr.element()
+    elem = discr.element()
 
     assert all_equal(discr.cell_sides, [0.5] * 2)
-    assert all_equal(vec.cell_sides, [0.5] * 2)
+    assert all_equal(elem.cell_sides, [0.5] * 2)
 
     # Degenerated case, uses interval size in 1-point dimensions
     discr = odl.uniform_discr([0, 0], [1, 1], [2, 1])
-    vec = discr.element()
+    elem = discr.element()
 
     assert all_equal(discr.cell_sides, [0.5, 1])
-    assert all_equal(vec.cell_sides, [0.5, 1])
+    assert all_equal(elem.cell_sides, [0.5, 1])
 
 
 def test_cell_volume():
     # Non-degenerated case
     discr = odl.uniform_discr([0, 0], [1, 1], [2, 2])
-    vec = discr.element()
+    elem = discr.element()
 
     assert discr.cell_volume == 0.25
-    assert vec.cell_volume == 0.25
+    assert elem.cell_volume == 0.25
 
     # Degenerated case, uses interval size in 1-point dimensions
     discr = odl.uniform_discr([0, 0], [1, 1], [2, 1])
-    vec = discr.element()
+    elem = discr.element()
 
     assert discr.cell_volume == 0.5
-    assert vec.cell_volume == 0.5
+    assert elem.cell_volume == 0.5
 
 
 def test_astype():
@@ -752,7 +752,7 @@ def test_ufunc(fn_impl, ufunc):
     ufunc = getattr(np, name)
 
     # Create some data
-    arrays, vectors = noise_vectors(space, n_args + n_out)
+    arrays, vectors = noise_elements(space, n_args + n_out)
     in_arrays = arrays[:n_args]
     out_arrays = arrays[n_args:]
     data_vector = vectors[0]
@@ -863,7 +863,7 @@ def test_reduction(fn_impl, reduction):
     ufunc = getattr(np, name)
 
     # Create some data
-    x_arr, x = noise_vectors(space, 1)
+    x_arr, x = noise_elements(space, 1)
     assert almost_equal(ufunc(x_arr), getattr(x.ufunc, name)())
 
 
@@ -879,7 +879,7 @@ def power(request):
 def test_power(fn_impl, power):
     space = odl.uniform_discr([0, 0], [1, 1], [2, 2], impl=fn_impl)
 
-    x_arr, x = noise_vectors(space, 1)
+    x_arr, x = noise_elements(space, 1)
     x_pos_arr = np.abs(x_arr)
     x_neg_arr = -x_pos_arr
     x_pos = np.abs(x)

--- a/test/largescale/space/fn_base_slow_test.py
+++ b/test/largescale/space/fn_base_slow_test.py
@@ -28,7 +28,7 @@ import numpy as np
 
 # ODL imports
 import odl
-from odl.util.testutils import all_almost_equal, almost_equal, noise_vectors
+from odl.util.testutils import all_almost_equal, almost_equal, noise_elements
 
 pytestmark = odl.util.skip_if_no_largescale
 
@@ -116,7 +116,7 @@ def fn_weighting(fn):
 def test_inner(fn):
     weighting = fn_weighting(fn)
 
-    [xarr, yarr], [x, y] = noise_vectors(fn, 2)
+    [xarr, yarr], [x, y] = noise_elements(fn, 2)
 
     correct_inner = np.vdot(yarr, xarr) * weighting
 
@@ -127,7 +127,7 @@ def test_inner(fn):
 def test_norm(fn):
     weighting = np.sqrt(fn_weighting(fn))
 
-    xarr, x = noise_vectors(fn)
+    xarr, x = noise_elements(fn)
 
     correct_norm = np.linalg.norm(xarr) * weighting
 
@@ -138,7 +138,7 @@ def test_norm(fn):
 def test_dist(fn):
     weighting = np.sqrt(fn_weighting(fn))
 
-    [xarr, yarr], [x, y] = noise_vectors(fn, 2)
+    [xarr, yarr], [x, y] = noise_elements(fn, 2)
 
     correct_dist = np.linalg.norm(xarr - yarr) * weighting
 
@@ -151,7 +151,7 @@ def _test_lincomb(fn, a, b):
     # data and given a,b
 
     # Unaliased arguments
-    [x_arr, y_arr, z_arr], [x, y, z] = noise_vectors(fn, 3)
+    [x_arr, y_arr, z_arr], [x, y, z] = noise_elements(fn, 3)
 
     z_arr[:] = a * x_arr + b * y_arr
     z.lincomb(a, x, b, y)
@@ -171,7 +171,7 @@ def _test_member_lincomb(spc, a):
     # Validates vector member lincomb against the result on host
 
     # Generate vectors
-    [x_host, y_host], [x_device, y_device] = noise_vectors(spc, 2)
+    [x_host, y_host], [x_device, y_device] = noise_elements(spc, 2)
 
     # Host side calculation
     y_host[:] = a * x_host
@@ -192,7 +192,7 @@ def test_member_lincomb(fn):
 def _test_unary_operator(spc, function):
     # Verify that the statement y=function(x) gives equivalent
     # results to Numpy.
-    x_arr, x = noise_vectors(spc)
+    x_arr, x = noise_elements(spc)
 
     y_arr = function(x_arr)
     y = function(x)
@@ -204,7 +204,7 @@ def _test_unary_operator(spc, function):
 def _test_binary_operator(spc, function):
     # Verify that the statement z=function(x,y) gives equivalent
     # results to Numpy.
-    [x_arr, y_arr], [x, y] = noise_vectors(spc, 2)
+    [x_arr, y_arr], [x, y] = noise_elements(spc, 2)
 
     z_arr = function(x_arr, y_arr)
     z = function(x, y)

--- a/test/solvers/advanced/proximal_operator_test.py
+++ b/test/solvers/advanced/proximal_operator_test.py
@@ -143,7 +143,7 @@ def test_combine_proximal():
     # Create an element in the domain of the operator
     x = prox_verify.domain.element([np.arange(-5, 5), np.arange(-5, 5)])
 
-    # Allocate output vector
+    # Allocate output element
     out = prox_verify.range.element()
 
     # Apply explicitly constructed and factory-function-combined proximal
@@ -239,7 +239,7 @@ def test_proximal_convconj_l2_sq_wo_data():
 
     assert isinstance(prox, odl.Operator)
 
-    # Allocate output vector
+    # Allocate output element
     x_out = space.element()
 
     # Optimal point returned by the proximal operator
@@ -274,7 +274,7 @@ def test_proximal_convconj_l2_sq_with_data():
 
     assert isinstance(prox, odl.Operator)
 
-    # Allocate output vector
+    # Allocate output element
     x_out = space.element()
 
     # Optimal point returned by the proximal operator
@@ -292,7 +292,7 @@ def test_proximal_convconj_l1_simple_space_without_data():
     # Image space
     space = odl.uniform_discr(0, 1, 10)
 
-    # Image vector
+    # Image element
     x_arr = np.arange(-5, 5)
     x = space.element(x_arr)
 
@@ -412,7 +412,7 @@ def test_proximal_convconj_kl_simple_space():
 
     assert isinstance(prox, odl.Operator)
 
-    # Allocate an output vector
+    # Allocate an output element
     x_opt = space.element()
 
     # Apply the proximal operator returning its optimal point
@@ -451,7 +451,7 @@ def test_proximal_convconj_kl_product_space():
 
     assert isinstance(prox, odl.Operator)
 
-    # Allocate an output vector
+    # Allocate an output element
     x_opt = op_domain.element()
 
     # Apply the proximal operator returning its optimal point

--- a/test/space/ntuples_test.py
+++ b/test/space/ntuples_test.py
@@ -40,7 +40,7 @@ from odl.space.npy_ntuples import (
     MatVecOperator)
 from odl.util.testutils import (almost_equal, all_almost_equal, all_equal,
                                 noise_array, noise_element,
-                                noise_vectors)
+                                noise_elements)
 from odl.util.ufuncs import UFUNCS, REDUCTIONS
 
 # Check for python3
@@ -227,31 +227,31 @@ def _test_lincomb(fn, a, b):
     # data and given a,b, contiguous and non-contiguous
 
     # Unaliased arguments
-    [xarr, yarr, zarr], [x, y, z] = noise_vectors(fn, 3)
+    [xarr, yarr, zarr], [x, y, z] = noise_elements(fn, 3)
     zarr[:] = a * xarr + b * yarr
     fn.lincomb(a, x, b, y, out=z)
     assert all_almost_equal([x, y, z], [xarr, yarr, zarr])
 
     # First argument aliased with output
-    [xarr, yarr, zarr], [x, y, z] = noise_vectors(fn, 3)
+    [xarr, yarr, zarr], [x, y, z] = noise_elements(fn, 3)
     zarr[:] = a * zarr + b * yarr
     fn.lincomb(a, z, b, y, out=z)
     assert all_almost_equal([x, y, z], [xarr, yarr, zarr])
 
     # Second argument aliased with output
-    [xarr, yarr, zarr], [x, y, z] = noise_vectors(fn, 3)
+    [xarr, yarr, zarr], [x, y, z] = noise_elements(fn, 3)
     zarr[:] = a * xarr + b * zarr
     fn.lincomb(a, x, b, z, out=z)
     assert all_almost_equal([x, y, z], [xarr, yarr, zarr])
 
     # Both arguments aliased with each other
-    [xarr, yarr, zarr], [x, y, z] = noise_vectors(fn, 3)
+    [xarr, yarr, zarr], [x, y, z] = noise_elements(fn, 3)
     zarr[:] = a * xarr + b * xarr
     fn.lincomb(a, x, b, x, out=z)
     assert all_almost_equal([x, y, z], [xarr, yarr, zarr])
 
     # All aliased
-    [xarr, yarr, zarr], [x, y, z] = noise_vectors(fn, 3)
+    [xarr, yarr, zarr], [x, y, z] = noise_elements(fn, 3)
     zarr[:] = a * zarr + b * zarr
     fn.lincomb(a, z, b, z, out=z)
     assert all_almost_equal([x, y, z], [xarr, yarr, zarr])
@@ -289,14 +289,14 @@ def test_lincomb_exceptions(fn):
 
 def test_multiply(fn):
     # space method
-    [x_arr, y_arr, out_arr], [x, y, out] = noise_vectors(fn, 3)
+    [x_arr, y_arr, out_arr], [x, y, out] = noise_elements(fn, 3)
     out_arr = x_arr * y_arr
 
     fn.multiply(x, y, out)
     assert all_almost_equal([x_arr, y_arr, out_arr], [x, y, out])
 
     # member method
-    [x_arr, y_arr, out_arr], [x, y, out] = noise_vectors(fn, 3)
+    [x_arr, y_arr, out_arr], [x, y, out] = noise_elements(fn, 3)
     out_arr = x_arr * y_arr
 
     x.multiply(y, out=out)
@@ -322,7 +322,7 @@ def test_multiply_exceptions(fn):
 
 def test_power(fn):
 
-    [x_arr, y_arr], [x, y] = noise_vectors(fn, n=2)
+    [x_arr, y_arr], [x, y] = noise_elements(fn, n=2)
     y_pos = fn.element(np.abs(y) + 0.1)
     y_pos_arr = np.abs(y_arr) + 0.1
 
@@ -349,7 +349,7 @@ def test_power(fn):
 def _test_unary_operator(fn, function):
     # Verify that the statement y=function(x) gives equivalent results
     # to NumPy
-    x_arr, x = noise_vectors(fn)
+    x_arr, x = noise_elements(fn)
 
     y_arr = function(x_arr)
 
@@ -361,7 +361,7 @@ def _test_unary_operator(fn, function):
 def _test_binary_operator(fn, function):
     # Verify that the statement z=function(x,y) gives equivalent results
     # to NumPy
-    [x_arr, y_arr], [x, y] = noise_vectors(fn, 2)
+    [x_arr, y_arr], [x, y] = noise_elements(fn, 2)
 
     z_arr = function(x_arr, y_arr)
     z = function(x, y)
@@ -492,7 +492,7 @@ def test_inner_exceptions(fn):
 
 
 def test_norm(fn):
-    xarr, x = noise_vectors(fn)
+    xarr, x = noise_elements(fn)
 
     correct_norm = np.linalg.norm(xarr)
 
@@ -512,7 +512,7 @@ def test_norm_exceptions(fn):
 
 def test_pnorm(exponent):
     for fn in (odl.rn(3, exponent=exponent), odl.cn(3, exponent=exponent)):
-        xarr, x = noise_vectors(fn)
+        xarr, x = noise_elements(fn)
         correct_norm = np.linalg.norm(xarr, ord=exponent)
 
         assert almost_equal(fn.norm(x), correct_norm)
@@ -520,7 +520,7 @@ def test_pnorm(exponent):
 
 
 def test_dist(fn):
-    [xarr, yarr], [x, y] = noise_vectors(fn, n=2)
+    [xarr, yarr], [x, y] = noise_elements(fn, n=2)
 
     correct_dist = np.linalg.norm(xarr - yarr)
 
@@ -544,7 +544,7 @@ def test_dist_exceptions(fn):
 
 def test_pdist(exponent):
     for fn in (odl.rn(3, exponent=exponent), odl.cn(3, exponent=exponent)):
-        [xarr, yarr], [x, y] = noise_vectors(fn, n=2)
+        [xarr, yarr], [x, y] = noise_elements(fn, n=2)
 
         correct_dist = np.linalg.norm(xarr - yarr, ord=exponent)
 
@@ -784,7 +784,7 @@ def test_array_method(fn):
 def test_array_wrap_method(fn):
     # Verify that the __array_wrap__ method works. This enables numpy ufuncs
     # on vectors
-    x_h, x = noise_vectors(fn)
+    x_h, x = noise_elements(fn)
     y_h = np.sin(x_h)
     y = np.sin(x)
 
@@ -793,7 +793,7 @@ def test_array_wrap_method(fn):
 
 
 def test_conj(fn):
-    xarr, x = noise_vectors(fn)
+    xarr, x = noise_elements(fn)
     xconj = x.conj()
     assert all_equal(xconj, xarr.conj())
     y = x.copy()
@@ -927,7 +927,7 @@ def test_matvec_call(fn):
     # Square cases
     sparse_mat = _sparse_matrix(fn)
     dense_mat = _dense_matrix(fn)
-    xarr, x = noise_vectors(fn)
+    xarr, x = noise_elements(fn)
 
     op_sparse = MatVecOperator(sparse_mat, fn, fn)
     op_dense = MatVecOperator(dense_mat, fn, fn)
@@ -1113,7 +1113,7 @@ def test_matrix_equiv():
 
 
 def test_matrix_inner(fn):
-    [xarr, yarr], [x, y] = noise_vectors(fn, 2)
+    [xarr, yarr], [x, y] = noise_elements(fn, 2)
     sparse_mat = _sparse_matrix(fn)
     sparse_mat_as_dense = np.asarray(sparse_mat.todense())
     dense_mat = _dense_matrix(fn)
@@ -1139,7 +1139,7 @@ def test_matrix_inner(fn):
 
 
 def test_matrix_norm(fn, exponent):
-    xarr, x = noise_vectors(fn)
+    xarr, x = noise_elements(fn)
     sparse_mat = _sparse_matrix(fn)
     sparse_mat_as_dense = np.asarray(sparse_mat.todense())
     dense_mat = _dense_matrix(fn)
@@ -1186,7 +1186,7 @@ def test_matrix_norm(fn, exponent):
 
 
 def test_matrix_dist(fn, exponent):
-    [xarr, yarr], [x, y] = noise_vectors(fn, n=2)
+    [xarr, yarr], [x, y] = noise_elements(fn, n=2)
     sparse_mat = _sparse_matrix(fn)
     sparse_mat_as_dense = np.asarray(sparse_mat.todense())
     dense_mat = _dense_matrix(fn)
@@ -1231,7 +1231,7 @@ def test_matrix_dist(fn, exponent):
 
 
 def test_matrix_dist_using_inner(fn):
-    [xarr, yarr], [x, y] = noise_vectors(fn, 2)
+    [xarr, yarr], [x, y] = noise_elements(fn, 2)
     mat = _dense_matrix(fn)
 
     w = NumpyFnMatrixWeighting(mat, dist_using_inner=True)
@@ -1341,7 +1341,7 @@ def test_vector_equiv():
 
 
 def test_vector_inner(fn):
-    [xarr, yarr], [x, y] = noise_vectors(fn, 2)
+    [xarr, yarr], [x, y] = noise_elements(fn, 2)
 
     weight_vec = _pos_array(fn)
     weighting_vec = NumpyFnVectorWeighting(weight_vec)
@@ -1361,7 +1361,7 @@ def test_vector_inner(fn):
 
 
 def test_vector_norm(fn, exponent):
-    xarr, x = noise_vectors(fn)
+    xarr, x = noise_elements(fn)
 
     weight_vec = _pos_array(fn)
     weighting_vec = NumpyFnVectorWeighting(weight_vec, exponent=exponent)
@@ -1380,7 +1380,7 @@ def test_vector_norm(fn, exponent):
 
 
 def test_vector_dist(fn, exponent):
-    [xarr, yarr], [x, y] = noise_vectors(fn, n=2)
+    [xarr, yarr], [x, y] = noise_elements(fn, n=2)
 
     weight_vec = _pos_array(fn)
     weighting_vec = NumpyFnVectorWeighting(weight_vec, exponent=exponent)
@@ -1400,7 +1400,7 @@ def test_vector_dist(fn, exponent):
 
 
 def test_vector_dist_using_inner(fn):
-    [xarr, yarr], [x, y] = noise_vectors(fn, 2)
+    [xarr, yarr], [x, y] = noise_elements(fn, 2)
 
     weight_vec = _pos_array(fn)
     w = NumpyFnVectorWeighting(weight_vec)
@@ -1490,7 +1490,7 @@ def test_constant_equiv():
 
 
 def test_constant_inner(fn):
-    [xarr, yarr], [x, y] = noise_vectors(fn, 2)
+    [xarr, yarr], [x, y] = noise_elements(fn, 2)
 
     constant = 1.5
     true_result_const = constant * np.vdot(yarr, xarr)
@@ -1505,7 +1505,7 @@ def test_constant_inner(fn):
 
 
 def test_constant_norm(fn, exponent):
-    xarr, x = noise_vectors(fn)
+    xarr, x = noise_elements(fn)
 
     constant = 1.5
     if exponent == float('inf'):
@@ -1523,7 +1523,7 @@ def test_constant_norm(fn, exponent):
 
 
 def test_constant_dist(fn, exponent):
-    [xarr, yarr], [x, y] = noise_vectors(fn, 2)
+    [xarr, yarr], [x, y] = noise_elements(fn, 2)
 
     constant = 1.5
     if exponent == float('inf'):
@@ -1541,7 +1541,7 @@ def test_constant_dist(fn, exponent):
 
 
 def test_const_dist_using_inner(fn):
-    [xarr, yarr], [x, y] = noise_vectors(fn, 2)
+    [xarr, yarr], [x, y] = noise_elements(fn, 2)
 
     constant = 1.5
     w = NumpyFnConstWeighting(constant)
@@ -1582,7 +1582,7 @@ def test_noweight():
 
 
 def test_custom_inner(fn):
-    [xarr, yarr], [x, y] = noise_vectors(fn, 2)
+    [xarr, yarr], [x, y] = noise_elements(fn, 2)
 
     def inner(x, y):
         return np.vdot(y, x)
@@ -1614,7 +1614,7 @@ def test_custom_inner(fn):
 
 
 def test_custom_norm(fn):
-    [xarr, yarr], [x, y] = noise_vectors(fn, 2)
+    [xarr, yarr], [x, y] = noise_elements(fn, 2)
 
     norm = np.linalg.norm
 
@@ -1643,7 +1643,7 @@ def test_custom_norm(fn):
 
 
 def test_custom_dist(fn):
-    [xarr, yarr], [x, y] = noise_vectors(fn, 2)
+    [xarr, yarr], [x, y] = noise_elements(fn, 2)
 
     def dist(x, y):
         return np.linalg.norm(x - y)
@@ -1711,7 +1711,7 @@ def test_ufuncs(fn, ufunc):
     npufunc = getattr(np, name)
 
     # Create some data
-    arrays, vectors = noise_vectors(fn, n_args + n_out)
+    arrays, vectors = noise_elements(fn, n_args + n_out)
     in_arrays = arrays[:n_args]
     out_arrays = arrays[n_args:]
     data_vector = vectors[0]
@@ -1749,7 +1749,7 @@ def _impl_test_reduction(fn, name):
     ufunc = getattr(np, name)
 
     # Create some data
-    x_arr, x = noise_vectors(fn, 1)
+    x_arr, x = noise_elements(fn, 1)
 
     assert ufunc(x_arr) == getattr(x.ufunc, name)()
 

--- a/test/space/pspace_test.py
+++ b/test/space/pspace_test.py
@@ -450,7 +450,7 @@ def test_getitem_fancy():
     assert H[[0, 2]][1] is r3
 
 
-def test_vector_equals():
+def test_element_equals():
     H = odl.ProductSpace(odl.rn(1), odl.rn(2))
     x = H.element([[0], [1, 2]])
 
@@ -467,7 +467,7 @@ def test_vector_equals():
     assert x != x_4
 
 
-def test_vector_getitem_single():
+def test_element_getitem_single():
     H = odl.ProductSpace(odl.rn(1), odl.rn(2))
 
     x1 = H[0].element([0])
@@ -483,7 +483,7 @@ def test_vector_getitem_single():
         x[2]
 
 
-def test_vector_getitem_slice():
+def test_element_getitem_slice():
     H = odl.ProductSpace(odl.rn(1), odl.rn(2), odl.rn(3))
 
     x1 = H[0].element([0])
@@ -496,7 +496,7 @@ def test_vector_getitem_slice():
     assert x[:2][1] is x2
 
 
-def test_vector_getitem_fancy():
+def test_element_getitem_fancy():
     H = odl.ProductSpace(odl.rn(1), odl.rn(2), odl.rn(3))
 
     x1 = H[0].element([0])
@@ -509,7 +509,7 @@ def test_vector_getitem_fancy():
     assert x[[0, 2]][1] is x3
 
 
-def test_vector_setitem_single():
+def test_element_setitem_single():
     H = odl.ProductSpace(odl.rn(1), odl.rn(2))
 
     x1 = H[0].element([0])
@@ -536,7 +536,7 @@ def test_vector_setitem_single():
         x[2] = x1
 
 
-def test_vector_setitem_slice():
+def test_element_setitem_slice():
     H = odl.ProductSpace(odl.rn(1), odl.rn(2), odl.rn(3))
 
     x1 = H[0].element([0])
@@ -551,7 +551,7 @@ def test_vector_setitem_slice():
     assert x[:2][1] is x2_new
 
 
-def test_vector_setitem_fancy():
+def test_element_setitem_fancy():
     H = odl.ProductSpace(odl.rn(1), odl.rn(2), odl.rn(3))
 
     x1 = H[0].element([0])

--- a/test/tomo/backends/astra_setup_test.py
+++ b/test/tomo/backends/astra_setup_test.py
@@ -358,7 +358,7 @@ def test_astra_algorithm():
 
 
 def test_geom_to_vec():
-    """Create ASTRA projection geometries vectors using ODL geometries."""
+    """Create ASTRA projection geometry vectors using ODL geometries."""
 
     apart = odl.uniform_partition(0, 2 * np.pi, 5)
     dpart = odl.uniform_partition(-40, 40, 10)


### PR DESCRIPTION
Besides variable names, the following classes have been renamed:

- `LinearSpaceVector` -> `LinearSpaceElement`
- `DiscreteLpVector` -> `DiscreteLpElement`
- `ProductSpaceVector` -> `ProductSpaceElement`
- `DiscretizedSetVector` -> `DiscretizedSetElement`
- `DiscretizedSpaceVector` -> `DiscretizedSpaceElement`
- `FunctionSetVector` -> `FunctionSetElement`
- `FunctionSpaceVector` -> `FunctionSpaceElement`

The other `Vector` classes were kept, they refer to structures which are one-dimensional tuples of data, so the vector notion is more suitable there. Also the term "vector multiplication" in contrast to "scalar multiplication" is untouched by this PR.