### PR TITLE
TST: add pywt and pyfftw to installed packages on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,9 @@ python:
 install:
   - sudo apt-get update
 
+  # Install FFTW for pyFFTW
+  - sudo apt-get install libfftw3-dev
+
   # Install LaTeX to render the math formulas in the docs
   - if [[ "$TRAVIS_PYTHON_VERSION" == "3.5" && "$TRAVIS_BRANCH" == "master" ]]; then
       sudo apt-get install texlive-latex-base texlive-latex-recommended texlive-latex-extra dvipng;
@@ -33,6 +36,10 @@ install:
 
   # Sphinx doc integration
   - pip install travis-sphinx
+
+  # Some packages which are only on PyPI, not on conda
+  - pip install pyfftw
+  - pip install pywavelets
 
   # Install our package
   - pip install -e .


### PR DESCRIPTION
My suggestion to get better (honest) test coverage. The test times don't go up significantly.

Question on the side, while we're at it: Travis now tests building the doc for every build with Python 3.5, which takes about 3 minutes alone. Since we seldom make changes to the doc infrastructure that break it, I could imagine doing that build only on the `master` branch, i.e. when PRs are merged or when someone pushes to `master` directly. This behavior is currently only realized for the "deploy" part of that building process.