### PR TITLE
Add OperatorMeta

### DIFF
--- a/odl/operator/operator.py
+++ b/odl/operator/operator.py
@@ -29,6 +29,8 @@ from numbers import Number, Integral
 import sys
 
 from odl.set import LinearSpace, LinearSpaceElement, Set, Field
+from odl.util.utility import with_metaclass
+from functools import wraps
 
 
 __all__ = ('Operator', 'OperatorComp', 'OperatorSum', 'OperatorVectorSum',
@@ -301,7 +303,33 @@ def _dispatch_call_args(cls=None, bound_call=None, unbound_call=None,
     return has_out, out_optional, spec
 
 
-class Operator(object):
+class OperatorMeta(type):
+
+    """Metaclass for Operators.
+
+    This metaclass wraps some methods to improve usability by users. The
+    methods that are wrapped are:
+
+    * ``derivative``
+    """
+
+    def __new__(meta, classname, bases, classDict):
+        newClassDict = dict(classDict)
+
+        if 'derivative' in classDict:
+            derivative_impl = classDict['derivative']
+
+            @wraps(derivative_impl)
+            def derivative(self, x):
+                x = self.domain.element(x)
+                return derivative_impl(self, x)
+
+            newClassDict['derivative'] = derivative
+
+        return type.__new__(meta, classname, bases, newClassDict)
+
+
+class Operator(with_metaclass(OperatorMeta)):
 
     """Abstract mathematical operator.
 


### PR DESCRIPTION
So this PR is currently very small and is intended as something we can use for discussion.

The overall idea here is rather far reaching, but would (imo) make ODL easier to understand (on the surface, at least) and reduce the possibility of mistakes.

The idea is that we replace the current behavior of users implementing `_call`, `_inner` etc, with a more general interface wherein users implement the actual methods that they would want called `__call__`, `inner`, etc, and we wrap them by using a metaclass.

As an example, I have implemented this for the `derivative`, and I'm hoping for input on this. If we feel it is a good paradigm, we could implement this change and replace lots of the `_` methods.

The main change for external users would be that they would be implementing the python standard methods instead of some ODL special thing, and also that stuff like

```python
def derivative(x):
    x = self.domain.element(x)
    return 2 * x
```

could be simplified to

```python
def derivative(x):
    return 2 * x
```