### PR TITLE
ENH: Add ordered subsets MLEM

### DIFF
--- a/odl/solvers/iterative/statistical.py
+++ b/odl/solvers/iterative/statistical.py
@@ -38,7 +38,7 @@ def mlem(op, x, data, niter=1, noise='poisson', callback=None, **kwargs):
 
         max_x L(x | data)
 
-    where ``L(x | data)`` is the likelihood of ``data`` given ``x``. The
+    where ``L(x | data)`` is the likelihood of ``x`` given ``data``. The
     likelihood depends on the forward operator ``op`` such that
     (approximately)::
 
@@ -109,7 +109,7 @@ def osmlem(op, x, data, niter=1, noise='poisson', callback=None, **kwargs):
 
         op[i](x) = data[i]
 
-    Where the precise form of *approximately* is determined by ``noise``.
+    where the precise form of *approximately* is determined by ``noise``.
 
     Parameters
     ----------

--- a/odl/solvers/iterative/statistical.py
+++ b/odl/solvers/iterative/statistical.py
@@ -24,13 +24,13 @@ standard_library.install_aliases()
 
 import numpy as np
 
-__all__ = ('mlem', 'loglikelihood')
+__all__ = ('mlem', 'osmlem', 'loglikelihood')
 
 
 AVAILABLE_MLEM_NOISE = ('poisson',)
 
 
-def mlem(op, x, data, niter=1, noise='poisson', callback=None):
+def mlem(op, x, data, niter=1, noise='poisson', callback=None, **kwargs):
 
     """Maximum Likelihood Expectation Maximation algorithm.
 
@@ -54,7 +54,7 @@ def mlem(op, x, data, niter=1, noise='poisson', callback=None):
         Vector to which the result is written. Its initial value is
         used as starting point of the iteration, and its values are
         updated in each iteration step.
-    data : ``op.range`` element
+    data : ``op.range`` `element-like`
         Right-hand side of the equation defining the inverse problem.
     niter : int, optional
         Number of iterations.
@@ -64,6 +64,13 @@ def mlem(op, x, data, niter=1, noise='poisson', callback=None):
         non-negative.
     callback : callable, optional
         Function called with the current iterate after each iteration.
+
+    Other Parameters
+    ----------------
+    sensitivities : float or ``op.domain`` `element-like`, optional
+        Usable with ``noise='poisson'``. The algorithm contains a ``A^T 1``
+        term, if this parameter is given, it is replaced by it.
+        Default: ``op.adjoint(op.range.one())``
 
     Notes
     -----
@@ -90,18 +97,28 @@ def mlem(op, x, data, niter=1, noise='poisson', callback=None):
     --------
     loglikelihood : Function for calculating the logarithm of the likelihood
     """
+    # TODO: Should this be call to osmlem?
+
     noise, noise_in = str(noise).lower(), noise
     if noise not in AVAILABLE_MLEM_NOISE:
         raise NotImplemented("noise '{}' not understood"
                              ''.format(noise_in))
 
+    # Convert data to range element
+    data = op.range.element(data)
+
     if noise == 'poisson':
+        # Parameter used to enforce positivity.
+        # TODO: let users give this.
+        eps = 1e-8
+
         if np.any(np.less(x, 0)):
             raise ValueError('`x` must be non-negative')
 
-        eps = 1e-8
+        sensitivities = kwargs.pop('sensitivities', None)
+        if sensitivities is None:
+            sensitivities = np.maximum(op.adjoint(op.range.one()), eps)
 
-        norm = np.maximum(op.adjoint(op.range.one()), eps)
         tmp_dom = op.domain.element()
         tmp_ran = op.range.element()
 
@@ -111,12 +128,137 @@ def mlem(op, x, data, niter=1, noise='poisson', callback=None):
             data.divide(tmp_ran, out=tmp_ran)
 
             op.adjoint(tmp_ran, out=tmp_dom)
-            tmp_dom /= norm
+            tmp_dom /= sensitivities
 
             x *= tmp_dom
 
             if callback is not None:
                 callback(x)
+    else:
+        raise RuntimeError('unknown noise model')
+
+
+def osmlem(op, x, data, niter=1, noise='poisson', callback=None, **kwargs):
+    """Ordered Subsets Maximum Likelihood Expectation Maximation algorithm.
+
+    Attempts to solve::
+
+        max_x L(data | x)
+
+    where ``L(data, | x)`` is the likelihood of ``data`` given ``x``. The
+    likelihood depends on the forward operators ``op[0], ..., op[n-1]`` such
+    that (approximately)::
+
+        op[i](x) = data[i]
+
+    With the precise form of *approximately* is determined by ``noise``.
+
+    Parameters
+    ----------
+    op : sequence of `Operator`
+        Forward operators in the inverse problem.
+    x : ``op.domain`` element
+        Vector to which the result is written. Its initial value is
+        used as starting point of the iteration, and its values are
+        updated in each iteration step.
+    data : sequence of ``op.range`` `element-like`
+        Right-hand sides of the equation defining the inverse problem.
+    niter : int, optional
+        Number of iterations.
+    noise : {'poisson'}, optional
+        Noise model determining the variant of MLEM.
+        For ``'poisson'``, the initial value of ``x`` should be
+        non-negative.
+    callback : callable, optional
+        Function called with the current iterate after each iteration.
+
+    Other Parameters
+    ----------------
+    sensitivities : float or ``op.domain`` `element-like`, optional
+        Usable with ``noise='poisson'``. The algorithm contains a ``A^T 1``
+        term, if this parameter is given, it is replaced by it.
+        Default: ``op[i].adjoint(op[i].range.one())``
+
+    Notes
+    -----
+    Given a forward models :math:`A_i`, data :math:`g_i`, :math:`i = 1, ..., M`
+    and noise model :math:`X`, the algorithm attempts find an :math:`x` that
+    maximizes:
+
+    .. math::
+
+        \prod_{i=1}^M P(g_i | g_i \\text{ is } X(A_i(x)) \\text{ distributed})
+
+    where the expectation of :math:`X(A_i(x))` satisfies
+
+    .. math::
+
+        \\mathbb{E}(X(A_i(x))) = A_i(x)
+
+    with 'poisson' noise the algorithm is given by partial updates:
+
+    .. math::
+
+       x_{n + m/M} =
+       \\frac{x_{n + (m - 1)/M}}{A_i^* 1} A_i^* (g_i / A_i(x_{n + (m - 1)/M}))
+
+    for :math:`m = 1, ..., M` and :math:`x_{n+1} = x_{n + M/M}`
+
+    See Also
+    --------
+    mlem : Ordinary MLEM algorithm without subsets.
+    loglikelihood : Function for calculating the logarithm of the likelihood
+    """
+    noise, noise_in = str(noise).lower(), noise
+    if noise not in AVAILABLE_MLEM_NOISE:
+        raise NotImplemented("noise '{}' not understood"
+                             ''.format(noise_in))
+
+    n_ops = len(op)
+    if len(data) != n_ops:
+        raise ValueError('number of data does not match number of operators')
+    if not all(x in opi.domain for opi in op):
+        raise ValueError('`x` not an element in the domains of all operators')
+
+    # Convert data to range elements
+    data = [op[i].range.element(data[i]) for i in range(len(op))]
+
+    if noise == 'poisson':
+        # Parameter used to enforce positivity.
+        # TODO: let users give this.
+        eps = 1e-8
+
+        if np.any(np.less(x, 0)):
+            raise ValueError('`x` must be non-negative')
+
+        # Extract the sensitivites parameter
+        sensitivities = kwargs.pop('sensitivities', None)
+        if sensitivities is None:
+            sensitivities = [np.maximum(opi.adjoint(opi.range.one()), eps)
+                             for opi in op]
+        else:
+            # Make sure the sensitivities is a list of the correct size.
+            try:
+                list(sensitivities)
+            except TypeError:
+                sensitivities = [sensitivities] * n_ops
+
+        tmp_dom = op[0].domain.element()
+        tmp_ran = [opi.range.element() for opi in op]
+
+        for _ in range(niter):
+            for i in range(n_ops):
+                op[i](x, out=tmp_ran[i])
+                tmp_ran[i].ufunc.maximum(eps, out=tmp_ran[i])
+                data[i].divide(tmp_ran[i], out=tmp_ran[i])
+
+                op[i].adjoint(tmp_ran[i], out=tmp_dom)
+                tmp_dom /= sensitivities[i]
+
+                x *= tmp_dom
+
+                if callback is not None:
+                    callback(x)
     else:
         raise RuntimeError('unknown noise model')
 

--- a/odl/test/solvers/iterative/iterative_test.py
+++ b/odl/test/solvers/iterative/iterative_test.py
@@ -34,7 +34,8 @@ import numpy as np
                         'landweber',
                         'conjugate_gradient',
                         'conjugate_gradient_normal',
-                        'mlem'])
+                        'mlem',
+                        'osmlem'])
 def iterative_solver(request):
     """Return a solver given by a name with interface solve(op, x, rhs)."""
     solver_name = request.param
@@ -58,6 +59,9 @@ def iterative_solver(request):
     elif solver_name == 'mlem':
         def solver(op, x, rhs):
             odl.solvers.mlem(op, x, rhs, niter=10)
+    elif solver_name == 'osmlem':
+        def solver(op, x, rhs):
+            odl.solvers.osmlem([op, op], x, [rhs, rhs], niter=10)
     else:
         raise ValueError('solver not valid')
 


### PR DESCRIPTION
Adds ordered subsets mlem as a separate option for MLEM, an option would be to merge this with the existing MLEM formulation (basically let users give a list of operators and data, optionally). How do we feel about it?
