### PR TITLE
ENH: implement pspace assignment broadcasting

### DIFF
--- a/odl/operator/pspace_ops.py
+++ b/odl/operator/pspace_ops.py
@@ -387,7 +387,7 @@ class ComponentProjection(Operator):
         ----------
         space : `ProductSpace`
             Space to project from.
-        index : int, slice, or iterable
+        index : int, slice, or list
             Indices defining the subspace. If ``index`` is not an integer,
             the `Operator.range` of this operator is also a `ProductSpace`.
 
@@ -398,7 +398,7 @@ class ComponentProjection(Operator):
         >>> r3 = odl.rn(3)
         >>> X = odl.ProductSpace(r1, r2, r3)
 
-        Projection on n-th component
+        Projection on n-th component:
 
         >>> proj = odl.ComponentProjection(X, 0)
         >>> x = [[1.0],
@@ -407,7 +407,7 @@ class ComponentProjection(Operator):
         >>> proj(x)
         rn(1).element([1.0])
 
-        Projection on sub-space
+        Projection on sub-space:
 
         >>> proj = odl.ComponentProjection(X, [0, 2])
         >>> proj(x)
@@ -466,7 +466,7 @@ class ComponentProjectionAdjoint(Operator):
         ----------
         space : `ProductSpace`
             Space to project to.
-        index : int, slice, or iterable
+        index : int, slice, or list
             Indexes to project from.
 
         Examples
@@ -479,8 +479,8 @@ class ComponentProjectionAdjoint(Operator):
 
         Projection on the 0-th component:
 
-        >>> proj = odl.ComponentProjectionAdjoint(X, 0)
-        >>> proj(x[0])
+        >>> proj_adj = odl.ComponentProjectionAdjoint(X, 0)
+        >>> proj_adj(x[0])
         ProductSpace(rn(1), rn(2), rn(3)).element([
             [1.0],
             [0.0, 0.0],
@@ -489,8 +489,8 @@ class ComponentProjectionAdjoint(Operator):
 
         Projection on a sub-space corresponding to indices 0 and 2:
 
-        >>> proj = odl.ComponentProjectionAdjoint(X, [0, 2])
-        >>> proj(x[0, 2])
+        >>> proj_adj = odl.ComponentProjectionAdjoint(X, [0, 2])
+        >>> proj_adj(x[[0, 2]])
         ProductSpace(rn(1), rn(2), rn(3)).element([
             [1.0],
             [0.0, 0.0],

--- a/odl/space/pspace.py
+++ b/odl/space/pspace.py
@@ -644,9 +644,11 @@ class ProductSpaceElement(LinearSpaceElement):
             return self.parts[indices]
         elif isinstance(indices, slice):
             return self.space[indices].element(self.parts[indices])
-        else:
+        elif isinstance(indices, list):
             out_parts = [self.parts[i] for i in indices]
             return self.space[indices].element(out_parts)
+        else:
+            raise TypeError('bad index type {}'.format(type(indices)))
 
     def __setitem__(self, indices, values):
         """Implement ``self[indices] = values``."""

--- a/odl/space/pspace.py
+++ b/odl/space/pspace.py
@@ -602,12 +602,12 @@ class ProductSpaceElement(LinearSpaceElement):
     def __init__(self, space, parts):
         """Initialize a new instance."""
         super().__init__(space)
-        self._parts = list(parts)
+        self.__parts = tuple(parts)
 
     @property
     def parts(self):
         """Parts of this product space element."""
-        return self._parts
+        return self.__parts
 
     @property
     def size(self):
@@ -650,11 +650,41 @@ class ProductSpaceElement(LinearSpaceElement):
 
     def __setitem__(self, indices, values):
         """Implement ``self[indices] = values``."""
+        # Get the parts to which we assign values
+        if isinstance(indices, Integral):
+            indexed_parts = (self.parts[indices],)
+            values = (values,)
+        elif isinstance(indices, slice):
+            indexed_parts = self.parts[indices]
+        elif isinstance(indices, list):
+            indexed_parts = tuple(self.parts[i] for i in indices)
+        else:
+            raise TypeError('bad index type {}'.format(type(indices)))
+
+        # Do the assignment, with broadcasting if desired
         try:
-            self.parts[indices] = values
+            iter(values)
         except TypeError:
-            for i, index in enumerate(indices):
-                self.parts[index] = values[i]
+            # `values` is not iterable, assume it can be assigned to
+            # all indexed parts
+            for p in indexed_parts:
+                p[:] = values
+        else:
+            # `values` is iterable; it could still represent a single
+            # element of a power space.
+            if self.space.is_power_space and values in self.space[0]:
+                # Broadcast a single element across a power space
+                for p in indexed_parts:
+                    p[:] = values
+            else:
+                # Now we really have one assigned value per part
+                if len(values) != len(indexed_parts):
+                    raise ValueError(
+                        'length of iterable `values` not equal to number of '
+                        'indexed parts ({} != {})'
+                        ''.format(len(values), len(indexed_parts)))
+                for p, v in zip(indexed_parts, values):
+                    p[:] = v
 
     @property
     def ufunc(self):

--- a/odl/test/space/pspace_test.py
+++ b/odl/test/space/pspace_test.py
@@ -521,14 +521,14 @@ def test_element_equals():
 def test_element_getitem_single():
     H = odl.ProductSpace(odl.rn(1), odl.rn(2))
 
-    x1 = H[0].element([0])
-    x2 = H[1].element([1, 2])
-    x = H.element([x1, x2])
+    x0 = H[0].element([0])
+    x1 = H[1].element([1, 2])
+    x = H.element([x0, x1])
 
-    assert x[-2] is x1
-    assert x[-1] is x2
-    assert x[0] is x1
-    assert x[1] is x2
+    assert x[-2] is x0
+    assert x[-1] is x1
+    assert x[0] is x0
+    assert x[1] is x1
     with pytest.raises(IndexError):
         x[-3]
         x[2]
@@ -537,84 +537,135 @@ def test_element_getitem_single():
 def test_element_getitem_slice():
     H = odl.ProductSpace(odl.rn(1), odl.rn(2), odl.rn(3))
 
-    x1 = H[0].element([0])
-    x2 = H[1].element([1, 2])
-    x3 = H[2].element([3, 4, 5])
-    x = H.element([x1, x2, x3])
+    x0 = H[0].element([0])
+    x1 = H[1].element([1, 2])
+    x2 = H[2].element([3, 4, 5])
+    x = H.element([x0, x1, x2])
 
     assert x[:2].space == H[:2]
-    assert x[:2][0] is x1
-    assert x[:2][1] is x2
+    assert x[:2][0] is x0
+    assert x[:2][1] is x1
 
 
 def test_element_getitem_fancy():
     H = odl.ProductSpace(odl.rn(1), odl.rn(2), odl.rn(3))
 
-    x1 = H[0].element([0])
-    x2 = H[1].element([1, 2])
-    x3 = H[2].element([3, 4, 5])
-    x = H.element([x1, x2, x3])
+    x0 = H[0].element([0])
+    x1 = H[1].element([1, 2])
+    x2 = H[2].element([3, 4, 5])
+    x = H.element([x0, x1, x2])
 
     assert x[[0, 2]].space == H[[0, 2]]
-    assert x[[0, 2]][0] is x1
-    assert x[[0, 2]][1] is x3
+    assert x[[0, 2]][0] is x0
+    assert x[[0, 2]][1] is x2
 
 
 def test_element_setitem_single():
-    H = odl.ProductSpace(odl.rn(1), odl.rn(2))
+    """Test assignment of pspace parts with single indices."""
+    pspace = odl.ProductSpace(odl.rn(1), odl.rn(2))
 
-    x1 = H[0].element([0])
-    x2 = H[1].element([1, 2])
-    x = H.element([x1, x2])
+    x0 = pspace[0].element([0])
+    x1 = pspace[1].element([1, 2])
+    x = pspace.element([x0, x1])
+    old_x0 = x[0]
+    old_x1 = x[1]
 
-    x1_1 = H[0].element([1])
-    x[-2] = x1_1
-    assert x[-2] is x1_1
+    # Check that values are set, but identity is preserved
+    new_x0 = pspace[0].element([1])
+    x[-2] = new_x0
+    assert x[-2] == new_x0
+    assert x[-2] is old_x0
 
-    x2_1 = H[1].element([3, 4])
-    x[-1] = x2_1
-    assert x[-1] is x2_1
+    new_x1 = pspace[1].element([3, 4])
+    x[-1] = new_x1
+    assert x[-1] == new_x1
+    assert x[-1] is old_x1
 
-    x1_2 = H[0].element([5])
-    x[0] = x1_2
+    # Set values with scalars
+    x[1] = -1
+    assert all_equal(x[1], [-1, -1])
+    assert x[1] is old_x1
 
-    x2_2 = H[1].element([3, 4])
-    x[1] = x2_2
-    assert x[1] is x2_2
-
+    # Check that out-of-bounds indices raise IndexError
     with pytest.raises(IndexError):
-        x[-3] = x2
-        x[2] = x1
+        x[-3] = x1
+    with pytest.raises(IndexError):
+        x[2] = x0
 
 
 def test_element_setitem_slice():
-    H = odl.ProductSpace(odl.rn(1), odl.rn(2), odl.rn(3))
+    """Test assignment of pspace parts with slices."""
+    pspace = odl.ProductSpace(odl.rn(1), odl.rn(2), odl.rn(3))
 
-    x1 = H[0].element([0])
-    x2 = H[1].element([1, 2])
-    x3 = H[2].element([3, 4, 5])
-    x = H.element([x1, x2, x3])
+    x0 = pspace[0].element([0])
+    x1 = pspace[1].element([1, 2])
+    x2 = pspace[2].element([3, 4, 5])
+    x = pspace.element([x0, x1, x2])
+    old_x0 = x[0]
+    old_x1 = x[1]
 
-    x1_new = H[0].element([6])
-    x2_new = H[1].element([7, 8])
-    x[:2] = H[:2].element([x1_new, x2_new])
-    assert x[:2][0] is x1_new
-    assert x[:2][1] is x2_new
+    # Check that values are set, but identity is preserved
+    new_x0 = pspace[0].element([6])
+    new_x1 = pspace[1].element([7, 8])
+    x[:2] = pspace[:2].element([new_x0, new_x1])
+    assert x[:2][0] is old_x0
+    assert x[:2][0] == new_x0
+    assert x[:2][1] is old_x1
+    assert x[:2][1] == new_x1
+
+    # Set values with sequences of scalars
+    x[:2] = [-1, -2]
+    assert x[:2][0] is old_x0
+    assert all_equal(x[:2][0], [-1])
+    assert x[:2][1] is old_x1
+    assert all_equal(x[:2][1], [-2, -2])
 
 
 def test_element_setitem_fancy():
-    H = odl.ProductSpace(odl.rn(1), odl.rn(2), odl.rn(3))
+    """Test assignment of pspace parts with lists."""
+    pspace = odl.ProductSpace(odl.rn(1), odl.rn(2), odl.rn(3))
 
-    x1 = H[0].element([0])
-    x2 = H[1].element([1, 2])
-    x3 = H[2].element([3, 4, 5])
-    x = H.element([x1, x2, x3])
+    x0 = pspace[0].element([0])
+    x1 = pspace[1].element([1, 2])
+    x2 = pspace[2].element([3, 4, 5])
+    x = pspace.element([x0, x1, x2])
+    old_x0 = x[0]
+    old_x2 = x[2]
 
-    x1_new = H[0].element([6])
-    x3_new = H[2].element([7, 8, 9])
-    x[[0, 2]] = H[[0, 2]].element([x1_new, x3_new])
-    assert x[[0, 2]][0] is x1_new
-    assert x[[0, 2]][1] is x3_new
+    # Check that values are set, but identity is preserved
+    new_x0 = pspace[0].element([6])
+    new_x2 = pspace[2].element([7, 8, 9])
+    x[[0, 2]] = pspace[[0, 2]].element([new_x0, new_x2])
+    assert x[[0, 2]][0] is old_x0
+    assert x[[0, 2]][0] == new_x0
+    assert x[[0, 2]][1] is old_x2
+    assert x[[0, 2]][1] == new_x2
+
+    # Set values with sequences of scalars
+    x[[0, 2]] = [-1, -2]
+    assert x[[0, 2]][0] is old_x0
+    assert all_equal(x[[0, 2]][0], [-1])
+    assert x[[0, 2]][1] is old_x2
+    assert all_equal(x[[0, 2]][1], [-2, -2, -2])
+
+
+def test_element_setitem_broadcast():
+    """Test assignment of power space parts with broadcasting."""
+    pspace = odl.ProductSpace(odl.rn(2), 3)
+    x0 = pspace[0].element([0, 1])
+    x1 = pspace[1].element([2, 3])
+    x2 = pspace[2].element([4, 5])
+    x = pspace.element([x0, x1, x2])
+    old_x0 = x[0]
+    old_x1 = x[1]
+
+    # Set values with a single base space element
+    new_x0 = pspace[0].element([4, 5])
+    x[:2] = new_x0
+    assert x[0] is old_x0
+    assert x[0] == new_x0
+    assert x[1] is old_x1
+    assert x[1] == new_x0
 
 
 def test_unary_ops():


### PR DESCRIPTION
In `ProductSpaceElement`:
- Make x.parts a tuple
- Re-implement `__setitem__` with broadcasting
- Adapt tests

Closes: #767