### PR TITLE
Add datasets module

### DIFF
--- a/odl/__init__.py
+++ b/odl/__init__.py
@@ -16,7 +16,8 @@ from __future__ import absolute_import
 
 __version__ = '0.6.1.dev0'
 __all__ = ('diagnostics', 'discr', 'operator', 'set', 'space', 'solvers',
-           'tomo', 'trafos', 'util', 'phantom', 'deform', 'ufunc_ops')
+           'tomo', 'trafos', 'util', 'phantom', 'deform', 'ufunc_ops',
+           'datasets')
 
 # Propagate names defined in __all__ of all submodules into the top-level
 # module
@@ -41,6 +42,8 @@ from . import util
 from . import phantom
 from . import deform
 from . import ufunc_ops
+from . import datasets
+
 
 from .util import test
 __all__ += ('test',)

--- a/odl/datasets/__init__.py
+++ b/odl/datasets/__init__.py
@@ -6,11 +6,11 @@
 # v. 2.0. If a copy of the MPL was not distributed with this file, You can
 # obtain one at https://mozilla.org/MPL/2.0/.
 
-"""Access to real or simulated datasets for use with ODL."""
+"""Access to real or simulated datasets."""
 
 from __future__ import absolute_import
 
 
-__all__ = ('ray_transform',)
+__all__ = ('tomo',)
 
-from . import ray_transform
+from . import tomo

--- a/odl/datasets/__init__.py
+++ b/odl/datasets/__init__.py
@@ -1,0 +1,16 @@
+# Copyright 2014-2017 The ODL contributors
+#
+# This file is part of ODL.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file, You can
+# obtain one at https://mozilla.org/MPL/2.0/.
+
+"""Access to real or simulated datasets for use with ODL."""
+
+from __future__ import absolute_import
+
+
+__all__ = ('ray_transform',)
+
+from . import ray_transform

--- a/odl/datasets/ray_transform.py
+++ b/odl/datasets/ray_transform.py
@@ -14,6 +14,10 @@ from odl.discr import uniform_partition
 from odl.tomo import FanFlatGeometry
 
 
+__all__ = ('walnut_data', 'walnut_geometry',
+           'lotus_root_data', 'lotus_root_geometry')
+
+
 DATA_SUBSET = 'ray_transform'
 
 def walnut_data():
@@ -140,22 +144,27 @@ if __name__ == '__main__':
     
     # Walnut example
     space = odl.uniform_discr([-20, -20], [20, 20], [2296, 2296])
-    geometry = walnut_geometry()
+    geometry = odl.datasets.ray_transform.walnut_geometry()
     
     ray_transform = odl.tomo.RayTransform(space, geometry)
     fbp_op = odl.tomo.fbp_op(ray_transform, filter_type='Hann')
     
-    data = walnut_data()
+    data = odl.datasets.ray_transform.walnut_data()
     fbp_op(data).show('walnut fbp', clim=[0, 0.05])
     
 
     # Lotus root example
     space = odl.uniform_discr([-50, -50], [50, 50], [2240, 2240])
-    geometry = lotus_root_geometry()
+    geometry = odl.datasets.ray_transform.lotus_root_geometry()
     
     ray_transform = odl.tomo.RayTransform(space, geometry)
     fbp_op = odl.tomo.fbp_op(ray_transform, filter_type='Hann')
     
-    data = lotus_root_data()
+    data = odl.datasets.ray_transform.lotus_root_data()
     fbp_op(data).show('lotus root fbp', clim=[0, 0.1])
+    
+    # Run doctests
+    # pylint: disable=wrong-import-position
+    from odl.util.testutils import run_doctests
+    run_doctests()
     

--- a/odl/datasets/ray_transform.py
+++ b/odl/datasets/ray_transform.py
@@ -32,6 +32,8 @@ def walnut_data():
     ----------
     .. Tomographic X-ray data of a walnut: https://arxiv.org/abs/1502.04064
     """
+    
+    # TODO: Store data in some ODL controlled url
     dct = get_data('walnut.mat', subset=DATA_SUBSET,
                    url='http://www.fips.fi/dataset/CT_walnut_v1/FullSizeSinograms.mat')
     
@@ -43,7 +45,7 @@ def walnut_data():
     return data
 
 def walnut_geometry():
-    """Tomographic geometry for walnut data
+    """Tomographic geometry for walnut data.
     
     Notes
     -----
@@ -58,10 +60,11 @@ def walnut_geometry():
     ----------
     .. Tomographic X-ray data of a walnut: https://arxiv.org/abs/1502.04064
     """
+    # To get the same rotation as in the reference article
     a_offset = -np.pi / 2
     apart = uniform_partition(a_offset, a_offset + 2*np.pi, 1200)
     
-    # Determined experimentally
+    # TODO: Find exact value, determined experimentally
     d_offset = -0.279
     dpart = uniform_partition(d_offset - 57.4, d_offset + 57.4, 2296)
     
@@ -88,6 +91,8 @@ def lotus_root_data():
     .. Tomographic X-ray data of a lotus root filled with attenuating objects:\
     https://arxiv.org/abs/1502.04064
     """
+    
+    # TODO: Store data in some ODL controlled url
     dct = get_data('lotus_root.mat', subset=DATA_SUBSET,
                    url='http://www.fips.fi/dataset/CT_Lotus_v1/sinogram.mat')
     
@@ -98,7 +103,7 @@ def lotus_root_data():
 
 
 def lotus_root_geometry():
-    """Tomographic geometry for walnut data
+    """Tomographic geometry for lotus root data.
     
     Notes
     -----
@@ -114,10 +119,13 @@ def lotus_root_geometry():
     .. Tomographic X-ray data of a lotus root filled with attenuating objects:\
     https://arxiv.org/abs/1609.07299
     """
+    # To get the same rotation as in the reference article
     a_offset = np.pi/2
-    apart = uniform_partition(a_offset, a_offset + 2*np.pi * 366. / 360., 366)
+    apart = uniform_partition(a_offset, 
+                              a_offset + 2 * np.pi * 366. / 360., 
+                              366)
     
-    # Determined experimentally
+    # TODO: Find exact value, determined experimentally
     d_offset = 0.35
     dpart = uniform_partition(d_offset - 60, d_offset + 60, 2240)
     

--- a/odl/datasets/ray_transform.py
+++ b/odl/datasets/ray_transform.py
@@ -20,46 +20,48 @@ __all__ = ('walnut_data', 'walnut_geometry',
 
 DATA_SUBSET = 'ray_transform'
 
+
 def walnut_data():
     """Tomographic X-ray data of a walnut.
-    
+
     Notes
     -----
     See the article `Tomographic X-ray data of a walnut`_ for further
     information.
-    
+
     See Also
     --------
     walnut_geometry
-    
+
     References
     ----------
     .. Tomographic X-ray data of a walnut: https://arxiv.org/abs/1502.04064
     """
-    
+
     # TODO: Store data in some ODL controlled url
-    dct = get_data('walnut.mat', subset=DATA_SUBSET,
-                   url='http://www.fips.fi/dataset/CT_walnut_v1/FullSizeSinograms.mat')
-    
+    url = 'http://www.fips.fi/dataset/CT_walnut_v1/FullSizeSinograms.mat'
+    dct = get_data('walnut.mat', subset=DATA_SUBSET, url=url)
+
     # Change axes to match ODL definitions
     data = np.swapaxes(dct['sinogram1200'], 0, 1)[:, ::-1]
-    
+
     # Very crude gain normalization
     data = -np.log(data / np.max(data, axis=1)[:, None])
     return data
 
+
 def walnut_geometry():
     """Tomographic geometry for walnut data.
-    
+
     Notes
     -----
     See the article `Tomographic X-ray data of a walnut`_ for further
     information.
-    
+
     See Also
     --------
     walnut_data
-    
+
     References
     ----------
     .. Tomographic X-ray data of a walnut: https://arxiv.org/abs/1502.04064
@@ -67,57 +69,57 @@ def walnut_geometry():
     # To get the same rotation as in the reference article
     a_offset = -np.pi / 2
     apart = uniform_partition(a_offset, a_offset + 2*np.pi, 1200)
-    
+
     # TODO: Find exact value, determined experimentally
     d_offset = -0.279
     dpart = uniform_partition(d_offset - 57.4, d_offset + 57.4, 2296)
-    
-    geometry = FanFlatGeometry(apart, dpart, 
+
+    geometry = FanFlatGeometry(apart, dpart,
                                src_radius=110, det_radius=190)
-    
+
     return geometry
 
 
 def lotus_root_data():
     """Tomographic X-ray data of a lotus root.
-    
+
     Notes
     -----
-    See the article `Tomographic X-ray data of a lotus root filled with 
+    See the article `Tomographic X-ray data of a lotus root filled with
     attenuating objects`_ for further information.
-    
+
     See Also
     --------
     lotus_root_geometry
-    
+
     References
     ----------
     .. Tomographic X-ray data of a lotus root filled with attenuating objects:\
     https://arxiv.org/abs/1502.04064
     """
-    
+
     # TODO: Store data in some ODL controlled url
-    dct = get_data('lotus_root.mat', subset=DATA_SUBSET,
-                   url='http://www.fips.fi/dataset/CT_Lotus_v1/sinogram.mat')
-    
+    url = 'http://www.fips.fi/dataset/CT_Lotus_v1/sinogram.mat'
+    dct = get_data('lotus_root.mat', subset=DATA_SUBSET, url=url)
+
     # Change axes to match ODL definitions
     data = np.swapaxes(dct['sinogram'], 0, 1)[::-1, :]
-    
+
     return data
 
 
 def lotus_root_geometry():
     """Tomographic geometry for lotus root data.
-    
+
     Notes
     -----
-    See the article `Tomographic X-ray data of a lotus root filled with 
+    See the article `Tomographic X-ray data of a lotus root filled with
     attenuating objects`_ for further information.
-    
+
     See Also
     --------
     lotus_root_geometry
-    
+
     References
     ----------
     .. Tomographic X-ray data of a lotus root filled with attenuating objects:\
@@ -125,46 +127,44 @@ def lotus_root_geometry():
     """
     # To get the same rotation as in the reference article
     a_offset = np.pi/2
-    apart = uniform_partition(a_offset, 
-                              a_offset + 2 * np.pi * 366. / 360., 
+    apart = uniform_partition(a_offset,
+                              a_offset + 2 * np.pi * 366. / 360.,
                               366)
-    
+
     # TODO: Find exact value, determined experimentally
     d_offset = 0.35
     dpart = uniform_partition(d_offset - 60, d_offset + 60, 2240)
-    
-    geometry = FanFlatGeometry(apart, dpart, 
+
+    geometry = FanFlatGeometry(apart, dpart,
                                src_radius=540, det_radius=90)
-    
+
     return geometry
 
 
 if __name__ == '__main__':
     import odl
-    
+
     # Walnut example
     space = odl.uniform_discr([-20, -20], [20, 20], [2296, 2296])
     geometry = odl.datasets.ray_transform.walnut_geometry()
-    
+
     ray_transform = odl.tomo.RayTransform(space, geometry)
     fbp_op = odl.tomo.fbp_op(ray_transform, filter_type='Hann')
-    
+
     data = odl.datasets.ray_transform.walnut_data()
     fbp_op(data).show('walnut fbp', clim=[0, 0.05])
-    
 
     # Lotus root example
     space = odl.uniform_discr([-50, -50], [50, 50], [2240, 2240])
     geometry = odl.datasets.ray_transform.lotus_root_geometry()
-    
+
     ray_transform = odl.tomo.RayTransform(space, geometry)
     fbp_op = odl.tomo.fbp_op(ray_transform, filter_type='Hann')
-    
+
     data = odl.datasets.ray_transform.lotus_root_data()
     fbp_op(data).show('lotus root fbp', clim=[0, 0.1])
-    
+
     # Run doctests
     # pylint: disable=wrong-import-position
     from odl.util.testutils import run_doctests
     run_doctests()
-    

--- a/odl/datasets/ray_transform.py
+++ b/odl/datasets/ray_transform.py
@@ -1,0 +1,153 @@
+# Copyright 2014-2017 The ODL contributors
+#
+# This file is part of ODL.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file, You can
+# obtain one at https://mozilla.org/MPL/2.0/.
+
+"""Datasets for the ray transform."""
+
+import numpy as np
+from odl.datasets.util import get_data
+from odl.discr import uniform_partition
+from odl.tomo import FanFlatGeometry
+
+
+DATA_SUBSET = 'ray_transform'
+
+def walnut_data():
+    """Tomographic X-ray data of a walnut.
+    
+    Notes
+    -----
+    See the article `Tomographic X-ray data of a walnut`_ for further
+    information.
+    
+    See Also
+    --------
+    walnut_geometry
+    
+    References
+    ----------
+    .. Tomographic X-ray data of a walnut: https://arxiv.org/abs/1502.04064
+    """
+    dct = get_data('walnut.mat', subset=DATA_SUBSET,
+                   url='http://www.fips.fi/dataset/CT_walnut_v1/FullSizeSinograms.mat')
+    
+    # Change axes to match ODL definitions
+    data = np.swapaxes(dct['sinogram1200'], 0, 1)[:, ::-1]
+    
+    # Very crude gain normalization
+    data = -np.log(data / np.max(data, axis=1)[:, None])
+    return data
+
+def walnut_geometry():
+    """Tomographic geometry for walnut data
+    
+    Notes
+    -----
+    See the article `Tomographic X-ray data of a walnut`_ for further
+    information.
+    
+    See Also
+    --------
+    walnut_data
+    
+    References
+    ----------
+    .. Tomographic X-ray data of a walnut: https://arxiv.org/abs/1502.04064
+    """
+    a_offset = -np.pi / 2
+    apart = uniform_partition(a_offset, a_offset + 2*np.pi, 1200)
+    
+    # Determined experimentally
+    d_offset = -0.279
+    dpart = uniform_partition(d_offset - 57.4, d_offset + 57.4, 2296)
+    
+    geometry = FanFlatGeometry(apart, dpart, 
+                               src_radius=110, det_radius=190)
+    
+    return geometry
+
+
+def lotus_root_data():
+    """Tomographic X-ray data of a lotus root.
+    
+    Notes
+    -----
+    See the article `Tomographic X-ray data of a lotus root filled with 
+    attenuating objects`_ for further information.
+    
+    See Also
+    --------
+    lotus_root_geometry
+    
+    References
+    ----------
+    .. Tomographic X-ray data of a lotus root filled with attenuating objects:\
+    https://arxiv.org/abs/1502.04064
+    """
+    dct = get_data('lotus_root.mat', subset=DATA_SUBSET,
+                   url='http://www.fips.fi/dataset/CT_Lotus_v1/sinogram.mat')
+    
+    # Change axes to match ODL definitions
+    data = np.swapaxes(dct['sinogram'], 0, 1)[::-1, :]
+    
+    return data
+
+
+def lotus_root_geometry():
+    """Tomographic geometry for walnut data
+    
+    Notes
+    -----
+    See the article `Tomographic X-ray data of a lotus root filled with 
+    attenuating objects`_ for further information.
+    
+    See Also
+    --------
+    lotus_root_geometry
+    
+    References
+    ----------
+    .. Tomographic X-ray data of a lotus root filled with attenuating objects:\
+    https://arxiv.org/abs/1609.07299
+    """
+    a_offset = np.pi/2
+    apart = uniform_partition(a_offset, a_offset + 2*np.pi * 366. / 360., 366)
+    
+    # Determined experimentally
+    d_offset = 0.35
+    dpart = uniform_partition(d_offset - 60, d_offset + 60, 2240)
+    
+    geometry = FanFlatGeometry(apart, dpart, 
+                               src_radius=540, det_radius=90)
+    
+    return geometry
+
+
+if __name__ == '__main__':
+    import odl
+    
+    # Walnut example
+    space = odl.uniform_discr([-20, -20], [20, 20], [2296, 2296])
+    geometry = walnut_geometry()
+    
+    ray_transform = odl.tomo.RayTransform(space, geometry)
+    fbp_op = odl.tomo.fbp_op(ray_transform, filter_type='Hann')
+    
+    data = walnut_data()
+    fbp_op(data).show('walnut fbp', clim=[0, 0.05])
+    
+
+    # Lotus root example
+    space = odl.uniform_discr([-50, -50], [50, 50], [2240, 2240])
+    geometry = lotus_root_geometry()
+    
+    ray_transform = odl.tomo.RayTransform(space, geometry)
+    fbp_op = odl.tomo.fbp_op(ray_transform, filter_type='Hann')
+    
+    data = lotus_root_data()
+    fbp_op(data).show('lotus root fbp', clim=[0, 0.1])
+    

--- a/odl/datasets/tomo.py
+++ b/odl/datasets/tomo.py
@@ -37,7 +37,6 @@ def walnut_data():
     ----------
     .. _Tomographic X-ray data of a walnut: https://arxiv.org/abs/1502.04064
     """
-
     # TODO: Store data in some ODL controlled url
     url = 'http://www.fips.fi/dataset/CT_walnut_v1/FullSizeSinograms.mat'
     dct = get_data('walnut.mat', subset=DATA_SUBSET, url=url)

--- a/odl/datasets/tomo.py
+++ b/odl/datasets/tomo.py
@@ -6,7 +6,7 @@
 # v. 2.0. If a copy of the MPL was not distributed with this file, You can
 # obtain one at https://mozilla.org/MPL/2.0/.
 
-"""Datasets for the ray transform."""
+"""Tomographic datasets."""
 
 import numpy as np
 from odl.datasets.util import get_data
@@ -18,7 +18,7 @@ __all__ = ('walnut_data', 'walnut_geometry',
            'lotus_root_data', 'lotus_root_geometry')
 
 
-DATA_SUBSET = 'ray_transform'
+DATA_SUBSET = 'tomo'
 
 
 def walnut_data():
@@ -35,7 +35,7 @@ def walnut_data():
 
     References
     ----------
-    .. Tomographic X-ray data of a walnut: https://arxiv.org/abs/1502.04064
+    .. _Tomographic X-ray data of a walnut: https://arxiv.org/abs/1502.04064
     """
 
     # TODO: Store data in some ODL controlled url
@@ -51,7 +51,7 @@ def walnut_data():
 
 
 def walnut_geometry():
-    """Tomographic geometry for walnut data.
+    """Tomographic geometry for the walnut dataset.
 
     Notes
     -----
@@ -64,11 +64,11 @@ def walnut_geometry():
 
     References
     ----------
-    .. Tomographic X-ray data of a walnut: https://arxiv.org/abs/1502.04064
+    .. _Tomographic X-ray data of a walnut: https://arxiv.org/abs/1502.04064
     """
     # To get the same rotation as in the reference article
     a_offset = -np.pi / 2
-    apart = uniform_partition(a_offset, a_offset + 2*np.pi, 1200)
+    apart = uniform_partition(a_offset, a_offset + 2 * np.pi, 1200)
 
     # TODO: Find exact value, determined experimentally
     d_offset = -0.279
@@ -94,10 +94,9 @@ def lotus_root_data():
 
     References
     ----------
-    .. Tomographic X-ray data of a lotus root filled with attenuating objects:\
-    https://arxiv.org/abs/1502.04064
+    .. _Tomographic X-ray data of a lotus root filled with attenuating objects:
+       https://arxiv.org/abs/1609.07299
     """
-
     # TODO: Store data in some ODL controlled url
     url = 'http://www.fips.fi/dataset/CT_Lotus_v1/sinogram.mat'
     dct = get_data('lotus_root.mat', subset=DATA_SUBSET, url=url)
@@ -109,7 +108,7 @@ def lotus_root_data():
 
 
 def lotus_root_geometry():
-    """Tomographic geometry for lotus root data.
+    """Tomographic geometry for the lotus root dataset.
 
     Notes
     -----
@@ -122,11 +121,11 @@ def lotus_root_geometry():
 
     References
     ----------
-    .. Tomographic X-ray data of a lotus root filled with attenuating objects:\
-    https://arxiv.org/abs/1609.07299
+    .. _Tomographic X-ray data of a lotus root filled with attenuating objects:
+       https://arxiv.org/abs/1609.07299
     """
     # To get the same rotation as in the reference article
-    a_offset = np.pi/2
+    a_offset = np.pi / 2
     apart = uniform_partition(a_offset,
                               a_offset + 2 * np.pi * 366. / 360.,
                               366)
@@ -146,23 +145,23 @@ if __name__ == '__main__':
 
     # Walnut example
     space = odl.uniform_discr([-20, -20], [20, 20], [2296, 2296])
-    geometry = odl.datasets.ray_transform.walnut_geometry()
+    geometry = odl.datasets.tomo.walnut_geometry()
 
     ray_transform = odl.tomo.RayTransform(space, geometry)
     fbp_op = odl.tomo.fbp_op(ray_transform, filter_type='Hann')
 
-    data = odl.datasets.ray_transform.walnut_data()
-    fbp_op(data).show('walnut fbp', clim=[0, 0.05])
+    data = odl.datasets.tomo.walnut_data()
+    fbp_op(data).show('Walnut FBP reconstruction', clim=[0, 0.05])
 
     # Lotus root example
     space = odl.uniform_discr([-50, -50], [50, 50], [2240, 2240])
-    geometry = odl.datasets.ray_transform.lotus_root_geometry()
+    geometry = odl.datasets.tomo.lotus_root_geometry()
 
     ray_transform = odl.tomo.RayTransform(space, geometry)
     fbp_op = odl.tomo.fbp_op(ray_transform, filter_type='Hann')
 
-    data = odl.datasets.ray_transform.lotus_root_data()
-    fbp_op(data).show('lotus root fbp', clim=[0, 0.1])
+    data = odl.datasets.tomo.lotus_root_data()
+    fbp_op(data).show('Lotus root FBP reconstruction', clim=[0, 0.1])
 
     # Run doctests
     # pylint: disable=wrong-import-position

--- a/odl/datasets/util.py
+++ b/odl/datasets/util.py
@@ -6,7 +6,7 @@
 # v. 2.0. If a copy of the MPL was not distributed with this file, You can
 # obtain one at https://mozilla.org/MPL/2.0/.
 
-"""Utilities for ODL datasets."""
+"""Utilities for datasets."""
 
 import os
 from os.path import join, expanduser, exists
@@ -27,7 +27,8 @@ __all__ = ('get_data_dir', 'get_data')
 
 def get_data_dir():
     """Get the data directory."""
-    data_home = expanduser(join('~', 'odl_data'))
+    base_odl_dir = os.environ.get('ODL_DIR', expanduser(join('~', 'odl')))
+    data_home = join(base_odl_dir, 'datasets')
     if not exists(data_home):
         os.makedirs(data_home)
     return data_home
@@ -52,8 +53,7 @@ def get_data(filename, subset, url):
         Dictionary containing the dataset.
     """
     # check if this data set has been already downloaded
-    data_dir = get_data_dir()
-    data_dir = join(data_dir, subset)
+    data_dir = join(get_data_dir(), subset)
     if not exists(data_dir):
         os.makedirs(data_dir)
 
@@ -61,7 +61,7 @@ def get_data(filename, subset, url):
 
     # if the file does not exist, download it
     if not exists(filename):
-        print('data {}/{} missing, downloading from {}'
+        print('data {}/{} not in local storage, downloading from {}'
               ''.format(subset, filename, url))
 
         # open the url of the data

--- a/odl/datasets/util.py
+++ b/odl/datasets/util.py
@@ -17,7 +17,7 @@ try:
 except ImportError:
     # Python 3+
     from urllib.request import urlopen
-    
+
 from shutil import copyfileobj
 from scipy import io
 
@@ -35,7 +35,7 @@ def get_data_dir():
 
 def get_data(filename, subset, url):
     """Get a dataset with from a url with local caching.
-    
+
     Parameters
     ----------
     filename : str
@@ -45,13 +45,12 @@ def get_data(filename, subset, url):
         is saved in a separate subfolder.
     url : str
         url to the dataset online.
-        
+
     Returns
     -------
     dataset : dict
         Dictionary containing the dataset.
     """
-
     # check if this data set has been already downloaded
     data_dir = get_data_dir()
     data_dir = join(data_dir, subset)
@@ -64,7 +63,7 @@ def get_data(filename, subset, url):
     if not exists(filename):
         print('data {}/{} missing, downloading from {}'
               ''.format(subset, filename, url))
-        
+
         # open the url of the data
         with urlopen(url) as data_url:
             # store downloaded file locally
@@ -81,4 +80,3 @@ if __name__ == '__main__':
     # pylint: disable=wrong-import-position
     from odl.util.testutils import run_doctests
     run_doctests()
-    

--- a/odl/datasets/util.py
+++ b/odl/datasets/util.py
@@ -21,6 +21,10 @@ except ImportError:
 from shutil import copyfileobj
 from scipy import io
 
+
+__all__ = ('get_data_dir', 'get_data')
+
+
 def get_data_dir():
     """Get the data directory."""
     data_home = expanduser(join('~', 'odl_data'))
@@ -72,3 +76,9 @@ def get_data(filename, subset, url):
         data_dict = io.loadmat(storage_file)
 
     return data_dict
+
+if __name__ == '__main__':
+    # pylint: disable=wrong-import-position
+    from odl.util.testutils import run_doctests
+    run_doctests()
+    

--- a/odl/datasets/util.py
+++ b/odl/datasets/util.py
@@ -27,7 +27,7 @@ __all__ = ('get_data_dir', 'get_data')
 
 def get_data_dir():
     """Get the data directory."""
-    base_odl_dir = os.environ.get('ODL_DIR', expanduser(join('~', 'odl')))
+    base_odl_dir = os.environ.get('ODL_HOME', expanduser(join('~', '.odl')))
     data_home = join(base_odl_dir, 'datasets')
     if not exists(data_home):
         os.makedirs(data_home)

--- a/odl/datasets/util.py
+++ b/odl/datasets/util.py
@@ -1,0 +1,69 @@
+# Copyright 2014-2017 The ODL contributors
+#
+# This file is part of ODL.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file, You can
+# obtain one at https://mozilla.org/MPL/2.0/.
+
+"""Utilities for ODL datasets."""
+
+import os
+from os.path import join, expanduser, exists
+
+try:
+    # Python 2
+    from urllib2 import HTTPError
+    from urllib2 import urlopen
+except ImportError:
+    # Python 3+
+    from urllib.error import HTTPError
+    from urllib.request import urlopen
+    
+from shutil import copyfileobj
+from scipy import io
+
+def get_data_dir():
+    """Get the data directory."""
+    data_home = expanduser(join('~', 'odl_data'))
+    if not exists(data_home):
+        os.makedirs(data_home)
+    return data_home
+
+
+def get_data(filename, subset, url):
+    """Download a dataset."""
+
+    # check if this data set has been already downloaded
+    data_dir = get_data_dir()
+    data_dir = join(data_dir, subset)
+    if not exists(data_dir):
+        os.makedirs(data_dir)
+
+    filename = join(data_dir, filename)
+
+    # if the file does not exist, download it
+    if not exists(filename):
+        print('data {}/{} missing, downloading from {}'
+              ''.format(subset, filename, url))
+        try:
+            data_url = urlopen(url)
+        except HTTPError as e:
+            if e.code == 404:
+                e.msg = "Dataset '%s' not found on mldata.org." % dataname
+            raise
+        # store downloaded file
+        try:
+            with open(filename, 'w+b') as storage_file:
+                copyfileobj(data_url, storage_file)
+        except Exception as e:
+            print(e)
+            os.remove(filename)
+            raise
+        data_url.close()
+
+    # load dataset matlab file
+    with open(filename, 'rb') as storage_file:
+        data_dict = io.loadmat(storage_file)
+
+    return data_dict


### PR DESCRIPTION
This is a proposal for how we could start including actual datasets into ODL.

The architecture works similarily to the datasets in `scikit-learn`, and it basically means data is not stored in the ODL repository, but somewhere else. On first access, the data is downloaded to a local folder in the home directory where it is cached.

So far I've only added two datasets (the walnut and lotus root from finland), but it should be relatively simple to add more.

Is this something we want?

Example results:

![walnut_fbp](https://cloud.githubusercontent.com/assets/2202312/25888972/7c451c5a-3568-11e7-82b1-f847d9ff8061.png)

![lotus_root_fbp](https://cloud.githubusercontent.com/assets/2202312/25888974/81131796-3568-11e7-97af-183153749e76.png)

