### PR TITLE
Issue 612  kullback leibler functionals

### DIFF
--- a/odl/solvers/functional/default_functionals.py
+++ b/odl/solvers/functional/default_functionals.py
@@ -612,7 +612,7 @@ class KullbackLeibler(Functional):
         ----------
         space : `DiscreteLp` or `FnBase`
             Domain of the functional.
-        prior : ``space`` element, optional
+        prior : ``space`` `element-like`, optional
             Data term, positive.
             Default: if None it is take as the one-element.
         """
@@ -711,8 +711,6 @@ class KullbackLeiblerConvexConj(Functional):
     where :math:`g` is the prior, and :math:`I_{1_X - x \geq 0}(x)` is the
     indicator function on :math:`x \leq 1`.
 
-    This is the convex conjugate functional of `KullbackLeibler`.
-
     See Also
     --------
     KullbackLeibler : convex conjugate functional
@@ -725,7 +723,7 @@ class KullbackLeiblerConvexConj(Functional):
         ----------
         space : `DiscreteLp` or `FnBase`
             Domain of the functional.
-        g : ``space`` element, optional
+        g : ``space`` `element-like`, optional
             Data term, positive.
             Default: if None it is take as the one-element.
         """
@@ -846,7 +844,7 @@ class KullbackLeiblerCrossEntropy(Functional):
         ----------
         space : `DiscreteLp` or `FnBase`
             Domain of the functional.
-        prior : ``space`` element, optional
+        prior : ``space`` `element-like`, optional
             Data term, positive.
             Default: if None it is take as the one-element.
         """
@@ -952,8 +950,6 @@ class KullbackLeiblerCrossEntropyConvexConj(Functional):
 
     where :math:`g` is the prior.
 
-    This is the convex conjugate functional of `KullbackLeiblerCrossEntropy`.
-
     See Also
     --------
     KullbackLeiblerCrossEntropy : convex conjugate functional
@@ -966,7 +962,7 @@ class KullbackLeiblerCrossEntropyConvexConj(Functional):
         ----------
         space : `DiscreteLp` or `FnBase`
             Domain of the functional.
-        g : ``space`` element, optional
+        g : ``space`` `element-like`, optional
             Data term, positive.
             Default: if None it is take as the one-element.
         """
@@ -992,6 +988,7 @@ class KullbackLeiblerCrossEntropyConvexConj(Functional):
             tmp = (self.prior * (np.exp(x) - 1)).inner(self.domain.one())
         return tmp
 
+    # TODO: replace this when UFuncOperators is in place: PL #576
     @property
     def gradient(self):
         """Gradient operator of the functional."""

--- a/odl/solvers/functional/default_functionals.py
+++ b/odl/solvers/functional/default_functionals.py
@@ -668,7 +668,7 @@ class KullbackLeibler(Functional):
                 if 0 in x:
                     # The derivative is not defined.
                     raise ValueError('The gradient of the Kullback-Leibler '
-                                     'functional is not defined for ´x´ with '
+                                     'functional is not defined for `x` with '
                                      'one or more components zero.'.format(x))
                 else:
                     if functional.prior is None:
@@ -788,7 +788,7 @@ class KullbackLeiblerConvexConj(Functional):
                 if 1.0 in x:
                     # The derivative is not defined.
                     raise ValueError('The gradient of the Kullback-Leibler '
-                                     'functional is not defined for ´x´ with '
+                                     'functional is not defined for `x` with '
                                      'one or more components one.'.format(x))
                 else:
                     if functional.prior is None:
@@ -881,9 +881,6 @@ class KullbackLeiblerCrossEntropy(Functional):
         else:
             return tmp
 
-    # TODO: note that the gradient should only be deinfed for x > 0 (since
-    # otherwise the functional is considered to be infinite). However, is there
-    # an efficient way to test this?
     @property
     def gradient(self):
         """Gradient operator of the functional.
@@ -917,7 +914,7 @@ class KullbackLeiblerCrossEntropy(Functional):
                     # The derivative is not defined.
                     raise ValueError('The gradient of the Kullback-Leibler '
                                      'Cross Entropy functional is not defined '
-                                     'for ´x´ with one or more components '
+                                     'for `x` with one or more components '
                                      'less than or equal to zero.'.format(x))
                 else:
                     return tmp

--- a/test/solvers/functional/default_functionals_test.py
+++ b/test/solvers/functional/default_functionals_test.py
@@ -25,7 +25,8 @@ import pytest
 # Internal
 import odl
 from odl.util.testutils import all_almost_equal, almost_equal, noise_element
-
+from odl.solvers.functional.default_functionals import (
+    KullbackLeiblerConvexConj, KullbackLeiblerCrossEntropyConvexConj)
 
 space_params = ['r10', 'uniform_discr']
 space_ids = [' space = {}'.format(p.ljust(10)) for p in space_params]
@@ -299,13 +300,13 @@ def test_kullback_leibler(space):
     """Test the kullback leibler functional and its convex conjugate."""
     # The prior needs to be positive
     prior = noise_element(space)
-    prior = prior.ufunc.absolute()
+    prior = np.abs(prior)
 
     func = odl.solvers.KullbackLeibler(space, prior)
 
     # The fucntional is only defined for positive elements
     x = noise_element(space)
-    x = x.ufunc.absolute()
+    x = np.abs(x)
     one_elem = space.one()
 
     # Evaluation of the functional
@@ -334,7 +335,7 @@ def test_kullback_leibler(space):
     # The convex conjugate functional
     cc_func = func.convex_conj
 
-    assert isinstance(cc_func, odl.solvers.KullbackLeiblerConvexConj)
+    assert isinstance(cc_func, KullbackLeiblerConvexConj)
 
     # The convex conjugate functional is only finite for elements with all
     # components smaller than 1.
@@ -369,13 +370,13 @@ def test_kullback_leibler_cross_entorpy(space):
     """Test the kullback leibler cross entropy and its convex conjugate."""
     # The prior needs to be positive
     prior = noise_element(space)
-    prior = prior.ufunc.absolute()
+    prior = np.abs(prior)
 
     func = odl.solvers.KullbackLeiblerCrossEntropy(space, prior)
 
     # The fucntional is only defined for positive elements
     x = noise_element(space)
-    x = x.ufunc.absolute()
+    x = np.abs(x)
     one_elem = space.one()
 
     # Evaluation of the functional
@@ -404,8 +405,7 @@ def test_kullback_leibler_cross_entorpy(space):
     # The convex conjugate functional
     cc_func = func.convex_conj
 
-    assert isinstance(cc_func,
-                      odl.solvers.KullbackLeiblerCrossEntropyConvexConj)
+    assert isinstance(cc_func, KullbackLeiblerCrossEntropyConvexConj)
 
     # The convex conjugate functional is defined for all values of x.
     x = noise_element(space)

--- a/test/solvers/functional/functional_test.py
+++ b/test/solvers/functional/functional_test.py
@@ -29,6 +29,8 @@ import pytest
 # Internal
 import odl
 from odl.util.testutils import all_almost_equal, almost_equal, noise_element
+from odl.solvers.functional.default_functionals import (
+    KullbackLeiblerConvexConj)
 
 
 # TODO: maybe add tests for if translations etc. belongs to the wrong space.
@@ -90,11 +92,11 @@ def functional(request, space):
     elif name == 'kl':
         func = odl.solvers.functional.KullbackLeibler(space)
     elif name == 'kl_cc':
-        func = odl.solvers.functional.KullbackLeiblerConvexConj(space)
+        func = odl.solvers.KullbackLeibler(space).convex_conj
     elif name == 'kl_cross_ent':
         func = odl.solvers.functional.KullbackLeiblerCrossEntropy(space)
     elif name == 'kl_cc_cross_ent':
-        func = odl.solvers.KullbackLeiblerCrossEntropyConvexConj(space)
+        func = odl.solvers.KullbackLeiblerCrossEntropy(space).convex_conj
     else:
         assert False
 
@@ -123,7 +125,7 @@ def test_derivative(functional, space):
         x = x.ufunc.absolute()
         y = y.ufunc.absolute()
 
-    if isinstance(functional, odl.solvers.KullbackLeiblerConvexConj):
+    if isinstance(functional, KullbackLeiblerConvexConj):
         # The functional is not defined for values >= 1
         x = x - x.ufunc.max() + 0.99
         y = y - y.ufunc.max() + 0.99

--- a/test/solvers/functional/functional_test.py
+++ b/test/solvers/functional/functional_test.py
@@ -52,7 +52,8 @@ def space(request, fn_impl):
 
 func_params = ['l1 ', 'l2', 'l2^2', 'constant', 'zero', 'ind_unit_ball_1',
                'ind_unit_ball_2', 'ind_unit_ball_pi', 'ind_unit_ball_inf',
-               'product', 'quotient', 'kl', 'kl_cc']
+               'product', 'quotient', 'kl', 'kl_cc', 'kl_cross_ent',
+               'kl_cc_cross_ent']
 func_ids = [' f = {} '.format(p.ljust(17)) for p in func_params]
 
 
@@ -90,6 +91,10 @@ def functional(request, space):
         func = odl.solvers.functional.KullbackLeibler(space)
     elif name == 'kl_cc':
         func = odl.solvers.functional.KullbackLeiblerConvexConj(space)
+    elif name == 'kl_cross_ent':
+        func = odl.solvers.functional.KullbackLeiblerCrossEntropy(space)
+    elif name == 'kl_cc_cross_ent':
+        func = odl.solvers.KullbackLeiblerCrossEntropyConvexConj(space)
     else:
         assert False
 
@@ -112,7 +117,8 @@ def test_derivative(functional, space):
     x = noise_element(functional.domain)
     y = noise_element(functional.domain)
 
-    if isinstance(functional, odl.solvers.KullbackLeibler):
+    if (isinstance(functional, odl.solvers.KullbackLeibler) or
+            isinstance(functional, odl.solvers.KullbackLeiblerCrossEntropy)):
         # The functional is not defined for values <= 0
         x = x.ufunc.absolute()
         y = y.ufunc.absolute()


### PR DESCRIPTION
This adds the kullback-leibler and the kullback-leibler corss entropy functionals. (Naming convention is taken in accordance with the previously implemented proximal operators).

It also implements the corresponding convex conjugate functionals. These are explicitly called `ConvexConjugate`, which have be criticized before in other functionals. However, I don't know what to call them: for me their "most basic property" is that they are the "convex conjugate functional"s of other, more well-known functionals. Any other suggestions for names?

Also: for kl the gradient is only defined for `x > 0`, since the const function is considered infinite for `x < 0`. However, the expression for the gradient makes sense as long as `0 no in x`. Is there an efficient way to test if all components of `x` are `> 0`? (similarly for kl convex conj, where I want to check that all components are `< 1`).