### PR TITLE
ENH: Add parallel_beam_geometry, closes #711

### DIFF
--- a/examples/solvers/chambolle_pock_tomography.py
+++ b/examples/solvers/chambolle_pock_tomography.py
@@ -41,8 +41,8 @@ reco_space = odl.uniform_discr(
     min_pt=[-20, -20], max_pt=[20, 20], shape=[300, 300], dtype='float32')
 
 # Make a parallel beam geometry with flat detector
-# Angles: uniformly spaced, n = 360, min = 0, max = 2 * pi
-angle_partition = odl.uniform_partition(0, 2 * np.pi, 360)
+# Angles: uniformly spaced, n = 360, min = 0, max = pi
+angle_partition = odl.uniform_partition(0, np.pi, 360)
 # Detector: uniformly sampled, n = 558, min = -30, max = 30
 detector_partition = odl.uniform_partition(-30, 30, 558)
 geometry = odl.tomo.Parallel2dGeometry(angle_partition, detector_partition)

--- a/examples/solvers/conjugate_gradient_tomography.py
+++ b/examples/solvers/conjugate_gradient_tomography.py
@@ -38,8 +38,8 @@ reco_space = odl.uniform_discr(
     min_pt=[-20, -20], max_pt=[20, 20], shape=[300, 300], dtype='float32')
 
 # Make a parallel beam geometry with flat detector
-# Angles: uniformly spaced, n = 360, min = 0, max = 2 * pi
-angle_partition = odl.uniform_partition(0, 2 * np.pi, 360)
+# Angles: uniformly spaced, n = 360, min = 0, max = pi
+angle_partition = odl.uniform_partition(0, np.pi, 360)
 
 # Detector: uniformly sampled, n = 300, min = -30, max = 30
 detector_partition = odl.uniform_partition(-30, 30, 300)

--- a/examples/solvers/nuclear_norm_tomography.py
+++ b/examples/solvers/nuclear_norm_tomography.py
@@ -53,8 +53,8 @@ space = odl.uniform_discr(
     min_pt=[-20, -20], max_pt=[20, 20], shape=[100, 100], dtype='float32')
 
 # Make a parallel beam geometry with flat detector
-# Angles: uniformly spaced, n = 300, min = 0, max = 2 * pi
-angle_partition = odl.uniform_partition(0, 2 * np.pi, 300)
+# Angles: uniformly spaced, n = 300, min = 0, max = pi
+angle_partition = odl.uniform_partition(0, np.pi, 300)
 # Detector: uniformly sampled, n = 300, min = -30, max = 30
 detector_partition = odl.uniform_partition(-30, 30, 300)
 geometry = odl.tomo.Parallel2dGeometry(angle_partition, detector_partition)

--- a/examples/solvers/proximal_gradient_wavelet_tomography.py
+++ b/examples/solvers/proximal_gradient_wavelet_tomography.py
@@ -40,8 +40,8 @@ space = odl.uniform_discr(
     min_pt=[-20, -20], max_pt=[20, 20], shape=[256, 256], dtype='float32')
 
 # Make a parallel beam geometry with flat detector
-# Angles: uniformly spaced, n = 300, min = 0, max = 2 * pi
-angle_partition = odl.uniform_partition(0, 2 * np.pi, 300)
+# Angles: uniformly spaced, n = 300, min = 0, max = pi
+angle_partition = odl.uniform_partition(0, np.pi, 300)
 # Detector: uniformly sampled, n = 300, min = -30, max = 30
 detector_partition = odl.uniform_partition(-30, 30, 300)
 geometry = odl.tomo.Parallel2dGeometry(angle_partition, detector_partition)

--- a/examples/solvers/proximal_lang_tomography.py
+++ b/examples/solvers/proximal_lang_tomography.py
@@ -39,8 +39,8 @@ reco_space = odl.uniform_discr(
     min_pt=[-20, -20], max_pt=[20, 20], shape=[300, 300], dtype='float32')
 
 # Make a parallel beam geometry with flat detector
-# Angles: uniformly spaced, n = 360, min = 0, max = 2 * pi
-angle_partition = odl.uniform_partition(0, 2 * np.pi, 360)
+# Angles: uniformly spaced, n = 360, min = 0, max = pi
+angle_partition = odl.uniform_partition(0, np.pi, 360)
 # Detector: uniformly sampled, n = 558, min = -30, max = 30
 detector_partition = odl.uniform_partition(-30, 30, 558)
 geometry = odl.tomo.Parallel2dGeometry(angle_partition, detector_partition)

--- a/examples/tomo/filtered_backprojection_parallel_2d.py
+++ b/examples/tomo/filtered_backprojection_parallel_2d.py
@@ -16,14 +16,15 @@
 # along with ODL.  If not, see <http://www.gnu.org/licenses/>.
 
 """
-Example using a filtered back-projection in 2d using the ray transform and a
+Example creating a filtered back-projection in 2d using the ray transform and a
 ramp filter. The ramp filter is implemented in fourier space.
 
 See https://en.wikipedia.org/wiki/Radon_transform#Inversion_formulas for
 more information.
 
 Also note that ODL has a utility function, `fbp_op` that can be used to perform
-filtered back-projection.
+filtered back-projection, and that this example is intended to show how this
+could be implemented in ODL.
 """
 
 import numpy as np

--- a/examples/tomo/filtered_backprojection_parallel_2d.py
+++ b/examples/tomo/filtered_backprojection_parallel_2d.py
@@ -17,14 +17,14 @@
 
 """
 Example creating a filtered back-projection in 2d using the ray transform and a
-ramp filter. The ramp filter is implemented in fourier space.
+ramp filter. The ramp filter is implemented in Fourier space.
 
 See https://en.wikipedia.org/wiki/Radon_transform#Inversion_formulas for
 more information.
 
 Also note that ODL has a utility function, `fbp_op` that can be used to perform
 filtered back-projection, and that this example is intended to show how this
-could be implemented in ODL.
+could be implemented by hand using ODL.
 """
 
 import numpy as np

--- a/examples/tomo/scikit_ray_trafo_parallel_2d.py
+++ b/examples/tomo/scikit_ray_trafo_parallel_2d.py
@@ -30,8 +30,8 @@ reco_space = odl.uniform_discr(
     min_pt=[-20, -20], max_pt=[20, 20], shape=[300, 300], dtype='float32')
 
 # Make a parallel beam geometry with flat detector
-# Angles: uniformly spaced, n = 360, min = 0, max = 2 * pi
-angle_partition = odl.uniform_partition(0, 2 * np.pi, 360)
+# Angles: uniformly spaced, n = 360, min = 0, max = pi
+angle_partition = odl.uniform_partition(0, np.pi, 360)
 # Detector: uniformly sampled, n = 558, min = -30, max = 30
 detector_partition = odl.uniform_partition(-30, 30, 558)
 geometry = odl.tomo.Parallel2dGeometry(angle_partition, detector_partition)

--- a/odl/test/tomo/geometry/geometry_test.py
+++ b/odl/test/tomo/geometry/geometry_test.py
@@ -123,6 +123,63 @@ def test_parallel_3d_single_axis_geometry():
     assert repr(geom)
 
 
+def test_parallel_beam_helper():
+    """Test that parallel_beam_geometry satisfies the sampling conditions."""
+    # --- 2d case ---
+    space = odl.uniform_discr([-1, -1], [1, 1], [20, 20])
+    geometry = odl.tomo.parallel_beam_geometry(space)
+
+    rho = np.sqrt(2)
+    omega = 2 * np.pi * 10.0
+
+    # Validate angles
+    assert geometry.motion_partition.is_uniform
+    assert pytest.approx(geometry.motion_partition.extent(), np.pi)
+    assert geometry.motion_partition.cell_sides <= np.pi / (rho * omega)
+
+    # Validate detector
+    assert geometry.det_partition.cell_sides <= np.pi / omega
+    assert pytest.approx(geometry.det_partition.extent(), 2 * rho)
+
+    # --- 3d case ---
+
+    space = odl.uniform_discr([-1, -1, 0], [1, 1, 2], [20, 20, 40])
+    geometry = odl.tomo.parallel_beam_geometry(space)
+
+    # Validate angles
+    assert geometry.motion_partition.is_uniform
+    assert pytest.approx(geometry.motion_partition.extent(), np.pi)
+    assert geometry.motion_partition.cell_sides <= np.pi / (rho * omega)
+
+    # Validate detector
+    assert geometry.det_partition.cell_sides[0] <= np.pi / omega
+    assert pytest.approx(geometry.det_partition.cell_sides[0], 0.05)
+    assert pytest.approx(geometry.det_partition.extent()[0], 2 * rho)
+
+    # Validate that new detector axis is correctly aligned with the rotation
+    # axis and that there is one detector row per slice
+    assert pytest.approx(geometry.det_partition.min_pt[1], 0.0)
+    assert pytest.approx(geometry.det_partition.max_pt[1], 2.0)
+    assert geometry.det_partition.shape[1] == space.shape[2]
+    assert all_equal(geometry.det_init_axes[1], geometry.axis)
+
+    # --- offset geometry ---
+    space = odl.uniform_discr([0, 0], [2, 2], [20, 20])
+    geometry = odl.tomo.parallel_beam_geometry(space)
+
+    rho = np.sqrt(2) * 2
+    omega = 2 * np.pi * 10.0
+
+    # Validate angles
+    assert geometry.motion_partition.is_uniform
+    assert pytest.approx(geometry.motion_partition.extent(), np.pi)
+    assert geometry.motion_partition.cell_sides <= np.pi / (rho * omega)
+
+    # Validate detector
+    assert geometry.det_partition.cell_sides <= np.pi / omega
+    assert pytest.approx(geometry.det_partition.extent(), 2 * rho)
+
+
 def test_fanflat():
     """2D fanbeam geometry with 1D line detector."""
 

--- a/odl/test/tomo/geometry/geometry_test.py
+++ b/odl/test/tomo/geometry/geometry_test.py
@@ -123,14 +123,14 @@ def test_parallel_3d_single_axis_geometry():
     assert repr(geom)
 
 
-def test_parallel_beam_helper():
+def test_parallel_beam_geometry_helper():
     """Test that parallel_beam_geometry satisfies the sampling conditions."""
     # --- 2d case ---
     space = odl.uniform_discr([-1, -1], [1, 1], [20, 20])
     geometry = odl.tomo.parallel_beam_geometry(space)
 
     rho = np.sqrt(2)
-    omega = 2 * np.pi * 10.0
+    omega = np.pi * 10.0
 
     # Validate angles
     assert geometry.motion_partition.is_uniform
@@ -168,7 +168,7 @@ def test_parallel_beam_helper():
     geometry = odl.tomo.parallel_beam_geometry(space)
 
     rho = np.sqrt(2) * 2
-    omega = 2 * np.pi * 10.0
+    omega = np.pi * 10.0
 
     # Validate angles
     assert geometry.motion_partition.is_uniform

--- a/odl/tomo/geometry/parallel.py
+++ b/odl/tomo/geometry/parallel.py
@@ -434,7 +434,7 @@ def parallel_beam_geometry(space, angles=None, det_shape=None):
     flexibility of the geometries, but simply want a geometry that works.
 
     This default geometry gives a fully sampled sinogram according to the
-    nyquist criterion, which in general results in a very large number of
+    Nyquist criterion, which in general results in a very large number of
     samples.
 
     Parameters
@@ -462,9 +462,9 @@ def parallel_beam_geometry(space, angles=None, det_shape=None):
     >>> space = odl.uniform_discr([-1, -1], [1, 1], [20, 20])
     >>> geometry = parallel_beam_geometry(space)
     >>> geometry.angles.size
-    89
+    45
     >>> geometry.detector.size
-    57
+    29
 
     Notes
     -----
@@ -507,9 +507,13 @@ http://dx.doi.org/10.1137/1.9780898718324
     corners = space.domain.corners()[:, :2]
     rho = np.max(np.linalg.norm(corners, axis=1))
 
-    # Find default values according to Nyquist criterion
+    # Find default values according to Nyquist criterion.
+
+    # We assume that the function is bandlimited by a wave along the x or y
+    # axis. The highest frequency we can measure is then a standing wave with
+    # period of twice the inter-node distance.
     min_side = min(space.partition.cell_sides[:2])
-    omega = 2 * np.pi / min_side
+    omega = np.pi / min_side
 
     if det_shape is None:
         if space.ndim == 2:

--- a/odl/tomo/geometry/parallel.py
+++ b/odl/tomo/geometry/parallel.py
@@ -428,13 +428,14 @@ class Parallel3dAxisGeometry(ParallelGeometry, AxisOrientedGeometry):
 
 
 def parallel_beam_geometry(space, angles=None, det_shape=None):
-    """Create default parallel beam geometry from space.
-
-    This default geometry gives a fully sampled sinogram according to the
-    nyquist criterion. In general this gives a very large number of samples.
+    """Create default parallel beam geometry from ``space``.
 
     This is intended for simple test cases where users do not need the full
-    flexibility of the geometries, but simply want a geomoetry that works.
+    flexibility of the geometries, but simply want a geometry that works.
+
+    This default geometry gives a fully sampled sinogram according to the
+    nyquist criterion, which in general results in a very large number of
+    samples.
 
     Parameters
     ----------
@@ -468,18 +469,18 @@ def parallel_beam_geometry(space, angles=None, det_shape=None):
     Notes
     -----
     According to `Mathematical Methods in Image Reconstruction`_ (page 72), for
-    a function :math:`f : \\mathbb{R}^2 \\to \\mathbb{R}`, that has compact
+    a function :math:`f : \\mathbb{R}^2 \\to \\mathbb{R}` that has compact
     support
 
     .. math::
         \| x \| > \\rho  \implies f(x) = 0,
 
-    and that is bandlimited in some appropriate sense
+    and is essentially bandlimited
 
     .. math::
-       \| \\xi \| > \\Omega \implies \\hat{f}(\\xi) = 0.
+       \| \\xi \| > \\Omega \implies \\hat{f}(\\xi) \\approx 0,
 
-    Then, in order to fully reconstruct the function from a parallel beam ray
+    then, in order to fully reconstruct the function from a parallel beam ray
     transform the function should be sampled at an angular interval
     :math:`\\Delta \psi` such that
 
@@ -494,7 +495,7 @@ def parallel_beam_geometry(space, angles=None, det_shape=None):
 
     The geometry returned by this function satisfies these conditions exactly.
 
-    If the domain is 3 dimensional, the geometry is "separable", in that each
+    If the domain is 3-dimensional, the geometry is "separable", in that each
     slice along the z-dimension of the data is treated as independed 2d data.
 
     References
@@ -506,7 +507,7 @@ http://dx.doi.org/10.1137/1.9780898718324
     corners = space.domain.corners()[:, :2]
     rho = np.max(np.linalg.norm(corners, axis=1))
 
-    # Find default values according to nyquist criterion
+    # Find default values according to Nyquist criterion
     min_side = min(space.partition.cell_sides[:2])
     omega = 2 * np.pi / min_side
 
@@ -535,6 +536,8 @@ http://dx.doi.org/10.1137/1.9780898718324
                                           [rho, max_h],
                                           det_shape)
         return Parallel3dAxisGeometry(angle_partition, det_partition)
+    else:
+        raise ValueError('``space.ndim`` must be 2 or 3.')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Adds a simple utility to create parallel beam geometries. Useful for testing and such cases where you don't really care about what the geometry is but simply "want it to work".