### PR TITLE
REL: bump version to 0.5.4.dev0

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -1,11 +1,11 @@
 package:
     name: odl
-    version: "0.5.3"
+    version: "0.5.4"
 
 source:
     git_url: https://github.com/odlgroup/odl
-    # git_rev: master  # for testing, put any branch here
-    git_rev: v0.5.3  # release
+    git_rev: master  # for testing, put any branch here
+    # git_rev: v0.5.3  # release
     # git_rev: a542c12d23da7fa5b92b360a51ea14e4804c58f6  # intermediate bugfix revision
 
 build:

--- a/doc/source/release_notes.rst
+++ b/doc/source/release_notes.rst
@@ -6,8 +6,8 @@
 Release Notes
 #############
 
-Upcoming release
-================
+Upcoming release (could be 0.5.4)
+=================================
 
 ODL 0.5.3 Release Notes (2017-01-17)
 ====================================

--- a/odl/__init__.py
+++ b/odl/__init__.py
@@ -25,7 +25,7 @@ to be used to write general code and faciliate code reuse.
 
 from __future__ import absolute_import
 
-__version__ = '0.5.3'
+__version__ = '0.5.4.dev0'
 __all__ = ('diagnostics', 'discr', 'operator', 'set', 'space', 'solvers',
            'tomo', 'trafos', 'util', 'phantom', 'deform', 'ufunc_ops')
 

--- a/setup.py
+++ b/setup.py
@@ -102,7 +102,7 @@ Features
 setup(
     name='odl',
 
-    version='0.5.3',
+    version='0.5.4.dev0',
 
     description='Operator Discretization Library',
     long_description=long_description,


### PR DESCRIPTION
As discussed earlier, the current master should have a larger version than the last release, but smaller than the next possible minimal release. That would be 0.5.4.dev0 in this case.
```python
>>> from pkg_resources import parse_version
>>> parse_version('0.5.3') < parse_version('0.5.4.dev0')
True
>>> parse_version('0.5.4') > parse_version('0.5.4.dev0')
True
```
The `conda/meta.yaml` file uses 0.5.4 straight since there won't be a package until next release anyway. I also changed the git tag to master again so that users who want to build their own conda pacakge can do that straight off master.