### PR TITLE
Add filter to fbp

### DIFF
--- a/examples/solvers/chambolle_pock_tomography.py
+++ b/examples/solvers/chambolle_pock_tomography.py
@@ -119,5 +119,5 @@ odl.solvers.chambolle_pock_solver(
 
 # Display images
 discr_phantom.show(title='Phantom')
-data.show(title='Projection data')
+data.show(title='Simulated data (Sinogram)')
 x.show(title='TV reconstruction', show=True)

--- a/examples/solvers/douglas_rachford_pd_tomography_tv.py
+++ b/examples/solvers/douglas_rachford_pd_tomography_tv.py
@@ -35,7 +35,7 @@ be solved with the `douglas_rachford_pd` solver.
 
 In this example, the problem is solved with only 22 angles available, which is
 highly under-sampled data. Despite this, we get a perfect reconstruction.
-A filtered backprojection (pseudoinverse) reconstruction is also shown at the
+A filtered back-projection (pseudoinverse) reconstruction is also shown at the
 end for comparsion.
 
 This is an implementation of the "puzzling numerical experiment" in the seminal
@@ -128,6 +128,6 @@ odl.solvers.douglas_rachford_pd(x, f, g, lin_ops,
                                 tau=0.1, sigma=[0.1, 0.02], lam=1.5,
                                 niter=200, callback=callback)
 
-# Compare with filtered backprojection
+# Compare with filtered back-projection
 fbp_recon = odl.tomo.fbp_op(ray_trafo)(data)
 fbp_recon.show('FBP reconstruction')

--- a/examples/tomo/filtered_backprojection_cone_2d.py
+++ b/examples/tomo/filtered_backprojection_cone_2d.py
@@ -16,7 +16,7 @@
 # along with ODL.  If not, see <http://www.gnu.org/licenses/>.
 
 """
-Example using a filtered backprojection (FBP) in fan beam using `fbp_op`.
+Example using a filtered back-projection (FBP) in fan beam using `fbp_op`.
 
 Note that the FBP is only approximate in this geometry, but still gives a
 decent reconstruction that can be used as an initial guess in more complicated
@@ -46,14 +46,16 @@ geometry = odl.tomo.FanFlatGeometry(
     angle_partition, detector_partition, src_radius=40, det_radius=40)
 
 
-# --- Create FilteredBackProjection (FBP) operator --- #
+# --- Create Filtered Back-Projection (FBP) operator --- #
 
 
 # Ray transform (= forward projection). We use the ASTRA CUDA backend.
 ray_trafo = odl.tomo.RayTransform(reco_space, geometry, impl='astra_cuda')
 
 # Create FBP operator using utility function
-fbp = odl.tomo.fbp_op(ray_trafo, filter_type='Hann', filter_cutoff=0.8)
+# We select a Hann filter, and only use the lowest 80% of frequencies to avoid
+# high frequency noise.
+fbp = odl.tomo.fbp_op(ray_trafo, filter_type='Hann', frequency_scaling=0.8)
 
 
 # --- Show some examples --- #
@@ -65,11 +67,11 @@ phantom = odl.phantom.shepp_logan(reco_space, modified=True)
 # Create projection data by calling the ray transform on the phantom
 proj_data = ray_trafo(phantom)
 
-# Calculate filtered backprojection of data
+# Calculate filtered back-projection of data
 fbp_reconstruction = fbp(proj_data)
 
 # Shows a slice of the phantom, projections, and reconstruction
 phantom.show(title='Phantom')
 proj_data.show(title='Projection data (sinogram)')
-fbp_reconstruction.show(title='Filtered backprojection')
+fbp_reconstruction.show(title='Filtered back-projection')
 (phantom - fbp_reconstruction).show(title='Error')

--- a/examples/tomo/filtered_backprojection_cone_2d.py
+++ b/examples/tomo/filtered_backprojection_cone_2d.py
@@ -53,7 +53,7 @@ geometry = odl.tomo.FanFlatGeometry(
 ray_trafo = odl.tomo.RayTransform(reco_space, geometry, impl='astra_cuda')
 
 # Create FBP operator using utility function
-fbp = odl.tomo.fbp_op(ray_trafo)
+fbp = odl.tomo.fbp_op(ray_trafo, filter_type='Hann', filter_cutoff=0.8)
 
 
 # --- Show some examples --- #

--- a/examples/tomo/filtered_backprojection_cone_3d.py
+++ b/examples/tomo/filtered_backprojection_cone_3d.py
@@ -16,7 +16,7 @@
 # along with ODL.  If not, see <http://www.gnu.org/licenses/>.
 
 """
-Example using a filtered backprojection (FBP) in cone-beam 3d using `fbp_op`.
+Example using a filtered back-projection (FBP) in cone-beam 3d using `fbp_op`.
 
 Note that the FBP is only approximate in this geometry, but still gives a
 decent reconstruction that can be used as an initial guess in more complicated
@@ -47,14 +47,17 @@ geometry = odl.tomo.CircularConeFlatGeometry(
     axis=[1, 1, 1])
 
 
-# --- Create FilteredBackProjection (FBP) operator --- #
+# --- Create Filteredback-projection (FBP) operator --- #
 
 
 # Ray transform (= forward projection). We use the ASTRA CUDA backend.
 ray_trafo = odl.tomo.RayTransform(reco_space, geometry, impl='astra_cuda')
 
 # Create FBP operator using utility function
-fbp = odl.tomo.fbp_op(ray_trafo, filter_type='Hann', filter_cutoff=0.8)
+# We select a Shepp-Logan filter, and only use the lowest 80% of frequencies to
+# avoid high frequency noise.
+fbp = odl.tomo.fbp_op(ray_trafo,
+                      filter_type='Shepp-Logan', frequency_scaling=0.8)
 
 
 # --- Show some examples --- #
@@ -66,11 +69,11 @@ phantom = odl.phantom.shepp_logan(reco_space, modified=True)
 # Create projection data by calling the ray transform on the phantom
 proj_data = ray_trafo(phantom)
 
-# Calculate filtered backprojection of data
+# Calculate filtered back-projection of data
 fbp_reconstruction = fbp(proj_data)
 
 # Shows a slice of the phantom, projections, and reconstruction
 phantom.show(title='Phantom')
-proj_data.show(title='Projection data (sinogram)')
-fbp_reconstruction.show(title='Filtered backprojection')
+proj_data.show(title='Simulated data (sinogram)')
+fbp_reconstruction.show(title='Filtered back-projection')
 (phantom - fbp_reconstruction).show(title='Error')

--- a/examples/tomo/filtered_backprojection_cone_3d.py
+++ b/examples/tomo/filtered_backprojection_cone_3d.py
@@ -54,7 +54,7 @@ geometry = odl.tomo.CircularConeFlatGeometry(
 ray_trafo = odl.tomo.RayTransform(reco_space, geometry, impl='astra_cuda')
 
 # Create FBP operator using utility function
-fbp = odl.tomo.fbp_op(ray_trafo)
+fbp = odl.tomo.fbp_op(ray_trafo, filter_type='Hann', filter_cutoff=0.8)
 
 
 # --- Show some examples --- #

--- a/examples/tomo/filtered_backprojection_helical_3d.py
+++ b/examples/tomo/filtered_backprojection_helical_3d.py
@@ -15,10 +15,20 @@
 # You should have received a copy of the GNU General Public License
 # along with ODL.  If not, see <http://www.gnu.org/licenses/>.
 
-"""Example using the ray transform with helical cone beam geometry."""
+"""
+Example using a filtered backprojection (FBP) in cone-beam 3d using `fbp_op`.
+
+Note that the FBP is only approximate in this geometry, but still gives a
+decent reconstruction that can be used as an initial guess in more complicated
+methods.
+"""
 
 import numpy as np
 import odl
+
+
+# --- Set-up geometry of the problem --- #
+
 
 # Discrete reconstruction space: discretized functions on the cube
 # [-20, 20]^2 x [0, 40] with 300 samples per dimension.
@@ -30,14 +40,29 @@ reco_space = odl.uniform_discr(
 # Angles: uniformly spaced, n = 2000, min = 0, max = 8 * 2 * pi
 angle_partition = odl.uniform_partition(0, 8 * 2 * np.pi, 2000)
 # Detector: uniformly sampled, n = (558, 60), min = (-30, -3), max = (30, 3)
-detector_partition = odl.uniform_partition([-30, -3], [30, 3], [558, 60])
+detector_partition = odl.uniform_partition([-40, -3], [40, 3], [558, 60])
 # Spiral has a pitch of 5, we run 8 rounds (due to max angle = 8 * 2 * pi)
 geometry = odl.tomo.HelicalConeFlatGeometry(
     angle_partition, detector_partition, src_radius=100, det_radius=100,
     pitch=5.0)
 
-# Ray transform (= forward projection). We use ASTRA CUDA backend.
+
+# --- Create FilteredBackProjection (FBP) operator --- #
+
+
+# Ray transform (= forward projection). We use the ASTRA CUDA backend.
 ray_trafo = odl.tomo.RayTransform(reco_space, geometry, impl='astra_cuda')
+
+# Unwindowed fbp
+unwindowed_fbp = odl.tomo.fbp_op(ray_trafo,
+                                 filter_type='Hann', filter_cutoff=0.8)
+
+# Create Tam-Danielson window to improve result
+windowed_fbp = unwindowed_fbp * odl.tomo.tam_danielson_window(ray_trafo)
+
+
+# --- Show some examples --- #
+
 
 # Create a discrete Shepp-Logan phantom (modified version)
 phantom = odl.phantom.shepp_logan(reco_space, modified=True)
@@ -45,13 +70,14 @@ phantom = odl.phantom.shepp_logan(reco_space, modified=True)
 # Create projection data by calling the ray transform on the phantom
 proj_data = ray_trafo(phantom)
 
-# Back-projection can be done by simply calling the adjoint operator on the
-# projection data (or any element in the projection space).
-backproj = ray_trafo.adjoint(proj_data)
+# Calculate filtered backprojection of data
+uw_fbp_reconstruction = unwindowed_fbp(proj_data)
+w_fbp_reconstruction = windowed_fbp(proj_data)
 
 # Shows a slice of the phantom, projections, and reconstruction
-phantom.show(indices=np.s_[:, :, 150], title='Phantom, middle z slice')
-proj_data.show(indices=np.s_[1000, :, :], title='Projection 1000')
-proj_data.show(indices=np.s_[1500, :, :], title='Projection 1500')
-backproj.show(indices=np.s_[:, :, 150],
-              title='back-projection, middle z slice')
+phantom.show(title='Phantom')
+proj_data.show(title='Projection data (sinogram)')
+uw_fbp_reconstruction.show(title='Filtered backprojection un-windowed',
+                           coords=[0, None, None], clim=[-0.1, 1.1])
+w_fbp_reconstruction.show(title='Filtered backprojection windowed',
+                           coords=[0, None, None], clim=[-0.1, 1.1])

--- a/examples/tomo/filtered_backprojection_helical_3d.py
+++ b/examples/tomo/filtered_backprojection_helical_3d.py
@@ -15,7 +15,7 @@
 # You should have received a copy of the GNU General Public License
 # along with ODL.  If not, see <http://www.gnu.org/licenses/>.
 
-"""Example using a FBP in helical 3D geometry using `fbp_op`.
+"""Example using FBP in helical 3D geometry using `fbp_op`.
 
 Note that the FBP is only approximate in this geometry, but still gives a
 decent reconstruction that can be used as an initial guess in more complex

--- a/examples/tomo/filtered_backprojection_helical_3d.py
+++ b/examples/tomo/filtered_backprojection_helical_3d.py
@@ -70,7 +70,7 @@ windowed_fbp = fbp * odl.tomo.tam_danielson_window(ray_trafo)
 # --- Show some examples --- #
 
 
-# Create a Shepp-Logan phantom (modified version)
+# Create a discrete Shepp-Logan phantom (modified version)
 phantom = odl.phantom.shepp_logan(reco_space, modified=True)
 
 # Create projection data by calling the ray transform on the phantom
@@ -81,7 +81,8 @@ fbp_reconstruction = fbp(proj_data)
 w_fbp_reconstruction = windowed_fbp(proj_data)
 
 # Show a slice of phantom, projections, and reconstruction
-phantom.show(title='Phantom')
+phantom.show(title='Phantom',
+             coords=[0, None, None], clim=[-0.1, 1.1])
 proj_data.show(title='Simulated data (sinogram)')
 fbp_reconstruction.show(title='Filtered back-projection',
                         coords=[0, None, None], clim=[-0.1, 1.1])

--- a/examples/tomo/filtered_backprojection_parallel_2d.py
+++ b/examples/tomo/filtered_backprojection_parallel_2d.py
@@ -16,11 +16,14 @@
 # along with ODL.  If not, see <http://www.gnu.org/licenses/>.
 
 """
-Example using a filtered backprojection in 2d using the ray transform and a
+Example using a filtered back-projection in 2d using the ray transform and a
 ramp filter. The ramp filter is implemented in fourier space.
 
 See https://en.wikipedia.org/wiki/Radon_transform#Inversion_formulas for
 more information.
+
+Also note that ODL has a utility function, `fbp_op` that can be used to perform
+filtered back-projection.
 """
 
 import numpy as np
@@ -45,7 +48,7 @@ detector_partition = odl.uniform_partition(-30, 30, 500)
 geometry = odl.tomo.Parallel2dGeometry(angle_partition, detector_partition)
 
 
-# --- Create FilteredBackProjection (FBP) operator --- #
+# --- Create Filtered Back-Projection (FBP) operator --- #
 
 
 # Ray transform (= forward projection). We use the ASTRA CUDA backend.
@@ -60,8 +63,8 @@ ramp_function = fourier.range.element(lambda x: np.abs(x[1]) / (2 * np.pi))
 # Create ramp filter via the convolution formula with fourier transforms
 ramp_filter = fourier.inverse * ramp_function * fourier
 
-# Create filtered backprojection by composing the backprojection (adjoint) with
-# the ramp filter.
+# Create filtered back-projection by composing the back-projection (adjoint)
+# with the ramp filter.
 fbp = ray_trafo.adjoint * ramp_filter
 
 
@@ -74,11 +77,11 @@ phantom = odl.phantom.shepp_logan(reco_space, modified=True)
 # Create projection data by calling the ray transform on the phantom
 proj_data = ray_trafo(phantom)
 
-# Calculate filtered backprojection of data
+# Calculate filtered back-projection of data
 fbp_reconstruction = fbp(proj_data)
 
 # Shows a slice of the phantom, projections, and reconstruction
 phantom.show(title='Phantom')
 proj_data.show(title='Projection data (sinogram)')
-fbp_reconstruction.show(title='Filtered backprojection')
+fbp_reconstruction.show(title='Filtered back-projection')
 (phantom - fbp_reconstruction).show(title='Error')

--- a/examples/tomo/filtered_backprojection_parallel_3d.py
+++ b/examples/tomo/filtered_backprojection_parallel_3d.py
@@ -15,8 +15,7 @@
 # You should have received a copy of the GNU General Public License
 # along with ODL.  If not, see <http://www.gnu.org/licenses/>.
 
-"""
-Example using a filtered backprojection (FBP) in prarallel 3d using `fbp_op`.
+"""Example using a FBP in prarallel 3D geometry using `fbp_op`.
 
 We use a rotated geometry to demonstrate that the FBP still works as expected.
 """
@@ -25,49 +24,51 @@ import numpy as np
 import odl
 
 
-# --- Set-up geometry of the problem --- #
+# --- Set up geometry of the problem --- #
 
 
-# Discrete reconstruction space: discretized functions on the cube
+# Reconstruction space: discretized functions on the cube
 # [-20, 20]^3 with 300 samples per dimension.
 reco_space = odl.uniform_discr(
     min_pt=[-20, -20, -20], max_pt=[20, 20, 20], shape=[300, 300, 300],
     dtype='float32')
 
-# Make a circular cone beam geometry with flat detector
-# Angles: uniformly spaced, n = 360, min = 0, max = 2 * pi
-angle_partition = odl.uniform_partition(0, 2 * np.pi, 360)
+# Make a parallel beam geometry with flat detector
+# Angles: uniformly spaced, n = 360, min = 0, max = pi
+angle_partition = odl.uniform_partition(0, np.pi, 180)
 # Detector: uniformly sampled, n = (558, 558), min = (-40, -40), max = (40, 40)
 detector_partition = odl.uniform_partition([-40, -40], [40, 40], [558, 558])
-# Geometry with large cone and fan angle and tilted axis.
+# Geometry with tilted axis.
 geometry = odl.tomo.Parallel3dAxisGeometry(
     angle_partition, detector_partition, axis=[1, 1, 1])
 
 
-# --- Create FilteredBackProjection (FBP) operator --- #
+# --- Create Filtered Back-Projection (FBP) operator --- #
 
 
 # Ray transform (= forward projection). We use the ASTRA CUDA backend.
 ray_trafo = odl.tomo.RayTransform(reco_space, geometry, impl='astra_cuda')
 
 # Create FBP operator using utility function
-fbp = odl.tomo.fbp_op(ray_trafo, filter_type='Hann', filter_cutoff=0.8)
+# We select a Hann filter, and only use the lowest 80% of frequencies to
+# avoid high frequency noise.
+fbp = odl.tomo.fbp_op(ray_trafo, filter_type='Hann', frequency_scaling=0.8)
 
 
 # --- Show some examples --- #
 
 
-# Create a discrete Shepp-Logan phantom (modified version)
+# Create a Shepp-Logan phantom (modified version)
 phantom = odl.phantom.shepp_logan(reco_space, modified=True)
 
 # Create projection data by calling the ray transform on the phantom
 proj_data = ray_trafo(phantom)
 
-# Calculate filtered backprojection of data
+# Calculate filtered back-projection of data
 fbp_reconstruction = fbp(proj_data)
 
-# Shows a slice of the phantom, projections, and reconstruction
+# Show a slice of phantom, projections, and reconstruction
 phantom.show(title='Phantom')
-proj_data.show(title='Projection data (sinogram)')
-fbp_reconstruction.show(title='Filtered backprojection')
+proj_data.show(title='Simulated data (sinogram)')
+fbp_reconstruction.show(title='Filtered back-projection')
 (phantom - fbp_reconstruction).show(title='Error')

--- a/examples/tomo/filtered_backprojection_parallel_3d.py
+++ b/examples/tomo/filtered_backprojection_parallel_3d.py
@@ -15,7 +15,7 @@
 # You should have received a copy of the GNU General Public License
 # along with ODL.  If not, see <http://www.gnu.org/licenses/>.
 
-"""Example using a FBP in prarallel 3D geometry using `fbp_op`.
+"""Example using FBP in prarallel 3D geometry using `fbp_op`.
 
 We use a rotated geometry to demonstrate that the FBP still works as expected.
 """

--- a/examples/tomo/filtered_backprojection_parallel_3d.py
+++ b/examples/tomo/filtered_backprojection_parallel_3d.py
@@ -1,0 +1,73 @@
+# Copyright 2014-2016 The ODL development group
+#
+# This file is part of ODL.
+#
+# ODL is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# ODL is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with ODL.  If not, see <http://www.gnu.org/licenses/>.
+
+"""
+Example using a filtered backprojection (FBP) in prarallel 3d using `fbp_op`.
+
+We use a rotated geometry to demonstrate that the FBP still works as expected.
+"""
+
+import numpy as np
+import odl
+
+
+# --- Set-up geometry of the problem --- #
+
+
+# Discrete reconstruction space: discretized functions on the cube
+# [-20, 20]^3 with 300 samples per dimension.
+reco_space = odl.uniform_discr(
+    min_pt=[-20, -20, -20], max_pt=[20, 20, 20], shape=[300, 300, 300],
+    dtype='float32')
+
+# Make a circular cone beam geometry with flat detector
+# Angles: uniformly spaced, n = 360, min = 0, max = 2 * pi
+angle_partition = odl.uniform_partition(0, 2 * np.pi, 360)
+# Detector: uniformly sampled, n = (558, 558), min = (-40, -40), max = (40, 40)
+detector_partition = odl.uniform_partition([-40, -40], [40, 40], [558, 558])
+# Geometry with large cone and fan angle and tilted axis.
+geometry = odl.tomo.Parallel3dAxisGeometry(
+    angle_partition, detector_partition, axis=[1, 1, 1])
+
+
+# --- Create FilteredBackProjection (FBP) operator --- #
+
+
+# Ray transform (= forward projection). We use the ASTRA CUDA backend.
+ray_trafo = odl.tomo.RayTransform(reco_space, geometry, impl='astra_cuda')
+
+# Create FBP operator using utility function
+fbp = odl.tomo.fbp_op(ray_trafo, filter_type='Hann', filter_cutoff=0.8)
+
+
+# --- Show some examples --- #
+
+
+# Create a discrete Shepp-Logan phantom (modified version)
+phantom = odl.phantom.shepp_logan(reco_space, modified=True)
+
+# Create projection data by calling the ray transform on the phantom
+proj_data = ray_trafo(phantom)
+
+# Calculate filtered backprojection of data
+fbp_reconstruction = fbp(proj_data)
+
+# Shows a slice of the phantom, projections, and reconstruction
+phantom.show(title='Phantom')
+proj_data.show(title='Projection data (sinogram)')
+fbp_reconstruction.show(title='Filtered backprojection')
+(phantom - fbp_reconstruction).show(title='Error')

--- a/odl/phantom/geometric.py
+++ b/odl/phantom/geometric.py
@@ -106,7 +106,8 @@ def defrise(space, nellipses=8, alternating=False):
         Discretized space in which the phantom is supposed to be created.
         Needs to be 2d or 3d.
     nellipses : int, optional
-        Number of ellipses
+        Number of ellipses. If more ellipses are used, each ellipse becomes
+        thinner.
     alternating : bool, optional
         True if the ellipses should have alternating densities (+1, -1),
         otherwise all ellipses have value +1.
@@ -134,7 +135,8 @@ def defrise_ellipses(ndim, nellipses=8, alternating=False):
     ndim : {2, 3}
         Dimension of the space the ellipses should be in.
     nellipses : int, optional
-        Number of ellipses
+        Number of ellipses. If more ellipses are used, each ellipse becomes
+        thinner.
     alternating : bool, optional
         True if the ellipses should have alternating densities (+1, -1),
         otherwise all ellipses have value +1.

--- a/odl/phantom/geometric.py
+++ b/odl/phantom/geometric.py
@@ -24,7 +24,7 @@ standard_library.install_aliases()
 
 import numpy as np
 
-__all__ = ('cuboid', 'ellipse_phantom', 'indicate_proj_axis')
+__all__ = ('cuboid', 'defrise', 'ellipse_phantom', 'indicate_proj_axis')
 
 
 def cuboid(space, min_pt=None, max_pt=None):
@@ -93,6 +93,92 @@ def cuboid(space, min_pt=None, max_pt=None):
         return result
 
     return space.element(phantom)
+
+
+def defrise(space, nellipses=8, alternating=False):
+    """Phantom with regularily spaced ellipses.
+
+    This phantom is often used to verify cone-beam algorithms.
+
+    Parameters
+    ----------
+    space : `DiscretizedSpace`
+        Discretized space in which the phantom is supposed to be created.
+        Needs to be 2d or 3d.
+    nellipses : int, optional
+        Number of ellipses
+    alternating : bool, optional
+        True if the ellipses should have alternating densities (+1, -1),
+        otherwise all ellipses have value +1.
+
+    Returns
+    -------
+    phantom : ``space`` element
+        The generated phantom in ``space``.
+
+    See Also
+    --------
+    odl.phantom.transmission.shepp_logan
+    """
+    ellipses = defrise_ellipses(space.ndim, nellipses=nellipses,
+                                alternating=alternating)
+
+    return ellipse_phantom(space, ellipses)
+
+
+def defrise_ellipses(ndim, nellipses=8, alternating=False):
+    """Ellipses for the standard Defrise phantom in 2 or 3 dimensions.
+
+    Parameters
+    ----------
+    ndim : {2, 3}
+        Dimension of the space the ellipses should be in.
+    nellipses : int, optional
+        Number of ellipses
+    alternating : bool, optional
+        True if the ellipses should have alternating densities (+1, -1),
+        otherwise all ellipses have value +1.
+
+    See Also
+    --------
+    odl.phantom.geometric.ellipse_phantom :
+        Function for creating arbitrary ellipse phantoms
+    shepp_logan : Create a phantom with these ellipses
+    """
+    ellipses = []
+    if ndim == 2:
+        for i in range(nellipses):
+            if alternating:
+                value = (-1.0 + 2.0 * (i % 2))
+            else:
+                value = 1.0
+
+            axis_1 = 0.5
+            axis_2 = 0.5 / (nellipses + 1)
+            center_x = 0.0
+            center_y = -1 + 2.0 / (nellipses + 1.0) * (i + 1)
+            rotation = 0
+            ellipses.append(
+                [value, axis_1, axis_2, center_x, center_y, rotation])
+    elif ndim == 3:
+        for i in range(nellipses):
+            if alternating:
+                value = (-1.0 + 2.0 * (i % 2))
+            else:
+                value = 1.0
+
+            axis_1 = axis_2 = 0.5
+            axis_3 = 0.5 / (nellipses + 1)
+            center_x = center_y = 0.0
+            center_z = -1 + 2.0 / (nellipses + 1.0) * (i + 1)
+            rotation_phi = rotation_theta = rotation_psi = 0
+
+            ellipses.append(
+                [value, axis_1, axis_2, axis_3,
+                 center_x, center_y, center_z,
+                 rotation_phi, rotation_theta, rotation_psi])
+
+    return ellipses
 
 
 def indicate_proj_axis(space, scale_structures=0.5):
@@ -482,6 +568,8 @@ def ellipse_phantom(space, ellipses):
         typically used for transmission imaging
     odl.phantom.transmission.shepp_logan_ellipses : Ellipses for the
         Shepp-Logan phantom
+    odl.phantom.geometric.defrise_ellipses : Ellipses for the
+        Defrise phantom
     """
 
     if space.ndim == 2:
@@ -520,6 +608,14 @@ if __name__ == '__main__':
     ellipses = [[1.0, 1.0, 1.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
                 [1.0, 0.6, 0.6, 0.6, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]]
     ellipse_phantom(discr, ellipses).show('ellipse phantom 3d')
+
+    # Defrise phantom 2D
+    discr = odl.uniform_discr([-1, -1], [1, 1], [300, 300])
+    defrise(discr).show('defrise 2D')
+
+    # Defrise phantom 2D
+    discr = odl.uniform_discr([-1, -1, -1], [1, 1, 1], [300, 300, 300])
+    defrise(discr).show('defrise 3D', coords=[0, None, None])
 
     # Run also the doctests
     # pylint: disable=wrong-import-position

--- a/odl/phantom/transmission.py
+++ b/odl/phantom/transmission.py
@@ -131,6 +131,7 @@ def shepp_logan(space, modified=False):
     See Also
     --------
     forbild : Similar phantom but with more complexity. Only supports 2d.
+    odl.phantom.geometric.defrise : Geometry test phantom
     shepp_logan_ellipses : Get the parameters that define this phantom
     odl.phantom.geometric.ellipse_phantom :
         Function for creating arbitrary ellipse phantoms

--- a/odl/test/largescale/tomo/analytic_slow_test.py
+++ b/odl/test/largescale/tomo/analytic_slow_test.py
@@ -156,7 +156,7 @@ def projector(request):
 
 @skip_if_no_largescale
 def test_fbp_reconstruction(projector):
-    """Test filtered backprojection with various projectors."""
+    """Test filtered back-projection with various projectors."""
 
     # Create Shepp-Logan phantom
     vol = odl.phantom.shepp_logan(projector.domain, modified=False)

--- a/odl/test/largescale/tomo/analytic_slow_test.py
+++ b/odl/test/largescale/tomo/analytic_slow_test.py
@@ -35,8 +35,8 @@ from odl.tomo.util.testutils import (skip_if_no_astra, skip_if_no_astra_cuda,
 
 filter_type = simple_fixture(
     'filter_type', ['Ram-Lak', 'Shepp-Logan', 'Cosine', 'Hamming', 'Hann'])
-filter_cutoff = simple_fixture(
-    'filter_cutoff', [0.5, 0.9, 1.0])
+frequency_scaling = simple_fixture(
+    'frequency_scaling', [0.5, 0.9, 1.0])
 
 # Find the valid projectors
 # TODO: Add nonuniform once #671 is solved
@@ -182,7 +182,7 @@ def test_fbp_reconstruction(projector):
 
 @skip_if_no_astra_cuda
 @skip_if_no_largescale
-def test_fbp_reconstruction_filters(filter_type, filter_cutoff):
+def test_fbp_reconstruction_filters(filter_type, frequency_scaling):
     """Validate that the various filters work as expected."""
 
     apart = odl.uniform_partition(0, np.pi, 500)
@@ -206,7 +206,7 @@ def test_fbp_reconstruction_filters(filter_type, filter_cutoff):
     # Create FBP operator with filters and apply to projections
     fbp_operator = odl.tomo.fbp_op(projector,
                                    filter_type=filter_type,
-                                   filter_cutoff=filter_cutoff)
+                                   frequency_scaling=frequency_scaling)
 
     fbp_result = fbp_operator(projections)
 

--- a/odl/tomo/analytic/filtered_back_projection.py
+++ b/odl/tomo/analytic/filtered_back_projection.py
@@ -118,7 +118,7 @@ def fbp_op(ray_trafo, padding=True, filter_type='Ram-Lak', filter_cutoff=1.0):
         # Define ramp filter
         def fft_filter(x):
             norm_freq = np.abs(x[1]) / np.max(np.abs(x[1]))
-            filt = smoothing_filter(norm_freq, filter_type, filter_cutoff)
+            filt = fbp_filter(norm_freq, filter_type, filter_cutoff)
             ramp = np.sqrt(x[1]**2)
             scaling = 1 / (2 * alen)
             return filt * ramp * scaling
@@ -165,7 +165,12 @@ def fbp_op(ray_trafo, padding=True, filter_type='Ram-Lak', filter_cutoff=1.0):
 
         # Define ramp filter
         def fft_filter(x):
-            return np.abs(c[0] * x[1] + c[1] * x[2]) * (scale / (2 * alen))
+            freq = np.abs(c[0] * x[1] + c[1] * x[2])
+            norm_freq = freq / np.max(freq)
+            filt = fbp_filter(norm_freq, filter_type, filter_cutoff)
+            ramp = np.sqrt(x[1]**2)
+            scaling = scale / (2 * alen)
+            return filt * ramp * scaling
 
         # Define (padded) fourier transform
         if padding:

--- a/odl/tomo/analytic/filtered_back_projection.py
+++ b/odl/tomo/analytic/filtered_back_projection.py
@@ -71,6 +71,7 @@ def fbp_filter(norm_freq, filter_type, filter_cutoff):
 
     return filt
 
+
 def fbp_op(ray_trafo, padding=True, filter_type='Ram-Lak', filter_cutoff=1.0):
     """Create filtered back-projection from a `RayTransform`.
 
@@ -117,11 +118,11 @@ def fbp_op(ray_trafo, padding=True, filter_type='Ram-Lak', filter_cutoff=1.0):
     if ray_trafo.domain.ndim == 2:
         # Define ramp filter
         def fft_filter(x):
-            norm_freq = np.abs(x[1]) / np.max(np.abs(x[1]))
+            abs_freq = np.abs(x[1])
+            norm_freq = abs_freq / np.max(abs_freq)
             filt = fbp_filter(norm_freq, filter_type, filter_cutoff)
-            ramp = np.sqrt(x[1]**2)
             scaling = 1 / (2 * alen)
-            return filt * ramp * scaling
+            return filt * abs_freq * scaling
 
         # Define (padded) fourier transform
         if padding:
@@ -165,12 +166,11 @@ def fbp_op(ray_trafo, padding=True, filter_type='Ram-Lak', filter_cutoff=1.0):
 
         # Define ramp filter
         def fft_filter(x):
-            freq = np.abs(c[0] * x[1] + c[1] * x[2])
-            norm_freq = freq / np.max(freq)
+            abs_freq = np.abs(c[0] * x[1] + c[1] * x[2])
+            norm_freq = abs_freq / np.max(abs_freq)
             filt = fbp_filter(norm_freq, filter_type, filter_cutoff)
-            ramp = np.sqrt(x[1]**2)
             scaling = scale / (2 * alen)
-            return filt * ramp * scaling
+            return filt * abs_freq * scaling
 
         # Define (padded) fourier transform
         if padding:
@@ -212,7 +212,7 @@ if __name__ == '__main__':
     # Display the various filters
     import matplotlib.pyplot as plt
     x = np.linspace(0, 1, 100)
-    cutoff = 0.9
+    cutoff = 0.7
 
     for filter_name in ['Ram-Lak', 'Shepp-Logan', 'Cosine', 'Hamming', 'Hann']:
         plt.plot(x, x * fbp_filter(x, filter_name, cutoff), label=filter_name)

--- a/odl/tomo/analytic/filtered_back_projection.py
+++ b/odl/tomo/analytic/filtered_back_projection.py
@@ -74,7 +74,11 @@ def _fbp_filter(norm_freq, filter_type, filter_cutoff):
 
 
 def tam_danielson_window(ray_trafo, smoothing_width=0.05):
-    """Create Tam-Danielson window.
+    """Create Tam-Danielson window from a `RayTransform`.
+
+    The Tam-Danielson window is an indicator function on the minimal set of
+    data needed to reconstruct a given data. It is useful in analytic
+    reconstruction methods such as FBP to give a more accurate reconstruction.
 
     Parameters
     ----------
@@ -82,6 +86,15 @@ def tam_danielson_window(ray_trafo, smoothing_width=0.05):
         The ray transform that the window should be computed for.
     smoothing_width : float
         Relative width of the smoothing applied to the windows edges.
+
+    Returns
+    -------
+    tam_danielson_window : ``ray_trafo.range`` element
+
+    See Also
+    --------
+    fbp_op : Filtered back-projection from `RayTransform`
+    HelicalConeFlatGeometry : The geometry this is most useful for.
     """
 
     # Extract parameters
@@ -113,7 +126,6 @@ def tam_danielson_window(ray_trafo, smoothing_width=0.05):
     lower_proj = lower_proj[None, :, None]
     upper_proj = upper_proj[None, :, None]
     width = width[None, :, None]
-    # proj_pitch = proj_pitch[None, :, None]
 
     # Create window function
     def window_fcn(x):
@@ -122,9 +134,7 @@ def tam_danielson_window(ray_trafo, smoothing_width=0.05):
 
         return lower_wndw * upper_wndw
 
-    window = ray_trafo.range.element(window_fcn)
-    window.show(coords=[0, None, None])
-    return window
+    return ray_trafo.range.element(window_fcn)
 
 
 def fbp_op(ray_trafo, padding=True, filter_type='Ram-Lak', filter_cutoff=1.0):
@@ -168,6 +178,10 @@ def fbp_op(ray_trafo, padding=True, filter_type='Ram-Lak', filter_cutoff=1.0):
     -------
     fbp : `Operator`
         Approximate inverse operator of ``ray_trafo``.
+
+    See Also
+    --------
+    tam_danielson_window : Windowing for helical data
     """
     impl = 'pyfftw' if PYFFTW_AVAILABLE else 'numpy'
     alen = ray_trafo.geometry.motion_params.length

--- a/odl/tomo/analytic/filtered_back_projection.py
+++ b/odl/tomo/analytic/filtered_back_projection.py
@@ -79,7 +79,7 @@ def _fbp_filter(norm_freq, filter_type, frequency_scaling):
 
     Examples
     --------
-    Create a FBP filter
+    Create an FBP filter
 
     >>> norm_freq = np.linspace(0, 1, 10)
     >>> filt = _fbp_filter(norm_freq,
@@ -287,9 +287,11 @@ def fbp_op(ray_trafo, padding=True,
                       ray_trafo.geometry.det_radius))
 
             if ray_trafo.geometry.pitch != 0:
-                # In helical geometry the whole volume is not in by each
-                # projection, ideally each point in the volume effects only by
-                # the projections in a half rotation.
+                # In helical geometry the whole volume is not in each
+                # projection and we need to use another weighting.
+                # Ideally each point in the volume effects only
+                # the projections in a half rotation, so we assume that that
+                # is the case.
                 scale *= alen / (np.pi)
         else:
             scale = 1.0

--- a/odl/tomo/analytic/filtered_back_projection.py
+++ b/odl/tomo/analytic/filtered_back_projection.py
@@ -24,7 +24,6 @@ import numpy as np
 import scipy as sp
 from odl.discr import ResizingOperator
 from odl.trafos import FourierTransform, PYFFTW_AVAILABLE
-from odl.tomo.util.utility import perpendicular_vector
 
 
 __all__ = ('fbp_op', 'tam_danielson_window')
@@ -60,63 +59,69 @@ def _rotation_direction_in_detector(geometry):
     return c / cnorm
 
 
-def _fbp_filter(norm_freq, filter_type, filter_cutoff):
+def _fbp_filter(norm_freq, filter_type, frequency_scaling):
     """Create a smoothing filter for FBP.
 
     Parameters
     ----------
     norm_freq : `array-like`
-        Normalized frequencies.
+        Frequencies normalized to lie in the interval [0, 1].
     filter_type : {'Ram-Lak', 'Shepp-Logan', 'Cosine', 'Hamming', 'Hann'}
         The type of filter to be used.
-    filter_cutoff : float
-        Relative cutoff frequency for the filter.
+    frequency_scaling : float
+        Scaling of the frequencies for the filter. All frequencies are scaled
+        by this number, any relative frequency above ``frequency_scaling`` is
+        set to 0.
 
     Returns
     -------
     smoothing_filter : `numpy.ndarray`
 
-    References
-    ----------
-    http://oftankonyv.reak.bme.hu/tiki-index.php?page=Reconstruction
-    """
-    if not (0 < filter_cutoff <= 1):
-        raise ValueError('`filter_cutoff` ({}) not in the interval (0, 1]'
-                         ''.format(filter_cutoff))
+    Examples
+    --------
+    Create a FBP filter
 
-    indicator = (norm_freq <= filter_cutoff)
+    >>> norm_freq = np.linspace(0, 1, 10)
+    >>> filt = _fbp_filter(norm_freq,
+    ...                    filter_type='Hann',
+    ...                    frequency_scaling=0.8)
+    """
 
     if filter_type == 'Ram-Lak':
-        filt = indicator
+        filt = 1
     elif filter_type == 'Shepp-Logan':
-        filt = indicator * np.sinc(norm_freq / (2 * filter_cutoff))
+        filt = np.sinc(norm_freq / (2 * frequency_scaling))
     elif filter_type == 'Cosine':
-        filt = indicator * np.cos(norm_freq * np.pi / (2 * filter_cutoff))
+        filt = np.cos(norm_freq * np.pi / (2 * frequency_scaling))
     elif filter_type == 'Hamming':
-        filt = indicator * (0.54 +
-                            0.46 * np.cos(norm_freq * np.pi / (filter_cutoff)))
+        filt = 0.54 + 0.46 * np.cos(norm_freq * np.pi / (frequency_scaling))
     elif filter_type == 'Hann':
-        filt = indicator * np.cos(norm_freq * np.pi / (2 * filter_cutoff)) ** 2
+        filt = np.cos(norm_freq * np.pi / (2 * frequency_scaling)) ** 2
     else:
         raise ValueError('unknown `filter_type` ({})'
                          ''.format(filter_type))
 
-    return filt
+    indicator = (norm_freq <= frequency_scaling)
+    return indicator * filt
 
 
 def tam_danielson_window(ray_trafo, smoothing_width=0.05):
     """Create Tam-Danielson window from a `RayTransform`.
 
     The Tam-Danielson window is an indicator function on the minimal set of
-    data needed to reconstruct a given data. It is useful in analytic
-    reconstruction methods such as FBP to give a more accurate reconstruction.
+    data needed to reconstruct a volume from given data. It is useful in
+    analytic reconstruction methods such as FBP to give a more accurate
+    reconstruction.
+
+    See TAM1998_ for more information.
 
     Parameters
     ----------
     ray_trafo : `RayTransform`
-        The ray transform that the window should be computed for.
-    smoothing_width : float
-        Relative width of the smoothing applied to the windows edges.
+        The ray transform for which to compute the window.
+    smoothing_width : positive float, optional
+        Width of the smoothing applied to the window's edges given as a
+        fraction of the width of the full window.
 
     Returns
     -------
@@ -124,18 +129,33 @@ def tam_danielson_window(ray_trafo, smoothing_width=0.05):
 
     See Also
     --------
-    fbp_op : Filtered back-projection from `RayTransform`
-    HelicalConeFlatGeometry : The geometry this is most useful for.
-    """
+    fbp_op : Filtered back-projection operator from `RayTransform`
+    HelicalConeFlatGeometry : The primary use case for this window function.
 
+    References
+    ----------
+    .. _TAM1998: http://iopscience.iop.org/article/10.1088/0031-9155/43/4/028
+    """
     # Extract parameters
     src_radius = ray_trafo.geometry.src_radius
     det_radius = ray_trafo.geometry.det_radius
     pitch = ray_trafo.geometry.pitch
-    dx = ray_trafo.range.meshgrid[1].ravel()
 
-    # Find the direction that the filter should be taken in
+    if pitch == 0:
+        raise ValueError('Tam-Danielson window is only defined with '
+                         '`pitch!=0`')
+
+    smoothing_width = float(smoothing_width)
+    if smoothing_width < 0:
+        raise ValueError('`smoothing_width` should be a positive float')
+
+    # Find projection of axis on detector
     axis_proj = _axis_in_detector(ray_trafo.geometry)
+    rot_dir = _rotation_direction_in_detector(ray_trafo.geometry)
+
+    # Find distance from projection of rotation axis for each pixel
+    dx = (rot_dir[0] * ray_trafo.range.meshgrid[1] +
+          rot_dir[1] * ray_trafo.range.meshgrid[2])
 
     # Compute angles
     phi = np.arctan(dx / (src_radius + det_radius))
@@ -143,10 +163,10 @@ def tam_danielson_window(ray_trafo, smoothing_width=0.05):
 
     # Compute lower and upper bound
     source_to_line_distance = src_radius + src_radius * np.cos(theta)
+    scale = (src_radius + det_radius) / source_to_line_distance
+
     source_to_line_lower = pitch * (theta - np.pi) / (2 * np.pi)
     source_to_line_upper = pitch * (theta + np.pi) / (2 * np.pi)
-
-    scale = (src_radius + det_radius) / source_to_line_distance
 
     lower_proj = source_to_line_lower * scale
     upper_proj = source_to_line_upper * scale
@@ -155,26 +175,25 @@ def tam_danielson_window(ray_trafo, smoothing_width=0.05):
     interval = (upper_proj - lower_proj)
     width = interval * smoothing_width / np.sqrt(2)
 
-    # Append axes
-    interval = interval[None, :, None]
-    lower_proj = lower_proj[None, :, None]
-    upper_proj = upper_proj[None, :, None]
-    width = width[None, :, None]
-
     # Create window function
     def window_fcn(x):
         x_along_axis = axis_proj[0] * x[1] + axis_proj[1] * x[2]
-        lower_wndw = 0.5 * (
-            1 + sp.special.erf((x_along_axis - lower_proj) / width))
-        upper_wndw = 0.5 * (
-            1 + sp.special.erf((upper_proj - x_along_axis) / width))
+        if smoothing_width != 0:
+            lower_wndw = 0.5 * (
+                1 + sp.special.erf((x_along_axis - lower_proj) / width))
+            upper_wndw = 0.5 * (
+                1 + sp.special.erf((upper_proj - x_along_axis) / width))
+        else:
+            lower_wndw = (x_along_axis >= lower_proj)
+            upper_wndw = (x_along_axis <= upper_proj)
 
         return lower_wndw * upper_wndw
 
     return ray_trafo.range.element(window_fcn)
 
 
-def fbp_op(ray_trafo, padding=True, filter_type='Ram-Lak', filter_cutoff=1.0):
+def fbp_op(ray_trafo, padding=True,
+           filter_type='Ram-Lak', frequency_scaling=1.0):
     """Create filtered back-projection from a `RayTransform`.
 
     The filtered back-projection is an approximate inverse to the ray
@@ -209,10 +228,11 @@ def fbp_op(ray_trafo, padding=True, filter_type='Ram-Lak', filter_cutoff=1.0):
         The type of filter to be used. The options are, approximate order from
         most noise senstive to least noise sensitive: 'Ram-Lak', 'Shepp-Logan',
         'Cosine', 'Hamming' and 'Hann'.
-    filter_cutoff : float, optional
-        Relative cutoff frequency for the filter, a scalar in the range (0, 1].
+    frequency_scaling : float, optional
+        Relative cutoff frequency for the filter.
         The normalized frequencies are rescaled so that they fit into the range
-        [0, filter_cutoff].
+        [0, frequency_scaling]. Any frequency above ``frequency_scaling`` is
+        set to zero.
 
     Returns
     -------
@@ -228,10 +248,10 @@ def fbp_op(ray_trafo, padding=True, filter_type='Ram-Lak', filter_cutoff=1.0):
 
     if ray_trafo.domain.ndim == 2:
         # Define ramp filter
-        def fft_filter(x):
+        def fourier_filter(x):
             abs_freq = np.abs(x[1])
             norm_freq = abs_freq / np.max(abs_freq)
-            filt = _fbp_filter(norm_freq, filter_type, filter_cutoff)
+            filt = _fbp_filter(norm_freq, filter_type, frequency_scaling)
             scaling = 1 / (2 * alen)
             return filt * abs_freq * scaling
 
@@ -267,16 +287,18 @@ def fbp_op(ray_trafo, padding=True, filter_type='Ram-Lak', filter_cutoff=1.0):
                       ray_trafo.geometry.det_radius))
 
             if ray_trafo.geometry.pitch != 0:
-                # In helical each projection hits the detector less than once.
+                # In helical geometry the whole volume is not in by each
+                # projection, ideally each point in the volume effects only by
+                # the projections in a half rotation.
                 scale *= alen / (np.pi)
         else:
             scale = 1.0
 
         # Define ramp filter
-        def fft_filter(x):
+        def fourier_filter(x):
             abs_freq = np.abs(rot_dir[0] * x[1] + rot_dir[1] * x[2])
             norm_freq = abs_freq / np.max(abs_freq)
-            filt = _fbp_filter(norm_freq, filter_type, filter_cutoff)
+            filt = _fbp_filter(norm_freq, filter_type, frequency_scaling)
             scaling = scale / (2 * alen)
             return filt * abs_freq * scaling
 
@@ -306,18 +328,19 @@ def fbp_op(ray_trafo, padding=True, filter_type='Ram-Lak', filter_cutoff=1.0):
         raise NotImplementedError('FBP only implemented in 2d and 3d')
 
     # Create ramp in the detector direction
-    ramp_function = fourier.range.element(fft_filter)
+    ramp_function = fourier.range.element(fourier_filter)
 
     # Create ramp filter via the convolution formula with fourier transforms
     ramp_filter = fourier.inverse * ramp_function * fourier
 
-    # Create filtered backprojection by composing the backprojection
+    # Create filtered back-projection by composing the backprojection
     # (adjoint) with the ramp filter.
     return ray_trafo.adjoint * ramp_filter
 
 
 if __name__ == '__main__':
     # Display the various filters
+    import odl
     import matplotlib.pyplot as plt
     x = np.linspace(0, 1, 100)
     cutoff = 0.7
@@ -325,8 +348,24 @@ if __name__ == '__main__':
     for filter_name in ['Ram-Lak', 'Shepp-Logan', 'Cosine', 'Hamming', 'Hann']:
         plt.plot(x, x * _fbp_filter(x, filter_name, cutoff), label=filter_name)
 
-    plt.title('Filters with cutoff = {}'.format(cutoff))
+    plt.title('Filters with frequency scaling = {}'.format(cutoff))
     plt.legend(loc=2)
+
+    # Show the Tam-Danielson window
+
+    # Create Ray Transform in helical geometry
+    reco_space = odl.uniform_discr(
+        min_pt=[-20, -20, 0], max_pt=[20, 20, 40], shape=[300, 300, 300])
+    angle_partition = odl.uniform_partition(0, 8 * 2 * np.pi, 2000)
+    detector_partition = odl.uniform_partition([-40, -4], [40, 4], [500, 500])
+    geometry = odl.tomo.HelicalConeFlatGeometry(
+        angle_partition, detector_partition, src_radius=100, det_radius=100,
+        pitch=5.0)
+    ray_trafo = odl.tomo.RayTransform(reco_space, geometry, impl='astra_cuda')
+
+    # Crete and show TD window
+    td_window = tam_danielson_window(ray_trafo, smoothing_width=0)
+    td_window.show('Tam-Danielson window', coords=[0, None, None])
 
     # pylint: disable=wrong-import-position
     from odl.util.testutils import run_doctests


### PR DESCRIPTION
* Adds filters, the same as in matlab, to `fbp_op`. Frequency response as follows:

![filters](https://cloud.githubusercontent.com/assets/2202312/21112236/4f6b86a2-c0a5-11e6-904f-710385cf89c3.png)

* Adds `tam_danielson_window` which allows good helical reconstructions.

Helical reconstruction before windowing:

![filtered_backprojection](https://cloud.githubusercontent.com/assets/2202312/21110202/92e48c70-c09c-11e6-9cd7-88b09b79ed87.png)

After windowing:

![windowed_filtered_backprojection](https://cloud.githubusercontent.com/assets/2202312/21110208/953e96e6-c09c-11e6-972c-f732da9d91be.png)

as you can see the results are basically "perfect".