### PR TITLE
Issue 910  matvec op

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -186,7 +186,7 @@ htmlhelp_basename = 'odldoc'
 # --- Options for LaTeX output --- #
 
 latex_elements = {
-    'preamble': '''
+    'preamble': r'''
 \usepackage{amsmath}
 \usepackage{amssymb}
 \usepackage{enumitem}

--- a/doc/source/getting_started/code/getting_started_convolution.py
+++ b/doc/source/getting_started/code/getting_started_convolution.py
@@ -115,4 +115,4 @@ tau = 1.0
 x = space.zero()
 odl.solvers.douglas_rachford_pd(x, f, g_funcs, lin_ops,
                                 tau=tau, sigma=sigma, niter=100)
-x.show('TV Douglas-Rachford', show=True)
+x.show('TV Douglas-Rachford', force_show=True)

--- a/doc/source/getting_started/code/getting_started_convolution.py
+++ b/doc/source/getting_started/code/getting_started_convolution.py
@@ -2,6 +2,7 @@
 
 import odl
 import scipy
+import scipy.signal
 
 
 class Convolution(odl.Operator):

--- a/doc/source/guide/code/functional_indepth_example.py
+++ b/doc/source/guide/code/functional_indepth_example.py
@@ -103,8 +103,6 @@ print('Value of the functional in a random point: {}'
 
 # Now we use the steepest-decent solver and backtracking linesearch in order to
 # find the minimum of the functional.
-# Create the gradient operator
-grad = my_func.gradient
 
 # Create a starting guess. Also used by the solver to update in-place.
 x = space.one()
@@ -113,7 +111,7 @@ x = space.one()
 line_search = odl.solvers.BacktrackingLineSearch(my_func, max_num_iter=10)
 
 # Call the solver
-odl.solvers.steepest_descent(grad=grad, x=x, niter=10, line_search=line_search)
+odl.solvers.steepest_descent(my_func, x, maxiter=10, line_search=line_search)
 
 print('Expected value: {}'.format((-1.0 / 2) * linear_term))
 print('Found value: {}'.format(x))

--- a/odl/operator/tensor_ops.py
+++ b/odl/operator/tensor_ops.py
@@ -30,7 +30,7 @@ from odl.set import RealNumbers, ComplexNumbers, LinearSpace
 from odl.space import ProductSpace
 
 
-__all__ = ('PointwiseNorm', 'PointwiseInner', 'PointwiseSum')
+__all__ = ('PointwiseNorm', 'PointwiseInner', 'PointwiseSum', 'MatVecOperator')
 
 _SUPPORTED_DIFF_METHODS = ('central', 'forward', 'backward')
 
@@ -690,6 +690,141 @@ class PointwiseSum(PointwiseInner):
 
         ones = vfspace.one()
         super().__init__(vfspace, vecfield=ones, weighting=weighting)
+
+
+class MatVecOperator(Operator):
+
+    """Matrix multiply operator :math:`\mathbb{F}^n -> \mathbb{F}^m`.
+
+    This operator uses a matrix to represent an operator, and get its adjoint
+    and inverse by doing computations on the matrix. This is in general a
+    rather slow approach, and users are recommended to use other alternatives
+    if available.
+    """
+
+    def __init__(self, matrix, domain=None, range=None):
+        """Initialize a new instance.
+
+        Parameters
+        ----------
+        matrix : `array-like` or  `scipy.sparse.spmatrix`
+            Matrix representing the linear operator. Its shape must be
+            ``(m, n)``, where ``n`` is the size of ``domain`` and ``m`` the
+            size of ``range``. Its dtype must be castable to the range
+            ``dtype``.
+        domain : `NumpyFn`, optional
+            Space on whose elements the matrix acts. If not provided,
+            the domain is inferred from the matrix ``dtype`` and
+            ``shape``. If provided, its dtype must be castable to the
+            range dtype.
+        range : `NumpyFn`, optional
+            Space to which the matrix maps. If not provided,
+            the domain is inferred from the matrix ``dtype`` and
+            ``shape``.
+        """
+        # TODO: fix dead link `scipy.sparse.spmatrix`
+        if isspmatrix(matrix):
+            self.__matrix = matrix
+        else:
+            self.__matrix = np.asarray(matrix)
+
+        if self.matrix.ndim != 2:
+            raise ValueError('matrix {} has {} axes instead of 2'
+                             ''.format(matrix, self.matrix.ndim))
+
+        # Infer domain and range from matrix if necessary
+        if domain is None:
+            domain = NumpyFn(self.matrix.shape[1], dtype=self.matrix.dtype)
+        elif not isinstance(domain, NumpyFn):
+            raise TypeError('`domain` {!r} is not an `NumpyFn` instance'
+                            ''.format(domain))
+
+        if range is None:
+            range = NumpyFn(self.matrix.shape[0], dtype=self.matrix.dtype)
+        elif not isinstance(range, NumpyFn):
+            raise TypeError('`range` {!r} is not an `NumpyFn` instance'
+                            ''.format(range))
+
+        # Check compatibility of matrix with domain and range
+        if not np.can_cast(domain.dtype, range.dtype):
+            raise TypeError('domain data type {!r} cannot be safely cast to '
+                            'range data type {!r}'
+                            ''.format(domain.dtype, range.dtype))
+
+        if self.matrix.shape != (range.size, domain.size):
+            raise ValueError('matrix shape {} does not match the required '
+                             'shape {} of a matrix {} --> {}'
+                             ''.format(self.matrix.shape,
+                                       (range.size, domain.size),
+                                       domain, range))
+        if not np.can_cast(self.matrix.dtype, range.dtype):
+            raise TypeError('matrix data type {!r} cannot be safely cast to '
+                            'range data type {!r}.'
+                            ''.format(matrix.dtype, range.dtype))
+
+        super().__init__(domain, range, linear=True)
+
+    @property
+    def matrix(self):
+        """Matrix representing this operator."""
+        return self.__matrix
+
+    @property
+    def matrix_issparse(self):
+        """Whether the representing matrix is sparse or not."""
+        return isspmatrix(self.matrix)
+
+    @property
+    def adjoint(self):
+        """Adjoint operator represented by the adjoint matrix.
+
+        Returns
+        -------
+        adjoint : `MatVecOperator`
+        """
+        if self.domain.field != self.range.field:
+            raise NotImplementedError('adjoint not defined since fields '
+                                      'of domain and range differ ({} != {})'
+                                      ''.format(self.domain.field,
+                                                self.range.field))
+        return MatVecOperator(self.matrix.conj().T,
+                              domain=self.range, range=self.domain)
+
+    @property
+    def inverse(self):
+        """Inverse operator represented by the inverse matrix.
+
+        Taking the inverse causes sparse matrices to become dense and is
+        generally very heavy computationally since the matrix is inverted
+        numerically (an O(n^3) operation). It is recommended to instead
+        use one of the solvers available in the ``odl.solvers`` package.
+
+        Returns
+        -------
+        inverse : `MatVecOperator`
+        """
+        if self.matrix_issparse:
+            dense_matrix = self.matrix.toarray()
+        else:
+            dense_matrix = self.matrix
+
+        return MatVecOperator(np.linalg.inv(dense_matrix),
+                              domain=self.range, range=self.domain)
+
+    def _call(self, x, out=None):
+        """Raw apply method on input, writing to given output."""
+        if out is None:
+            return self.range.element(self.matrix.dot(x.data))
+        else:
+            if self.matrix_issparse:
+                # Unfortunately, there is no native in-place dot product for
+                # sparse matrices
+                out.data[:] = self.matrix.dot(x.data)
+            else:
+                self.matrix.dot(x.data, out=out.data)
+
+    # TODO: repr and str
+
 
 
 if __name__ == '__main__':

--- a/odl/operator/tensor_ops.py
+++ b/odl/operator/tensor_ops.py
@@ -32,7 +32,7 @@ from odl.space import ProductSpace
 from odl.space.npy_ntuples import NumpyFn
 
 
-__all__ = ('PointwiseNorm', 'PointwiseInner', 'PointwiseSum', 'MatVecOperator')
+__all__ = ('PointwiseNorm', 'PointwiseInner', 'PointwiseSum', 'MatrixOperator')
 
 _SUPPORTED_DIFF_METHODS = ('central', 'forward', 'backward')
 
@@ -694,7 +694,7 @@ class PointwiseSum(PointwiseInner):
         super().__init__(vfspace, vecfield=ones, weighting=weighting)
 
 
-class MatVecOperator(Operator):
+class MatrixOperator(Operator):
 
     """Matrix multiply operator :math:`\mathbb{F}^n -> \mathbb{F}^m`.
 
@@ -782,14 +782,14 @@ class MatVecOperator(Operator):
 
         Returns
         -------
-        adjoint : `MatVecOperator`
+        adjoint : `MatrixOperator`
         """
         if self.domain.field != self.range.field:
             raise NotImplementedError('adjoint not defined since fields '
                                       'of domain and range differ ({} != {})'
                                       ''.format(self.domain.field,
                                                 self.range.field))
-        return MatVecOperator(self.matrix.conj().T,
+        return MatrixOperator(self.matrix.conj().T,
                               domain=self.range, range=self.domain)
 
     @property
@@ -803,14 +803,14 @@ class MatVecOperator(Operator):
 
         Returns
         -------
-        inverse : `MatVecOperator`
+        inverse : `MatrixOperator`
         """
         if self.matrix_issparse:
             dense_matrix = self.matrix.toarray()
         else:
             dense_matrix = self.matrix
 
-        return MatVecOperator(np.linalg.inv(dense_matrix),
+        return MatrixOperator(np.linalg.inv(dense_matrix),
                               domain=self.range, range=self.domain)
 
     def _call(self, x, out=None):

--- a/odl/operator/tensor_ops.py
+++ b/odl/operator/tensor_ops.py
@@ -24,10 +24,12 @@ standard_library.install_aliases()
 from builtins import super
 
 import numpy as np
+import scipy
 
 from odl.operator import Operator
 from odl.set import RealNumbers, ComplexNumbers, LinearSpace
 from odl.space import ProductSpace
+from odl.space.npy_ntuples import NumpyFn
 
 
 __all__ = ('PointwiseNorm', 'PointwiseInner', 'PointwiseSum', 'MatVecOperator')
@@ -723,7 +725,7 @@ class MatVecOperator(Operator):
             ``shape``.
         """
         # TODO: fix dead link `scipy.sparse.spmatrix`
-        if isspmatrix(matrix):
+        if scipy.sparse.isspmatrix(matrix):
             self.__matrix = matrix
         else:
             self.__matrix = np.asarray(matrix)
@@ -772,7 +774,7 @@ class MatVecOperator(Operator):
     @property
     def matrix_issparse(self):
         """Whether the representing matrix is sparse or not."""
-        return isspmatrix(self.matrix)
+        return scipy.sparse.isspmatrix(self.matrix)
 
     @property
     def adjoint(self):
@@ -824,7 +826,6 @@ class MatVecOperator(Operator):
                 self.matrix.dot(x.data, out=out.data)
 
     # TODO: repr and str
-
 
 
 if __name__ == '__main__':

--- a/odl/solvers/functional/example_funcs.py
+++ b/odl/solvers/functional/example_funcs.py
@@ -26,7 +26,7 @@ from builtins import super
 import numpy as np
 
 from odl.solvers.functional.functional import Functional
-from odl.operator import Operator, MatVecOperator
+from odl.operator import Operator, MatrixOperator
 from odl.space.base_ntuples import FnBase
 
 
@@ -159,7 +159,7 @@ class RosenbrockFunctional(Functional):
                     matrix[i, i + 1] = -4 * c * x[i]
                 matrix[-1, -1] = 2 * c
                 matrix[0, 0] = 2 + 12 * c * x[0] ** 2 - 4 * c * x[1]
-                return MatVecOperator(matrix, self.domain, self.range)
+                return MatrixOperator(matrix, self.domain, self.range)
 
         return RosenbrockGradient()
 

--- a/odl/solvers/functional/example_funcs.py
+++ b/odl/solvers/functional/example_funcs.py
@@ -26,9 +26,8 @@ from builtins import super
 import numpy as np
 
 from odl.solvers.functional.functional import Functional
-from odl.operator.operator import Operator
+from odl.operator import Operator, MatVecOperator
 from odl.space.base_ntuples import FnBase
-from odl.space.npy_ntuples import MatVecOperator
 
 
 __all__ = ('RosenbrockFunctional',)

--- a/odl/test/operator/operator_test.py
+++ b/odl/test/operator/operator_test.py
@@ -32,7 +32,7 @@ import odl
 from odl import (Operator, OperatorSum, OperatorComp,
                  OperatorLeftScalarMult, OperatorRightScalarMult,
                  FunctionalLeftVectorMult, OperatorRightVectorMult,
-                 MatVecOperator, OperatorLeftVectorMult,
+                 MatrixOperator, OperatorLeftVectorMult,
                  OpTypeError, OpDomainError, OpRangeError)
 from odl.operator.operator import _signature_from_spec, _dispatch_call_args
 from odl.util.testutils import almost_equal, all_almost_equal, noise_element
@@ -58,7 +58,7 @@ class MultiplyAndSquareOp(Operator):
             out **= 2
 
     def derivative(self, x):
-        return 2 * odl.MatVecOperator(self.matrix)
+        return 2 * odl.MatrixOperator(self.matrix)
 
     def __str__(self):
         return "MaS: " + str(self.matrix) + " ** 2"
@@ -210,7 +210,7 @@ def test_linear_Op():
     x = np.random.rand(3)
     out = np.random.rand(3)
 
-    Aop = MatVecOperator(A)
+    Aop = MatrixOperator(A)
     xvec = Aop.domain.element(x)
     outvec = Aop.range.element()
 
@@ -229,7 +229,7 @@ def test_linear_op_nonsquare():
     x = np.random.rand(3)
     out = np.random.rand(4)
 
-    Aop = MatVecOperator(A)
+    Aop = MatrixOperator(A)
 
     xvec = Aop.domain.element(x)
     outvec = Aop.range.element()
@@ -248,7 +248,7 @@ def test_linear_adjoint():
     x = np.random.rand(4)
     out = np.random.rand(3)
 
-    Aop = MatVecOperator(A)
+    Aop = MatrixOperator(A)
     xvec = Aop.range.element(x)
     outvec = Aop.domain.element()
 
@@ -267,8 +267,8 @@ def test_linear_addition():
     x = np.random.rand(3)
     y = np.random.rand(4)
 
-    Aop = MatVecOperator(A)
-    Bop = MatVecOperator(B)
+    Aop = MatrixOperator(A)
+    Bop = MatrixOperator(B)
     xvec = Aop.domain.element(x)
     yvec = Aop.range.element(y)
 
@@ -293,7 +293,7 @@ def test_linear_scale():
     x = np.random.rand(3)
     y = np.random.rand(4)
 
-    Aop = MatVecOperator(A)
+    Aop = MatrixOperator(A)
     xvec = Aop.domain.element(x)
     yvec = Aop.range.element(y)
 
@@ -323,7 +323,7 @@ def test_linear_scale():
 def test_linear_right_vector_mult():
     A = np.random.rand(4, 3)
 
-    Aop = MatVecOperator(A)
+    Aop = MatrixOperator(A)
     vec = Aop.domain.element([1, 2, 3])
     x = Aop.domain.element([4, 5, 6])
     y = Aop.range.element([5, 6, 7, 8])
@@ -352,8 +352,8 @@ def test_linear_composition():
     x = np.random.rand(3)
     y = np.random.rand(5)
 
-    Aop = MatVecOperator(A)
-    Bop = MatVecOperator(B)
+    Aop = MatrixOperator(A)
+    Bop = MatrixOperator(B)
     xvec = Bop.domain.element(x)
     yvec = Aop.range.element(y)
 
@@ -370,7 +370,7 @@ def test_type_errors():
     r3 = odl.rn(3)
     r4 = odl.rn(4)
 
-    Aop = MatVecOperator(np.random.rand(3, 3))
+    Aop = MatrixOperator(np.random.rand(3, 3))
     r3Vec1 = r3.zero()
     r3Vec2 = r3.zero()
     r4Vec1 = r4.zero()

--- a/odl/test/operator/oputils_test.py
+++ b/odl/test/operator/oputils_test.py
@@ -40,7 +40,7 @@ def test_matrix_representation():
     n = 3
     A = np.random.rand(n, n)
 
-    Aop = odl.MatVecOperator(A)
+    Aop = odl.MatrixOperator(A)
 
     the_matrix = matrix_representation(Aop)
 
@@ -53,12 +53,12 @@ def test_matrix_representation_product_to_lin_space():
     n = 3
     rn = odl.rn(n)
     A = np.random.rand(n, n)
-    Aop = odl.MatVecOperator(A)
+    Aop = odl.MatrixOperator(A)
 
     m = 2
     rm = odl.rn(m)
     B = np.random.rand(n, m)
-    Bop = odl.MatVecOperator(B)
+    Bop = odl.MatrixOperator(B)
 
     dom = ProductSpace(rn, rm)
     ran = ProductSpace(rn, 1)
@@ -77,12 +77,12 @@ def test_matrix_representation_lin_space_to_product():
     n = 3
     rn = odl.rn(n)
     A = np.random.rand(n, n)
-    Aop = odl.MatVecOperator(A)
+    Aop = odl.MatrixOperator(A)
 
     m = 2
     rm = odl.rn(m)
     B = np.random.rand(m, n)
-    Bop = odl.MatVecOperator(B)
+    Bop = odl.MatrixOperator(B)
 
     dom = ProductSpace(rn, 1)
     ran = ProductSpace(rn, rm)
@@ -101,12 +101,12 @@ def test_matrix_representation_product_to_product():
     n = 3
     rn = odl.rn(n)
     A = np.random.rand(n, n)
-    Aop = odl.MatVecOperator(A)
+    Aop = odl.MatrixOperator(A)
 
     m = 2
     rm = odl.rn(m)
     B = np.random.rand(m, m)
-    Bop = odl.MatVecOperator(B)
+    Bop = odl.MatrixOperator(B)
 
     ran_and_dom = ProductSpace(rn, rm)
 
@@ -126,10 +126,10 @@ def test_matrix_representation_product_to_product_two():
     n = 3
     rn = odl.rn(n)
     A = np.random.rand(n, n)
-    Aop = odl.MatVecOperator(A)
+    Aop = odl.MatrixOperator(A)
 
     B = np.random.rand(n, n)
-    Bop = odl.MatVecOperator(B)
+    Bop = odl.MatrixOperator(B)
 
     ran_and_dom = ProductSpace(rn, 2)
 
@@ -203,7 +203,7 @@ def test_power_method_opnorm_symm():
     mat = np.array([[10, -18],
                     [6, -11]], dtype=float)
 
-    op = odl.MatVecOperator(mat)
+    op = odl.MatrixOperator(mat)
     true_opnorm = 2
     opnorm_est = power_method_opnorm(op)
     assert almost_equal(opnorm_est, true_opnorm, places=2)
@@ -222,7 +222,7 @@ def test_power_method_opnorm_nonsymm():
                     [1.90246927, 2.54424763],
                     [5.32935411, 0.04573162]])
 
-    op = odl.MatVecOperator(mat)
+    op = odl.MatrixOperator(mat)
     true_opnorm = 6
 
     # Start vector (1, 1) is close to the wrong eigenvector
@@ -255,14 +255,14 @@ def test_power_method_opnorm_exceptions():
 
     with pytest.raises(ValueError):
         # Input vector in the nullspace
-        op = odl.MatVecOperator([[0., 1.],
+        op = odl.MatrixOperator([[0., 1.],
                                  [0., 0.]])
 
         power_method_opnorm(op, maxiter=2, xstart=op.domain.one())
 
     with pytest.raises(ValueError):
         # Uneven number of iterates for non square operator
-        op = odl.MatVecOperator([[1., 2., 3.],
+        op = odl.MatrixOperator([[1., 2., 3.],
                                  [4., 5., 6.]])
 
         power_method_opnorm(op, maxiter=1, xstart=op.domain.one())

--- a/odl/test/operator/oputils_test.py
+++ b/odl/test/operator/oputils_test.py
@@ -31,8 +31,6 @@ import odl
 from odl.operator.oputils import matrix_representation, power_method_opnorm
 from odl.space.pspace import ProductSpace
 from odl.operator.pspace_ops import ProductSpaceOperator
-
-from odl.space.npy_ntuples import MatVecOperator
 from odl.util.testutils import almost_equal
 
 
@@ -42,7 +40,7 @@ def test_matrix_representation():
     n = 3
     A = np.random.rand(n, n)
 
-    Aop = MatVecOperator(A)
+    Aop = odl.MatVecOperator(A)
 
     the_matrix = matrix_representation(Aop)
 
@@ -55,12 +53,12 @@ def test_matrix_representation_product_to_lin_space():
     n = 3
     rn = odl.rn(n)
     A = np.random.rand(n, n)
-    Aop = MatVecOperator(A)
+    Aop = odl.MatVecOperator(A)
 
     m = 2
     rm = odl.rn(m)
     B = np.random.rand(n, m)
-    Bop = MatVecOperator(B)
+    Bop = odl.MatVecOperator(B)
 
     dom = ProductSpace(rn, rm)
     ran = ProductSpace(rn, 1)
@@ -79,12 +77,12 @@ def test_matrix_representation_lin_space_to_product():
     n = 3
     rn = odl.rn(n)
     A = np.random.rand(n, n)
-    Aop = MatVecOperator(A)
+    Aop = odl.MatVecOperator(A)
 
     m = 2
     rm = odl.rn(m)
     B = np.random.rand(m, n)
-    Bop = MatVecOperator(B)
+    Bop = odl.MatVecOperator(B)
 
     dom = ProductSpace(rn, 1)
     ran = ProductSpace(rn, rm)
@@ -103,12 +101,12 @@ def test_matrix_representation_product_to_product():
     n = 3
     rn = odl.rn(n)
     A = np.random.rand(n, n)
-    Aop = MatVecOperator(A)
+    Aop = odl.MatVecOperator(A)
 
     m = 2
     rm = odl.rn(m)
     B = np.random.rand(m, m)
-    Bop = MatVecOperator(B)
+    Bop = odl.MatVecOperator(B)
 
     ran_and_dom = ProductSpace(rn, rm)
 
@@ -128,10 +126,10 @@ def test_matrix_representation_product_to_product_two():
     n = 3
     rn = odl.rn(n)
     A = np.random.rand(n, n)
-    Aop = MatVecOperator(A)
+    Aop = odl.MatVecOperator(A)
 
     B = np.random.rand(n, n)
-    Bop = MatVecOperator(B)
+    Bop = odl.MatVecOperator(B)
 
     ran_and_dom = ProductSpace(rn, 2)
 

--- a/odl/test/operator/tensor_ops_test.py
+++ b/odl/test/operator/tensor_ops_test.py
@@ -60,7 +60,7 @@ def _sparse_matrix(fn):
 exponent = simple_fixture('exponent', [2.0, 1.0, float('inf'), 3.5, 1.5])
 fn = simple_fixture('fn', [odl.rn(10, np.float64), odl.rn(10, np.float32),
                            odl.cn(10, np.complex128), odl.cn(10, np.complex64),
-                           odl.rn(100)])
+                           odl.rn(100), odl.uniform_discr(0, 1, 5)])
 
 
 # ---- PointwiseNorm ----
@@ -536,6 +536,11 @@ def test_mat_op_init_and_basic_properties():
     op = MatrixOperator(sparse_mat, domain=odl.rn(5), range=odl.rn(5))
     assert isinstance(op.matrix, scipy.sparse.spmatrix)
     assert op.matrix_issparse
+
+    # Init with uniform_discr space (subclass of FnBase)
+    dom = odl.uniform_discr(0, 1, 3)
+    ran = odl.uniform_discr(0, 1, 2)
+    MatrixOperator(rect_mat, domain=dom, range=ran)
 
 
 def test_mat_op_adjoint(fn):

--- a/odl/test/solvers/iterative/iterative_test.py
+++ b/odl/test/solvers/iterative/iterative_test.py
@@ -84,7 +84,7 @@ def optimization_problem(request):
     if problem_name == 'MatVec':
         # Define problem
         op_arr = np.eye(5) * 5 + np.ones([5, 5])
-        op = odl.MatVecOperator(op_arr)
+        op = odl.MatrixOperator(op_arr)
 
         # Simple right hand side
         rhs = op.range.one()

--- a/odl/test/space/ntuples_test.py
+++ b/odl/test/space/ntuples_test.py
@@ -26,7 +26,7 @@ from builtins import range
 import numpy as np
 import pytest
 import operator
-import scipy as sp
+import scipy
 
 # ODL imports
 import odl
@@ -37,8 +37,7 @@ from odl.space.npy_ntuples import (
     NumpyFnConstWeighting, NumpyFnArrayWeighting, NumpyFnMatrixWeighting,
     NumpyFnNoWeighting, NumpyFnCustomInner, NumpyFnCustomNorm,
     NumpyFnCustomDist,
-    npy_weighted_inner, npy_weighted_norm, npy_weighted_dist,
-    MatVecOperator)
+    npy_weighted_inner, npy_weighted_norm, npy_weighted_dist)
 from odl.util.testutils import (almost_equal, all_almost_equal, all_equal,
                                 noise_array, noise_element,
                                 noise_elements, simple_fixture)
@@ -74,7 +73,7 @@ def _dense_matrix(fn):
 
 def _sparse_matrix(fn):
     """Create a sparse positive definite Hermitian matrix for `fn`."""
-    return sp.sparse.coo_matrix(_dense_matrix(fn))
+    return scipy.sparse.coo_matrix(_dense_matrix(fn))
 
 
 # Pytest fixtures
@@ -810,208 +809,6 @@ def test_conj(fn):
     assert all_equal(y, xarr.conj())
 
 
-# ---- MatVecOperator ---- #
-
-
-def test_matvec_init(fn):
-    # Square matrices, sparse and dense
-    sparse_mat = _sparse_matrix(fn)
-    dense_mat = _dense_matrix(fn)
-
-    MatVecOperator(sparse_mat, fn, fn)
-    MatVecOperator(dense_mat, fn, fn)
-
-    # Test defaults
-    op_float = MatVecOperator([[1.0, 2],
-                               [-1, 0.5]])
-
-    assert isinstance(op_float.domain, NumpyFn)
-    assert op_float.domain.is_rn
-    assert isinstance(op_float.range, NumpyFn)
-    assert op_float.domain.is_rn
-
-    op_complex = MatVecOperator([[1.0, 2 + 1j],
-                                 [-1 - 1j, 0.5]])
-
-    assert isinstance(op_complex.domain, NumpyFn)
-    assert op_complex.domain.is_cn
-    assert isinstance(op_complex.range, NumpyFn)
-    assert op_complex.domain.is_cn
-
-    op_int = MatVecOperator([[1, 2],
-                             [-1, 0]])
-
-    assert isinstance(op_int.domain, NumpyFn)
-    assert op_int.domain.dtype == int
-    assert isinstance(op_int.range, NumpyFn)
-    assert op_int.domain.dtype == int
-
-    # Rectangular
-    rect_mat = 2 * np.eye(2, 3)
-    r2 = odl.rn(2)
-    r3 = odl.rn(3)
-
-    MatVecOperator(rect_mat, r3, r2)
-
-    with pytest.raises(ValueError):
-        MatVecOperator(rect_mat, r2, r2)
-
-    with pytest.raises(ValueError):
-        MatVecOperator(rect_mat, r3, r3)
-
-    with pytest.raises(ValueError):
-        MatVecOperator(rect_mat, r2, r3)
-
-    # Rn to Cn okay
-    MatVecOperator(rect_mat, r3, odl.cn(2))
-
-    # Cn to Rn not okay (no safe cast)
-    with pytest.raises(TypeError):
-        MatVecOperator(rect_mat, odl.cn(3), r2)
-
-    # Complex matrix between real spaces not okay
-    rect_complex_mat = rect_mat + 1j
-    with pytest.raises(TypeError):
-        MatVecOperator(rect_complex_mat, r3, r2)
-
-    # Init with array-like structure (including numpy.matrix)
-    MatVecOperator(rect_mat.tolist(), r3, r2)
-    MatVecOperator(np.asmatrix(rect_mat), r3, r2)
-
-
-def test_matvec_simple_properties():
-    # Matrix - always ndarray in for dense input, scipy.sparse.spmatrix else
-    rect_mat = 2 * np.eye(2, 3)
-    r2 = odl.rn(2)
-    r3 = odl.rn(3)
-
-    op = MatVecOperator(rect_mat, r3, r2)
-    assert isinstance(op.matrix, np.ndarray)
-
-    op = MatVecOperator(np.asmatrix(rect_mat), r3, r2)
-    assert isinstance(op.matrix, np.ndarray)
-
-    op = MatVecOperator(rect_mat.tolist(), r3, r2)
-    assert isinstance(op.matrix, np.ndarray)
-    assert not op.matrix_issparse
-
-    sparse_mat = _sparse_matrix(odl.rn(5))
-    op = MatVecOperator(sparse_mat, odl.rn(5), odl.rn(5))
-    assert isinstance(op.matrix, sp.sparse.spmatrix)
-    assert op.matrix_issparse
-
-
-def test_matvec_adjoint(fn):
-    # Square cases
-    sparse_mat = _sparse_matrix(fn)
-    dense_mat = _dense_matrix(fn)
-
-    op_sparse = MatVecOperator(sparse_mat, fn, fn)
-    op_dense = MatVecOperator(dense_mat, fn, fn)
-
-    # Just test if it runs, nothing interesting to test here
-    op_sparse.adjoint
-    op_dense.adjoint
-
-    # Rectangular case
-    rect_mat = 2 * np.eye(2, 3)
-    r2, r3 = odl.rn(2), odl.rn(3)
-    c2 = odl.cn(2)
-
-    op = MatVecOperator(rect_mat, r3, r2)
-    op_adj = op.adjoint
-    assert op_adj.domain == op.range
-    assert op_adj.range == op.domain
-    assert np.array_equal(op_adj.matrix, op.matrix.conj().T)
-    assert np.array_equal(op_adj.adjoint.matrix, op.matrix)
-
-    # The operator Rn -> Cn has no adjoint
-    op_noadj = MatVecOperator(rect_mat, r3, c2)
-    with pytest.raises(NotImplementedError):
-        op_noadj.adjoint
-
-
-def test_matvec_inverse(fn):
-    # Sparse case
-    sparse_mat = _sparse_matrix(fn)
-    op_sparse = MatVecOperator(sparse_mat, fn, fn)
-
-    op_sparse_inv = op_sparse.inverse
-    assert op_sparse_inv.domain == op_sparse.range
-    assert op_sparse_inv.range == op_sparse.domain
-    assert all_almost_equal(op_sparse_inv.matrix,
-                            np.linalg.inv(op_sparse.matrix.todense()))
-    assert all_almost_equal(op_sparse_inv.inverse.matrix,
-                            op_sparse.matrix.todense())
-
-    # Test application
-    x = noise_element(fn)
-    assert all_almost_equal(x, op_sparse.inverse(op_sparse(x)))
-
-    # Dense case
-    dense_mat = _dense_matrix(fn)
-    op_dense = MatVecOperator(dense_mat, fn, fn)
-    op_dense_inv = op_dense.inverse
-    assert op_dense_inv.domain == op_dense.range
-    assert op_dense_inv.range == op_dense.domain
-    assert all_almost_equal(op_dense_inv.matrix,
-                            np.linalg.inv(op_dense.matrix))
-    assert all_almost_equal(op_dense_inv.inverse.matrix,
-                            op_dense.matrix)
-
-    # Test application
-    x = noise_element(fn)
-    assert all_almost_equal(x, op_dense.inverse(op_dense(x)))
-
-
-def test_matvec_call(fn):
-    # Square cases
-    sparse_mat = _sparse_matrix(fn)
-    dense_mat = _dense_matrix(fn)
-    xarr, x = noise_elements(fn)
-
-    op_sparse = MatVecOperator(sparse_mat, fn, fn)
-    op_dense = MatVecOperator(dense_mat, fn, fn)
-
-    yarr_sparse = sparse_mat.dot(xarr)
-    yarr_dense = dense_mat.dot(xarr)
-
-    # Out-of-place
-    y = op_sparse(x)
-    assert all_almost_equal(y, yarr_sparse)
-
-    y = op_dense(x)
-    assert all_almost_equal(y, yarr_dense)
-
-    # In-place
-    y = fn.element()
-    op_sparse(x, out=y)
-    assert all_almost_equal(y, yarr_sparse)
-
-    y = fn.element()
-    op_dense(x, out=y)
-    assert all_almost_equal(y, yarr_dense)
-
-    # Rectangular case
-    rect_mat = 2 * np.eye(2, 3)
-    r2, r3 = odl.rn(2), odl.rn(3)
-
-    op = MatVecOperator(rect_mat, r3, r2)
-    xarr = np.arange(3, dtype=float)
-    x = r3.element(xarr)
-
-    yarr = rect_mat.dot(xarr)
-
-    # Out-of-place
-    y = op(x)
-    assert all_almost_equal(y, yarr)
-
-    # In-place
-    y = r2.element()
-    op(x, out=y)
-    assert all_almost_equal(y, yarr)
-
-
 # --- Weighting tests --- #
 
 
@@ -1040,7 +837,7 @@ def test_matrix_matrix():
     w_sparse = NumpyFnMatrixWeighting(sparse_mat)
     w_dense = NumpyFnMatrixWeighting(dense_mat)
 
-    assert isinstance(w_sparse.matrix, sp.sparse.spmatrix)
+    assert isinstance(w_sparse.matrix, scipy.sparse.spmatrix)
     assert isinstance(w_dense.matrix, np.ndarray)
 
 
@@ -1122,20 +919,20 @@ def test_matrix_equiv():
     assert not w_dense.equiv(w_different_dense)
 
     # Test shortcuts
-    sparse_eye = sp.sparse.eye(5)
+    sparse_eye = scipy.sparse.eye(5)
     w_eye = NumpyFnMatrixWeighting(sparse_eye)
     w_dense_eye = NumpyFnMatrixWeighting(sparse_eye.todense())
     w_eye_vec = NumpyFnArrayWeighting(np.ones(5))
 
     w_eye_wrong_exp = NumpyFnMatrixWeighting(sparse_eye, exponent=1)
 
-    sparse_smaller_eye = sp.sparse.eye(4)
+    sparse_smaller_eye = scipy.sparse.eye(4)
     w_smaller_eye = NumpyFnMatrixWeighting(sparse_smaller_eye)
 
-    sparse_shifted_eye = sp.sparse.eye(5, k=1)
+    sparse_shifted_eye = scipy.sparse.eye(5, k=1)
     w_shifted_eye = NumpyFnMatrixWeighting(sparse_shifted_eye)
 
-    sparse_almost_eye = sp.sparse.dia_matrix((np.ones(4), [0]), (5, 5))
+    sparse_almost_eye = scipy.sparse.dia_matrix((np.ones(4), [0]), (5, 5))
     w_almost_eye = NumpyFnMatrixWeighting(sparse_almost_eye)
 
     assert w_eye.equiv(w_dense_eye)
@@ -1201,7 +998,7 @@ def test_matrix_norm(fn, exponent):
         true_norm_dense = np.linalg.norm(dense_mat.dot(xarr), ord=exponent)
     else:  # ||x||_{A,p} = ||A^{1/p} x||_p
         # Calculate matrix power
-        eigval, eigvec = sp.linalg.eigh(dense_mat)
+        eigval, eigvec = scipy.linalg.eigh(dense_mat)
         eigval **= 1.0 / exponent
         mat_pow = (eigval * eigvec).dot(eigvec.conj().T)
         true_norm_dense = np.linalg.norm(np.dot(mat_pow, xarr), ord=exponent)
@@ -1249,7 +1046,7 @@ def test_matrix_dist(fn, exponent):
                                          ord=exponent)
     else:  # d(x, y)_{A,p} = ||A^{1/p} (x-y)||_p
         # Calculate matrix power
-        eigval, eigvec = sp.linalg.eigh(dense_mat)
+        eigval, eigvec = scipy.linalg.eigh(dense_mat)
         eigval **= 1.0 / exponent
         mat_pow = (eigval * eigvec).dot(eigvec.conj().T)
         true_dist_dense = np.linalg.norm(np.dot(mat_pow, xarr - yarr),
@@ -1483,8 +1280,8 @@ def test_constant_equals():
     w_other_const = NumpyFnConstWeighting(constant + 1)
     w_other_exp = NumpyFnConstWeighting(constant, exponent=1)
 
-    const_sparse_mat = sp.sparse.dia_matrix(([constant] * n, [0]),
-                                            shape=(n, n))
+    const_sparse_mat = scipy.sparse.dia_matrix(([constant] * n, [0]),
+                                               shape=(n, n))
     const_dense_mat = constant * np.eye(n)
     w_matrix_sp = NumpyFnMatrixWeighting(const_sparse_mat)
     w_matrix_de = NumpyFnMatrixWeighting(const_dense_mat)
@@ -1508,8 +1305,8 @@ def test_constant_equiv():
     w_const = NumpyFnConstWeighting(constant)
     w_const2 = NumpyFnConstWeighting(constant)
 
-    const_sparse_mat = sp.sparse.dia_matrix(([constant] * n, [0]),
-                                            shape=(n, n))
+    const_sparse_mat = scipy.sparse.dia_matrix(([constant] * n, [0]),
+                                               shape=(n, n))
     const_dense_mat = constant * np.eye(n)
     w_matrix_sp = NumpyFnMatrixWeighting(const_sparse_mat)
     w_matrix_de = NumpyFnMatrixWeighting(const_dense_mat)


### PR DESCRIPTION
Fix for #910 and move of `MatVecOperator` from `space/npy_ntuples` to `operator/tensor_ops`, plus rename from `MatVecOperator` to `MatrixOperator`.
No other work like docs or test improvement since #861 also has its part in it.