### PR TITLE
TST: avoid random failures in functional tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,6 +81,7 @@ target/
 .spyproject/
 .spyderproject
 .spyderworkspace
+.spyproject/
 
 # PyCharm project files
 .idea

--- a/odl/operator/operator.py
+++ b/odl/operator/operator.py
@@ -1062,21 +1062,22 @@ class OperatorSum(Operator):
         rn(3).element([2.0, 4.0, 6.0])
         """
         if left.range != right.range:
-            raise TypeError('operator ranges {!r} and {!r} do not match'
-                            ''.format(left.range, right.range))
+            raise OpTypeError('operator ranges {!r} and {!r} do not match'
+                              ''.format(left.range, right.range))
         if not isinstance(left.range, (LinearSpace, Field)):
-            raise TypeError('`left.range` {!r} not a `LinearSpace` or `Field` '
-                            'instance'.format(left.range))
+            raise OpTypeError('`left.range` {!r} not a `LinearSpace` or '
+                              '`Field` instance'.format(left.range))
         if left.domain != right.domain:
-            raise TypeError('operator domains {!r} and {!r} do not match'
-                            ''.format(left.domain, right.domain))
+            raise OpTypeError('operator domains {!r} and {!r} do not match'
+                              ''.format(left.domain, right.domain))
 
         if tmp_ran is not None and tmp_ran not in left.range:
-            raise TypeError('`tmp_ran` {!r} not an element of the operator '
-                            'range {!r}'.format(tmp_ran, left.range))
+            raise OpRangeError('`tmp_ran` {!r} not an element of the operator '
+                               'range {!r}'.format(tmp_ran, left.range))
         if tmp_dom is not None and tmp_dom not in left.domain:
-            raise TypeError('`tmp_dom` {!r} not an element of the operator '
-                            'domain {!r}'.format(tmp_dom, left.domain))
+            raise OpDomainError('`tmp_dom` {!r} not an element of the '
+                                'operator domain {!r}'
+                                ''.format(tmp_dom, left.domain))
 
         super().__init__(left.domain, left.range,
                          linear=left.is_linear and right.is_linear)
@@ -1270,14 +1271,16 @@ class OperatorComp(Operator):
             operator.
         """
         if right.range != left.domain:
-            raise TypeError('`range` {!r} of the right operator {!r} not equal'
-                            ' to the domain {!r} of the left operator {!r}'
-                            ''.format(right.range, right,
-                                      left.domain, left))
+            raise OpTypeError('`range` {!r} of the right operator {!r} not '
+                              'equal to the domain {!r} of the left '
+                              'operator {!r}'
+                              ''.format(right.range, right,
+                                        left.domain, left))
 
         if tmp is not None and tmp not in left.domain:
-            raise TypeError('`tmp` {!r} not an element of the left '
-                            'operator domain {!r}'.format(tmp, left.domain))
+            raise OpDomainError('`tmp` {!r} not an element of the left '
+                                'operator domain {!r}'
+                                ''.format(tmp, left.domain))
 
         super().__init__(right.domain, left.range,
                          linear=left.is_linear and right.is_linear)
@@ -1393,14 +1396,14 @@ class OperatorPointwiseProduct(Operator):
             ``left``.
         """
         if left.range != right.range:
-            raise TypeError('operator ranges {!r} and {!r} do not match'
-                            ''.format(left.range, right.range))
+            raise OpTypeError('operator ranges {!r} and {!r} do not match'
+                              ''.format(left.range, right.range))
         if not isinstance(left.range, (LinearSpace, Field)):
-            raise TypeError('range {!r} not a `LinearSpace` or `Field` '
-                            'instance'.format(left.range))
+            raise OpTypeError('range {!r} not a `LinearSpace` or `Field` '
+                              'instance'.format(left.range))
         if left.domain != right.domain:
-            raise TypeError('operator domains {!r} and {!r} do not match'
-                            ''.format(left.domain, right.domain))
+            raise OpTypeError('operator domains {!r} and {!r} do not match'
+                              ''.format(left.domain, right.domain))
 
         super().__init__(left.domain, left.range, linear=False)
         self.__left = left
@@ -1468,8 +1471,8 @@ class OperatorLeftScalarMult(Operator):
         rn(3).element([3.0, 6.0, 9.0])
         """
         if not isinstance(operator.range, (LinearSpace, Field)):
-            raise TypeError('range {!r} not a `LinearSpace` or `Field` '
-                            'instance'.format(operator.range))
+            raise OpTypeError('range {!r} not a `LinearSpace` or `Field` '
+                              'instance'.format(operator.range))
 
         if scalar not in operator.range.field:
             raise TypeError('`scalar` {!r} not in the field {!r} of the '
@@ -1644,8 +1647,8 @@ class OperatorRightScalarMult(Operator):
         rn(3).element([3.0, 6.0, 9.0])
         """
         if not isinstance(operator.domain, (LinearSpace, Field)):
-            raise TypeError('domain {!r} not a `LinearSpace` or `Field` '
-                            'instance'.format(operator.domain))
+            raise OpTypeError('domain {!r} not a `LinearSpace` or `Field` '
+                              'instance'.format(operator.domain))
 
         if scalar not in operator.domain.field:
             raise TypeError('`scalar` {!r} not in the field {!r} of the '
@@ -1654,9 +1657,9 @@ class OperatorRightScalarMult(Operator):
                                       operator.domain))
 
         if tmp is not None and tmp not in operator.domain:
-            raise TypeError('`tmp` {!r} not an element of the '
-                            'operator domain {!r}'
-                            ''.format(tmp, operator.domain))
+            raise OpDomainError('`tmp` {!r} not an element of the '
+                                'operator domain {!r}'
+                                ''.format(tmp, operator.domain))
 
         super().__init__(operator.domain, operator.range, operator.is_linear)
         self.__operator = operator
@@ -1829,8 +1832,8 @@ class FunctionalLeftVectorMult(Operator):
                             ''.format(vector))
 
         if functional.range != vector.space.field:
-            raise TypeError('range {!r} not is not vector.space.field {!r}'
-                            ''.format(functional.range, vector.space.field))
+            raise OpTypeError('range {!r} not is not vector.space.field {!r}'
+                              ''.format(functional.range, vector.space.field))
 
         super().__init__(functional.domain, vector.space,
                          linear=functional.is_linear)
@@ -1920,8 +1923,8 @@ class OperatorLeftVectorMult(Operator):
             The vector to multiply by
         """
         if vector not in operator.range:
-            raise TypeError('`vector` {!r} not in operator.range {!r}'
-                            ''.format(vector, operator.range))
+            raise OpRangeError('`vector` {!r} not in operator.range {!r}'
+                               ''.format(vector, operator.range))
 
         super().__init__(operator.domain, operator.range,
                          linear=operator.is_linear)
@@ -2033,8 +2036,8 @@ class OperatorRightVectorMult(Operator):
                             ''.format(operator))
 
         if vector not in operator.domain:
-            raise TypeError('`vector` {!r} not in operator.domain {!r}'
-                            ''.format(vector.space, operator.domain))
+            raise OpDomainError('`vector` {!r} not in operator.domain {!r}'
+                                ''.format(vector.space, operator.domain))
 
         super().__init__(operator.domain, operator.range,
                          linear=operator.is_linear)

--- a/odl/solvers/functional/functional.py
+++ b/odl/solvers/functional/functional.py
@@ -780,7 +780,7 @@ class FunctionalTranslation(Functional):
 
         See Also
         --------
-        odl.solvers.advanced.proximal_operators.proximal_translation
+        odl.solvers.nonsmooth.proximal_operators.proximal_translation
         """
         return proximal_translation(self.functional.proximal,
                                     self.translation)
@@ -848,7 +848,8 @@ class FunctionalLinearPerturb(Functional):
 
         See Also
         --------
-        odl.solvers.advanced.proximal_operators.proximal_quadratic_perturbation
+        odl.solvers.nonsmooth.proximal_operators.\
+proximal_quadratic_perturbation
         """
         return proximal_quadratic_perturbation(
             self.functional.proximal, a=0, u=self.linear_term)

--- a/odl/solvers/nonsmooth/proximal_operators.py
+++ b/odl/solvers/nonsmooth/proximal_operators.py
@@ -77,8 +77,8 @@ def combine_proximals(*factory_list):
         (\mathrm{prox}_{\\sigma F}(x), \mathrm{prox}_{\\sigma G}(y)).
     """
 
-    def make_diag(sigma):
-        """Diagonal matrix of operators
+    def diag_op_factory(sigma):
+        """Diagonal matrix of operators.
 
         Parameters
         ----------
@@ -92,7 +92,7 @@ def combine_proximals(*factory_list):
         return DiagonalOperator(
             *[factory(sigma) for factory in factory_list])
 
-    return make_diag
+    return diag_op_factory
 
 
 def proximal_cconj(prox_factory):
@@ -146,6 +146,7 @@ def proximal_cconj(prox_factory):
         proximal : `Operator`
             The proximal operator of ``s * F^*`` where ``s`` is the step size
         """
+        sigma = float(sigma)
         prox_other = (sigma * prox_factory(1.0 / sigma) * (1.0 / sigma))
         return IdentityOperator(prox_other.domain) - prox_other
 

--- a/odl/test/discr/diff_ops_test.py
+++ b/odl/test/discr/diff_ops_test.py
@@ -287,6 +287,8 @@ def test_part_deriv(space, method, padding):
 def test_gradient(space, method, padding):
     """Discretized spatial gradient operator."""
 
+    places = 2 if space.dtype == np.float32 else 4
+
     with pytest.raises(TypeError):
         Gradient(odl.rn(1), method=method)
 
@@ -325,7 +327,7 @@ def test_gradient(space, method, padding):
     # Check not to use trivial data
     assert lhs != 0
     assert rhs != 0
-    assert almost_equal(lhs, rhs, places=4)
+    assert almost_equal(lhs, rhs, places=places)
 
     # higher dimensional arrays
     lin_size = 3

--- a/odl/test/operator/operator_test.py
+++ b/odl/test/operator/operator_test.py
@@ -33,7 +33,7 @@ from odl import (Operator, OperatorSum, OperatorComp,
                  OperatorLeftScalarMult, OperatorRightScalarMult,
                  FunctionalLeftVectorMult, OperatorRightVectorMult,
                  MatVecOperator, OperatorLeftVectorMult,
-                 OpDomainError, OpRangeError)
+                 OpTypeError, OpDomainError, OpRangeError)
 from odl.operator.operator import _signature_from_spec, _dispatch_call_args
 from odl.util.testutils import almost_equal, all_almost_equal
 
@@ -111,7 +111,7 @@ def test_nonlinear_addition():
     C = np.random.rand(4, 4)
     Cop = MultiplyAndSquareOp(C)
 
-    with pytest.raises(TypeError):
+    with pytest.raises(OpTypeError):
         C = OperatorSum(Aop, Cop)
 
 
@@ -196,7 +196,7 @@ def test_nonlinear_composition():
     evaluate(C, xvec, mult_sq_np(A, mult_sq_np(B, x)))
 
     # Verify that incorrect order fails
-    with pytest.raises(TypeError):
+    with pytest.raises(OpTypeError):
         C = OperatorComp(Bop, Aop)
 
 
@@ -377,7 +377,7 @@ def test_type_errors():
     Aop(r3Vec1, r3Vec2)
     Aop.adjoint(r3Vec1, r3Vec2)
 
-    # Test that erroneous usage raises TypeError
+    # Test that erroneous usage raises
     with pytest.raises(OpDomainError):
         Aop(r4Vec1)
 
@@ -836,4 +836,4 @@ def test_dispatch_call_args_class():
         _dispatch_call_args(cls=WithClassMethod)
 
 if __name__ == '__main__':
-    pytest.main(str(__file__.replace('\\', '/')) + ' -v')
+    pytest.main(str(__file__.replace('\\', '/')), ' -v')

--- a/odl/test/solvers/functional/functional_test.py
+++ b/odl/test/solvers/functional/functional_test.py
@@ -28,6 +28,7 @@ import pytest
 
 # Internal
 import odl
+from odl.operator import OpTypeError
 from odl.util.testutils import all_almost_equal, almost_equal, noise_element
 from odl.solvers.functional.default_functionals import (
     KullbackLeiblerConvexConj)
@@ -35,10 +36,32 @@ from odl.solvers.functional.default_functionals import (
 
 # TODO: maybe add tests for if translations etc. belongs to the wrong space.
 # These tests doesn't work as intended now, since casting is possible between
-# spaces with the same number of discrete points.
+# spaces with the same number of discretization points.
+
+
+# --- pytest fixtures --- #
+
+
+scalar_params = [0.01, 2.7, 10, -2, -0.2, -7.1, 0]
+scalar_ids = [' scalar={} '.format(s) for s in scalar_params]
+
+
+@pytest.fixture(scope='module', params=scalar_params, ids=scalar_ids)
+def scalar(request):
+    return request.param
+
 
 space_params = ['r10', 'uniform_discr']
-space_ids = [' space = {} '.format(p.ljust(13)) for p in space_params]
+space_ids = [' space = {} '.format(p) for p in space_params]
+
+
+sigma_params = [0.001, 2.7, np.array(0.5), 10]
+sigma_ids = [' sigma={} '.format(s) for s in sigma_params]
+
+
+@pytest.fixture(scope='module', params=sigma_params, ids=sigma_ids)
+def sigma(request):
+    return request.param
 
 
 @pytest.fixture(scope="module", ids=space_ids, params=space_params)
@@ -103,6 +126,9 @@ def functional(request, space):
     return func
 
 
+# --- functional tests --- #
+
+
 def test_derivative(functional, space):
     """Test for the derivative of a functional.
 
@@ -130,7 +156,7 @@ def test_derivative(functional, space):
         x = x - x.ufunc.max() + 0.99
         y = y - y.ufunc.max() + 0.99
 
-    # Compute step size according to dtype of space
+    # Compute a "small" step size according to dtype of space
     step = float(np.sqrt(np.finfo(space.dtype).eps))
 
     # Numerical test of gradient, only low accuracy can be guaranteed.
@@ -167,236 +193,260 @@ def test_arithmetic():
     assert (functional * y)(x) == functional(y * x)
 
 
-def test_left_scalar_multiplication(space):
+def test_left_scalar_mult(space, scalar):
     """Test for right and left multiplication of a functional with a scalar."""
+    # Less strict checking for single precision
+    places = 3 if space.dtype == np.float32 else 5
+
     x = noise_element(space)
+    func = odl.solvers.functional.L2Norm(space)
+    lmul_func = scalar * func
 
-    scal = np.random.standard_normal()
-    F = odl.solvers.functional.L2Norm(space)
+    if scalar == 0:
+        assert isinstance(scalar * func, odl.solvers.ZeroFunctional)
+        return
 
-    # Evaluation of left scalar multiplication
-    assert all_almost_equal((scal * F)(x), scal * (F(x)))
+    # Test functional evaluation
+    assert almost_equal(lmul_func(x), scalar * func(x), places=places)
 
     # Test gradient of left scalar multiplication
-    assert all_almost_equal((scal * F).gradient(x), scal * (F.gradient(x)))
+    assert all_almost_equal(lmul_func.gradient(x), scalar * func.gradient(x),
+                            places=places)
 
     # Test derivative of left scalar multiplication
     p = noise_element(space)
-    assert all_almost_equal(((scal * F).derivative(x))(p),
-                            scal * ((F.derivative(x))(p)))
+    assert all_almost_equal(lmul_func.derivative(x)(p),
+                            scalar * (func.derivative(x))(p),
+                            places=places)
 
-    # Test conjugate functional. This requiers positive scaling to work
-    scal = np.random.rand()
-    neg_scal = -np.random.rand()
+    # Test convex conjugate. This requires positive scaling to work
+    pos_scalar = abs(scalar)
+    neg_scalar = -pos_scalar
 
     with pytest.raises(ValueError):
-        (neg_scal * F).convex_conj
+        (neg_scalar * func).convex_conj
 
-    assert all_almost_equal((scal * F).convex_conj(x),
-                            scal * (F.convex_conj(x / scal)))
+    assert all_almost_equal((pos_scalar * func).convex_conj(x),
+                            pos_scalar * func.convex_conj(x / pos_scalar),
+                            places=places)
 
-    # Test proximal operator. This requiers scaling to be positive.
-    sigma = 1.0
+    # Test proximal operator. This requires scaling to be positive.
+    sigma = 1.2
     with pytest.raises(ValueError):
-        (neg_scal * F).proximal(sigma)
+        (neg_scalar * func).proximal(sigma)
 
-    sigma = np.random.rand()
-    assert all_almost_equal(((scal * F).proximal(sigma))(x),
-                            (F.proximal(sigma * scal))(x))
-
-    # Test left multiplication with zero
-    assert isinstance(0 * F, odl.solvers.ZeroFunctional)
+    assert all_almost_equal((pos_scalar * func).proximal(sigma)(x),
+                            func.proximal(sigma * pos_scalar)(x))
 
 
-def test_right_scalar_multiplication(space):
+def test_right_scalar_mult(space, scalar):
     """Test for right and left multiplication of a functional with a scalar."""
+    # Less strict checking for single precision
+    places = 3 if space.dtype == np.float32 else 5
+
     x = noise_element(space)
+    func = odl.solvers.functional.L2NormSquared(space)
+    rmul_func = func * scalar
 
-    scal = np.random.standard_normal()
-    F = odl.solvers.functional.L2NormSquared(space)
+    if scalar == 0:
+        # expecting the constant functional x -> func(0)
+        assert isinstance(rmul_func, odl.solvers.ConstantFunctional)
+        assert all_almost_equal(rmul_func(x), func(space.zero()),
+                                places=places)
+        # Nothing more to do, rest is part of ConstantFunctional test
+        return
 
-    # Evaluation of right scalar multiplication
-    assert all_almost_equal((F * scal)(x), (F)(scal * x))
+    # Test functional evaluation
+    assert almost_equal(rmul_func(x), func(scalar * x), places=places)
 
     # Test gradient of right scalar multiplication
-    assert all_almost_equal((F * scal).gradient(x),
-                            scal * (F.gradient(scal * x)))
+    assert all_almost_equal(rmul_func.gradient(x),
+                            scalar * func.gradient(scalar * x),
+                            places=places)
 
     # Test derivative of right scalar multiplication
     p = noise_element(space)
-    assert all_almost_equal(((F * scal).derivative(x))(p),
-                            scal * (F.derivative(scal * x))(p))
+    assert all_almost_equal(rmul_func.derivative(x)(p),
+                            scalar * func.derivative(scalar * x)(p),
+                            places=places)
 
-    # Test conjugate functional: positive, negative and zero scalar
-    scal = np.random.rand()
-    assert all_almost_equal((F * scal).convex_conj(x),
-                            (F.convex_conj(x / scal)))
+    # Test convex conjugate conjugate
+    assert all_almost_equal(rmul_func.convex_conj(x),
+                            func.convex_conj(x / scalar),
+                            places=places)
 
-    neg_scal = -np.random.rand()
-    assert all_almost_equal((F * neg_scal).convex_conj(x),
-                            (F.convex_conj(x / neg_scal)))
+    # Test proximal operator
+    sigma = 1.2
+    assert all_almost_equal(
+        rmul_func.proximal(sigma)(x),
+        (1.0 / scalar) * func.proximal(sigma * scalar ** 2)(x * scalar),
+        places=places)
 
-    assert isinstance((F * 0), odl.solvers.ConstantFunctional)
-    assert almost_equal((F * 0)(x), F(space.zero()))
-
-    # Test proximal operator: positive, negative and zero scalar
-    sigma = np.random.rand()
-    assert all_almost_equal(((F * scal).proximal(sigma))(x),
-                            ((1.0 / scal) * F.proximal(
-                                sigma * scal**2))(x * scal))
-
-    assert all_almost_equal(((F * neg_scal).proximal(sigma))(x),
-                            ((1.0 / neg_scal) * F.proximal(
-                                sigma * neg_scal**2))(x * neg_scal))
-
-    # The proximal operator of a constant functional is the identity operator
-    assert isinstance((F * 0).proximal(sigma), odl.IdentityOperator)
-
-    # Test that for linear functionals, left multiplication is used.
+    # Verify that for linear functionals, left multiplication is used.
     func = odl.solvers.ZeroFunctional(space)
-    assert isinstance(func * scal, odl.solvers.FunctionalLeftScalarMult)
+    assert isinstance(func * scalar, odl.solvers.FunctionalLeftScalarMult)
 
 
 def test_functional_composition(space):
     """Test composition from the right with an operator."""
+    # Less strict checking for single precision
+    places = 3 if space.dtype == np.float32 else 5
+
     func = odl.solvers.L2NormSquared(space)
 
-    # Test composition with operator from the right
-    scalar = np.random.rand()
+    # Verify that an error is raised if an invalid operator is used
+    # (e.g. wrong range)
+    scalar = 2.1
     wrong_space = odl.uniform_discr(1, 2, 10)
     op_wrong = odl.operator.ScalingOperator(wrong_space, scalar)
 
-    with pytest.raises(TypeError):
+    with pytest.raises(OpTypeError):
         func * op_wrong
 
+    # Test composition with operator from the right
     op = odl.operator.ScalingOperator(space, scalar)
-    assert isinstance(func * op, odl.solvers.Functional)
+    func_op_comp = func * op
+    assert isinstance(func_op_comp, odl.solvers.Functional)
 
     x = noise_element(space)
-    assert almost_equal((func * op)(x), func(op(x)))
+    assert almost_equal(func_op_comp(x), func(op(x)), places=places)
 
     # Test gradient and derivative with composition from the right
-    assert all_almost_equal(((func * op).gradient)(x),
-                            (op.adjoint * func.gradient * op)(x))
+    assert all_almost_equal(func_op_comp.gradient(x),
+                            (op.adjoint * func.gradient * op)(x),
+                            places=places)
 
     p = noise_element(space)
-    assert all_almost_equal((func * op).derivative(x)(p),
-                            (op.adjoint * func.gradient * op)(x).inner(p))
+    assert all_almost_equal(func_op_comp.derivative(x)(p),
+                            (op.adjoint * func.gradient * op)(x).inner(p),
+                            places=places)
 
 
 def test_functional_sum(space):
     """Test for the sum of two functionals."""
+    # Less strict checking for single precision
+    places = 3 if space.dtype == np.float32 else 5
+
     func1 = odl.solvers.L2NormSquared(space)
     func2 = odl.solvers.L2Norm(space)
 
-    # Test for sum where one is not a functional
+    # Verify that an error is raised if one operand is "wrong"
     op = odl.operator.IdentityOperator(space)
-    with pytest.raises(TypeError):
+    with pytest.raises(OpTypeError):
         func1 + op
 
-    # Test for different domain of the functionals
     wrong_space = odl.uniform_discr(1, 2, 10)
     func_wrong_domain = odl.solvers.L2Norm(wrong_space)
-    with pytest.raises(TypeError):
+    with pytest.raises(OpTypeError):
         func1 + func_wrong_domain
 
+    func_sum = func1 + func2
     x = noise_element(space)
     p = noise_element(space)
 
-    # Test evaluation of the functionals
-    assert almost_equal((func1 + func2)(x),
-                        func1(x) + func2(x))
+    # Test functional evaluation
+    assert almost_equal(func_sum(x), func1(x) + func2(x), places=places)
 
-    # Test for the gradient and derivative
-    assert all_almost_equal((func1 + func2).gradient(x),
-                            func1.gradient(x) + func2.gradient(x))
+    # Test gradient and derivative
+    assert all_almost_equal(func_sum.gradient(x),
+                            func1.gradient(x) + func2.gradient(x),
+                            places=places)
 
-    assert almost_equal((func1 + func2).derivative(x)(p),
-                        (func1.gradient(x).inner(p) +
-                            func2.gradient(x).inner(p)))
+    assert almost_equal(
+        func_sum.derivative(x)(p),
+        func1.gradient(x).inner(p) + func2.gradient(x).inner(p),
+        places=places)
 
-    # Test that prox is not known
+    # Verify that proximal raises
     with pytest.raises(NotImplementedError):
-        (func1 + func2).proximal
+        func_sum.proximal
 
-    # Test that we cannot evaluate the convex conjugate
+    # Test the convex conjugate raises
     with pytest.raises(NotImplementedError):
-        (func1 + func2).convex_conj(x)
+        func_sum.convex_conj(x)
 
 
 def test_functional_plus_scalar(space):
     """Test for sum of functioanl and scalar."""
+    # Less strict checking for single precision
+    places = 3 if space.dtype == np.float32 else 5
+
     func = odl.solvers.L2NormSquared(space)
-    scalar = np.random.randn()
+    scalar = -1.3
 
     # Test for scalar not in the field (field of unifor_discr is RealNumbers)
     complex_scalar = 1j
     with pytest.raises(TypeError):
         func + complex_scalar
 
+    func_scalar_sum = func + scalar
     x = noise_element(space)
     p = noise_element(space)
 
     # Test for evaluation
-    assert almost_equal((func + scalar)(x), func(x) + scalar)
+    assert almost_equal(func_scalar_sum(x), func(x) + scalar, places=places)
 
     # Test for derivative and gradient
-    assert all_almost_equal((func + scalar).gradient(x),
-                            func.gradient(x))
+    assert all_almost_equal(func_scalar_sum.gradient(x), func.gradient(x),
+                            places=places)
 
-    assert almost_equal((func + scalar).derivative(x)(p),
-                        func.gradient(x).inner(p))
+    assert almost_equal(func_scalar_sum.derivative(x)(p),
+                        func.gradient(x).inner(p),
+                        places=places)
 
     # Test proximal operator
-    sigma = np.random.rand()
-    assert all_almost_equal((func + scalar).proximal(sigma)(x),
-                            func.proximal(sigma)(x))
+    sigma = 1.2
+    assert all_almost_equal(func_scalar_sum.proximal(sigma)(x),
+                            func.proximal(sigma)(x),
+                            places=places)
 
     # Test convex conjugate functional
-    assert almost_equal((func + scalar).convex_conj(x),
-                        func.convex_conj(x) - scalar)
+    assert almost_equal(func_scalar_sum.convex_conj(x),
+                        func.convex_conj(x) - scalar,
+                        places=places)
 
-    assert all_almost_equal((func + scalar).convex_conj.gradient(x),
-                            func.convex_conj.gradient(x))
+    assert all_almost_equal(func_scalar_sum.convex_conj.gradient(x),
+                            func.convex_conj.gradient(x),
+                            places=places)
 
 
 def test_translation_of_functional(space):
-    """Test for the translation of a functional: (f(. - y))^*"""
+    """Test for the translation of a functional: (f(. - y))^*."""
+    # Less strict checking for single precision
+    places = 3 if space.dtype == np.float32 else 5
+
     # The translation; an element in the domain
     translation = noise_element(space)
 
-    # Creating the functional ||x||_2^2
     test_functional = odl.solvers.L2NormSquared(space)
-
-    # Create translated functional
     translated_functional = test_functional.translated(translation)
-
-    # Create an element in the space, in which to evaluate
     x = noise_element(space)
 
     # Test for evaluation of the functional
     expected_result = test_functional(x - translation)
-    assert all_almost_equal(translated_functional(x), expected_result)
+    assert all_almost_equal(translated_functional(x), expected_result,
+                            places=places)
 
     # Test for the gradient
     expected_result = test_functional.gradient(x - translation)
     translated_gradient = translated_functional.gradient
-    assert all_almost_equal(translated_gradient(x), expected_result)
+    assert all_almost_equal(translated_gradient(x), expected_result,
+                            places=places)
 
     # Test for proximal
-    sigma = np.random.rand()
+    sigma = 1.2
     # The helper function below is tested explicitly in proximal_utils_test
     expected_result = odl.solvers.proximal_translation(
         test_functional.proximal, translation)(sigma)(x)
     assert all_almost_equal(translated_functional.proximal(sigma)(x),
-                            expected_result)
+                            expected_result, places=places)
 
     # Test for conjugate functional
     # The helper function below is tested explicitly further down in this file
     expected_result = odl.solvers.FunctionalLinearPerturb(
         test_functional.convex_conj, translation)(x)
     assert all_almost_equal(translated_functional.convex_conj(x),
-                            expected_result)
+                            expected_result, places=places)
 
     # Test for derivative in direction p
     p = noise_element(space)
@@ -404,7 +454,7 @@ def test_translation_of_functional(space):
     # Explicit computation in point x, in direction p: <x/2 + translation, p>
     expected_result = p.inner(test_functional.gradient(x - translation))
     assert all_almost_equal(translated_functional.derivative(x)(p),
-                            expected_result)
+                            expected_result, places=places)
 
     # Test for optimized implementation, when translating a translated
     # functional
@@ -414,11 +464,15 @@ def test_translation_of_functional(space):
 
     # Evaluation
     assert almost_equal(double_translated_functional(x),
-                        test_functional(x - translation - second_translation))
+                        test_functional(x - translation - second_translation),
+                        places=places)
 
 
 def test_multiplication_with_vector(space):
     """Test for multiplying a functional with a vector, both left and right."""
+    # Less strict checking for single precision
+    places = 3 if space.dtype == np.float32 else 5
+
     x = noise_element(space)
     y = noise_element(space)
     func = odl.solvers.L2NormSquared(space)
@@ -432,18 +486,19 @@ def test_multiplication_with_vector(space):
     assert isinstance(func_times_y, odl.solvers.FunctionalRightVectorMult)
 
     expected_result = func(y * x)
-    assert almost_equal(func_times_y(x), expected_result)
+    assert almost_equal(func_times_y(x), expected_result, places=places)
 
     # Test for the gradient.
     # Explicit calculations: 2*y*y*x
     expected_result = 2.0 * y * y * x
-    assert all_almost_equal(func_times_y.gradient(x), expected_result)
+    assert all_almost_equal(func_times_y.gradient(x), expected_result,
+                            places=places)
 
     # Test for convex_conj
     cc_func_times_y = func_times_y.convex_conj
     # Explicit calculations: 1/4 * ||x/y||_2^2
     expected_result = 1.0 / 4.0 * (x / y).norm()**2
-    assert almost_equal(cc_func_times_y(x), expected_result)
+    assert almost_equal(cc_func_times_y(x), expected_result, places=places)
 
     # Make sure that right muliplication is not allowed with vector from
     # another space
@@ -455,7 +510,7 @@ def test_multiplication_with_vector(space):
     assert isinstance(y_times_func, odl.FunctionalLeftVectorMult)
 
     expected_result = y * func(x)
-    assert all_almost_equal(y_times_func(x), expected_result)
+    assert all_almost_equal(y_times_func(x), expected_result, places=places)
 
     # Now, multiplication with vector from another space is ok (since it is the
     # same as scaling that vector with the scalar returned by the functional).
@@ -463,11 +518,15 @@ def test_multiplication_with_vector(space):
     assert isinstance(y_other_times_func, odl.FunctionalLeftVectorMult)
 
     expected_result = y_other_space * func(x)
-    assert all_almost_equal(y_other_times_func(x), expected_result)
+    assert all_almost_equal(y_other_times_func(x), expected_result,
+                            places=places)
 
 
 def test_functional_linear_perturb(space):
     """Test for the functional f(.) + <y, .>."""
+    # Less strict checking for single precision
+    places = 3 if space.dtype == np.float32 else 5
+
     # The translation; an element in the domain
     linear_term = noise_element(space)
 
@@ -479,31 +538,37 @@ def test_functional_linear_perturb(space):
     x = noise_element(space)
 
     # Test for evaluation of the functional
-    assert all_almost_equal(functional(x), x.norm()**2 + x.inner(linear_term))
+    assert all_almost_equal(functional(x), x.norm()**2 + x.inner(linear_term),
+                            places=places)
 
     # Test for the gradient
-    assert all_almost_equal(functional.gradient(x), 2.0 * x + linear_term)
+    assert all_almost_equal(functional.gradient(x), 2.0 * x + linear_term,
+                            places=places)
 
     # Test for derivative in direction p
     p = noise_element(space)
     assert all_almost_equal(functional.derivative(x)(p),
-                            p.inner(2 * x + linear_term))
+                            p.inner(2 * x + linear_term),
+                            places=places)
 
     # Test for the proximal operator
-    sigma = np.random.rand()
+    sigma = 1.2
     # Explicit computation gives (x - sigma * translation)/(2 * sigma + 1)
     expected_result = (x - sigma * linear_term) / (2.0 * sigma + 1.0)
-    assert all_almost_equal(functional.proximal(sigma)(x), expected_result)
+    assert all_almost_equal(functional.proximal(sigma)(x), expected_result,
+                            places=places)
 
     # Test convex conjugate functional
     assert almost_equal(functional.convex_conj(x),
-                        orig_func.convex_conj.translated(linear_term)(x))
+                        orig_func.convex_conj.translated(linear_term)(x),
+                        places=places)
 
     # Test proximal of the convex conjugate
     assert all_almost_equal(
         functional.convex_conj.proximal(sigma)(x),
-        orig_func.convex_conj.translated(linear_term).proximal(sigma)(x))
+        orig_func.convex_conj.translated(linear_term).proximal(sigma)(x),
+        places=places)
 
 
 if __name__ == '__main__':
-    pytest.main(str(__file__.replace('\\', '/')) + ' -v')
+    pytest.main(str(__file__.replace('\\', '/')), ' -v')


### PR DESCRIPTION
Using constants or fixtures for tests where scalar values matter. Random values are prone to lead to random failures (especially for `sigma` in proximals and exponent values).

While testing the final changes, I got another random failure in the `diff_ops_test`, which was, as usual, a too strict test for CUDA (i.e. single precision arithmetic). We should try to solve that problem in general in some elegant way.

Closes #622 