### PR TITLE
BUG: fence pytest import in tomo testutils

### DIFF
--- a/odl/tomo/util/testutils.py
+++ b/odl/tomo/util/testutils.py
@@ -16,14 +16,8 @@ __all__ = ('skip_if_no_astra', 'skip_if_no_astra_cuda', 'skip_if_no_skimage')
 try:
     import pytest
 except ImportError:
-    # Make trivial decorator
-    from odl.util import OptionalArgDecorator
-
-    class ident(OptionalArgDecorator):
-        @staticmethod
-        def _wrapper(f, *a, **kw):
-            return f
-
+    # Use the identity decorator (default of OptionalArgDecorator)
+    from odl.util import OptionalArgDecorator as ident
     skip_if_no_astra = skip_if_no_astra_cuda = skip_if_no_skimage = ident
 
 else:

--- a/odl/tomo/util/testutils.py
+++ b/odl/tomo/util/testutils.py
@@ -11,17 +11,25 @@ from __future__ import print_function, division, absolute_import
 from future import standard_library
 standard_library.install_aliases()
 
-import pytest
-
-
 __all__ = ('skip_if_no_astra', 'skip_if_no_astra_cuda', 'skip_if_no_skimage')
 
+try:
+    import pytest
+except ImportError:
+    # Make trivial decorator
+    from odl.util import OptionalArgDecorator
 
-skip_if_no_astra = pytest.mark.skipif("not odl.tomo.ASTRA_AVAILABLE",
-                                      reason='ASTRA not available')
+    class ident(OptionalArgDecorator):
+        @staticmethod
+        def _wrapper(f, *a, **kw):
+            return f
 
-skip_if_no_astra_cuda = pytest.mark.skipif("not odl.tomo.ASTRA_CUDA_AVAILABLE",
-                                           reason='ASTRA CUDA not available')
+    skip_if_no_astra = skip_if_no_astra_cuda = skip_if_no_skimage = ident
 
-skip_if_no_skimage = pytest.mark.skipif("not odl.tomo.SKIMAGE_AVAILABLE",
-                                        reason='skimage not available')
+else:
+    skip_if_no_astra = pytest.mark.skipif('not odl.tomo.ASTRA_AVAILABLE',
+                                          reason='ASTRA not available')
+    skip_if_no_astra_cuda = pytest.mark.skipif(
+        'not odl.tomo.ASTRA_CUDA_AVAILABLE', reason='ASTRA CUDA not available')
+    skip_if_no_skimage = pytest.mark.skipif(
+        'not odl.tomo.SKIMAGE_AVAILABLE', reason='skimage not available')

--- a/odl/util/pytest_plugins.py
+++ b/odl/util/pytest_plugins.py
@@ -18,16 +18,13 @@ import os
 
 import odl
 from odl.trafos.backends import PYFFTW_AVAILABLE, PYWT_AVAILABLE
-from odl.util import dtype_repr, OptionalArgDecorator
+from odl.util import dtype_repr
 
 try:
     from pytest import fixture
 except ImportError:
-    # Make trivial decorator
-    class fixture(OptionalArgDecorator):
-        @staticmethod
-        def _wrapper(f, *a, **kw):
-            return f
+    # Make fixture the identity decorator (default of OptionalArgDecorator)
+    from odl.util import OptionalArgDecorator as fixture
 
 
 # --- Add numpy and ODL to all doctests ---

--- a/odl/util/vectorization.py
+++ b/odl/util/vectorization.py
@@ -106,7 +106,7 @@ class OptionalArgDecorator(object):
                def myfunc(x):
                    pass
 
-           which is equivalent to::
+           which is equivalent to ::
 
                def myfunc(x):
                    pass
@@ -123,7 +123,7 @@ class OptionalArgDecorator(object):
                def myfunc(x):
                    pass
 
-           which is equivalent to::
+           which is equivalent to ::
 
                def myfunc(x):
                    pass
@@ -172,8 +172,12 @@ class OptionalArgDecorator(object):
 
     @staticmethod
     def _wrapper(func, *wrapper_args, **wrapper_kwargs):
-        """Return the wrapped function."""
-        raise NotImplementedError('abstract method')
+        """Make a wrapper for ``func`` and return it.
+
+        This is a default implementation that simply returns the wrapped
+        function, i.e., the resulting decorator is the identity.
+        """
+        return func
 
 
 class vectorize(OptionalArgDecorator):
@@ -221,7 +225,7 @@ class vectorize(OptionalArgDecorator):
     def _wrapper(func, *vect_args, **vect_kwargs):
         """Return the vectorized wrapper function."""
         if not hasattr(func, '__name__'):
-            # Set name if not available. Happens if func is actually a callable
+            # Set name if not available. Happens if func is actually a function
             func.__name__ = '{}.__call__'.format(func.__class__.__name__)
 
         return wraps(func)(_NumpyVectorizeWrapper(func, *vect_args,


### PR DESCRIPTION
Another thing that needs last-minute fix. Import in a new environment without `pytest` installed would fail.