### PR TITLE
ENH: Add axis_labels option to DiscreteLp, use in RayTrafo and Fourier

### DIFF
--- a/odl/discr/lp_discr.py
+++ b/odl/discr/lp_discr.py
@@ -157,9 +157,9 @@ class DiscreteLp(DiscretizedSpace):
         axis_labels = kwargs.pop('axis_labels', None)
         if axis_labels is None:
             if self.ndim <= 3:
-                self.axis_labels = ['x', 'y', 'z'][:self.ndim]
+                self.axis_labels = ['$x$', '$y$', '$z$'][:self.ndim]
             else:
-                self.axis_labels = ['x{}'.format(axis)
+                self.axis_labels = ['$x_{}$'.format(axis)
                                     for axis in range(self.ndim)]
         else:
             self.axis_labels = tuple(str(label) for label in axis_labels)

--- a/odl/discr/lp_discr.py
+++ b/odl/discr/lp_discr.py
@@ -87,6 +87,10 @@ class DiscreteLp(DiscretizedSpace):
             first axis varies slowest, the last axis fastest;
             vice versa for 'F'.
             Default: 'C'
+        axis_labels : sequence of str, optional
+            Names of the axes to use for plotting etc.
+            Default: ['x'] in 1-D, ['x', 'y'] in 2-D, ['x', 'y', 'z'] in 3-D
+            and ['x1', 'x2', ..., 'xn'] in n-D.
         """
         if not isinstance(fspace, FunctionSpace):
             raise TypeError('{!r} is not a FunctionSpace instance'
@@ -149,6 +153,19 @@ class DiscreteLp(DiscretizedSpace):
                 self.exponent != dspace.exponent):
             raise ValueError('`exponent` {} not equal to data space exponent '
                              '{}'.format(self.exponent, dspace.exponent))
+
+        axis_labels = kwargs.pop('axis_labels', None)
+        if axis_labels is None:
+            if self.ndim <= 3:
+                self.axis_labels = ['x', 'y', 'z'][:self.ndim]
+            else:
+                self.axis_labels = ['x{}'.format(axis)
+                                    for axis in range(self.ndim)]
+        else:
+            self.axis_labels = tuple(str(label) for label in axis_labels)
+
+        if kwargs:
+            raise ValueError('unknown arguments {}'.format(kwargs))
 
     @property
     def interp(self):
@@ -841,20 +858,17 @@ class DiscreteLpElement(DiscretizedSpaceElement):
             raise ValueError('too many axes ({} > {})'.format(len(indices),
                                                               self.ndim))
 
-        if self.ndim <= 3:
-            axis_labels = ['x', 'y', 'z']
-        else:
-            axis_labels = ['x{}'.format(axis) for axis in range(self.ndim)]
         squeezed_axes = [axis for axis in range(self.ndim)
                          if not isinstance(indices[axis], Integral)]
-        axis_labels = [axis_labels[axis] for axis in squeezed_axes]
+        axis_labels = [self.space.axis_labels[axis] for axis in squeezed_axes]
 
         # Squeeze grid and values according to the index expression
         part = self.space.partition[indices].squeeze()
         values = self.asarray()[indices].squeeze()
 
         return show_discrete_data(values, part, title=title, method=method,
-                                  show=show, fig=fig, axis_labels=axis_labels,
+                                  show=show, fig=fig,
+                                  axis_labels=axis_labels,
                                   **kwargs)
 
 
@@ -956,7 +970,8 @@ def uniform_discr_frompartition(partition, exponent=2.0, interp='nearest',
         dspace = ds_type(partition.size, impl=impl, weight=weight,
                          exponent=exponent)
 
-    return DiscreteLp(fspace, partition, dspace, exponent, interp, order=order)
+    return DiscreteLp(fspace, partition, dspace, exponent, interp, order=order,
+                      **kwargs)
 
 
 def uniform_discr_fromspace(fspace, shape, exponent=2.0, interp='nearest',
@@ -1523,7 +1538,8 @@ def uniform_discr_fromdiscr(discr, min_pt=None, max_pt=None,
                                  nodes_on_bdry=nodes_on_bdry)
 
     return uniform_discr_frompartition(new_part, exponent=discr.exponent,
-                                       interp=discr.interp, impl=discr.impl)
+                                       interp=discr.interp, impl=discr.impl,
+                                       **kwargs)
 
 
 def _scaling_func_list(bdry_fracs, exponent=1.0):

--- a/odl/tomo/operators/ray_trafo.py
+++ b/odl/tomo/operators/ray_trafo.py
@@ -155,9 +155,9 @@ class RayTransform(Operator):
                                                     weight=weight, dtype=dtype)
 
             if geometry.ndim == 2:
-                axis_labels = ['$\\theta$ (rad)', 's']
+                axis_labels = ['$\\theta$', '$s$']
             elif geometry.ndim == 3:
-                axis_labels = ['$\\theta$ (rad)', 'u', 'v']
+                axis_labels = ['$\\theta$', '$u$', '$v$']
             else:
                 # TODO Add this when we add nd ray transform.
                 axis_labels = None
@@ -286,9 +286,9 @@ class RayBackProjection(Operator):
                                                     weight=weight, dtype=dtype)
 
             if geometry.ndim == 2:
-                axis_labels = ['$\\theta$ (rad)', 's']
+                axis_labels = ['$\\theta$', '$s$']
             elif geometry.ndim == 3:
-                axis_labels = ['$\\theta$ (rad)', 'u', 'v']
+                axis_labels = ['$\\theta$', '$u$', '$v$']
             else:
                 # TODO Add this when we add nd ray transform.
                 axis_labels = None

--- a/odl/tomo/operators/ray_trafo.py
+++ b/odl/tomo/operators/ray_trafo.py
@@ -154,10 +154,19 @@ class RayTransform(Operator):
             range_dspace = discr_domain.dspace_type(geometry.partition.size,
                                                     weight=weight, dtype=dtype)
 
+            if geometry.ndim == 2:
+                axis_labels = ['$\\theta$ (rad)', 's']
+            elif geometry.ndim == 3:
+                axis_labels = ['$\\theta$ (rad)', 'u', 'v']
+            else:
+                # TODO Add this when we add nd ray transform.
+                axis_labels = None
+
             range_interp = kwargs.get('interp', 'nearest')
             discr_range = DiscreteLp(
                 range_uspace, geometry.partition, range_dspace,
-                interp=range_interp, order=discr_domain.order)
+                interp=range_interp, order=discr_domain.order,
+                axis_labels=axis_labels)
 
         super().__init__(discr_domain, discr_range, linear=True)
 
@@ -276,10 +285,19 @@ class RayBackProjection(Operator):
             domain_dspace = discr_range.dspace_type(geometry.partition.size,
                                                     weight=weight, dtype=dtype)
 
+            if geometry.ndim == 2:
+                axis_labels = ['$\\theta$ (rad)', 's']
+            elif geometry.ndim == 3:
+                axis_labels = ['$\\theta$ (rad)', 'u', 'v']
+            else:
+                # TODO Add this when we add nd ray transform.
+                axis_labels = None
+
             domain_interp = kwargs.get('interp', 'nearest')
             discr_domain = DiscreteLp(
                 domain_uspace, geometry.partition, domain_dspace,
-                interp=domain_interp, order=discr_range.order)
+                interp=domain_interp, order=discr_range.order,
+                axis_labels=axis_labels)
         super().__init__(discr_domain, discr_range, linear=True)
 
     @property

--- a/odl/trafos/util/ft_utils.py
+++ b/odl/trafos/util/ft_utils.py
@@ -642,7 +642,9 @@ def reciprocal_space(space, axes=None, halfcomplex=False, shift=True,
     # Use convention of adding a hat to represent fourier transform of variable
     axis_labels = list(space.axis_labels)
     for i in axes:
-        axis_labels[i] = '$\^{{{}}}$'.format(axis_labels[i])
+        # Avoid double math
+        label = axis_labels[i].replace('$', '')
+        axis_labels[i] = '$\^{{{}}}$'.format(label)
 
     recip_spc = uniform_discr_frompartition(part, exponent=exponent,
                                             dtype=dtype, impl=impl,

--- a/odl/trafos/util/ft_utils.py
+++ b/odl/trafos/util/ft_utils.py
@@ -639,8 +639,14 @@ def reciprocal_space(space, axes=None, halfcomplex=False, shift=True,
     else:
         part = uniform_partition_fromgrid(recip_grid)
 
+    # Use convention of adding a hat to represent fourier transform of variable
+    axis_labels = list(space.axis_labels)
+    for i in axes:
+        axis_labels[i] = '$\^{{{}}}$'.format(axis_labels[i])
+
     recip_spc = uniform_discr_frompartition(part, exponent=exponent,
-                                            dtype=dtype, impl=impl)
+                                            dtype=dtype, impl=impl,
+                                            axis_labels=axis_labels)
 
     return recip_spc
 

--- a/odl/util/graphics.py
+++ b/odl/util/graphics.py
@@ -119,16 +119,19 @@ def show_discrete_data(values, grid, title=None, method='',
     show : bool, optional
         If the plot should be showed now or deferred until later
 
-    fig : `matplotlib.figure.Figure`
+    fig : `matplotlib.figure.Figure`, optional
         The figure to show in. Expected to be of same "style", as the figure
         given by this function. The most common usecase is that fig is the
         return value from an earlier call to this function.
 
-    interp : {'nearest', 'linear'}
+    interp : {'nearest', 'linear'}, optional
         Interpolation method to use.
 
-    axis_labels : string
+    axis_labels : string, optional
         Axis labels, default: ['x', 'y']
+
+    axis_fontsize : int, optional
+        Fontsize for the axes. Default: 16
 
     kwargs : {'figsize', 'saveto', ...}
         Extra keyword arguments passed on to display method
@@ -166,6 +169,7 @@ def show_discrete_data(values, grid, title=None, method='',
     figsize = kwargs.pop('figsize', None)
     saveto = kwargs.pop('saveto', None)
     interp = kwargs.pop('interp', 'nearest')
+    axis_fontsize = kwargs.pop('axis_fontsize', 16)
 
     if values.ndim == 1:  # TODO: maybe a plotter class would be better
         if not method:
@@ -260,9 +264,9 @@ def show_discrete_data(values, grid, title=None, method='',
             # Create new axis if needed
             sub_re = plt.subplot(arrange_subplots[0], **sub_kwargs)
             sub_re.set_title('Real part')
-            sub_re.set_xlabel(axis_labels[0])
+            sub_re.set_xlabel(axis_labels[0], fontsize=axis_fontsize)
             if values.ndim == 2:
-                sub_re.set_ylabel(axis_labels[1])
+                sub_re.set_ylabel(axis_labels[1], fontsize=axis_fontsize)
             else:
                 sub_re.set_ylabel('value')
         else:
@@ -296,9 +300,9 @@ def show_discrete_data(values, grid, title=None, method='',
         if len(fig.axes) < 3:
             sub_im = plt.subplot(arrange_subplots[1], **sub_kwargs)
             sub_im.set_title('Imaginary part')
-            sub_im.set_xlabel(axis_labels[0])
+            sub_im.set_xlabel(axis_labels[0], fontsize=axis_fontsize)
             if values.ndim == 2:
-                sub_im.set_ylabel(axis_labels[1])
+                sub_im.set_ylabel(axis_labels[1], fontsize=axis_fontsize)
             else:
                 sub_im.set_ylabel('value')
         else:
@@ -332,9 +336,9 @@ def show_discrete_data(values, grid, title=None, method='',
         if len(fig.axes) == 0:
             # Create new axis object if needed
             sub = plt.subplot(111, **sub_kwargs)
-            sub.set_xlabel(axis_labels[0])
+            sub.set_xlabel(axis_labels[0], fontsize=axis_fontsize)
             if values.ndim == 2:
-                sub.set_ylabel(axis_labels[1])
+                sub.set_ylabel(axis_labels[1], fontsize=axis_fontsize)
             else:
                 sub.set_ylabel('value')
             try:


### PR DESCRIPTION
Adds axis labels and defaults, mostly intended to be used with stuff like there RayTransform where `x` for an angle makes absolutely no sense.

Example 1, fourier transform. Note that when the fourier transform is only along one axis this is clearly indicated in the plots now.

![fourier_transform_along_axis_0](https://cloud.githubusercontent.com/assets/2202312/21315931/aee7594a-c5fe-11e6-8fb6-5e36c697d73e.png)

Example 2, ray transform. former "x" variable is now the much more readable theta, even properly typeset.

![projection_data_ sinogram](https://cloud.githubusercontent.com/assets/2202312/21315935/b11ea7ae-c5fe-11e6-8136-bb76e8d43a4b.png)

