### PR TITLE
BUG: Handle nan and inf properly in show, closes #920

### DIFF
--- a/odl/util/graphics.py
+++ b/odl/util/graphics.py
@@ -35,15 +35,23 @@ def _safe_minmax(values):
     """Calculate min and max of array with guards for nan and inf."""
 
     # Nan and inf guarded min and max
-    minval = np.min(values[np.isfinite(values)])
-    maxval = np.max(values[np.isfinite(values)])
+    isfinite = np.isfinite(values)
+    if np.any(isfinite):
+        # Only use finite values
+        values = values[isfinite]
+
+    minval = np.min(values)
+    maxval = np.max(values)
 
     return minval, maxval
 
 
 def _colorbar_ticks(minval, maxval):
     """Return the ticks (values show) in the colorbar."""
-    return [minval, (maxval + minval) / 2., maxval]
+    if not (np.isfinite(minval) and np.isfinite(maxval)):
+        return [0, 0, 0]
+    else:
+        return [minval, (maxval + minval) / 2., maxval]
 
 
 def _digits(minval, maxval):
@@ -56,7 +64,10 @@ def _digits(minval, maxval):
 
 def _colorbar_format(minval, maxval):
     """Return the format string for the colorbar."""
-    return '%.{}f'.format(_digits(minval, maxval))
+    if not (np.isfinite(minval) and np.isfinite(maxval)):
+        return str(maxval)
+    else:
+        return '%.{}f'.format(_digits(minval, maxval))
 
 
 def _axes_info(grid, npoints=5):


### PR DESCRIPTION
Now produces plots like this instead of crashing:

```python
spc = odl.uniform_discr([0, 0], [1, 1], [3, 3])
spc.element([[np.nan]]).show()
```

![nan](https://cloud.githubusercontent.com/assets/2202312/23059017/cbc620aa-f4f7-11e6-9ea3-3261f4e16dd1.png)

```python
spc = odl.uniform_discr([0, 0], [1, 1], [3, 3])
spc.element([[np.inf]]).show()
```

![inf](https://cloud.githubusercontent.com/assets/2202312/23059018/ceef3b4a-f4f7-11e6-98a2-69dd5c97f243.png)
