### PR TITLE
BUG: Fix uncompr_bin string fail on CentOS

### DIFF
--- a/odl/tomo/data/uncompr_bin.py
+++ b/odl/tomo/data/uncompr_bin.py
@@ -21,7 +21,7 @@
 from __future__ import print_function, division, absolute_import
 from future import standard_library
 standard_library.install_aliases()
-from builtins import int, object, open, str
+from builtins import int, object, open
 
 from collections import OrderedDict
 import csv


### PR DESCRIPTION
We were getting the error

```
>           if struct.calcsize(fmt) != size_bytes:
E           TypeError: Struct() argument 1 must be string, not newstr
```

this is fixed if we only use the "default" string type of the system.

Tested on CentOS with Python 2.7.