### PR TITLE
Improve show efficiency

### DIFF
--- a/examples/solvers/chambolle_pock_deconvolve.py
+++ b/examples/solvers/chambolle_pock_deconvolve.py
@@ -32,7 +32,7 @@ import numpy as np
 import odl
 
 # Discretization parameters
-n = 50
+n = 128
 
 # Discretized spaces
 space = odl.uniform_discr([0, 0], [n, n], [n, n])
@@ -42,7 +42,7 @@ space = odl.uniform_discr([0, 0], [n, n], [n, n])
 # Where F[.] is the Fourier transform and the fourier transform of a guassian
 # with standard deviation filter_width is another gaussian with width
 # 1 / filter_width
-filter_width = 2.0  # standard deviation of the Gaussian filter
+filter_width = 3.0  # standard deviation of the Gaussian filter
 ft = odl.trafos.FourierTransform(space)
 c = filter_width ** 2 / 4.0 ** 2
 gaussian = ft.range.element(lambda x: np.exp(-(x[0] ** 2 + x[1] ** 2) * c))
@@ -85,10 +85,9 @@ f = odl.solvers.SeparableSum(l2_norm_squared, l1_norm)
 # Estimated operator norm, add 10 percent to ensure ||K||_2^2 * sigma * tau < 1
 op_norm = 1.1 * odl.power_method_opnorm(op)
 
-niter = 500  # Number of iterations
-tau = 1.0 / op_norm  # Step size for the primal variable
-sigma = 1.0 / op_norm  # Step size for the dual variable
-
+niter = 300  # Number of iterations
+tau = 10.0 / op_norm  # Step size for the primal variable
+sigma = 0.1 / op_norm  # Step size for the dual variables
 
 # Optionally pass callback to the solver to display intermediate results
 callback = (odl.solvers.CallbackPrintIteration() &

--- a/examples/solvers/chambolle_pock_denoising.py
+++ b/examples/solvers/chambolle_pock_denoising.py
@@ -63,7 +63,7 @@ op = odl.BroadcastOperator(odl.IdentityOperator(space), gradient)
 l2_norm = odl.solvers.L2NormSquared(space).translated(noisy)
 
 # Isotropic TV-regularization: l1-norm of grad(x)
-l1_norm = 0.2 * odl.solvers.L1Norm(gradient.range)
+l1_norm = 0.15 * odl.solvers.L1Norm(gradient.range)
 
 # Make separable sum of functionals, order must correspond to the operator K
 f = odl.solvers.SeparableSum(l2_norm, l1_norm)
@@ -78,13 +78,13 @@ g = odl.solvers.IndicatorNonnegativity(op.domain)
 # Estimated operator norm, add 10 percent to ensure ||K||_2^2 * sigma * tau < 1
 op_norm = 1.1 * odl.power_method_opnorm(op, xstart=noisy)
 
-niter = 400  # Number of iterations
+niter = 200  # Number of iterations
 tau = 1.0 / op_norm  # Step size for the primal variable
 sigma = 1.0 / op_norm  # Step size for the dual variable
 
 # Optional: pass callback objects to solver
 callback = (odl.solvers.CallbackPrintIteration() &
-            odl.solvers.CallbackShow(display_step=20))
+            odl.solvers.CallbackShow(display_step=5))
 
 # Starting point
 x = op.domain.zero()

--- a/examples/solvers/chambolle_pock_tomography.py
+++ b/examples/solvers/chambolle_pock_tomography.py
@@ -74,7 +74,7 @@ data += odl.phantom.white_noise(ray_trafo.range) * np.mean(data) * 0.1
 
 
 # Initialize gradient operator
-gradient = odl.Gradient(reco_space, method='forward')
+gradient = odl.Gradient(reco_space)
 
 # Column vector of two operators
 op = odl.BroadcastOperator(ray_trafo, gradient)
@@ -88,7 +88,7 @@ g = odl.solvers.ZeroFunctional(op.domain)
 l2_norm = odl.solvers.L2NormSquared(ray_trafo.range).translated(data)
 
 # Isotropic TV-regularization i.e. the l1-norm
-l1_norm = 0.03 * odl.solvers.L1Norm(gradient.range)
+l1_norm = 0.01 * odl.solvers.L1Norm(gradient.range)
 
 # Combine functionals, order must correspond to the operator K
 f = odl.solvers.SeparableSum(l2_norm, l1_norm)
@@ -98,16 +98,16 @@ f = odl.solvers.SeparableSum(l2_norm, l1_norm)
 
 
 # Estimated operator norm, add 10 percent to ensure ||K||_2^2 * sigma * tau < 1
-op_norm = 1.3 * odl.power_method_opnorm(op, maxiter=6)
+op_norm = 1.3 * odl.power_method_opnorm(op, maxiter=10)
 
 niter = 100  # Number of iterations
 tau = 1.0 / op_norm  # Step size for the primal variable
 sigma = 1.0 / op_norm  # Step size for the dual variable
-gamma = 0.2
+gamma = 0.1
 
 # Optionally pass callback to the solver to display intermediate results
 callback = (odl.solvers.CallbackPrintIteration() &
-            odl.solvers.CallbackShow(display_step=5))
+            odl.solvers.CallbackShow())
 
 # Choose a starting point
 x = op.domain.zero()

--- a/examples/solvers/denoising_with_entropy_type_regularization.py
+++ b/examples/solvers/denoising_with_entropy_type_regularization.py
@@ -79,7 +79,7 @@ f = odl.solvers.SeparableSum(kl_divergence, l1_norm)
 
 # Optional: pass callback objects to solver
 callback = (odl.solvers.CallbackPrintIteration() &
-            odl.solvers.CallbackShow(display_step=20))
+            odl.solvers.CallbackShow(display_step=5))
 
 
 # --- Select solver parameters and solve using Chambolle-Pock --- #

--- a/examples/solvers/douglas_rachford_pd_mri.py
+++ b/examples/solvers/douglas_rachford_pd_mri.py
@@ -61,10 +61,10 @@ f = odl.solvers.IndicatorBox(space, 0, 1)
 
 # Solve
 x = mri_op.domain.zero()
-callback = (odl.solvers.CallbackShow(display_step=20, clim=[0, 1]) &
+callback = (odl.solvers.CallbackShow(display_step=5, clim=[0, 1]) &
             odl.solvers.CallbackPrintIteration())
 odl.solvers.douglas_rachford_pd(x, f, g, lin_ops,
-                                tau=1.0, sigma=[1.0, 0.2],
+                                tau=2.0, sigma=[1.0, 0.1],
                                 niter=500, callback=callback)
 
 x.show('douglas rachford result')

--- a/examples/solvers/douglas_rachford_pd_tomography_tv.py
+++ b/examples/solvers/douglas_rachford_pd_tomography_tv.py
@@ -52,7 +52,7 @@ import odl
 
 # Parameters
 lam = 0.01
-data_matching = 'inexact'
+data_matching = 'exact'
 
 # --- Create spaces, forward operator and simulated data ---
 
@@ -121,7 +121,7 @@ g = [indicator_data, cross_norm]
 
 # Create callback that prints the iteration number and shows partial results
 callback = (odl.solvers.CallbackShow('iterates',
-                                     display_step=20, clim=[0, 1]) &
+                                     display_step=5, clim=[0, 1]) &
             odl.solvers.CallbackPrintIteration())
 
 # Solve with initial guess x = 0.

--- a/examples/solvers/lbfgs_tomography_tv.py
+++ b/examples/solvers/lbfgs_tomography_tv.py
@@ -94,7 +94,7 @@ hessinv_estimate = odl.ScalingOperator(reco_space, 1 / opnorm ** 2)
 
 # Optionally pass callback to the solver to display intermediate results
 callback = (odl.solvers.CallbackPrintIteration() &
-            odl.solvers.CallbackShow(display_step=5))
+            odl.solvers.CallbackShow())
 
 # Pick parameters
 maxiter = 30

--- a/examples/solvers/lbfgs_tomography_tv.py
+++ b/examples/solvers/lbfgs_tomography_tv.py
@@ -111,4 +111,4 @@ odl.solvers.bfgs_method(
 # Display images
 discr_phantom.show(title='original image')
 data.show(title='sinogram')
-x.show(title='reconstructed image', show=True)
+x.show(title='reconstructed image', force_show=True)

--- a/examples/solvers/nuclear_norm_tomography.py
+++ b/examples/solvers/nuclear_norm_tomography.py
@@ -113,7 +113,7 @@ f = odl.solvers.IndicatorBox(forward_op.domain, 0, 1)
 # Create callback that prints current iterate value and displays every 20th
 # iterate.
 func = f + l2err * forward_op + lam * nuc_norm * pgradient
-callback = (odl.solvers.CallbackShow(display_step=20) &
+callback = (odl.solvers.CallbackShow() &
             odl.solvers.CallbackPrint(func=func))
 
 # Solve the problem. Here the parameters are chosen in order to ensure

--- a/examples/solvers/proximal_gradient_denoising.py
+++ b/examples/solvers/proximal_gradient_denoising.py
@@ -61,7 +61,7 @@ gamma = 0.01
 
 # Optionally pass callback to the solver to display intermediate results
 callback = (odl.solvers.CallbackPrintIteration() &
-            odl.solvers.CallbackShow(display_step=10))
+            odl.solvers.CallbackShow())
 
 # Run the algorithm (ISTA)
 x = space.zero()

--- a/examples/solvers/proximal_gradient_wavelet_tomography.py
+++ b/examples/solvers/proximal_gradient_wavelet_tomography.py
@@ -99,7 +99,7 @@ gamma = 0.05
 
 # Optionally pass callback to the solver to display intermediate results
 callback = (odl.solvers.CallbackPrintIteration() &
-            odl.solvers.CallbackShow(display_step=10))
+            odl.solvers.CallbackShow())
 
 
 def callb(x):

--- a/examples/solvers/proximal_gradient_wavelet_tomography.py
+++ b/examples/solvers/proximal_gradient_wavelet_tomography.py
@@ -84,7 +84,7 @@ scales = W.scales()
 Wtrafoinv = W.inverse * (1 / (np.power(1.7, scales)))
 
 # Create regularizer as l1 norm
-regularizer = 0.0002 * odl.solvers.L1Norm(W.range)
+regularizer = 0.0005 * odl.solvers.L1Norm(W.range)
 
 # l2-squared norm of residual
 l2_norm_sq = odl.solvers.L2NormSquared(ray_trafo.range).translated(data)
@@ -94,12 +94,12 @@ data_discrepancy = l2_norm_sq * ray_trafo * Wtrafoinv
 
 # --- Select solver parameters and solve using proximal gradient --- #
 
-# Select step-size that guarantees convergence.
-gamma = 0.05
+# Select step-size that gives convergence.
+gamma = 0.2
 
 # Optionally pass callback to the solver to display intermediate results
 callback = (odl.solvers.CallbackPrintIteration() &
-            odl.solvers.CallbackShow())
+            odl.solvers.CallbackShow(display_step=5))
 
 
 def callb(x):
@@ -109,7 +109,7 @@ def callb(x):
 # Run the algorithm (FISTA)
 x = data_discrepancy.domain.zero()
 odl.solvers.accelerated_proximal_gradient(
-    x, f=regularizer, g=data_discrepancy, niter=200, gamma=gamma,
+    x, f=regularizer, g=data_discrepancy, niter=400, gamma=gamma,
     callback=callb)
 
 # Display images

--- a/examples/visualization/show_update_in_place_2d.py
+++ b/examples/visualization/show_update_in_place_2d.py
@@ -1,0 +1,38 @@
+# Copyright 2014-2016 The ODL development group
+#
+# This file is part of ODL.
+#
+# ODL is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# ODL is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with ODL.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Example on using show and updating the figure in real time in 2d.
+
+This example uses the update_in_place option, which can improve performance.
+"""
+
+import odl
+import matplotlib.pyplot as plt
+
+n = 100
+m = 200
+space = odl.uniform_discr([0, 0], [1, 1], [n, n])
+phantom = odl.phantom.shepp_logan(space, modified=True)
+
+# Create a figure by saving the result of show
+fig = None
+
+# Reuse the figure indefinitely, values are overwritten.
+for i in range(m):
+    fig = (phantom * i).show(fig=fig, clim=[0, m], update_in_place=True)
+
+plt.show()

--- a/odl/solvers/util/callback.py
+++ b/odl/solvers/util/callback.py
@@ -385,11 +385,18 @@ class CallbackShow(SolverCallback):
         self.fig = kwargs.pop('fig', None)
         self.display_step = kwargs.pop('display_step', 1)
         self.iter = 0
+        self.space_of_last_x = None
 
     def __call__(self, x):
         """Show the current iterate."""
+        # Check if we should update the figure in place
+        x_space = x.space
+        update_in_place = (self.space_of_last_x == x_space)
+        self.space_of_last_x = x_space
+
         if (self.iter % self.display_step) == 0:
-            self.fig = x.show(*self.args, fig=self.fig, **self.kwargs)
+            self.fig = x.show(*self.args, fig=self.fig,
+                              update_in_place=update_in_place, **self.kwargs)
 
         self.iter += 1
 

--- a/odl/space/pspace.py
+++ b/odl/space/pspace.py
@@ -852,15 +852,15 @@ class ProductSpaceElement(LinearSpaceElement):
 
         if indices is None:
             if len(self) < 5:
-                indices = np.arange(self.size)
+                indices = list(np.arange(self.size))
             else:
-                indices = np.linspace(0, self.size - 1, 4, dtype=int)
+                indices = list(np.linspace(0, self.size - 1, 4, dtype=int))
         else:
             if isinstance(indices, tuple):
                 indices, kwargs['indices'] = indices[0], indices[1:]
 
             if isinstance(indices, slice):
-                indices = range(*indices.indices(self.size))
+                indices = list(range(*indices.indices(self.size)))
             elif isinstance(indices, Integral):
                 indices = [indices]
 

--- a/odl/util/graphics.py
+++ b/odl/util/graphics.py
@@ -430,11 +430,15 @@ def show_discrete_data(values, grid, title=None, method='',
         plt.show(block=False)
         if not update_in_place:
             plt.draw()
-            plt.pause(0.1)
+            plt.pause(0.0001)
         else:
-            fig.canvas.update()
-            fig.canvas.flush_events()
-            if not plt.isinteractive():
+            try:
+                sub.draw_artist(csub)
+                fig.canvas.blit(fig.bbox)
+                fig.canvas.update()
+                fig.canvas.flush_events()
+            except AttributeError:
+                plt.draw()
                 plt.pause(0.0001)
 
     if force_show:

--- a/odl/util/graphics.py
+++ b/odl/util/graphics.py
@@ -432,9 +432,8 @@ def show_discrete_data(values, grid, title=None, method='',
             plt.draw()
             plt.pause(0.1)
         else:
-            sub.draw_artist(csub)
-            fig.canvas.blit(fig.bbox)
-            fig.canvas.draw()
+            fig.canvas.update()
+            fig.canvas.flush_events()
 
     if force_show:
         plt.show()

--- a/odl/util/graphics.py
+++ b/odl/util/graphics.py
@@ -125,12 +125,21 @@ def show_discrete_data(values, grid, title=None, method='',
         The figure to show in. Expected to be of same "style", as the figure
         given by this function. The most common usecase is that fig is the
         return value from an earlier call to this function.
+        Default: New figure
 
     interp : {'nearest', 'linear'}, optional
         Interpolation method to use.
+        Default: 'nearest'
 
     axis_labels : string, optional
         Axis labels, default: ['x', 'y']
+
+    update_in_place : bool, optional
+        Update the content of the figure in place. Intended for faster real
+        time plotting, typically ~5 times faster.
+        This is only performed for ``method == 'imshow'`` with real data and
+        ``fig != None``. Otherwise this parameter is treated as False.
+        Default: False
 
     axis_fontsize : int, optional
         Fontsize for the axes. Default: 16
@@ -170,6 +179,13 @@ def show_discrete_data(values, grid, title=None, method='',
     saveto = kwargs.pop('saveto', None)
     interp = kwargs.pop('interp', 'nearest')
     axis_fontsize = kwargs.pop('axis_fontsize', 16)
+
+    # Check if we should and can update the plot in place
+    update_in_place = kwargs.pop('update_in_place', False)
+    if (update_in_place and
+            (fig is None or values_are_complex or values.ndim != 2 or
+             (values.ndim == 2 and method not in ('', 'imshow')))):
+        update_in_place = False
 
     if values.ndim == 1:  # TODO: maybe a plotter class would be better
         if not method:
@@ -250,7 +266,7 @@ def show_discrete_data(values, grid, title=None, method='',
             fig = plt.figure(fig.number)
             updatefig = True
 
-            if values.ndim > 1:
+            if values.ndim > 1 and not update_in_place:
                 # If the figure is larger than 1d, we can clear it since we
                 # dont reuse anything. Keeping it causes performance problems.
                 fig.clf()
@@ -349,8 +365,27 @@ def show_discrete_data(values, grid, title=None, method='',
         else:
             sub = fig.axes[0]
 
-        display = getattr(sub, method)
-        csub = display(*args_re, **dsp_kwargs)
+        if update_in_place:
+            import matplotlib as mpl
+            imgs = [obj for obj in sub.get_children()
+                    if isinstance(obj, mpl.image.AxesImage)]
+            if len(imgs) > 0 and updatefig:
+                imgs[0].set_data(args_re[0])
+                csub = imgs[0]
+
+                # Update min-max
+                if 'clim' not in kwargs:
+                    minval, maxval = _safe_minmax(values)
+                else:
+                    minval, maxval = kwargs['clim']
+
+                csub.set_clim(minval, maxval)
+            else:
+                display = getattr(sub, method)
+                csub = display(*args_re, **dsp_kwargs)
+        else:
+            display = getattr(sub, method)
+            csub = display(*args_re, **dsp_kwargs)
 
         # Axis ticks
         if method == 'imshow' and not grid.is_uniform:
@@ -358,9 +393,8 @@ def show_discrete_data(values, grid, title=None, method='',
             plt.xticks(xpts, xlabels)
             plt.yticks(ypts, ylabels)
 
-        if method == 'imshow' and len(fig.axes) < 2:
-            # Create colorbar if none seems to exist
-
+        if method == 'imshow':
+            # Add colorbar
             # Use clim from kwargs if given
             if 'clim' not in kwargs:
                 minval, maxval = _safe_minmax(values)
@@ -369,25 +403,38 @@ def show_discrete_data(values, grid, title=None, method='',
 
             ticks = _colorbar_ticks(minval, maxval)
             format = _colorbar_format(minval, maxval)
-
-            plt.colorbar(mappable=csub, ticks=ticks, format=format)
+            if len(fig.axes) < 2:
+                # Create colorbar if none seems to exist
+                plt.colorbar(mappable=csub, ticks=ticks, format=format)
+            elif update_in_place:
+                # If it exists and we should update it
+                csub.colorbar.set_clim(minval, maxval)
+                csub.colorbar.set_ticks(ticks)
+                csub.colorbar.set_ticklabels([format % tick for tick in ticks])
+                csub.colorbar.draw_all()
 
     # Fixes overlapping stuff at the expense of potentially squashed subplots
-    fig.tight_layout()
+    if not update_in_place:
+        fig.tight_layout()
 
-    if title is not None:
-        if not values_are_complex:
-            # Do not overwrite title for complex values
-            plt.title(title)
-        fig.canvas.manager.set_window_title(title)
+        if title is not None:
+            if not values_are_complex:
+                # Do not overwrite title for complex values
+                plt.title(title)
+            fig.canvas.manager.set_window_title(title)
 
     if updatefig or plt.isinteractive():
         # If we are running in interactive mode, we can always show the fig
         # This causes an artifact, where users of `CallbackShow` without
         # interactive mode only shows the figure after the second iteration.
         plt.show(block=False)
-        plt.draw()
-        plt.pause(0.1)
+        if not update_in_place:
+            plt.draw()
+            plt.pause(0.1)
+        else:
+            sub.draw_artist(csub)
+            fig.canvas.blit(fig.bbox)
+            fig.canvas.draw()
 
     if force_show:
         plt.show()

--- a/odl/util/graphics.py
+++ b/odl/util/graphics.py
@@ -434,6 +434,8 @@ def show_discrete_data(values, grid, title=None, method='',
         else:
             fig.canvas.update()
             fig.canvas.flush_events()
+            if not plt.isinteractive():
+                plt.pause(0.0001)
 
     if force_show:
         plt.show()


### PR DESCRIPTION
Made some fixes to the most common use pattern of `show_discrete_data`. Now actually uses the "correct" methods to update the plot instead of re-drawing the full figure in each iteration. This behavior needs to be enabled with a flag, which is currently only used by `CallbackShow`, which is the prime example of updating plots repeatedly.

For a relatively simple use case, a 200x200 pixel image, the run-time went from ~0.3s down to 0.04s for a single update. This allows "almost real time" updating, as compared to the rather clunky version before.

In response to the changes, I also increased the FPS of some examples.

The main issue with this that is yet to be solved is that Ubuntu (for some reason) identifies the plot as un-responsive after a few seconds and greys it out. I have no idea how to fix this personally without changing the behavior on OS level (which I did).