### PR TITLE
ENH: allow anisotropic voxels in 3d

### DIFF
--- a/examples/tomo/anisotropic_voxels.py
+++ b/examples/tomo/anisotropic_voxels.py
@@ -1,19 +1,23 @@
-"""Example using the ray transform with 3d parallel beam geometry."""
+"""Example for ray transform with 3d parallel beam and anisotropic voxels.
+
+Anisotropic voxels are supported in ASTRA v1.8 and upwards; lower versions
+will trigger an error.
+"""
 
 import numpy as np
 import odl
 
 # Discrete reconstruction space: discretized functions on the cube
-# [-20, 20]^3 with 300 samples per dimension.
+# [-20, 20]^3 with 300 samples in x and y, and 100 samples in z direction.
 reco_space = odl.uniform_discr(
-    min_pt=[-20, -20, -20], max_pt=[20, 20, 20], shape=[300, 300, 300],
+    min_pt=[-20, -20, -20], max_pt=[20, 20, 20], shape=[300, 300, 100],
     dtype='float32')
 
 # Make a parallel beam geometry with flat detector
 # Angles: uniformly spaced, n = 180, min = 0, max = pi
 angle_partition = odl.uniform_partition(0, np.pi, 180)
-# Detector: uniformly sampled, n = (558, 558), min = (-30, -30), max = (30, 30)
-detector_partition = odl.uniform_partition([-30, -30], [30, 30], [558, 558])
+# Detector: uniformly sampled, n = (500, 500), min = (-30, -30), max = (30, 30)
+detector_partition = odl.uniform_partition([-30, -30], [30, 30], [500, 500])
 # Discrete reconstruction space
 
 # Some versions of ASTRA cannot handle axis-aligned origin_to_det unless
@@ -35,9 +39,9 @@ proj_data = ray_trafo(phantom)
 # projection data (or any element in the projection space).
 backproj = ray_trafo.adjoint(proj_data)
 
-# Show the slice z=0 of phantom and backprojection, as well as a projection
+# Show the slice y=0 of phantom and backprojection, as well as a projection
 # image at theta=0 and a sinogram at v=0 (middle detector row)
-phantom.show(coords=[None, None, 0], title='Phantom, middle z slice')
+phantom.show(coords=[None, 0, None], title='Phantom, middle y slice')
 proj_data.show(coords=[0, None, None], title='Projection at theta=0')
 proj_data.show(coords=[None, None, 0], title='Sinogram, middle slice')
-backproj.show(coords=[None, None, 0], title='Back-projection, middle z slice')
+backproj.show(coords=[None, 0, None], title='Back-projection, middle y slice')

--- a/examples/tomo/anisotropic_voxels.py
+++ b/examples/tomo/anisotropic_voxels.py
@@ -1,6 +1,6 @@
 """Example for ray transform with 3d parallel beam and anisotropic voxels.
 
-Anisotropic voxels are supported in ASTRA v1.8 and upwards; lower versions
+Anisotropic voxels are supported in ASTRA v1.8 and upwards; earlier versions
 will trigger an error.
 """
 
@@ -13,17 +13,11 @@ reco_space = odl.uniform_discr(
     min_pt=[-20, -20, -20], max_pt=[20, 20, 20], shape=[300, 300, 100],
     dtype='float32')
 
-# Make a parallel beam geometry with flat detector
+# Make a 3d single-axis parallel beam geometry with flat detector
 # Angles: uniformly spaced, n = 180, min = 0, max = pi
 angle_partition = odl.uniform_partition(0, np.pi, 180)
 # Detector: uniformly sampled, n = (500, 500), min = (-30, -30), max = (30, 30)
 detector_partition = odl.uniform_partition([-30, -30], [30, 30], [500, 500])
-# Discrete reconstruction space
-
-# Some versions of ASTRA cannot handle axis-aligned origin_to_det unless
-# it is aligned with the third coordinate axis, see issue #18 at ASTRA's
-# GitHub. This is fixed in ASTRA v1.7.2.; with older versions, the following
-# may produce a zero result.
 geometry = odl.tomo.Parallel3dAxisGeometry(angle_partition, detector_partition)
 
 # Ray transform (= forward projection).
@@ -42,6 +36,6 @@ backproj = ray_trafo.adjoint(proj_data)
 # Show the slice y=0 of phantom and backprojection, as well as a projection
 # image at theta=0 and a sinogram at v=0 (middle detector row)
 phantom.show(coords=[None, 0, None], title='Phantom, middle y slice')
+backproj.show(coords=[None, 0, None], title='Back-projection, middle y slice')
 proj_data.show(coords=[0, None, None], title='Projection at theta=0')
 proj_data.show(coords=[None, None, 0], title='Sinogram, middle slice')
-backproj.show(coords=[None, 0, None], title='Back-projection, middle y slice')

--- a/examples/tomo/ray_trafo_parallel_3d.py
+++ b/examples/tomo/ray_trafo_parallel_3d.py
@@ -9,17 +9,11 @@ reco_space = odl.uniform_discr(
     min_pt=[-20, -20, -20], max_pt=[20, 20, 20], shape=[300, 300, 300],
     dtype='float32')
 
-# Make a parallel beam geometry with flat detector
+# Make a 3d single-axis parallel beam geometry with flat detector
 # Angles: uniformly spaced, n = 180, min = 0, max = pi
 angle_partition = odl.uniform_partition(0, np.pi, 180)
 # Detector: uniformly sampled, n = (558, 558), min = (-30, -30), max = (30, 30)
 detector_partition = odl.uniform_partition([-30, -30], [30, 30], [558, 558])
-# Discrete reconstruction space
-
-# Some versions of ASTRA cannot handle axis-aligned origin_to_det unless
-# it is aligned with the third coordinate axis, see issue #18 at ASTRA's
-# GitHub. This is fixed in ASTRA v1.7.2.; with older versions, the following
-# may produce a zero result.
 geometry = odl.tomo.Parallel3dAxisGeometry(angle_partition, detector_partition)
 
 # Ray transform (= forward projection).
@@ -38,6 +32,6 @@ backproj = ray_trafo.adjoint(proj_data)
 # Show the slice z=0 of phantom and backprojection, as well as a projection
 # image at theta=0 and a sinogram at v=0 (middle detector row)
 phantom.show(coords=[None, None, 0], title='Phantom, middle z slice')
+backproj.show(coords=[None, None, 0], title='Back-projection, middle z slice')
 proj_data.show(coords=[0, None, None], title='Projection at theta=0')
 proj_data.show(coords=[None, None, 0], title='Sinogram, middle slice')
-backproj.show(coords=[None, None, 0], title='Back-projection, middle z slice')

--- a/odl/discr/lp_discr.py
+++ b/odl/discr/lp_discr.py
@@ -211,7 +211,7 @@ class DiscreteLp(DiscretizedSpace):
 
     @property
     def is_uniform(self):
-        """``True`` if ``self.partition`` is uniform."""
+        """``True`` if `partition` is uniform."""
         return self.partition.is_uniform
 
     @property

--- a/odl/discr/partition.py
+++ b/odl/discr/partition.py
@@ -229,8 +229,26 @@ class RectPartition(object):
 
     @property
     def is_uniform(self):
-        """``True`` if ``self.grid`` is uniform."""
+        """``True`` if `grid` is uniform."""
         return self.grid.is_uniform
+
+    @property
+    def has_isotropic_cells(self):
+        """``True`` if `grid` is uniform and `cell sides` are all equal.
+
+        Always ``True`` for 1D partitions.
+
+        Examples
+        --------
+        >>> part = uniform_partition([0, -1], [1, 1], (5, 10))
+        >>> part.has_isotropic_cells
+        True
+        >>> part = uniform_partition([0, -1], [1, 1], (5, 5))
+        >>> part.has_isotropic_cells
+        False
+        """
+        return self.is_uniform and np.allclose(self.cell_sides[:-1],
+                                               self.cell_sides[1:])
 
     @property
     def ndim(self):

--- a/odl/test/tomo/operators/ray_trafo_test.py
+++ b/odl/test/tomo/operators/ray_trafo_test.py
@@ -45,7 +45,7 @@ def geometry(request):
         return tomo.Parallel2dGeometry(apart, dpart)
     elif geom == 'par3d':
         apart = odl.uniform_partition(0, np.pi, n_angles)
-        dpart = odl.uniform_partition([-30] * 2, [30] * 2, [m] * 2)
+        dpart = odl.uniform_partition([-30, -30], [30, 30], (m, m))
         return tomo.Parallel3dAxisGeometry(apart, dpart)
     elif geom == 'cone2d':
         apart = odl.uniform_partition(0, 2 * np.pi, n_angles)
@@ -54,12 +54,12 @@ def geometry(request):
                                     det_radius=100)
     elif geom == 'cone3d':
         apart = odl.uniform_partition(0, 2 * np.pi, n_angles)
-        dpart = odl.uniform_partition([-60] * 2, [60] * 2, [m] * 2)
+        dpart = odl.uniform_partition([-60, -60], [60, 60], (m, m))
         return tomo.CircularConeFlatGeometry(apart, dpart, src_radius=200,
                                              det_radius=100)
     elif geom == 'helical':
         apart = odl.uniform_partition(0, 8 * 2 * np.pi, n_angles)
-        dpart = odl.uniform_partition([-30, -3], [30, 3], [m] * 2)
+        dpart = odl.uniform_partition([-30, -3], [30, 3], (m, m))
         return tomo.HelicalConeFlatGeometry(apart, dpart, pitch=5.0,
                                             src_radius=200, det_radius=100)
     else:
@@ -272,7 +272,7 @@ def test_complex(impl):
     assert all_almost_equal(data.imag, true_data_im)
 
 
-def test_aniso_voxels(geometry):
+def test_anisotropic_voxels(geometry):
     """Test projection and backprojection with anisotropic voxels."""
     ndim = geometry.ndim
     shape = [10] * (ndim - 1) + [5]

--- a/odl/test/tomo/operators/ray_trafo_test.py
+++ b/odl/test/tomo/operators/ray_trafo_test.py
@@ -29,6 +29,42 @@ impl_params = [skip_if_no_astra('astra_cpu'),
                skip_if_no_skimage('skimage')]
 impl = simple_fixture('impl', impl_params, fmt=" {name} = '{value.args[1]}' ")
 
+geometry_params = ['par2d', 'par3d', 'cone2d', 'cone3d', 'helical']
+geometry_ids = [' geometry = {} '.format(p) for p in geometry_params]
+
+
+@pytest.fixture(scope='module', ids=geometry_ids, params=geometry_params)
+def geometry(request):
+    geom = request.param
+    m = 100
+    n_angles = 100
+
+    if geom == 'par2d':
+        apart = odl.uniform_partition(0, np.pi, n_angles)
+        dpart = odl.uniform_partition(-30, 30, m)
+        return tomo.Parallel2dGeometry(apart, dpart)
+    elif geom == 'par3d':
+        apart = odl.uniform_partition(0, np.pi, n_angles)
+        dpart = odl.uniform_partition([-30] * 2, [30] * 2, [m] * 2)
+        return tomo.Parallel3dAxisGeometry(apart, dpart)
+    elif geom == 'cone2d':
+        apart = odl.uniform_partition(0, 2 * np.pi, n_angles)
+        dpart = odl.uniform_partition(-30, 30, m)
+        return tomo.FanFlatGeometry(apart, dpart, src_radius=200,
+                                    det_radius=100)
+    elif geom == 'cone3d':
+        apart = odl.uniform_partition(0, 2 * np.pi, n_angles)
+        dpart = odl.uniform_partition([-60] * 2, [60] * 2, [m] * 2)
+        return tomo.CircularConeFlatGeometry(apart, dpart, src_radius=200,
+                                             det_radius=100)
+    elif geom == 'helical':
+        apart = odl.uniform_partition(0, 8 * 2 * np.pi, n_angles)
+        dpart = odl.uniform_partition([-30, -3], [30, 3], [m] * 2)
+        return tomo.HelicalConeFlatGeometry(apart, dpart, pitch=5.0,
+                                            src_radius=200, det_radius=100)
+    else:
+        raise ValueError('geom not valid')
+
 
 # Find the valid projectors
 projectors = [skip_if_no_astra('par2d astra_cpu uniform'),
@@ -55,11 +91,11 @@ projectors = [skip_if_no_astra('par2d astra_cpu uniform'),
               skip_if_no_skimage('par2d skimage half_uniform')]
 
 
-projector_ids = ['geom={}, impl={}, angles={}'
+projector_ids = [' geom={}, impl={}, angles={} '
                  ''.format(*p.args[1].split()) for p in projectors]
 
 
-@pytest.fixture(scope="module", params=projectors, ids=projector_ids)
+@pytest.fixture(scope='module', params=projectors, ids=projector_ids)
 def projector(request):
     n = 100
     m = 100
@@ -89,52 +125,45 @@ def projector(request):
         raise ValueError('angle not valid')
 
     if geom == 'par2d':
-        # Discrete reconstruction space
+        # Reconstruction space
         reco_space = odl.uniform_discr([-20] * 2, [20] * 2, [n] * 2,
                                        dtype=dtype)
-
         # Geometry
         dpart = odl.uniform_partition(-30, 30, m)
         geom = tomo.Parallel2dGeometry(apart, dpart)
-
+        # Ray transform
         return tomo.RayTransform(reco_space, geom, impl=impl)
 
     elif geom == 'par3d':
-        # Discrete reconstruction space
+        # Reconstruction space
         reco_space = odl.uniform_discr([-20] * 3, [20] * 3, [n] * 3,
                                        dtype=dtype)
 
         # Geometry
-        dpart = odl.uniform_partition([-30] * 2, [30] * 2, [n] * 2)
+        dpart = odl.uniform_partition([-30] * 2, [30] * 2, [m] * 2)
         geom = tomo.Parallel3dAxisGeometry(apart, dpart)
-
         # Ray transform
         return tomo.RayTransform(reco_space, geom, impl=impl)
 
     elif geom == 'cone2d':
-        # Discrete reconstruction space
+        # Reconstruction space
         reco_space = odl.uniform_discr([-20] * 2, [20] * 2, [n] * 2,
                                        dtype=dtype)
-
         # Geometry
         dpart = odl.uniform_partition(-30, 30, m)
         geom = tomo.FanFlatGeometry(apart, dpart, src_radius=200,
                                     det_radius=100)
-
         # Ray transform
         return tomo.RayTransform(reco_space, geom, impl=impl)
 
     elif geom == 'cone3d':
-        # Discrete reconstruction space
+        # Reconstruction space
         reco_space = odl.uniform_discr([-20] * 3, [20] * 3, [n] * 3,
                                        dtype=dtype)
-
         # Geometry
         dpart = odl.uniform_partition([-60] * 2, [60] * 2, [m] * 2)
-
         geom = tomo.CircularConeFlatGeometry(apart, dpart, src_radius=200,
                                              det_radius=100)
-
         # Ray transform
         return tomo.RayTransform(reco_space, geom, impl=impl)
 
@@ -142,20 +171,18 @@ def projector(request):
         # Discrete reconstruction space
         reco_space = odl.uniform_discr([-20, -20, 0], [20, 20, 40],
                                        [n] * 3, dtype=dtype)
-
-        # overwrite angle
+        # Geometry, overwriting angle partition
         apart = odl.uniform_partition(0, 8 * 2 * np.pi, n_angles)
         dpart = odl.uniform_partition([-30, -3], [30, 3], [m] * 2)
         geom = tomo.HelicalConeFlatGeometry(apart, dpart, pitch=5.0,
                                             src_radius=200, det_radius=100)
-
         # Ray transform
         return tomo.RayTransform(reco_space, geom, impl=impl)
     else:
         raise ValueError('geom not valid')
 
 
-@pytest.fixture(scope="module",
+@pytest.fixture(scope='module',
                 params=[True, False],
                 ids=[' in-place ', ' out-of-place '])
 def in_place(request):
@@ -212,7 +239,6 @@ def test_adjoint(projector):
 
 def test_angles(projector):
     """Test discrete Ray transform angle conventions."""
-
     # Smoothed line/hyperplane around 0:th dimension
     vol = projector.domain.element(lambda x: np.exp(-x[0] ** 2))
 
@@ -244,6 +270,39 @@ def test_complex(impl):
 
     assert all_almost_equal(data.real, true_data_re)
     assert all_almost_equal(data.imag, true_data_im)
+
+
+def test_aniso_voxels(geometry):
+    """Test projection and backprojection with anisotropic voxels."""
+    ndim = geometry.ndim
+    shape = [10] * (ndim - 1) + [5]
+    space = odl.uniform_discr([-1] * ndim, [1] * ndim, shape=shape,
+                              dtype='float32')
+
+    # If no implementation is available, skip
+    if ndim == 2 and not odl.tomo.ASTRA_AVAILABLE:
+        pytest.skip(msg='ASTRA not available, skipping 2d test')
+    elif ndim == 3 and not odl.tomo.ASTRA_CUDA_AVAILABLE:
+        pytest.skip(msg='ASTRA_CUDA not available, skipping 3d test')
+
+    ray_trafo = odl.tomo.RayTransform(space, geometry)
+    vol_one = ray_trafo.domain.one()
+    data_one = ray_trafo.range.one()
+
+    if ndim == 2:
+        # Should raise
+        with pytest.raises(NotImplementedError):
+            ray_trafo(vol_one)
+        with pytest.raises(NotImplementedError):
+            ray_trafo.adjoint(data_one)
+    elif ndim == 3:
+        # Just check that this doesn't crash and computes something nonzero
+        data = ray_trafo(vol_one)
+        backproj = ray_trafo.adjoint(data_one)
+        assert data.norm() > 0
+        assert backproj.norm() > 0
+    else:
+        assert False
 
 
 if __name__ == '__main__':

--- a/odl/tomo/backends/astra_setup.py
+++ b/odl/tomo/backends/astra_setup.py
@@ -43,21 +43,21 @@ try:
                                   str(astra_ver_num % 100)])
 
     if parse_version(ASTRA_VERSION) < parse_version('1.7'):
-        raise RuntimeError('ASTRA version < 1.7 not supported')
+        raise RuntimeError('ASTRA version < 1.7 not supported, please update')
 except ImportError:
     ASTRA_AVAILABLE = False
     ASTRA_VERSION = ''
 
 import numpy as np
-import operator
 
 from odl.discr import DiscreteLp, DiscreteLpElement
 from odl.tomo.geometry import (
     Geometry, Parallel2dGeometry, DivergentBeamGeometry, ParallelGeometry,
     FlatDetector)
+from odl.util.utility import pkg_supports
 
 
-__all__ = ('ASTRA_AVAILABLE', 'ASTRA_VERSION',
+__all__ = ('ASTRA_AVAILABLE', 'ASTRA_VERSION', 'astra_supports',
            'astra_volume_geometry', 'astra_projection_geometry',
            'astra_data', 'astra_projector', 'astra_algorithm',
            'astra_conebeam_3d_geom_to_vec',
@@ -66,12 +66,33 @@ __all__ = ('ASTRA_AVAILABLE', 'ASTRA_VERSION',
 
 
 # Dictionary specifying which ASTRA versions support which feature. The dict
-# values can be given as exact version '==1.7' or '1.7', as range '1.7-1.7.4',
-# as inequality '>=1.7' or as comma-separated composition of such (the items
-# will be OR-ed together), e.g. '<=1.7, >=1.7.2'.
-ASTRA_FEATURES = {'anisotropic_voxels_2d': None,
-                  'anisotropic_voxels_3d': '>=1.8',
-                  }
+# values must be specified as valid setuptools package requirements without
+# package name, e.g., as exact version '==1.7', as inequality '>=1.7' or as
+# several requirements that need to be satisfied simultaneously, e.g.,
+# '>=1.8,<=2.0'.
+# To give multiple requirements that should be OR-ed together, use a
+# sequence instead of a single string in the dictionary, e.g.,
+# ['==1.7', '>=1.8,<=2.0'].
+ASTRA_FEATURES = {
+    # Cell sizes not equal in both axes in 2d, currently crashes
+    'anisotropic_voxels_2d': None,
+    # Cell sizes not equal all 3 axes in 3d, see ASTRA PR #41
+    'anisotropic_voxels_3d': '>=1.8',
+    # Density weighting for cone 2d (fan beam), not supported yet,
+    # see the discussion in ASTRA issue #71
+    'cone2d_density_weighting': None,
+    # Hacky version of ray-density weighting in cone beam backprojection for
+    # constant source-detector distance, see ASTRA issue #71 and ASTRA PR #84
+    'cone3d_hacky_density_weighting': '>=1.8',
+    # General case not supported yet, see the discussion in ASTRA issue #71
+    'cone3d_density_weighting': None,
+    # Fix for division by zero with detector midpoint normal perpendicular
+    # to geometry axis in parallel 3d, see ASTRA issue #18
+    'par3d_det_mid_pt_perp_to_axis': '>=1.7.2',
+    # Linking instead of copying of GPU memory, see ASTRA issue #93.
+    # This will be in the next release.
+    'gpulink': '>1.8',
+}
 
 
 def astra_supports(feature):
@@ -80,8 +101,8 @@ def astra_supports(feature):
     Parameters
     ----------
     feature : str
-        String standing for a potential feature of ASTRA.
-        See ``ASTRA_FEATURES`` for possible values.
+        Name of a potential feature of ASTRA. See ``ASTRA_FEATURES`` for
+        possible values.
 
     Returns
     -------
@@ -89,44 +110,7 @@ def astra_supports(feature):
         ``True`` if the currently imported version of ASTRA supports the
         feature in question, ``False`` otherwise.
     """
-    feature = str(feature).lower()
-    supp_versions = ASTRA_FEATURES.get(feature, None)
-    if supp_versions is None:
-        return False
-
-    astra_ver = parse_version(ASTRA_VERSION)
-    ver_specs = supp_versions.split(',')
-    for spec in ver_specs:
-        spec = spec.strip()
-        if '-' in spec:
-            # Match range
-            minver, maxver = spec.split('-', maxsplit=1)
-            if (astra_ver >= parse_version(minver) and
-                    astra_ver <= parse_version(maxver)):
-                return True
-            else:
-                continue
-        else:
-            # Match (in)equality
-            ver = spec.strip('=<> ')
-            mod = spec[:-len(ver)] or '=='
-            if mod == '==':
-                op = operator.eq
-            elif mod == '>=':
-                op = operator.ge
-            elif mod == '>':
-                op = operator.gt
-            elif mod == '<=':
-                op = operator.le
-            elif mod == '<':
-                op = operator.lt
-            else:
-                raise ValueError('invalid operator {!r}'.format(mod))
-
-            if op(astra_ver, parse_version(ver)):
-                return True
-    # No match
-    return False
+    return pkg_supports(feature, ASTRA_VERSION, ASTRA_FEATURES)
 
 
 def astra_volume_geometry(discr_reco):
@@ -175,8 +159,7 @@ def astra_volume_geometry(discr_reco):
         # values for the volume extent, but running the algorithm fails
         # if voxels are non-isotropic. We raise an exception here in
         # the meanwhile.
-        if (not np.allclose(discr_reco.partition.cell_sides[1:],
-                            discr_reco.partition.cell_sides[:-1]) and
+        if (not discr_reco.partition.has_isotropic_cells and
                 not astra_supports('anisotropic_voxels_2d')):
             raise NotImplementedError(
                 'non-isotropic pixels in 2d volumes not supported by ASTRA '
@@ -190,16 +173,16 @@ def astra_volume_geometry(discr_reco):
         #   'WindowMaxY': x_max
         #   'WindowMinX': y_min
         #   'WindowMinY': x_min
-        if (not np.allclose(discr_reco.partition.cell_sides[1:],
-                            discr_reco.partition.cell_sides[:-1]) and
-                not astra_supports('anisotropic_voxels_3d')):
-            raise NotImplementedError(
-                'non-isotropic voxels in 3d volumes not supported by ASTRA '
-                'v{}'.format(ASTRA_VERSION))
         vol_geom = astra.create_vol_geom(vol_shp[0], vol_shp[1],
                                          vol_min[1], vol_max[1],
                                          vol_min[0], vol_max[0])
     elif discr_reco.ndim == 3:
+        # Not supported in all versions of ASTRA
+        if (not discr_reco.partition.has_isotropic_cells and
+                not astra_supports('anisotropic_voxels_3d')):
+            raise NotImplementedError(
+                'non-isotropic voxels in 3d volumes not supported by ASTRA '
+                'v{}'.format(ASTRA_VERSION))
         # Given a 3D array of shape (x, y, z), a volume geometry is created as:
         #    astra.create_vol_geom(y, z, x, )
         # yielding a dictionary:
@@ -247,7 +230,6 @@ def astra_conebeam_3d_geom_to_vec(geometry):
     vectors : `numpy.ndarray`
         Numpy array of shape ``(number of angles, 12)``
     """
-
     angles = geometry.angles
     vectors = np.zeros((angles.size, 12))
 
@@ -302,7 +284,6 @@ def astra_conebeam_2d_geom_to_vec(geometry):
     vectors : `numpy.ndarray`
         Numpy array of shape ``(number of angles, 6)``
     """
-
     angles = geometry.angles
     vectors = np.zeros((angles.size, 6))
 
@@ -357,7 +338,6 @@ def astra_parallel_3d_geom_to_vec(geometry):
     vectors : `numpy.ndarray`
         Numpy array of shape ``(number of angles, 12)``
     """
-
     angles = geometry.angles
     vectors = np.zeros((angles.size, 12))
 
@@ -385,7 +365,6 @@ def astra_parallel_3d_geom_to_vec(geometry):
     for i in range(4):
         new_ind += [2 + 3 * i, 1 + 3 * i, 0 + 3 * i]
     vectors = vectors[:, new_ind]
-
     return vectors
 
 
@@ -617,9 +596,8 @@ def astra_projector(vol_interp, astra_vol_geom, astra_proj_geom, ndim, impl):
 
     # Add the hacky 1/r^2 weighting exposed in intermediate versions of
     # ASTRA
-    # TODO: add upper bound when the exposed feature is removed
-    if (parse_version(ASTRA_VERSION) >= parse_version('1.8rc1') and
-            proj_type in ('cone', 'cone_vec')):
+    if (proj_type in ('cone', 'cone_vec') and
+            astra_supports('cone3d_hacky_density_weighting')):
         proj_cfg['options']['DensityWeighting'] = True
 
     if ndim == 2:
@@ -660,10 +638,10 @@ def astra_algorithm(direction, ndim, vol_id, sino_id, proj_id, impl):
     if impl not in ('cpu', 'cuda'):
         raise ValueError("`impl` type '{}' not understood"
                          ''.format(impl))
-    if ndim is 3 and impl is 'cpu':
+    if ndim == 3 and impl == 'cpu':
         raise NotImplementedError(
             '3d algorithms for CPU not supported by ASTRA')
-    if proj_id is None and impl is 'cpu':
+    if proj_id is None and impl == 'cpu':
         raise ValueError("'cpu' implementation requires projector ID")
 
     algo_map = {'forward': {2: {'cpu': 'FP', 'cuda': 'FP_CUDA'},


### PR DESCRIPTION
This is partially supported in upstream - 3d works for all geometries, 2d still fails.