### PR TITLE
WIP: Add caching to astra cuda projectors

### DIFF
--- a/examples/tomo/backends/astra_performance_cpu_parallel_2d_cg.py
+++ b/examples/tomo/backends/astra_performance_cpu_parallel_2d_cg.py
@@ -1,0 +1,116 @@
+# Copyright 2014-2016 The ODL development group
+#
+# This file is part of ODL.
+#
+# ODL is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# ODL is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with ODL.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Performance example of running native astra vs using ODL for reconstruction.
+
+In this example, a 512x512 image is reconstructed using the Conjugate Gradient
+Least Squares method on the CPU.
+
+In general, ASTRA is fater than ODL since it does not need to perform any
+copies and all arithmetic is performed in place. Dispite this, ODL is not much
+slower. In this example, the overhead is about x1.2, depending on the
+hardware used.
+"""
+
+import astra
+import numpy as np
+import matplotlib.pyplot as plt
+import scipy
+import odl
+
+
+# Common geometry parameters
+
+domain_size = np.array([512, 512])
+n_angles = 180
+det_size = 362
+niter = 20
+data = np.rot90(scipy.misc.ascent().astype('float'), -1)
+
+
+# --- ASTRA ---
+
+
+# Define ASTRA geometry
+vol_geom = astra.create_vol_geom(domain_size[0], domain_size[1])
+proj_geom = astra.create_proj_geom('parallel',
+                                   np.linalg.norm(domain_size) / det_size,
+                                   det_size,
+                                   np.linspace(0, np.pi, n_angles))
+
+# Create ASTRA projector
+proj_id = astra.create_projector('line', proj_geom, vol_geom)
+
+# Create sinogram
+sinogram_id, sinogram = astra.create_sino(data, proj_id)
+
+# Create a data object for the reconstruction
+rec_id = astra.data2d.create('-vol', vol_geom)
+
+# Set up the parameters for a reconstruction algorithm using the CUDA backend
+cfg = astra.astra_dict('CGLS')
+cfg['ReconstructionDataId'] = rec_id
+cfg['ProjectionDataId'] = sinogram_id
+cfg['ProjectorId'] = proj_id
+
+# Create the algorithm object from the configuration structure
+alg_id = astra.algorithm.create(cfg)
+
+with odl.util.Timer('Astra run'):
+    # Run the algorithm
+    astra.algorithm.run(alg_id, niter)
+
+# Get the result
+rec = astra.data2d.get(rec_id)
+
+# Clean up.
+astra.algorithm.delete(alg_id)
+astra.data2d.delete(rec_id)
+astra.data2d.delete(sinogram_id)
+astra.projector.delete(proj_id)
+
+# --- ODL ---
+
+# Create reconstruction space
+reco_space = odl.uniform_discr(-domain_size/2, domain_size/2, domain_size)
+
+# Create geometry
+geometry = odl.tomo.parallel_beam_geometry(reco_space, n_angles, det_size)
+
+# Create ray transform
+ray_trafo = odl.tomo.RayTransform(reco_space, geometry, impl='astra_cpu')
+
+# Create sinogram
+rhs = ray_trafo(data)
+
+# Solve with CGLS (aka CGN)
+x = reco_space.zero()
+with odl.util.Timer('ODL run'):
+    odl.solvers.conjugate_gradient_normal(ray_trafo, x, rhs, niter=niter)
+
+# Display results for comparsion
+plt.figure('data')
+plt.imshow(data.T, origin='lower', cmap='bone')
+plt.figure('ASTRA sinogram')
+plt.imshow(sinogram.T, origin='lower', cmap='bone')
+plt.figure('ASTRA reconstruction')
+plt.imshow(rec.T, origin='lower', cmap='bone')
+plt.figure('ODL sinogram')
+plt.imshow(rhs.asarray().T, origin='lower', cmap='bone')
+plt.figure('ODL reconstruction')
+plt.imshow(x.asarray().T, origin='lower', cmap='bone')
+plt.show()

--- a/examples/tomo/backends/astra_performance_cpu_parallel_2d_cg.py
+++ b/examples/tomo/backends/astra_performance_cpu_parallel_2d_cg.py
@@ -15,13 +15,13 @@
 # You should have received a copy of the GNU General Public License
 # along with ODL.  If not, see <http://www.gnu.org/licenses/>.
 
-"""Performance example of running native astra vs using ODL for reconstruction.
+"""Performance example of running native ASTRA vs using ODL for reconstruction.
 
 In this example, a 512x512 image is reconstructed using the Conjugate Gradient
 Least Squares method on the CPU.
 
-In general, ASTRA is fater than ODL since it does not need to perform any
-copies and all arithmetic is performed in place. Dispite this, ODL is not much
+In general, ASTRA is faster than ODL since it does not need to perform any
+copies and all arithmetic is performed in place. Despite this, ODL is not much
 slower. In this example, the overhead is about x1.2, depending on the
 hardware used.
 """
@@ -61,7 +61,7 @@ sinogram_id, sinogram = astra.create_sino(data, proj_id)
 # Create a data object for the reconstruction
 rec_id = astra.data2d.create('-vol', vol_geom)
 
-# Set up the parameters for a reconstruction algorithm using the CUDA backend
+# Set up the parameters for a reconstruction algorithm using the CPU backend
 cfg = astra.astra_dict('CGLS')
 cfg['ReconstructionDataId'] = rec_id
 cfg['ProjectionDataId'] = sinogram_id
@@ -70,7 +70,7 @@ cfg['ProjectorId'] = proj_id
 # Create the algorithm object from the configuration structure
 alg_id = astra.algorithm.create(cfg)
 
-with odl.util.Timer('Astra run'):
+with odl.util.Timer('ASTRA run'):
     # Run the algorithm
     astra.algorithm.run(alg_id, niter)
 
@@ -86,7 +86,7 @@ astra.projector.delete(proj_id)
 # --- ODL ---
 
 # Create reconstruction space
-reco_space = odl.uniform_discr(-domain_size/2, domain_size/2, domain_size)
+reco_space = odl.uniform_discr(-domain_size / 2, domain_size / 2, domain_size)
 
 # Create geometry
 geometry = odl.tomo.parallel_beam_geometry(reco_space, n_angles, det_size)
@@ -102,7 +102,7 @@ x = reco_space.zero()
 with odl.util.Timer('ODL run'):
     odl.solvers.conjugate_gradient_normal(ray_trafo, x, rhs, niter=niter)
 
-# Display results for comparsion
+# Display results for comparison
 plt.figure('data')
 plt.imshow(data.T, origin='lower', cmap='bone')
 plt.figure('ASTRA sinogram')

--- a/examples/tomo/backends/astra_performance_cuda_parallel_2d_cg.py
+++ b/examples/tomo/backends/astra_performance_cuda_parallel_2d_cg.py
@@ -15,13 +15,13 @@
 # You should have received a copy of the GNU General Public License
 # along with ODL.  If not, see <http://www.gnu.org/licenses/>.
 
-"""Performance example of running native astra vs using ODL for reconstruction.
+"""Performance example of running native ASTRA vs using ODL for reconstruction.
 
 In this example, a 512x512 image is reconstructed using the Conjugate Gradient
 Least Squares method on the GPU.
 
 In general, ASTRA is fater than ODL since it does not need to perform any
-copies and all arithmetic is performed on the GPU. Dispite this, ODL is not
+copies and all arithmetic is performed on the GPU. Despite this, ODL is not
 much slower. In this example, the overhead is about x2, depending on the
 hardware used.
 """
@@ -70,7 +70,7 @@ cfg['ProjectorId'] = proj_id
 # Create the algorithm object from the configuration structure
 alg_id = astra.algorithm.create(cfg)
 
-with odl.util.Timer('Astra run'):
+with odl.util.Timer('ASTRA run'):
     # Run the algorithm
     astra.algorithm.run(alg_id, niter)
 
@@ -86,7 +86,7 @@ astra.projector.delete(proj_id)
 # --- ODL ---
 
 # Create reconstruction space
-reco_space = odl.uniform_discr(-domain_size/2, domain_size/2, domain_size)
+reco_space = odl.uniform_discr(-domain_size / 2, domain_size / 2, domain_size)
 
 # Create geometry
 geometry = odl.tomo.parallel_beam_geometry(reco_space, n_angles, det_size)
@@ -102,7 +102,7 @@ x = reco_space.zero()
 with odl.util.Timer('ODL run'):
     odl.solvers.conjugate_gradient_normal(ray_trafo, x, rhs, niter=niter)
 
-# Display results for comparsion
+# Display results for comparison
 plt.figure('data')
 plt.imshow(data.T, origin='lower', cmap='bone')
 plt.figure('ASTRA sinogram')

--- a/examples/tomo/backends/astra_performance_cuda_parallel_2d_cg.py
+++ b/examples/tomo/backends/astra_performance_cuda_parallel_2d_cg.py
@@ -1,0 +1,116 @@
+# Copyright 2014-2016 The ODL development group
+#
+# This file is part of ODL.
+#
+# ODL is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# ODL is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with ODL.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Performance example of running native astra vs using ODL for reconstruction.
+
+In this example, a 512x512 image is reconstructed using the Conjugate Gradient
+Least Squares method on the GPU.
+
+In general, ASTRA is fater than ODL since it does not need to perform any
+copies and all arithmetic is performed on the GPU. Dispite this, ODL is not
+much slower. In this example, the overhead is about x2, depending on the
+hardware used.
+"""
+
+import astra
+import numpy as np
+import matplotlib.pyplot as plt
+import scipy
+import odl
+
+
+# Common geometry parameters
+
+domain_size = np.array([512, 512])
+n_angles = 180
+det_size = 362
+niter = 50
+data = np.rot90(scipy.misc.ascent().astype('float'), -1)
+
+
+# --- ASTRA ---
+
+
+# Define ASTRA geometry
+vol_geom = astra.create_vol_geom(domain_size[0], domain_size[1])
+proj_geom = astra.create_proj_geom('parallel',
+                                   np.linalg.norm(domain_size) / det_size,
+                                   det_size,
+                                   np.linspace(0, np.pi, n_angles))
+
+# Create ASTRA projector
+proj_id = astra.create_projector('cuda', proj_geom, vol_geom)
+
+# Create sinogram
+sinogram_id, sinogram = astra.create_sino(data, proj_id)
+
+# Create a data object for the reconstruction
+rec_id = astra.data2d.create('-vol', vol_geom)
+
+# Set up the parameters for a reconstruction algorithm using the CUDA backend
+cfg = astra.astra_dict('CGLS_CUDA')
+cfg['ReconstructionDataId'] = rec_id
+cfg['ProjectionDataId'] = sinogram_id
+cfg['ProjectorId'] = proj_id
+
+# Create the algorithm object from the configuration structure
+alg_id = astra.algorithm.create(cfg)
+
+with odl.util.Timer('Astra run'):
+    # Run the algorithm
+    astra.algorithm.run(alg_id, niter)
+
+# Get the result
+rec = astra.data2d.get(rec_id)
+
+# Clean up.
+astra.algorithm.delete(alg_id)
+astra.data2d.delete(rec_id)
+astra.data2d.delete(sinogram_id)
+astra.projector.delete(proj_id)
+
+# --- ODL ---
+
+# Create reconstruction space
+reco_space = odl.uniform_discr(-domain_size/2, domain_size/2, domain_size)
+
+# Create geometry
+geometry = odl.tomo.parallel_beam_geometry(reco_space, n_angles, det_size)
+
+# Create ray transform
+ray_trafo = odl.tomo.RayTransform(reco_space, geometry, impl='astra_cuda')
+
+# Create sinogram
+rhs = ray_trafo(data)
+
+# Solve with CGLS (aka CGN)
+x = reco_space.zero()
+with odl.util.Timer('ODL run'):
+    odl.solvers.conjugate_gradient_normal(ray_trafo, x, rhs, niter=niter)
+
+# Display results for comparsion
+plt.figure('data')
+plt.imshow(data.T, origin='lower', cmap='bone')
+plt.figure('ASTRA sinogram')
+plt.imshow(sinogram.T, origin='lower', cmap='bone')
+plt.figure('ASTRA reconstruction')
+plt.imshow(rec.T, origin='lower', cmap='bone')
+plt.figure('ODL sinogram')
+plt.imshow(rhs.asarray().T, origin='lower', cmap='bone')
+plt.figure('ODL reconstruction')
+plt.imshow(x.asarray().T, origin='lower', cmap='bone')
+plt.show()

--- a/odl/test/tomo/backends/astra_cuda_test.py
+++ b/odl/test/tomo/backends/astra_cuda_test.py
@@ -30,168 +30,98 @@ import sys
 # Internal
 import odl
 from odl.tomo.backends.astra_cuda import (
-    astra_cuda_forward_projector, astra_cuda_back_projector)
+    AstraCudaProjectorImpl, AstraCudaBackProjectorImpl)
 from odl.tomo.util.testutils import skip_if_no_astra_cuda
+from odl.util.testutils import simple_fixture
 
 
 # TODO: test with CUDA implemented uniform_discr
 
 
-@skip_if_no_astra_cuda
-def test_astra_cuda_projector_parallel2d():
+use_cache = simple_fixture('use_cache', [False, True])
+
+# Find the valid projectors
+projectors = [skip_if_no_astra_cuda('par2d'),
+              skip_if_no_astra_cuda('cone2d'),
+              skip_if_no_astra_cuda('par3d'),
+              skip_if_no_astra_cuda('cone3d'),
+              skip_if_no_astra_cuda('helical')]
+
+
+space_and_geometry_ids = ['geom = {}'.format(p.args[1]) for p in projectors]
+
+
+@pytest.fixture(scope="module", params=projectors, ids=space_and_geometry_ids)
+def space_and_geometry(request):
+    dtype = 'float32'
+    geom = request.param
+
+    apart = odl.uniform_partition(0, 2 * np.pi, 8)
+
+    if geom == 'par2d':
+        reco_space = odl.uniform_discr([-4, -5], [4, 5], (4, 5),
+                                       dtype=dtype)
+        dpart = odl.uniform_partition(-6, 6, 6)
+        geom = odl.tomo.Parallel2dGeometry(apart, dpart)
+    elif geom == 'par3d':
+        reco_space = odl.uniform_discr([-4, -5, -6], [4, 5, 6], (4, 5, 6),
+                                       dtype=dtype)
+        dpart = odl.uniform_partition([-7, -8], [7, 8], (7, 8))
+        geom = odl.tomo.Parallel3dAxisGeometry(apart, dpart)
+    elif geom == 'cone2d':
+        reco_space = odl.uniform_discr([-4, -5], [4, 5], (4, 5),
+                                       dtype=dtype)
+        dpart = odl.uniform_partition(-6, 6, 6)
+        geom = odl.tomo.FanFlatGeometry(apart, dpart, src_radius=100,
+                                        det_radius=10)
+    elif geom == 'cone3d':
+        reco_space = odl.uniform_discr([-4, -5, -6], [4, 5, 6], (4, 5, 6),
+                                       dtype=dtype)
+        dpart = odl.uniform_partition([-7, -8], [7, 8], (7, 8))
+
+        geom = odl.tomo.CircularConeFlatGeometry(apart, dpart, src_radius=200,
+                                                 det_radius=100)
+    elif geom == 'helical':
+        reco_space = odl.uniform_discr([-4, -5, -6], [4, 5, 6], (4, 5, 6),
+                                       dtype=dtype)
+
+        # overwrite angle
+        apart = odl.uniform_partition(0, 2 * 2 * np.pi, 18)
+        dpart = odl.uniform_partition([-7, -8], [7, 8], (7, 8))
+        geom = odl.tomo.HelicalConeFlatGeometry(apart, dpart, pitch=1.0,
+                                                src_radius=200, det_radius=100)
+    else:
+        raise ValueError('geom not valid')
+
+    return reco_space, geom
+
+
+def test_astra_cuda_projector(space_and_geometry, use_cache):
     """Parallel 2D forward and backward projectors on the GPU."""
 
     # Create reco space and a phantom
-    reco_space = odl.uniform_discr([-4, -5], [4, 5], (4, 5), dtype='float32')
-    phantom = odl.phantom.cuboid(reco_space, min_pt=[0, 0], max_pt=[4, 5])
-
-    # Create parallel geometry
-    angle_part = odl.uniform_partition(0, np.pi, 8)
-    det_part = odl.uniform_partition(-6, 6, 6)
-    geom = odl.tomo.Parallel2dGeometry(angle_part, det_part)
+    reco_space, geom = space_and_geometry
+    phantom = odl.phantom.cuboid(reco_space)
 
     # Make projection space
     proj_space = odl.uniform_discr_frompartition(geom.partition,
-                                                 dtype='float32')
+                                                 dtype=reco_space.dtype)
 
     # Forward evaluation
-    proj_data = astra_cuda_forward_projector(phantom, geom, proj_space)
+    projector = AstraCudaProjectorImpl(geom, reco_space, proj_space,
+                                       use_cache=use_cache)
+    proj_data = projector.call_forward(phantom)
     assert proj_data.shape == proj_space.shape
     assert proj_data.norm() > 0
+    assert np.all(proj_data.asarray() >= 0)
 
     # Backward evaluation
-    backproj = astra_cuda_back_projector(proj_data, geom, reco_space)
+    back_projector = AstraCudaBackProjectorImpl(geom, reco_space, proj_space,
+                                                use_cache=use_cache)
+    backproj = back_projector.call_backward(proj_data)
     assert backproj.shape == reco_space.shape
     assert backproj.norm() > 0
-
-
-@skip_if_no_astra_cuda
-def test_astra_cuda_projector_fanflat():
-    """Fanflat 2D forward and backward projectors on the GPU."""
-
-    # Create reco space and a phantom
-    reco_space = odl.uniform_discr([-4, -5], [4, 5], (4, 5), dtype='float32')
-    phantom = odl.phantom.cuboid(reco_space, min_pt=[0, 0], max_pt=[4, 5])
-
-    # Create fan beam geometry with flat detector
-    angle_part = odl.uniform_partition(0, 2 * np.pi, 8)
-    det_part = odl.uniform_partition(-6, 6, 6)
-    src_rad = 100
-    det_rad = 10
-    geom = odl.tomo.FanFlatGeometry(angle_part, det_part, src_rad, det_rad)
-
-    # Make projection space
-    proj_space = odl.uniform_discr_frompartition(geom.partition,
-                                                 dtype='float32')
-
-    # Forward evaluation
-    proj_data = astra_cuda_forward_projector(phantom, geom, proj_space)
-    assert proj_data.shape == proj_space.shape
-    assert proj_data.norm() > 0
-
-    # Backward evaluation
-    backproj = astra_cuda_back_projector(proj_data, geom, reco_space)
-    assert backproj.shape == reco_space.shape
-    assert backproj.norm() > 0
-
-
-@pytest.mark.xfail(sys.platform == 'win32', strict=True,
-                   reason="Fails on windows")
-@skip_if_no_astra_cuda
-def test_astra_cuda_projector_parallel3d():
-    """Test 3D forward and backward projection functions on the GPU."""
-
-    # Create reco space and a phantom
-    reco_space = odl.uniform_discr([-4, -5, -6], [4, 5, 6], (4, 5, 6),
-                                   dtype='float32')
-    phantom = odl.phantom.cuboid(reco_space, min_pt=[0, 0, 0],
-                                 max_pt=[4, 5, 6])
-
-    # Create parallel geometry
-    angle_part = odl.uniform_partition(0, np.pi, 8)
-    det_part = odl.uniform_partition([-7, -8], [7, 8], (7, 8))
-    geom = odl.tomo.Parallel3dAxisGeometry(angle_part, det_part)
-
-    # Make projection space
-    proj_space = odl.uniform_discr_frompartition(geom.partition,
-                                                 dtype='float32')
-
-    # Forward evaluation
-    proj_data = astra_cuda_forward_projector(phantom, geom, proj_space)
-    assert proj_data.shape == proj_space.shape
-    assert proj_data.norm() > 0
-
-    # Backward evaluation
-    backproj = astra_cuda_back_projector(proj_data, geom, reco_space)
-    assert backproj.shape == reco_space.shape
-    assert backproj.norm() > 0
-
-
-@skip_if_no_astra_cuda
-def test_astra_gpu_projector_circular_conebeam():
-    """Test 3D forward and backward projection functions on the GPU."""
-
-    # Create reco space and a phantom
-    reco_space = odl.uniform_discr([-4, -5, -6], [4, 5, 6], (4, 5, 6),
-                                   dtype='float32')
-    phantom = odl.phantom.cuboid(reco_space, min_pt=[0, 0, 0],
-                                 max_pt=[4, 5, 6])
-
-    # Create circular cone beam geometry with flat detector
-    angle_part = odl.uniform_partition(0, 2 * np.pi, 8)
-    det_part = odl.uniform_partition([-7, -8], [7, 8], (7, 8))
-    src_rad = 1000
-    det_rad = 100
-    geom = odl.tomo.CircularConeFlatGeometry(angle_part, det_part, src_rad,
-                                             det_rad)
-
-    # Make projection space
-    proj_space = odl.uniform_discr_frompartition(geom.partition,
-                                                 dtype='float32')
-
-    # Forward evaluation
-    proj_data = astra_cuda_forward_projector(phantom, geom, proj_space)
-    assert proj_data.shape == proj_space.shape
-    assert proj_data.norm() > 0
-
-    # Backward evaluation
-    backproj = astra_cuda_back_projector(proj_data, geom, reco_space)
-    assert backproj.shape == reco_space.shape
-    assert backproj.norm() > 0
-
-
-@skip_if_no_astra_cuda
-def test_astra_cuda_projector_helical_conebeam():
-    """Test 3D forward and backward projection functions on the GPU."""
-
-    # Create reco space and a phantom
-    reco_space = odl.uniform_discr([-4, -5, -6], [4, 5, 6], (4, 5, 6),
-                                   dtype='float32')
-    phantom = odl.phantom.cuboid(reco_space, min_pt=[0, 0, 0],
-                                 max_pt=[4, 5, 6])
-
-    # Create circular cone beam geometry with flat detector
-    angle_part = odl.uniform_partition(0, 2 * np.pi, 8)
-    det_part = odl.uniform_partition([-7, -8], [7, 8], (7, 8))
-    src_rad = 1000
-    det_rad = 100
-    pitch = 0.5
-    geom = odl.tomo.HelicalConeFlatGeometry(angle_part, det_part, src_rad,
-                                            det_rad, pitch)
-
-    # Make projection space
-    proj_space = odl.uniform_discr_frompartition(geom.partition,
-                                                 dtype='float32')
-
-    # Forward evaluation
-    proj_data = astra_cuda_forward_projector(phantom, geom, proj_space)
-    assert proj_data.shape == proj_space.shape
-    assert proj_data.norm() > 0
-
-    # Backward evaluation
-    backproj = astra_cuda_back_projector(proj_data, geom, reco_space)
-    assert backproj.shape == reco_space.shape
-    assert backproj.norm() > 0
+    assert np.all(proj_data.asarray() >= 0)
 
 
 if __name__ == '__main__':

--- a/odl/test/tomo/backends/astra_cuda_test.py
+++ b/odl/test/tomo/backends/astra_cuda_test.py
@@ -97,7 +97,7 @@ def space_and_geometry(request):
 
 
 def test_astra_cuda_projector(space_and_geometry, use_cache):
-    """Parallel 2D forward and backward projectors on the GPU."""
+    """Test ASTRA CUDA projector."""
 
     # Create reco space and a phantom
     reco_space, geom = space_and_geometry
@@ -111,7 +111,7 @@ def test_astra_cuda_projector(space_and_geometry, use_cache):
     projector = AstraCudaProjectorImpl(geom, reco_space, proj_space,
                                        use_cache=use_cache)
     proj_data = projector.call_forward(phantom)
-    assert proj_data.shape == proj_space.shape
+    assert proj_data in proj_space
     assert proj_data.norm() > 0
     assert np.all(proj_data.asarray() >= 0)
 
@@ -119,7 +119,7 @@ def test_astra_cuda_projector(space_and_geometry, use_cache):
     back_projector = AstraCudaBackProjectorImpl(geom, reco_space, proj_space,
                                                 use_cache=use_cache)
     backproj = back_projector.call_backward(proj_data)
-    assert backproj.shape == reco_space.shape
+    assert backproj in reco_space
     assert backproj.norm() > 0
     assert np.all(proj_data.asarray() >= 0)
 

--- a/odl/test/tomo/backends/scikit_test.py
+++ b/odl/test/tomo/backends/scikit_test.py
@@ -35,20 +35,19 @@ from odl.tomo.util.testutils import skip_if_no_scikit
 
 @skip_if_no_scikit
 def test_scikit_radon_projector_parallel2d():
-    """Parallel 2D forward and backward projectors on the GPU."""
+    """Parallel 2D forward and backward projectors with scikit."""
 
     # Create reco space and a phantom
-    reco_space = odl.uniform_discr([-5, -5], [5, 5], (5, 5), dtype='float32')
+    reco_space = odl.uniform_discr([-5, -5], [5, 5], (5, 5))
     phantom = odl.phantom.cuboid(reco_space, min_pt=[0, 0], max_pt=[5, 5])
 
     # Create parallel geometry
-    angle_part = odl.uniform_partition(0, 2 * np.pi, 8)
+    angle_part = odl.uniform_partition(0, np.pi, 5)
     det_part = odl.uniform_partition(-6, 6, 6)
     geom = odl.tomo.Parallel2dGeometry(angle_part, det_part)
 
     # Make projection space
-    proj_space = odl.uniform_discr_frompartition(geom.partition,
-                                                 dtype='float32')
+    proj_space = odl.uniform_discr_frompartition(geom.partition)
 
     # Forward evaluation
     proj_data = scikit_radon_forward(phantom, geom, proj_space)

--- a/odl/tomo/backends/astra_cpu.py
+++ b/odl/tomo/backends/astra_cpu.py
@@ -128,12 +128,12 @@ def astra_cpu_forward_projector(vol_data, geometry, proj_space, out=None):
 
 
 def astra_cpu_back_projector(proj_data, geometry, reco_space, out=None):
-    """Run an ASTRA backward projection on the given data using the CPU.
+    """Run an ASTRA back-projection on the given data using the CPU.
 
     Parameters
     ----------
     proj_data : `DiscreteLpElement`
-        Projection data to which the backward projector is applied
+        Projection data to which the back-projector is applied
     geometry : `Geometry`
         Geometry defining the tomographic setup
     reco_space : `DiscreteLp`

--- a/odl/tomo/backends/astra_cuda.py
+++ b/odl/tomo/backends/astra_cuda.py
@@ -41,8 +41,7 @@ from odl.tomo.geometry import (
 from odl.util import writable_array
 
 
-__all__ = ('astra_cuda_back_projector',
-           'ASTRA_CUDA_AVAILABLE',
+__all__ = ('ASTRA_CUDA_AVAILABLE',
            'AstraCudaProjectorImpl', 'AstraCudaBackProjectorImpl')
 
 
@@ -113,14 +112,12 @@ class AstraCudaProjectorImpl(object):
 
         ndim = vol_data.ndim
 
-        # Create astra geometries
-        vol_geom = astra_volume_geometry(vol_data.space)
-
         # Create ASTRA data structures
 
         # In the case dim == 3, we need to swap axes, so can't perform the FP
         # in-place
         if self.vol_id is None:
+            vol_geom = astra_volume_geometry(vol_data.space)
             proj_geom = astra_projection_geometry(self.geometry)
             self.vol_id = astra_data(vol_geom, datatype='volume', data=vol_data,
                                      allow_copy=True)
@@ -316,12 +313,11 @@ class AstraCudaBackProjectorImpl(object):
                                      ndim=self.reco_space.ndim)
         if self.algo_id is None:
             # Create algorithm
-            algo_id = astra_algorithm('backward', ndim, self.vol_id, self.sino_id,
-                                      proj_id=self.proj_id, impl='cuda')
+            self.algo_id = astra_algorithm('backward', ndim, self.vol_id, self.sino_id,
+                                           proj_id=self.proj_id, impl='cuda')
 
         # Run algorithm
-        astra.algorithm.run(algo_id)
-
+        astra.algorithm.run(self.algo_id)
 
         if out is None:
             out = self.proj_space.element()

--- a/odl/tomo/backends/astra_cuda.py
+++ b/odl/tomo/backends/astra_cuda.py
@@ -187,19 +187,24 @@ class AstraCudaProjectorImpl(object):
         return out
 
     def delete_ids(self):
-        # Delete ASTRA objects
-        astra.algorithm.delete(self.algo_id)
+        """Delete ASTRA objects."""
         if self.geometry.ndim == 2:
-            astra.data2d.delete((self.vol_id, self.sino_id))
-            astra.projector.delete(self.proj_id)
+            adata, aproj = astra.data2d, astra.projector
         else:
-            astra.data3d.delete((self.vol_id, self.sino_id))
-            astra.projector3d.delete(self.proj_id)
+            adata, aproj = astra.data3d, astra.projector3d
 
-        self.algo_id = None
-        self.vol_id = None
-        self.sino_id = None
-        self.proj_id = None
+        if self.algo_id is not None:
+            astra.algorithm.delete(self.algo_id)
+            self.algo_id = None
+        if self.vol_id is not None:
+            adata.delete(self.vol_id)
+            self.vol_id = None
+        if self.sino_id is not None:
+            adata.delete(self.sino_id)
+            self.sino_id = None
+        if self.proj_id is not None:
+            aproj.delete(self.proj_id)
+            self.proj_id = None
 
     def __del__(self):
         self.delete_ids()
@@ -297,9 +302,6 @@ class AstraCudaBackProjectorImpl(object):
             self.proj_id = astra_projector('nearest', vol_geom, proj_geom, ndim,
                                            impl='cuda')
 
-        # Reconstruction volume
-        if out is None:
-            out = self.reco_space.element()
 
         if self.use_cache:
             out_array = self.out_array
@@ -319,10 +321,10 @@ class AstraCudaBackProjectorImpl(object):
         # Run algorithm
         astra.algorithm.run(self.algo_id)
 
+        # Reconstruction volume
         if out is None:
-            out = self.proj_space.element()
-        else:
-            out[:] = self.out_array
+            out = self.reco_space.element()
+        out[:] = out_array
 
         out *= astra_cuda_bp_scaling_factor(self.reco_space, self.geometry)
 
@@ -332,19 +334,24 @@ class AstraCudaBackProjectorImpl(object):
         return out
 
     def delete_ids(self):
-        # Delete ASTRA objects
-        astra.algorithm.delete(self.algo_id)
+        """Delete ASTRA objects."""
         if self.geometry.ndim == 2:
-            astra.data2d.delete((self.vol_id, self.sino_id))
-            astra.projector.delete(self.proj_id)
+            adata, aproj = astra.data2d, astra.projector
         else:
-            astra.data3d.delete((self.vol_id, self.sino_id))
-            astra.projector3d.delete(self.proj_id)
+            adata, aproj = astra.data3d, astra.projector3d
 
-        self.algo_id = None
-        self.vol_id = None
-        self.sino_id = None
-        self.proj_id = None
+        if self.algo_id is not None:
+            astra.algorithm.delete(self.algo_id)
+            self.algo_id = None
+        if self.vol_id is not None:
+            adata.delete(self.vol_id)
+            self.vol_id = None
+        if self.sino_id is not None:
+            adata.delete(self.sino_id)
+            self.sino_id = None
+        if self.proj_id is not None:
+            aproj.delete(self.proj_id)
+            self.proj_id = None
 
     def __del__(self):
         self.delete_ids()

--- a/odl/tomo/operators/ray_trafo.py
+++ b/odl/tomo/operators/ray_trafo.py
@@ -198,7 +198,8 @@ class RayTransform(Operator):
                 proj = getattr(self, 'astra_projector', None)
                 if proj is None:
                     self.astra_projector = AstraCudaProjectorImpl(
-                        self.geometry, self.range, use_cache=self.use_cache)
+                        self.geometry, self.domain, self.range,
+                        use_cache=self.use_cache)
 
                 return self.astra_projector.call_forward(x, out)
             else:
@@ -222,7 +223,8 @@ class RayTransform(Operator):
 
         kwargs = self.kwargs.copy()
         kwargs['discr_domain'] = self.range
-        self.backproj = RayBackProjection(self.domain, self.geometry, self.impl, use_cache=self.use_cache,
+        self.backproj = RayBackProjection(self.domain, self.geometry,
+                                          self.impl, use_cache=self.use_cache,
                                           **kwargs)
         return self.backproj
 
@@ -345,7 +347,8 @@ class RayBackProjection(Operator):
                 backproj = getattr(self, 'astra_backprojector', None)
                 if backproj is None:
                     self.astra_backprojector = AstraCudaBackProjectorImpl(
-                        self.geometry, self.range, use_cache=self.use_cache)
+                        self.geometry, self.range, self.domain,
+                        use_cache=self.use_cache)
 
                 return self.astra_backprojector.call_backward(x, out)
             else:
@@ -370,7 +373,8 @@ class RayBackProjection(Operator):
 
         kwargs = self.kwargs.copy()
         kwargs['discr_range'] = self.domain
-        self.ray_trafo = RayTransform(self.range, self.geometry, impl=self.impl, use_cache=self.use_cache,
+        self.ray_trafo = RayTransform(self.range, self.geometry,
+                                      impl=self.impl, use_cache=self.use_cache,
                                       **kwargs)
         return self.ray_trafo
 

--- a/odl/tomo/operators/ray_trafo.py
+++ b/odl/tomo/operators/ray_trafo.py
@@ -73,7 +73,11 @@ class RayTransform(Operator):
             Discretized space, the range of the forward projector.
             Default: Infered from parameters.
         use_cache : bool
-            True if data should be cached. Default: True
+            If ``True``, data is cached. Note that this causes notable memory
+            overhead, both on the GPU and on the CPU since a full volume and
+            projection is stored. In the 3D case, some users may want to
+            disable this.
+            Default: True
 
         Notes
         -----
@@ -257,7 +261,10 @@ class RayBackProjection(Operator):
             Discretized space, the range of the forward projector.
             Default: Infered from parameters.
         use_cache : bool
-            True if data should be cached. Default: True
+            If ``True``, data is cached. Note that this causes notable memory
+            overhead, both on the GPU and on the CPU since a full volume and
+            projection is stored. In the 3D case, some users may want to
+            disable this.
         """
         if not isinstance(discr_range, DiscreteLp):
             raise TypeError('`discr_range` {!r} is not a `DiscreteLp`'


### PR DESCRIPTION
Work in progress.

Adds caching of the CUDA memory for astra projectors, resulting in rather immense speedups. On my Titan X card I can get speed-up of about x10.

TODO:

- [x] cleanup
- [x] add test
- [x] Optimize back-projection as well
- [x] Fix 3d case.
- [x] Fix GPU memory leak. Clarification: It seems GPU memory use goes in a "zig-zag" pattern, increasing for a while then dropping to "zero". Edit: Fixed, forgot to remove a ASTRA memory handle.