### PR TITLE
MAINT: rename and harmonize weightings

### DIFF
--- a/odl/discr/lp_discr.py
+++ b/odl/discr/lp_discr.py
@@ -35,7 +35,7 @@ from odl.discr.partition import (
     RectPartition, uniform_partition_fromintv, uniform_partition)
 from odl.set import RealNumbers, ComplexNumbers, IntervalProd
 from odl.space import FunctionSpace, ProductSpace, FN_IMPLS
-from odl.space.weighting import WeightingBase
+from odl.space.weighting import Weighting
 from odl.util.normalize import (
     normalized_scalar_param_list, safe_int_conv, normalized_nodes_on_bdry)
 from odl.util.numerics import apply_on_boundary
@@ -950,24 +950,21 @@ def uniform_discr_frompartition(partition, exponent=2.0, interp='nearest',
     order = kwargs.pop('order', 'C')
 
     weighting = kwargs.pop('weighting', 'const')
-    if isinstance(weighting, WeightingBase):
-        # TODO: harmonize names, should be 'weighting' across the board
-        weight = weighting
-    else:
+    if not isinstance(weighting, Weighting):
         weighting, weighting_in = str(weighting).lower(), weighting
         if weighting == 'none' or float(exponent) == float('inf'):
-            weight = None
+            weighting = None
         elif weighting == 'const':
-            weight = partition.cell_volume
+            weighting = partition.cell_volume
         else:
             raise ValueError("`weighting` '{}' not understood"
                              "".format(weighting_in))
 
     if dtype is not None:
-        dspace = ds_type(partition.size, dtype=dtype, impl=impl, weight=weight,
-                         exponent=exponent)
+        dspace = ds_type(partition.size, dtype=dtype, impl=impl,
+                         weighting=weighting, exponent=exponent)
     else:
-        dspace = ds_type(partition.size, impl=impl, weight=weight,
+        dspace = ds_type(partition.size, impl=impl, weighting=weighting,
                          exponent=exponent)
 
     return DiscreteLp(fspace, partition, dspace, exponent, interp, order=order,

--- a/odl/space/base_ntuples.py
+++ b/odl/space/base_ntuples.py
@@ -548,7 +548,7 @@ class FnBase(NtuplesBase, LinearSpace):
 
     def _astype(self, dtype):
         """Internal helper for ``astype``. Can be overridden by subclasses."""
-        return type(self)(self.size, dtype=dtype, weight=self.weighting)
+        return type(self)(self.size, dtype=dtype, weighting=self.weighting)
 
     def astype(self, dtype):
         """Return a copy of this space with new ``dtype``.

--- a/odl/space/npy_ntuples.py
+++ b/odl/space/npy_ntuples.py
@@ -36,16 +36,16 @@ from odl.set import RealNumbers, ComplexNumbers
 from odl.space.base_ntuples import (
     NtuplesBase, NtuplesBaseVector, FnBase, FnBaseVector)
 from odl.space.weighting import (
-    WeightingBase, MatrixWeightingBase, VectorWeightingBase,
-    ConstWeightingBase, NoWeightingBase,
-    CustomInnerProductBase, CustomNormBase, CustomDistBase)
+    Weighting, MatrixWeighting, ArrayWeighting,
+    ConstWeighting, NoWeighting,
+    CustomInnerProduct, CustomNorm, CustomDist)
 from odl.util.ufuncs import NumpyNtuplesUfuncs
 from odl.util.utility import dtype_repr, is_real_dtype
 
 
 __all__ = ('NumpyNtuples', 'NumpyNtuplesVector', 'NumpyFn', 'NumpyFnVector',
            'MatVecOperator',
-           'NumpyFnMatrixWeighting', 'NumpyFnVectorWeighting',
+           'NumpyFnMatrixWeighting', 'NumpyFnArrayWeighting',
            'NumpyFnConstWeighting',
            'npy_weighted_dist', 'npy_weighted_norm', 'npy_weighted_inner')
 
@@ -605,11 +605,11 @@ class NumpyFn(FnBase, NumpyNtuples):
 
             Only scalar data types are allowed.
 
-        weight : optional
+        weighting : optional
             Use weighted inner product, norm, and dist. The following
-            types are supported as ``weight``:
+            types are supported as ``weighting``:
 
-            `FnWeightingBase`:
+            `FnWeighting`:
             Use this weighting as-is. Compatibility with this
             space's elements is not checked during init.
 
@@ -654,7 +654,7 @@ class NumpyFn(FnBase, NumpyNtuples):
             This creates an intermediate array ``x - y``, which can be
             avoided by choosing ``dist_using_inner=True``.
 
-            This option cannot be combined with ``weight``,
+            This option cannot be combined with ``weighting``,
             ``norm`` or ``inner``.
 
         norm : callable, optional
@@ -670,7 +670,7 @@ class NumpyFn(FnBase, NumpyNtuples):
 
             By default, ``norm(x)`` is calculated as ``inner(x, x)``.
 
-            This option cannot be combined with ``weight``,
+            This option cannot be combined with ``weighting``,
             ``dist`` or ``inner``.
 
         inner : callable, optional
@@ -684,7 +684,7 @@ class NumpyFn(FnBase, NumpyNtuples):
             - ``<s*x + y, z> = s * <x, z> + <y, z>``
             - ``<x, x> = 0``  if and only if  ``x = 0``
 
-            This option cannot be combined with ``weight``,
+            This option cannot be combined with ``weighting``,
             ``dist`` or ``norm``.
 
         dist_using_inner : bool, optional
@@ -707,7 +707,7 @@ class NumpyFn(FnBase, NumpyNtuples):
         See Also
         --------
         NumpyFnMatrixWeighting
-        NumpyFnVectorWeighting
+        NumpyFnArrayWeighting
         NumpyFnConstWeighting
 
         Examples
@@ -715,9 +715,9 @@ class NumpyFn(FnBase, NumpyNtuples):
         >>> space = NumpyFn(3, 'float')
         >>> space
         rn(3)
-        >>> space = NumpyFn(3, 'float', weight=[1, 2, 3])
+        >>> space = NumpyFn(3, 'float', weighting=[1, 2, 3])
         >>> space
-        rn(3, weight=[1, 2, 3])
+        rn(3, weighting=[1, 2, 3])
         """
         # TODO: fix dead link `scipy.sparse.spmatrix`
         NumpyNtuples.__init__(self, size, dtype)
@@ -726,13 +726,13 @@ class NumpyFn(FnBase, NumpyNtuples):
         dist = kwargs.pop('dist', None)
         norm = kwargs.pop('norm', None)
         inner = kwargs.pop('inner', None)
-        weight = kwargs.pop('weight', None)
+        weighting = kwargs.pop('weighting', None)
         exponent = kwargs.pop('exponent', 2.0)
         dist_using_inner = bool(kwargs.pop('dist_using_inner', False))
 
         # Check validity of option combination (3 or 4 out of 4 must be None)
-        if sum(x is None for x in (dist, norm, inner, weight)) < 3:
-            raise ValueError('invalid combination of options `weight`, '
+        if sum(x is None for x in (dist, norm, inner, weighting)) < 3:
+            raise ValueError('invalid combination of options `weighting`, '
                              '`dist`, `norm` and `inner`')
 
         if any(x is not None for x in (dist, norm, inner)) and exponent != 2.0:
@@ -740,54 +740,54 @@ class NumpyFn(FnBase, NumpyNtuples):
                              '`dist`, `norm` and `inner`')
 
         # Set the weighting
-        if weight is not None:
-            if isinstance(weight, WeightingBase):
-                self._weighting = weight
-            elif np.isscalar(weight):
-                self._weighting = NumpyFnConstWeighting(
-                    weight, exponent, dist_using_inner=dist_using_inner)
-            elif weight is None:
+        if weighting is not None:
+            if isinstance(weighting, Weighting):
+                self.__weighting = weighting
+            elif np.isscalar(weighting):
+                self.__weighting = NumpyFnConstWeighting(
+                    weighting, exponent, dist_using_inner=dist_using_inner)
+            elif weighting is None:
                 # Need to wait until dist, norm and inner are handled
                 pass
-            elif isspmatrix(weight):
-                self._weighting = NumpyFnMatrixWeighting(
-                    weight, exponent, dist_using_inner=dist_using_inner,
+            elif isspmatrix(weighting):
+                self.__weighting = NumpyFnMatrixWeighting(
+                    weighting, exponent, dist_using_inner=dist_using_inner,
                     **kwargs)
             else:  # last possibility: make a matrix
-                arr = np.asarray(weight)
+                arr = np.asarray(weighting)
                 if arr.dtype == object:
-                    raise ValueError('invalid weight argument {}'
-                                     ''.format(weight))
+                    raise ValueError('invalid weighting argument {}'
+                                     ''.format(weighting))
                 if arr.ndim == 1:
-                    self._weighting = NumpyFnVectorWeighting(
+                    self.__weighting = NumpyFnArrayWeighting(
                         arr, exponent, dist_using_inner=dist_using_inner)
                 elif arr.ndim == 2:
-                    self._weighting = NumpyFnMatrixWeighting(
+                    self.__weighting = NumpyFnMatrixWeighting(
                         arr, exponent, dist_using_inner=dist_using_inner,
                         **kwargs)
                 else:
                     raise ValueError('array-like input {} is not 1- or '
-                                     '2-dimensional'.format(weight))
+                                     '2-dimensional'.format(weighting))
 
         elif dist is not None:
-            self._weighting = NumpyFnCustomDist(dist)
+            self.__weighting = NumpyFnCustomDist(dist)
         elif norm is not None:
-            self._weighting = NumpyFnCustomNorm(norm)
+            self.__weighting = NumpyFnCustomNorm(norm)
         elif inner is not None:
-            self._weighting = NumpyFnCustomInnerProduct(inner)
+            self.__weighting = NumpyFnCustomInnerProduct(inner)
         else:  # all None -> no weighing
-            self._weighting = NumpyFnNoWeighting(
+            self.__weighting = NumpyFnNoWeighting(
                 exponent, dist_using_inner=dist_using_inner)
 
     @property
     def exponent(self):
         """Exponent of the norm and distance."""
-        return self._weighting.exponent
+        return self.weighting.exponent
 
     @property
     def weighting(self):
         """This space's weighting scheme."""
-        return self._weighting
+        return self.__weighting
 
     @property
     def is_weighted(self):
@@ -1428,39 +1428,39 @@ class MatVecOperator(Operator):
     # TODO: repr and str
 
 
-def _weighting(weight, exponent, dist_using_inner=False):
+def _weighting(weights, exponent, dist_using_inner=False):
     """Return a weighting whose type is inferred from the arguments."""
-    if np.isscalar(weight):
+    if np.isscalar(weights):
         weighting = NumpyFnConstWeighting(
-            weight, exponent=exponent, dist_using_inner=dist_using_inner)
-    elif isspmatrix(weight):
+            weights, exponent=exponent, dist_using_inner=dist_using_inner)
+    elif isspmatrix(weights):
         weighting = NumpyFnMatrixWeighting(
-            weight, exponent=exponent, dist_using_inner=dist_using_inner)
+            weights, exponent=exponent, dist_using_inner=dist_using_inner)
     else:
-        weight_ = np.asarray(weight)
-        if weight_.dtype == object:
-            raise ValueError('bad weight {}'.format(weight))
-        if weight_.ndim == 1:
-            weighting = NumpyFnVectorWeighting(
-                weight_, exponent=exponent, dist_using_inner=dist_using_inner)
-        elif weight_.ndim == 2:
+        weights, weights_in = np.asarray(weights), weights
+        if weights.dtype == object:
+            raise ValueError('bad weights {}'.format(weights_in))
+        if weights.ndim == 1:
+            weighting = NumpyFnArrayWeighting(
+                weights, exponent=exponent, dist_using_inner=dist_using_inner)
+        elif weights.ndim == 2:
             weighting = NumpyFnMatrixWeighting(
-                weight_, exponent=exponent, dist_using_inner=dist_using_inner)
+                weights, exponent=exponent, dist_using_inner=dist_using_inner)
         else:
-            raise ValueError('array-like weight must have 1 or 2 dimensions, '
-                             'but {} has {} dimensions'
-                             ''.format(weight, weight_.ndim))
+            raise ValueError('array-like `weights` must have 1 or 2 '
+                             'dimensions, but {} has {} dimensions'
+                             ''.format(weights, weights.ndim))
     return weighting
 
 
-def npy_weighted_inner(weight):
+def npy_weighted_inner(weights):
     """Weighted inner product on `NumpyFn` spaces as free function.
 
     Parameters
     ----------
-    weight : scalar or `array-like`
-        Weight of the inner product. A scalar is interpreted as a
-        constant weight, a 1-dim. array as a weighting vector and a
+    weights : scalar or `array-like`
+        Weights of the inner product. A scalar is interpreted as a
+        constant weight, a 1-dim. array as a weighting array and a
         2-dimensional array as a weighting matrix.
 
     Returns
@@ -1472,19 +1472,19 @@ def npy_weighted_inner(weight):
 
     See Also
     --------
-    NumpyFnConstWeighting, NumpyFnVectorWeighting, NumpyFnMatrixWeighting
+    NumpyFnConstWeighting, NumpyFnArrayWeighting, NumpyFnMatrixWeighting
     """
-    return _weighting(weight, exponent=2.0).inner
+    return _weighting(weights, exponent=2.0).inner
 
 
-def npy_weighted_norm(weight, exponent=2.0):
+def npy_weighted_norm(weights, exponent=2.0):
     """Weighted norm on `NumpyFn` spaces as free function.
 
     Parameters
     ----------
-    weight : scalar or `array-like`
-        Weight of the norm. A scalar is interpreted as a
-        constant weight, a 1-dim. array as a weighting vector and a
+    weights : scalar or `array-like`
+        Weights of the norm. A scalar is interpreted as a
+        constant weight, a 1-dim. array as a weighting array and a
         2-dimensional array as a weighting matrix.
     exponent : positive float
         Exponent of the norm. If ``weight`` is a sparse matrix, only
@@ -1499,19 +1499,19 @@ def npy_weighted_norm(weight, exponent=2.0):
 
     See Also
     --------
-    NumpyFnConstWeighting, NumpyFnVectorWeighting, NumpyFnMatrixWeighting
+    NumpyFnConstWeighting, NumpyFnArrayWeighting, NumpyFnMatrixWeighting
     """
-    return _weighting(weight, exponent=exponent).norm
+    return _weighting(weights, exponent=exponent).norm
 
 
-def npy_weighted_dist(weight, exponent=2.0, use_inner=False):
+def npy_weighted_dist(weights, exponent=2.0, use_inner=False):
     """Weighted distance on `NumpyFn` spaces as free function.
 
     Parameters
     ----------
-    weight : scalar or `array-like`
-        Weight of the distance. A scalar is interpreted as a
-        constant weight, a 1-dim. array as a weighting vector and a
+    weights : scalar or `array-like`
+        Weights of the distance. A scalar is interpreted as a
+        constant weight, a 1-dim. array as a weighting array and a
         2-dimensional array as a weighting matrix.
     exponent : positive float
         Exponent of the norm. If ``weight`` is a sparse matrix, only
@@ -1536,9 +1536,9 @@ def npy_weighted_dist(weight, exponent=2.0, use_inner=False):
 
     See Also
     --------
-    NumpyFnConstWeighting, NumpyFnVectorWeighting, NumpyFnMatrixWeighting
+    NumpyFnConstWeighting, NumpyFnArrayWeighting, NumpyFnMatrixWeighting
     """
-    return _weighting(weight, exponent=exponent,
+    return _weighting(weights, exponent=exponent,
                       dist_using_inner=use_inner).dist
 
 
@@ -1584,7 +1584,7 @@ def _inner_default(x1, x2):
     return dot(x2.data, x1.data)
 
 
-class NumpyFnMatrixWeighting(MatrixWeightingBase):
+class NumpyFnMatrixWeighting(MatrixWeighting):
 
     """Matrix weighting for `NumpyFn`.
 
@@ -1747,11 +1747,11 @@ class NumpyFnMatrixWeighting(MatrixWeightingBase):
                                     self.exponent))
 
 
-class NumpyFnVectorWeighting(VectorWeightingBase):
+class NumpyFnArrayWeighting(ArrayWeighting):
 
     """Vector weighting for `NumpyFn`.
 
-    For exponent 2.0, a new weighted inner product with vector ``w``
+    For exponent 2.0, a new weighted inner product with array ``w``
     is defined as::
 
         <a, b>_w := <w * a, b> = b^H (w * a)
@@ -1775,18 +1775,18 @@ class NumpyFnVectorWeighting(VectorWeightingBase):
 
     unless ``w = (1,...,1)``.
 
-    The vector may only have positive entries, otherwise it does not
+    The array may only have positive entries, otherwise it does not
     define an inner product or norm, respectively. This is not checked
     during initialization.
     """
 
-    def __init__(self, vector, exponent=2.0, dist_using_inner=False):
+    def __init__(self, array, exponent=2.0, dist_using_inner=False):
         """Initialize a new instance.
 
         Parameters
         ----------
-        vector : `array-like`, one-dim.
-            Weighting vector of the inner product, norm and distance
+        array : `array-like`, one-dim.
+            Weighting array of the inner product, norm and distance.
         exponent : positive float
             Exponent of the norm. For values other than 2.0, the inner
             product is not defined.
@@ -1801,11 +1801,11 @@ class NumpyFnVectorWeighting(VectorWeightingBase):
 
             This option can only be used if ``exponent`` is 2.0.
         """
-        super().__init__(vector, impl='numpy', exponent=exponent,
+        super().__init__(array, impl='numpy', exponent=exponent,
                          dist_using_inner=dist_using_inner)
 
     def inner(self, x1, x2):
-        """Calculate the vector weighted inner product of two vectors.
+        """Calculate the array-weighted inner product of two vectors.
 
         Parameters
         ----------
@@ -1822,14 +1822,14 @@ class NumpyFnVectorWeighting(VectorWeightingBase):
                                       'exponent != 2 (got {})'
                                       ''.format(self.exponent))
         else:
-            inner = _inner_default(x1 * self.vector, x2)
+            inner = _inner_default(x1 * self.array, x2)
             if is_real_dtype(x1.dtype):
                 return float(inner)
             else:
                 return complex(inner)
 
     def norm(self, x):
-        """Calculate the vector-weighted norm of a vector.
+        """Calculate the array-weighted norm of a vector.
 
         Parameters
         ----------
@@ -1847,10 +1847,10 @@ class NumpyFnVectorWeighting(VectorWeightingBase):
                 norm_squared = 0.0  # Compensate for numerical error
             return np.sqrt(norm_squared)
         else:
-            return float(_pnorm_diagweight(x, self.exponent, self.vector))
+            return float(_pnorm_diagweight(x, self.exponent, self.array))
 
 
-class NumpyFnConstWeighting(ConstWeightingBase):
+class NumpyFnConstWeighting(ConstWeighting):
 
     """Weighting of `NumpyFn` by a constant.
 
@@ -1975,7 +1975,7 @@ class NumpyFnConstWeighting(ConstWeightingBase):
                     float(_pnorm_default(x1 - x2, self.exponent)))
 
 
-class NumpyFnNoWeighting(NoWeightingBase, NumpyFnConstWeighting):
+class NumpyFnNoWeighting(NoWeighting, NumpyFnConstWeighting):
 
     """Weighting of `NumpyFn` with constant 1.
 
@@ -2035,7 +2035,7 @@ class NumpyFnNoWeighting(NoWeightingBase, NumpyFnConstWeighting):
                          dist_using_inner=dist_using_inner)
 
 
-class NumpyFnCustomInnerProduct(CustomInnerProductBase):
+class NumpyFnCustomInnerProduct(CustomInnerProduct):
 
     """Class for handling a user-specified inner product in `NumpyFn`."""
 
@@ -2067,7 +2067,7 @@ class NumpyFnCustomInnerProduct(CustomInnerProductBase):
                          dist_using_inner=dist_using_inner)
 
 
-class NumpyFnCustomNorm(CustomNormBase):
+class NumpyFnCustomNorm(CustomNorm):
 
     """Class for handling a user-specified norm in `NumpyFn`.
 
@@ -2092,7 +2092,7 @@ class NumpyFnCustomNorm(CustomNormBase):
         super().__init__(norm, impl='numpy')
 
 
-class NumpyFnCustomDist(CustomDistBase):
+class NumpyFnCustomDist(CustomDist):
 
     """Class for handling a user-specified distance in `NumpyFn`.
 

--- a/odl/space/weighting.py
+++ b/odl/space/weighting.py
@@ -32,12 +32,12 @@ from odl.space.base_ntuples import FnBaseVector
 from odl.util.utility import array1d_repr, arraynd_repr
 
 
-__all__ = ('MatrixWeightingBase', 'VectorWeightingBase', 'ConstWeightingBase',
-           'NoWeightingBase',
-           'CustomInnerProductBase', 'CustomNormBase', 'CustomDistBase')
+__all__ = ('MatrixWeighting', 'ArrayWeighting', 'ConstWeighting',
+           'NoWeighting',
+           'CustomInnerProduct', 'CustomNorm', 'CustomDist')
 
 
-class WeightingBase(object):
+class Weighting(object):
 
     """Abstract base class for weighting of finite-dimensional spaces.
 
@@ -114,7 +114,7 @@ class WeightingBase(object):
         arrays may be compared entry-wise. That is the task of the
         `equiv` method.
         """
-        return (isinstance(other, WeightingBase) and
+        return (isinstance(other, Weighting) and
                 self.impl == other.impl and
                 self.exponent == other.exponent and
                 self.dist_using_inner == other.dist_using_inner)
@@ -127,7 +127,7 @@ class WeightingBase(object):
         Returns
         -------
         equivalent : bool
-            ``True`` if ``other`` is a `WeightingBase` instance which
+            ``True`` if ``other`` is a `Weighting` instance which
             yields the same result as this inner product for any
             input, ``False`` otherwise.
         """
@@ -192,7 +192,7 @@ class WeightingBase(object):
             return self.norm(x1 - x2)
 
 
-class MatrixWeightingBase(WeightingBase):
+class MatrixWeighting(Weighting):
 
     """Weighting of a space by a matrix.
 
@@ -389,7 +389,7 @@ class MatrixWeightingBase(WeightingBase):
         Returns
         -------
         equals : bool
-            ``True`` if other is a `MatrixWeightingBase` instance
+            ``True`` if other is a `MatrixWeighting` instance
             with **identical** matrix, ``False`` otherwise.
 
         See Also
@@ -408,10 +408,10 @@ class MatrixWeightingBase(WeightingBase):
         Returns
         -------
         equivalent : bool
-            ``True`` if other is a `WeightingBase` instance with the same
-            `WeightingBase.impl`, which yields the same result as this
+            ``True`` if other is a `Weighting` instance with the same
+            `Weighting.impl`, which yields the same result as this
             weighting for any input, ``False`` otherwise. This is checked
-            by entry-wise comparison of matrices/vectors/constants.
+            by entry-wise comparison of matrices/arrays/constants.
         """
         # Optimization for equality
         if self == other:
@@ -420,7 +420,7 @@ class MatrixWeightingBase(WeightingBase):
         elif self.exponent != getattr(other, 'exponent', -1):
             return False
 
-        elif isinstance(other, MatrixWeightingBase):
+        elif isinstance(other, MatrixWeighting):
             if self.matrix.shape != other.matrix.shape:
                 return False
 
@@ -441,17 +441,17 @@ class MatrixWeightingBase(WeightingBase):
                 else:
                     return np.array_equal(self.matrix, other.matrix)
 
-        elif isinstance(other, VectorWeightingBase):
+        elif isinstance(other, ArrayWeighting):
             if self.matrix_issparse:
                 return (np.array_equiv(self.matrix.diagonal(),
-                                       other.vector) and
+                                       other.array) and
                         np.array_equal(self.matrix.asformat('dia').offsets,
                                        np.array([0])))
             else:
                 return np.array_equal(
-                    self.matrix, other.vector * np.eye(self.matrix.shape[0]))
+                    self.matrix, other.array * np.eye(self.matrix.shape[0]))
 
-        elif isinstance(other, ConstWeightingBase):
+        elif isinstance(other, ConstWeighting):
             if self.matrix_issparse:
                 return (np.array_equiv(self.matrix.diagonal(), other.const) and
                         np.array_equal(self.matrix.asformat('dia').offsets,
@@ -466,9 +466,9 @@ class MatrixWeightingBase(WeightingBase):
     def repr_part(self):
         """Return a string usable in a space's ``__repr__`` method."""
         if self.matrix_issparse:
-            part = 'weight={}'.format(self.matrix)
+            part = 'weighting={}'.format(self.matrix)
         else:
-            part = 'weight={}'.format(arraynd_repr(self.matrix, nprint=10))
+            part = 'weighting={}'.format(arraynd_repr(self.matrix, nprint=10))
         if self.exponent != 2.0:
             part += ', exponent={}'.format(self.exponent)
         if self.dist_using_inner:
@@ -511,25 +511,25 @@ class MatrixWeightingBase(WeightingBase):
                                                             self.matrix)
 
 
-class VectorWeightingBase(WeightingBase):
+class ArrayWeighting(Weighting):
 
-    """Weighting of a space by a vector.
+    """Weighting of a space by an array.
 
     The exact definition of the weighted inner product, norm and
     distance functions depend on the concrete space.
 
-    The vector may only have positive entries, otherwise it does not
+    The array may only have positive entries, otherwise it does not
     define an inner product or norm, respectively. This is not checked
     during initialization.
     """
 
-    def __init__(self, vector, impl, exponent=2.0, dist_using_inner=False):
+    def __init__(self, array, impl, exponent=2.0, dist_using_inner=False):
         """Initialize a new instance.
 
         Parameters
         ----------
-        vector : 1-dim. `array-like`
-            Weighting vector of the inner product.
+        array : 1-dim. `array-like`
+            Weighting array of the inner product.
         impl : string
             Specifier for the implementation backend.
         exponent : positive float
@@ -551,26 +551,26 @@ class VectorWeightingBase(WeightingBase):
         super().__init__(impl=impl, exponent=exponent,
                          dist_using_inner=dist_using_inner)
 
-        if isinstance(vector, FnBaseVector):
-            self._vector = vector
+        if isinstance(array, FnBaseVector):
+            self.__array = array
         else:
-            self._vector = np.asarray(vector)
+            self.__array = np.asarray(array)
 
-        if self.vector.dtype == object:
-            raise ValueError('invalid vector {}'.format(vector))
-        elif self.vector.ndim != 1:
-            raise ValueError('vector {} is {}-dimensional instead of '
+        if self.array.dtype == object:
+            raise ValueError('invalid array {}'.format(array))
+        elif self.array.ndim != 1:
+            raise ValueError('array {} is {}-dimensional instead of '
                              '1-dimensional'
-                             ''.format(vector, self._vector.ndim))
+                             ''.format(array, self._array.ndim))
 
     @property
-    def vector(self):
-        """Weighting vector of this inner product."""
-        return self._vector
+    def array(self):
+        """Weighting array of this inner product."""
+        return self.__array
 
     def is_valid(self):
-        """Test if the vector is a valid weight, i.e. positive."""
-        return np.all(np.greater(self.vector, 0))
+        """Test if the array is a valid weight, i.e. positive."""
+        return np.all(np.greater(self.array, 0))
 
     def __eq__(self, other):
         """Return ``self == other``.
@@ -578,8 +578,8 @@ class VectorWeightingBase(WeightingBase):
         Returns
         -------
         equals : bool
-            ``True`` if other is a `VectorWeightingBase` instance with
-            **identical** vector, ``False`` otherwise.
+            ``True`` if other is a `ArrayWeighting` instance with
+            **identical** array, ``False`` otherwise.
 
         See Also
         --------
@@ -589,7 +589,7 @@ class VectorWeightingBase(WeightingBase):
             return True
 
         return (super().__eq__(other) and
-                self.vector is getattr(other, 'vector', None))
+                self.array is getattr(other, 'array', None))
 
     def equiv(self, other):
         """Test if other is an equivalent weighting.
@@ -597,28 +597,28 @@ class VectorWeightingBase(WeightingBase):
         Returns
         -------
         equivalent : bool
-            ``True`` if other is a `WeightingBase` instance with the same
-            `WeightingBase.impl`, which yields the same result as this
+            ``True`` if other is a `Weighting` instance with the same
+            `Weighting.impl`, which yields the same result as this
             weighting for any input, ``False`` otherwise. This is checked
-            by entry-wise comparison of matrices/vectors/constants.
+            by entry-wise comparison of matrices/arrays/constants.
         """
         # Optimization for equality
         if self == other:
             return True
-        elif (not isinstance(other, WeightingBase) or
+        elif (not isinstance(other, Weighting) or
               self.exponent != other.exponent):
             return False
-        elif isinstance(other, MatrixWeightingBase):
+        elif isinstance(other, MatrixWeighting):
             return other.equiv(self)
-        elif isinstance(other, ConstWeightingBase):
-            return np.array_equiv(self.vector, other.const)
+        elif isinstance(other, ConstWeighting):
+            return np.array_equiv(self.array, other.const)
         else:
-            return np.array_equal(self.vector, other.vector)
+            return np.array_equal(self.array, other.array)
 
     @property
     def repr_part(self):
         """String usable in a space's ``__repr__`` method."""
-        part = 'weight={}'.format(array1d_repr(self.vector, nprint=10))
+        part = 'weighting={}'.format(array1d_repr(self.array, nprint=10))
         if self.exponent != 2.0:
             part += ', exponent={}'.format(self.exponent)
         if self.dist_using_inner:
@@ -627,25 +627,25 @@ class VectorWeightingBase(WeightingBase):
 
     def __repr__(self):
         """Return ``repr(self)``."""
-        inner_fstr = '{vector!r}'
+        inner_fstr = '{array!r}'
         if self.exponent != 2.0:
             inner_fstr += ', exponent={ex}'
         if self.dist_using_inner:
             inner_fstr += ', dist_using_inner=True'
 
-        inner_str = inner_fstr.format(vector=self.vector, ex=self.exponent)
+        inner_str = inner_fstr.format(array=self.array, ex=self.exponent)
         return '{}({})'.format(self.__class__.__name__, inner_str)
 
     def __str__(self):
         """Return ``str(self)``."""
         if self.exponent == 2.0:
-            return 'Weighting: vector =\n{}'.format(self.vector)
+            return 'Weighting: array =\n{}'.format(self.array)
         else:
-            return 'Weighting: p = {}, vector =\n{}'.format(self.exponent,
-                                                            self.vector)
+            return 'Weighting: p = {}, array =\n{}'.format(self.exponent,
+                                                           self.array)
 
 
-class ConstWeightingBase(WeightingBase):
+class ConstWeighting(Weighting):
 
     """Weighting of a space by a constant.
 
@@ -694,7 +694,7 @@ class ConstWeightingBase(WeightingBase):
         Returns
         -------
         equal : bool
-            ``True`` if other is a `ConstWeightingBase` instance with the
+            ``True`` if other is a `ConstWeighting` instance with the
             same constant, ``False`` otherwise.
         """
         if other is self:
@@ -709,14 +709,14 @@ class ConstWeightingBase(WeightingBase):
         Returns
         -------
         equivalent : bool
-            ``True`` if other is a `WeightingBase` instance with the same
-            `WeightingBase.impl`, which yields the same result as this
+            ``True`` if other is a `Weighting` instance with the same
+            `Weighting.impl`, which yields the same result as this
             weighting for any input, ``False`` otherwise. This is checked
-            by entry-wise comparison of matrices/vectors/constants.
+            by entry-wise comparison of matrices/arrays/constants.
         """
-        if isinstance(other, ConstWeightingBase):
+        if isinstance(other, ConstWeighting):
             return self == other
-        elif isinstance(other, (VectorWeightingBase, MatrixWeightingBase)):
+        elif isinstance(other, (ArrayWeighting, MatrixWeighting)):
             return other.equiv(self)
         else:
             return False
@@ -726,7 +726,7 @@ class ConstWeightingBase(WeightingBase):
         """String usable in a space's ``__repr__`` method."""
         sep = ''
         if self.const != 1.0:
-            part = 'weight={:.4}'.format(self.const)
+            part = 'weighting={:.4}'.format(self.const)
             sep = ', '
         else:
             part = ''
@@ -758,7 +758,7 @@ class ConstWeightingBase(WeightingBase):
                 self.exponent, self.const)
 
 
-class NoWeightingBase(ConstWeightingBase):
+class NoWeighting(ConstWeighting):
 
     """Weighting with constant 1."""
 
@@ -785,7 +785,7 @@ class NoWeightingBase(ConstWeightingBase):
         """
         # Support singleton pattern for subclasses
         if not hasattr(self, '_initialized'):
-            ConstWeightingBase.__init__(
+            ConstWeighting.__init__(
                 self, constant=1.0, impl=impl, exponent=exponent,
                 dist_using_inner=dist_using_inner)
             self._initialized = True
@@ -809,7 +809,7 @@ class NoWeightingBase(ConstWeightingBase):
             return 'NoWeighting: p = {}'.format(self.exponent)
 
 
-class CustomInnerProductBase(WeightingBase):
+class CustomInnerProduct(Weighting):
 
     """Class for handling a user-specified inner product."""
 
@@ -861,7 +861,7 @@ class CustomInnerProductBase(WeightingBase):
         Returns
         -------
         equal : bool
-            ``True`` if other is a `CustomInnerProductBase`
+            ``True`` if other is a `CustomInner`
             instance with the same inner product, ``False`` otherwise.
         """
         return super().__eq__(other) and self.inner == other.inner
@@ -886,7 +886,7 @@ class CustomInnerProductBase(WeightingBase):
         return '{}({})'.format(self.__class__.__name__, inner_str)
 
 
-class CustomNormBase(WeightingBase):
+class CustomNorm(Weighting):
 
     """Class for handling a user-specified norm.
 
@@ -933,7 +933,7 @@ class CustomNormBase(WeightingBase):
         Returns
         -------
         equal : bool
-            ``True`` if other is a `CustomNormBase` instance with the same
+            ``True`` if other is a `CustomNorm` instance with the same
             norm, ``False`` otherwise.
         """
         return super().__eq__(other) and self.norm == other.norm
@@ -955,7 +955,7 @@ class CustomNormBase(WeightingBase):
         return '{}({})'.format(self.__class__.__name__, inner_str)
 
 
-class CustomDistBase(WeightingBase):
+class CustomDist(Weighting):
 
     """Class for handling a user-specified distance.
 
@@ -1006,7 +1006,7 @@ class CustomDistBase(WeightingBase):
         Returns
         -------
         equal : bool
-            ``True`` if other is a `CustomDistBase` instance with the same
+            ``True`` if other is a `CustomDist` instance with the same
             dist, ``False`` otherwise.
         """
         return super().__eq__(other) and self.dist == other.dist

--- a/odl/test/discr/lp_discr_test.py
+++ b/odl/test/discr/lp_discr_test.py
@@ -153,7 +153,7 @@ def test_factory_nd(exponent):
 def test_element_1d(exponent):
     discr = odl.uniform_discr(0, 1, 3, impl='numpy', exponent=exponent)
     weight = 1.0 if exponent == float('inf') else discr.cell_volume
-    dspace = odl.rn(3, exponent=exponent, weight=weight)
+    dspace = odl.rn(3, exponent=exponent, weighting=weight)
     elem = discr.element()
     assert isinstance(elem, odl.DiscreteLpElement)
     assert elem.ntuple in dspace
@@ -163,7 +163,7 @@ def test_element_2d(exponent):
     discr = odl.uniform_discr([0, 0], [1, 1], [3, 3],
                               impl='numpy', exponent=exponent)
     weight = 1.0 if exponent == float('inf') else discr.cell_volume
-    dspace = odl.rn(9, exponent=exponent, weight=weight)
+    dspace = odl.rn(9, exponent=exponent, weighting=weight)
     elem = discr.element()
     assert isinstance(elem, odl.DiscreteLpElement)
     assert elem.ntuple in dspace
@@ -1000,7 +1000,7 @@ def test_norm_rectangle_boundary(fn_impl, exponent):
     part = odl.RectPartition(rect, grid)
     weight = 1.0 if exponent == float('inf') else part.cell_volume
     dspace = odl.rn(part.size, dtype=dtype, impl=fn_impl, exponent=exponent,
-                    weight=weight)
+                    weighting=weight)
     discr = DiscreteLp(fspace, part, dspace, exponent=exponent)
 
     if exponent == float('inf'):

--- a/odl/test/discr/tensor_ops_test.py
+++ b/odl/test/discr/tensor_ops_test.py
@@ -59,7 +59,7 @@ def test_pointwise_norm_init_properties():
     pwnorm = PointwiseNorm(vfspace, exponent=2)
     assert pwnorm.exponent == 2
 
-    pwnorm = PointwiseNorm(vfspace, weight=2)
+    pwnorm = PointwiseNorm(vfspace, weighting=2)
     assert all_equal(pwnorm.weights, [2])
     assert pwnorm.is_weighted
 
@@ -78,7 +78,7 @@ def test_pointwise_norm_init_properties():
     pwnorm = PointwiseNorm(vfspace, exponent=2)
     assert pwnorm.exponent == 2
 
-    pwnorm = PointwiseNorm(vfspace, weight=[1, 2, 3])
+    pwnorm = PointwiseNorm(vfspace, weighting=[1, 2, 3])
     assert all_equal(pwnorm.weights, [1, 2, 3])
     assert pwnorm.is_weighted
 
@@ -90,10 +90,10 @@ def test_pointwise_norm_init_properties():
         PointwiseNorm(vfspace, exponent=0.5)  # < 1 not allowed
 
     with pytest.raises(ValueError):
-        PointwiseNorm(vfspace, weight=-1)  # < 0 not allowed
+        PointwiseNorm(vfspace, weighting=-1)  # < 0 not allowed
 
     with pytest.raises(ValueError):
-        PointwiseNorm(vfspace, weight=[1, 0, 1])  # 0 invalid
+        PointwiseNorm(vfspace, weighting=[1, 0, 1])  # 0 invalid
 
 
 def test_pointwise_norm_real(exponent):
@@ -165,7 +165,7 @@ def test_pointwise_norm_weighted(exponent):
     fspace = odl.uniform_discr([0, 0], [1, 1], (2, 2))
     vfspace = ProductSpace(fspace, 3)
     weight = np.array([1.0, 2.0, 3.0])
-    pwnorm = PointwiseNorm(vfspace, exponent, weight=weight)
+    pwnorm = PointwiseNorm(vfspace, exponent, weighting=weight)
 
     testarr = np.array([[[1, 2],
                          [3, 4]],
@@ -205,7 +205,7 @@ def test_pointwise_inner_init_properties():
     assert not pwinner.is_weighted
     repr(pwinner)
 
-    pwinner = PointwiseInner(vfspace, vfspace.one(), weight=[1, 2, 3])
+    pwinner = PointwiseInner(vfspace, vfspace.one(), weighting=[1, 2, 3])
     assert all_equal(pwinner.weights, [1, 2, 3])
     assert pwinner.is_weighted
 
@@ -311,7 +311,7 @@ def test_pointwise_inner_weighted():
                        [1, 1]]])
 
     weight = np.array([1.0, 2.0, 3.0])
-    pwinner = PointwiseInner(vfspace, vecfield=array, weight=weight)
+    pwinner = PointwiseInner(vfspace, vecfield=array, weighting=weight)
 
     testarr = np.array([[[1, 2],
                          [3, 4]],
@@ -382,7 +382,7 @@ def test_pointwise_inner_adjoint():
 def test_pointwise_inner_adjoint_weighted():
     # Weighted product space only
     fspace = odl.uniform_discr([0, 0], [1, 1], (2, 2), dtype=complex)
-    vfspace = ProductSpace(fspace, 3, weight=[2, 4, 6])
+    vfspace = ProductSpace(fspace, 3, weighting=[2, 4, 6])
     array = np.array([[[-1 - 1j, -3],
                        [2, 2j]],
                       [[-1j, 0],
@@ -406,7 +406,7 @@ def test_pointwise_inner_adjoint_weighted():
     assert all_almost_equal(out, true_inner_adj.reshape([3, -1]))
 
     # Using different weighting in the inner product
-    pwinner = PointwiseInner(vfspace, vecfield=array, weight=[4, 8, 12])
+    pwinner = PointwiseInner(vfspace, vecfield=array, weighting=[4, 8, 12])
 
     testarr = np.array([[1 + 1j, 2],
                         [3, 4 - 2j]])

--- a/odl/test/operator/pspace_ops_test.py
+++ b/odl/test/operator/pspace_ops_test.py
@@ -61,7 +61,7 @@ def test_pspace_op_init():
 def test_pspace_op_weighted_init():
 
     r3 = odl.rn(3)
-    ran = odl.ProductSpace(r3, 2, weight=[1, 2])
+    ran = odl.ProductSpace(r3, 2, weighting=[1, 2])
     I = odl.IdentityOperator(r3)
 
     with pytest.raises(NotImplementedError):

--- a/odl/test/space/ntuples_test.py
+++ b/odl/test/space/ntuples_test.py
@@ -34,7 +34,7 @@ from odl import NumpyNtuples, NumpyFn, NumpyFnVector
 from odl.operator.operator import Operator
 from odl.set.space import LinearSpaceTypeError
 from odl.space.npy_ntuples import (
-    NumpyFnConstWeighting, NumpyFnVectorWeighting, NumpyFnMatrixWeighting,
+    NumpyFnConstWeighting, NumpyFnArrayWeighting, NumpyFnMatrixWeighting,
     NumpyFnNoWeighting, NumpyFnCustomInnerProduct, NumpyFnCustomNorm,
     NumpyFnCustomDist,
     npy_weighted_inner, npy_weighted_norm, npy_weighted_dist,
@@ -150,12 +150,12 @@ def test_init():
 
     # Init with weights or custom space functions
     const = 1.5
-    weight_vec = _pos_array(odl.rn(3, float))
+    weight_arr = _pos_array(odl.rn(3, float))
     weight_mat = _dense_matrix(odl.rn(3, float))
 
-    odl.rn(3, weight=const)
-    odl.rn(3, weight=weight_vec)
-    odl.rn(3, weight=weight_mat)
+    odl.rn(3, weighting=const)
+    odl.rn(3, weighting=weight_arr)
+    odl.rn(3, weighting=weight_mat)
 
     # Different exponents
     exponents = [0.5, 1.0, 2.0, 5.0, float('inf')]
@@ -165,14 +165,14 @@ def test_init():
 
 def test_init_weighting(exponent):
     const = 1.5
-    weight_vec = _pos_array(odl.rn(3, float))
+    weight_arr = _pos_array(odl.rn(3, float))
     weight_mat = _dense_matrix(odl.rn(3, float))
 
-    spaces = [NumpyFn(3, complex, exponent=exponent, weight=const),
-              NumpyFn(3, complex, exponent=exponent, weight=weight_vec),
-              NumpyFn(3, complex, exponent=exponent, weight=weight_mat)]
+    spaces = [NumpyFn(3, complex, exponent=exponent, weighting=const),
+              NumpyFn(3, complex, exponent=exponent, weighting=weight_arr),
+              NumpyFn(3, complex, exponent=exponent, weighting=weight_mat)]
     weightings = [NumpyFnConstWeighting(const, exponent=exponent),
-                  NumpyFnVectorWeighting(weight_vec, exponent=exponent),
+                  NumpyFnArrayWeighting(weight_arr, exponent=exponent),
                   NumpyFnMatrixWeighting(weight_mat, exponent=exponent)]
 
     for spc, weight in zip(spaces, weightings):
@@ -180,10 +180,10 @@ def test_init_weighting(exponent):
 
 
 def test_astype():
-    rn = odl.rn(3, weight=1.5)
-    cn = odl.cn(3, weight=1.5)
-    rn_s = odl.rn(3, weight=1.5, dtype='float32')
-    cn_s = odl.cn(3, weight=1.5, dtype='complex64')
+    rn = odl.rn(3, weighting=1.5)
+    cn = odl.cn(3, weighting=1.5)
+    rn_s = odl.rn(3, weighting=1.5, dtype='float32')
+    cn_s = odl.cn(3, weighting=1.5, dtype='complex64')
 
     # Real
     assert rn.astype('float32') == rn_s
@@ -1076,7 +1076,7 @@ def test_matrix_equiv():
     sparse_eye = sp.sparse.eye(5)
     w_eye = NumpyFnMatrixWeighting(sparse_eye)
     w_dense_eye = NumpyFnMatrixWeighting(sparse_eye.todense())
-    w_eye_vec = NumpyFnVectorWeighting(np.ones(5))
+    w_eye_vec = NumpyFnArrayWeighting(np.ones(5))
 
     w_eye_wrong_exp = NumpyFnMatrixWeighting(sparse_eye, exponent=1)
 
@@ -1242,69 +1242,69 @@ def test_matrix_dist_using_inner(fn):
     assert almost_equal(w_dist(x, y), true_dist)
 
 
-def test_vector_init(exponent):
+def test_array_init(exponent):
     rn = odl.rn(5)
-    weight_vec = _pos_array(rn)
+    weight_arr = _pos_array(rn)
 
-    NumpyFnVectorWeighting(weight_vec, exponent=exponent)
-    NumpyFnVectorWeighting(rn.element(weight_vec), exponent=exponent)
+    NumpyFnArrayWeighting(weight_arr, exponent=exponent)
+    NumpyFnArrayWeighting(rn.element(weight_arr), exponent=exponent)
 
 
-def test_vector_vector():
+def test_array_array():
     rn = odl.rn(5)
-    weight_vec = _pos_array(rn)
-    weight_elem = rn.element(weight_vec)
+    weight_arr = _pos_array(rn)
+    weight_elem = rn.element(weight_arr)
 
-    weighting_vec = NumpyFnVectorWeighting(weight_vec)
-    weighting_elem = NumpyFnVectorWeighting(weight_elem)
+    weighting_arr = NumpyFnArrayWeighting(weight_arr)
+    weighting_elem = NumpyFnArrayWeighting(weight_elem)
 
-    assert isinstance(weighting_vec.vector, np.ndarray)
-    assert isinstance(weighting_elem.vector, NumpyFnVector)
+    assert isinstance(weighting_arr.array, np.ndarray)
+    assert isinstance(weighting_elem.array, NumpyFnVector)
 
 
-def test_vector_is_valid():
+def test_array_is_valid():
     rn = odl.rn(5)
-    weight_vec = _pos_array(rn)
-    weighting_vec = NumpyFnVectorWeighting(weight_vec)
+    weight_arr = _pos_array(rn)
+    weighting_arr = NumpyFnArrayWeighting(weight_arr)
 
-    assert weighting_vec.is_valid()
+    assert weighting_arr.is_valid()
 
     # Invalid
-    weight_vec[0] = 0
-    weighting_vec = NumpyFnVectorWeighting(weight_vec)
-    assert not weighting_vec.is_valid()
+    weight_arr[0] = 0
+    weighting_arr = NumpyFnArrayWeighting(weight_arr)
+    assert not weighting_arr.is_valid()
 
 
-def test_vector_equals():
+def test_array_equals():
     rn = odl.rn(5)
-    weight_vec = _pos_array(rn)
-    weight_elem = rn.element(weight_vec)
+    weight_arr = _pos_array(rn)
+    weight_elem = rn.element(weight_arr)
 
-    weighting_vec = NumpyFnVectorWeighting(weight_vec)
-    weighting_vec2 = NumpyFnVectorWeighting(weight_vec)
-    weighting_elem = NumpyFnVectorWeighting(weight_elem)
-    weighting_elem2 = NumpyFnVectorWeighting(weight_elem)
-    weighting_other_vec = NumpyFnVectorWeighting(weight_vec - 1)
-    weighting_other_exp = NumpyFnVectorWeighting(weight_vec - 1, exponent=1)
+    weighting_arr = NumpyFnArrayWeighting(weight_arr)
+    weighting_arr2 = NumpyFnArrayWeighting(weight_arr)
+    weighting_elem = NumpyFnArrayWeighting(weight_elem)
+    weighting_elem2 = NumpyFnArrayWeighting(weight_elem)
+    weighting_other_vec = NumpyFnArrayWeighting(weight_arr - 1)
+    weighting_other_exp = NumpyFnArrayWeighting(weight_arr - 1, exponent=1)
 
-    assert weighting_vec == weighting_vec2
-    assert weighting_vec != weighting_elem
+    assert weighting_arr == weighting_arr2
+    assert weighting_arr != weighting_elem
     assert weighting_elem == weighting_elem2
-    assert weighting_vec != weighting_other_vec
-    assert weighting_vec != weighting_other_exp
+    assert weighting_arr != weighting_other_vec
+    assert weighting_arr != weighting_other_exp
 
 
-def test_vector_equiv():
+def test_array_equiv():
     rn = odl.rn(5)
-    weight_vec = _pos_array(rn)
-    weight_elem = rn.element(weight_vec)
-    diag_mat = weight_vec * np.eye(5)
-    different_vec = weight_vec - 1
+    weight_arr = _pos_array(rn)
+    weight_elem = rn.element(weight_arr)
+    diag_mat = weight_arr * np.eye(5)
+    different_vec = weight_arr - 1
 
-    w_vec = NumpyFnVectorWeighting(weight_vec)
-    w_elem = NumpyFnVectorWeighting(weight_elem)
+    w_vec = NumpyFnArrayWeighting(weight_arr)
+    w_elem = NumpyFnArrayWeighting(weight_elem)
     w_diag_mat = NumpyFnMatrixWeighting(diag_mat)
-    w_different_vec = NumpyFnVectorWeighting(different_vec)
+    w_different_vec = NumpyFnArrayWeighting(different_vec)
 
     # Equal -> True
     assert w_vec.equiv(w_vec)
@@ -1317,7 +1317,7 @@ def test_vector_equiv():
     # Test shortcuts
     const_vec = np.ones(5) * 1.5
 
-    w_vec = NumpyFnVectorWeighting(const_vec)
+    w_vec = NumpyFnArrayWeighting(const_vec)
     w_const = NumpyFnConstWeighting(1.5)
     w_wrong_const = NumpyFnConstWeighting(1)
     w_wrong_exp = NumpyFnConstWeighting(1.5, exponent=1)
@@ -1332,82 +1332,82 @@ def test_vector_equiv():
     assert not w_vec.equiv(None)
 
 
-def test_vector_inner(fn):
+def test_array_inner(fn):
     [xarr, yarr], [x, y] = noise_elements(fn, 2)
 
-    weight_vec = _pos_array(fn)
-    weighting_vec = NumpyFnVectorWeighting(weight_vec)
+    weight_arr = _pos_array(fn)
+    weighting_arr = NumpyFnArrayWeighting(weight_arr)
 
-    true_inner = np.vdot(yarr, xarr * weight_vec)
+    true_inner = np.vdot(yarr, xarr * weight_arr)
 
-    assert almost_equal(weighting_vec.inner(x, y), true_inner)
+    assert almost_equal(weighting_arr.inner(x, y), true_inner)
 
     # With free function
-    inner_vec = npy_weighted_inner(weight_vec)
+    inner_vec = npy_weighted_inner(weight_arr)
 
     assert almost_equal(inner_vec(x, y), true_inner)
 
     # Exponent != 2 -> no inner product, should raise
     with pytest.raises(NotImplementedError):
-        NumpyFnVectorWeighting(weight_vec, exponent=1.0).inner(x, y)
+        NumpyFnArrayWeighting(weight_arr, exponent=1.0).inner(x, y)
 
 
-def test_vector_norm(fn, exponent):
+def test_array_norm(fn, exponent):
     xarr, x = noise_elements(fn)
 
-    weight_vec = _pos_array(fn)
-    weighting_vec = NumpyFnVectorWeighting(weight_vec, exponent=exponent)
+    weight_arr = _pos_array(fn)
+    weighting_arr = NumpyFnArrayWeighting(weight_arr, exponent=exponent)
 
     if exponent == float('inf'):
-        true_norm = np.linalg.norm(weight_vec * xarr, ord=float('inf'))
+        true_norm = np.linalg.norm(weight_arr * xarr, ord=float('inf'))
     else:
-        true_norm = np.linalg.norm(weight_vec ** (1 / exponent) * xarr,
+        true_norm = np.linalg.norm(weight_arr ** (1 / exponent) * xarr,
                                    ord=exponent)
 
-    assert almost_equal(weighting_vec.norm(x), true_norm)
+    assert almost_equal(weighting_arr.norm(x), true_norm)
 
     # With free function
-    pnorm_vec = npy_weighted_norm(weight_vec, exponent=exponent)
+    pnorm_vec = npy_weighted_norm(weight_arr, exponent=exponent)
     assert almost_equal(pnorm_vec(x), true_norm)
 
 
-def test_vector_dist(fn, exponent):
+def test_array_dist(fn, exponent):
     [xarr, yarr], [x, y] = noise_elements(fn, n=2)
 
-    weight_vec = _pos_array(fn)
-    weighting_vec = NumpyFnVectorWeighting(weight_vec, exponent=exponent)
+    weight_arr = _pos_array(fn)
+    weighting_arr = NumpyFnArrayWeighting(weight_arr, exponent=exponent)
 
     if exponent == float('inf'):
         true_dist = np.linalg.norm(
-            weight_vec * (xarr - yarr), ord=float('inf'))
+            weight_arr * (xarr - yarr), ord=float('inf'))
     else:
         true_dist = np.linalg.norm(
-            weight_vec ** (1 / exponent) * (xarr - yarr), ord=exponent)
+            weight_arr ** (1 / exponent) * (xarr - yarr), ord=exponent)
 
-    assert almost_equal(weighting_vec.dist(x, y), true_dist)
+    assert almost_equal(weighting_arr.dist(x, y), true_dist)
 
     # With free function
-    pdist_vec = npy_weighted_dist(weight_vec, exponent=exponent)
+    pdist_vec = npy_weighted_dist(weight_arr, exponent=exponent)
     assert almost_equal(pdist_vec(x, y), true_dist)
 
 
-def test_vector_dist_using_inner(fn):
+def test_array_dist_using_inner(fn):
     [xarr, yarr], [x, y] = noise_elements(fn, 2)
 
-    weight_vec = _pos_array(fn)
-    w = NumpyFnVectorWeighting(weight_vec)
+    weight_arr = _pos_array(fn)
+    w = NumpyFnArrayWeighting(weight_arr)
 
-    true_dist = np.linalg.norm(np.sqrt(weight_vec) * (xarr - yarr))
+    true_dist = np.linalg.norm(np.sqrt(weight_arr) * (xarr - yarr))
     # Using 3 places (single precision default) since the result is always
     # double even if the underlying computation was only single precision
     assert almost_equal(w.dist(x, y), true_dist, places=3)
 
     # Only possible for exponent=2
     with pytest.raises(ValueError):
-        NumpyFnVectorWeighting(weight_vec, exponent=1, dist_using_inner=True)
+        NumpyFnArrayWeighting(weight_arr, exponent=1, dist_using_inner=True)
 
     # With free function
-    w_dist = npy_weighted_dist(weight_vec, use_inner=True)
+    w_dist = npy_weighted_dist(weight_arr, use_inner=True)
     assert almost_equal(w_dist(x, y), true_dist, places=3)
 
 

--- a/odl/test/space/pspace_test.py
+++ b/odl/test/space/pspace_test.py
@@ -249,7 +249,7 @@ def test_vector_weighting(exponent):
     dists = [5, 7]
 
     weight = [0.5, 1.5]
-    pspace = odl.ProductSpace(r2, r3, weight=weight, exponent=exponent)
+    pspace = odl.ProductSpace(r2, r3, weighting=weight, exponent=exponent)
     x = pspace.element((r2x, r3x))
     y = pspace.element((r2y, r3y))
 
@@ -293,7 +293,7 @@ def test_const_weighting(exponent):
     dists = [5, 7]
 
     weight = 2.0
-    pspace = odl.ProductSpace(r2, r3, weight=weight, exponent=exponent)
+    pspace = odl.ProductSpace(r2, r3, weighting=weight, exponent=exponent)
     x = pspace.element((r2x, r3x))
     y = pspace.element((r2y, r3y))
 
@@ -394,13 +394,13 @@ def test_custom_funcs():
         odl.ProductSpace(r2, r3, norm=custom_norm, exponent=1.0)
 
     with pytest.raises(ValueError):
-        odl.ProductSpace(r2, r3, norm=custom_norm, weight=2.0)
+        odl.ProductSpace(r2, r3, norm=custom_norm, weighting=2.0)
 
     with pytest.raises(ValueError):
-        odl.ProductSpace(r2, r3, dist=custom_dist, weight=2.0)
+        odl.ProductSpace(r2, r3, dist=custom_dist, weighting=2.0)
 
     with pytest.raises(ValueError):
-        odl.ProductSpace(r2, r3, inner=custom_inner, weight=2.0)
+        odl.ProductSpace(r2, r3, inner=custom_inner, weighting=2.0)
 
 
 def test_power_RxR():

--- a/odl/tomo/operators/ray_trafo.py
+++ b/odl/tomo/operators/ray_trafo.py
@@ -152,7 +152,8 @@ class RayTransform(Operator):
             weight = extent / size
 
             range_dspace = discr_domain.dspace_type(geometry.partition.size,
-                                                    weight=weight, dtype=dtype)
+                                                    weighting=weight,
+                                                    dtype=dtype)
 
             if geometry.ndim == 2:
                 axis_labels = ['$\\theta$', '$s$']
@@ -283,7 +284,8 @@ class RayBackProjection(Operator):
             weight = extent / size
 
             domain_dspace = discr_range.dspace_type(geometry.partition.size,
-                                                    weight=weight, dtype=dtype)
+                                                    weighting=weight,
+                                                    dtype=dtype)
 
             if geometry.ndim == 2:
                 axis_labels = ['$\\theta$', '$s$']


### PR DESCRIPTION
Extremely boring PR, getting it out of the way for the tensors. Basically scrapping "Base" from weighting classes, harmonizing input parameter names etc.