### PR TITLE
BUG: fix scaling for current ASTRA version

### DIFF
--- a/examples/tomo/ray_trafo_parallel_2d.py
+++ b/examples/tomo/ray_trafo_parallel_2d.py
@@ -26,8 +26,8 @@ reco_space = odl.uniform_discr(
     min_pt=[-20, -20], max_pt=[20, 20], shape=[300, 300], dtype='float32')
 
 # Make a parallel beam geometry with flat detector
-# Angles: uniformly spaced, n = 360, min = 0, max = pi
-angle_partition = odl.uniform_partition(0, np.pi, 360)
+# Angles: uniformly spaced, n = 180, min = 0, max = pi
+angle_partition = odl.uniform_partition(0, np.pi, 180)
 # Detector: uniformly sampled, n = 558, min = -30, max = 30
 detector_partition = odl.uniform_partition(-30, 30, 558)
 geometry = odl.tomo.Parallel2dGeometry(angle_partition, detector_partition)

--- a/examples/tomo/ray_trafo_parallel_3d.py
+++ b/examples/tomo/ray_trafo_parallel_3d.py
@@ -27,8 +27,8 @@ reco_space = odl.uniform_discr(
     dtype='float32')
 
 # Make a parallel beam geometry with flat detector
-# Angles: uniformly spaced, n = 360, min = 0, max = 2 * pi
-angle_partition = odl.uniform_partition(0, 2 * np.pi, 360)
+# Angles: uniformly spaced, n = 180, min = 0, max = pi
+angle_partition = odl.uniform_partition(0, np.pi, 180)
 # Detector: uniformly sampled, n = (558, 558), min = (-30, -30), max = (30, 30)
 detector_partition = odl.uniform_partition([-30, -30], [30, 30], [558, 558])
 # Discrete reconstruction space

--- a/odl/test/tomo/backends/astra_cuda_test.py
+++ b/odl/test/tomo/backends/astra_cuda_test.py
@@ -46,7 +46,7 @@ def test_astra_cuda_projector_parallel2d():
     phantom = odl.phantom.cuboid(reco_space, min_pt=[0, 0], max_pt=[4, 5])
 
     # Create parallel geometry
-    angle_part = odl.uniform_partition(0, 2 * np.pi, 8)
+    angle_part = odl.uniform_partition(0, np.pi, 8)
     det_part = odl.uniform_partition(-6, 6, 6)
     geom = odl.tomo.Parallel2dGeometry(angle_part, det_part)
 
@@ -108,7 +108,7 @@ def test_astra_cuda_projector_parallel3d():
                                  max_pt=[4, 5, 6])
 
     # Create parallel geometry
-    angle_part = odl.uniform_partition(0, 2 * np.pi, 8)
+    angle_part = odl.uniform_partition(0, np.pi, 8)
     det_part = odl.uniform_partition([-7, -8], [7, 8], (7, 8))
     geom = odl.tomo.Parallel3dAxisGeometry(angle_part, det_part)
 


### PR DESCRIPTION
Fixes #724.

I left the testing code in the examples so you can test the changes. When done, I'll rebase and remove it again.
Test the code with the latest ASTRA git version or take the newest conda package:
```
conda install -c wjpalenstijn astra-toolbox
```
There is still an issue with all cone beam geometries, namely that the density of lines is not taken into account in the backprojection. Basically the backprojectors interpolate the value in a voxel from the two closest lines to the center (ish?), but that does not differentiate between regions with low and high line density. That also explains the large tolerance required especially for the `cone3d` tests because there the line density is least homogeneuous. For helical the situation is better and the error smaller.

This issue is known and on the agenda here :-).