### PR TITLE
(Not so) minor optimizations

### DIFF
--- a/odl/discr/discretization.py
+++ b/odl/discr/discretization.py
@@ -535,7 +535,6 @@ class DiscretizedSpaceElement(DiscretizedSetElement, FnBaseVector):
 
     def __init__(self, space, data):
         """Initialize a new instance."""
-        assert isinstance(space, DiscretizedSpace)
         DiscretizedSetElement.__init__(self, space, data)
 
     def __ipow__(self, p):

--- a/odl/discr/grid.py
+++ b/odl/discr/grid.py
@@ -390,15 +390,22 @@ class RectGrid(Set):
         >>> g.stride
         array([  1.,  nan])
         """
-        strd = []
-        for i in range(self.ndim):
-            if not self.is_uniform_byaxis[i]:
-                strd.append(float('nan'))
-            elif self.nondegen_byaxis[i]:
-                strd.append(self.extent[i] / (self.shape[i] - 1.0))
-            else:
-                strd.append(0.0)
-        return np.array(strd)
+        # Cache for efficiency instead of re-computing
+        try:
+            strd = self.__stride
+        except AttributeError:
+            strd = []
+            for i in range(self.ndim):
+                if not self.is_uniform_byaxis[i]:
+                    strd.append(float('nan'))
+                elif self.nondegen_byaxis[i]:
+                    strd.append(self.extent[i] / (self.shape[i] - 1.0))
+                else:
+                    strd.append(0.0)
+            self.__stride = np.array(strd)
+            return self.__stride.copy()
+        else:
+            return strd.copy()
 
     @property
     def extent(self):

--- a/odl/discr/grid.py
+++ b/odl/discr/grid.py
@@ -401,13 +401,13 @@ class RectGrid(Set):
 
         >>> g = RectGrid([0, 1, 2], [0, 1, 4])
         >>> g.stride
-        array([  1.,  nan])
+        array([ 1.,  nan])
 
         0.0 returned for degenerate dimension:
 
         >>> g = RectGrid([0, 1, 2], [0])
         >>> g.stride
-        array([  1.,  0.0])
+        array([ 1.,  0.])
         """
         # Cache for efficiency instead of re-computing
         if self.__stride is None:

--- a/odl/operator/operator.py
+++ b/odl/operator/operator.py
@@ -15,6 +15,7 @@ from future.utils import raise_from
 standard_library.install_aliases()
 from builtins import object, super
 
+from functools import lru_cache
 import inspect
 from numbers import Number, Integral
 import sys
@@ -123,6 +124,7 @@ def _signature_from_spec(func):
     return '{}({})'.format(func.__name__, argstr)
 
 
+@lru_cache()
 def _dispatch_call_args(cls=None, bound_call=None, unbound_call=None,
                         attr='_call'):
     """Check the arguments of ``_call()`` or similar for conformity.

--- a/odl/operator/operator.py
+++ b/odl/operator/operator.py
@@ -15,12 +15,12 @@ from future.utils import raise_from
 standard_library.install_aliases()
 from builtins import object, super
 
-from functools import lru_cache
 import inspect
 from numbers import Number, Integral
 import sys
 
 from odl.set import LinearSpace, LinearSpaceElement, Set, Field
+from odl.util import cache_arguments
 
 
 __all__ = ('Operator', 'OperatorComp', 'OperatorSum', 'OperatorVectorSum',
@@ -124,7 +124,7 @@ def _signature_from_spec(func):
     return '{}({})'.format(func.__name__, argstr)
 
 
-@lru_cache()
+@cache_arguments
 def _dispatch_call_args(cls=None, bound_call=None, unbound_call=None,
                         attr='_call'):
     """Check the arguments of ``_call()`` or similar for conformity.

--- a/odl/operator/pspace_ops.py
+++ b/odl/operator/pspace_ops.py
@@ -887,7 +887,8 @@ class ReductionOperator(Operator):
             return self.prod_op(x)[0]
         else:
             wrapped_out = self.prod_op.range.element([out], cast=False)
-            return self.prod_op(x, out=wrapped_out)
+            result = self.prod_op(x, out=wrapped_out)
+            return result[0]
 
     def derivative(self, x):
         """Derivative of the reduction operator.

--- a/odl/solvers/nonsmooth/douglas_rachford.py
+++ b/odl/solvers/nonsmooth/douglas_rachford.py
@@ -160,32 +160,54 @@ def douglas_rachford_pd(x, f, g, L, tau, sigma, niter,
     w1 = x.space.zero()
     w2 = [Li.range.zero() for Li in L]
 
+    # Temporaries (not in original article)
+    tmp_domain = x.space.zero()
+
     for k in range(niter):
-        tmp_1 = sum(Li.adjoint(vi) for Li, vi in zip(L, v))
-        tmp_1.lincomb(1, x, -tau / 2, tmp_1)
-        f.proximal(tau)(tmp_1, out=p1)
+        lam_k = lam(k)
+
+        # Compute tmp_domain = sum(Li.adjoint(vi) for Li, vi in zip(L, v))
+        L[0].adjoint(v[0], out=tmp_domain)
+        for Li, vi in zip(L[1:], v[1:]):
+            Li.adjoint(vi, out=p1)
+            tmp_domain += p1
+
+        tmp_domain.lincomb(1, x, -tau / 2, tmp_domain)
+        f.proximal(tau)(tmp_domain, out=p1)
         w1.lincomb(2, p1, -1, x)
 
         for i in range(m):
-            prox_cc_g[i](sigma[i])(v[i] + (sigma[i] / 2.0) * L[i](w1),
-                                   out=p2[i])
+            tmp = v[i] + (sigma[i] / 2.0) * L[i](w1)
+            prox_cc_g[i](sigma[i])(tmp, out=p2[i])
             w2[i].lincomb(2.0, p2[i], -1, v[i])
 
-        tmp_2 = sum(Li.adjoint(wi) for Li, wi in zip(L, w2))
-        z1.lincomb(1.0, w1, - (tau / 2.0), tmp_2)
-        x += lam(k) * (z1 - p1)
+        # Compute tmp_domain = sum(Li.adjoint(wi) for Li, w2i in zip(L, w2))
+        L[0].adjoint(w2[0], out=tmp_domain)
+        for Li, w2i in zip(L[1:], w2[1:]):
+            Li.adjoint(w2i, out=z1)
+            tmp_domain += z1
 
+        z1.lincomb(1.0, w1, - (tau / 2.0), tmp_domain)
+
+        # Compute x += lam(k) * (z1 - p1)
+        x.lincomb(1, x, lam_k, z1)
+        x.lincomb(1, x, -lam_k, p1)
+
+        tmp_domain.lincomb(2, z1, -1, w1)
         for i in range(m):
-            tmp = w2[i] + (sigma[i] / 2.0) * L[i](2.0 * z1 - w1)
             if l is not None:
                 # In this case the infimal convolution is used.
+                tmp = w2[i] + (sigma[i] / 2.0) * L[i](tmp_domain)
                 prox_cc_l[i](sigma[i])(tmp, out=z2[i])
             else:
                 # If the infimal convolution is not given, prox_cc_l is the
                 # identity and hence omitted. For more details, see the
                 # documentation.
-                z2[i].assign(tmp)
-            v[i] += lam(k) * (z2[i] - p2[i])
+                z2[i].lincomb(1, w2[i], sigma[i] / 2.0, L[i](tmp_domain))
+
+            # Compute v[i] += lam(k) * (z2[i] - p2[i])
+            v[i].lincomb(1, v[i], lam_k, z2[i])
+            v[i].lincomb(1, v[i], -lam_k, p2[i])
 
         if callback is not None:
             callback(p1)

--- a/odl/solvers/nonsmooth/proximal_operators.py
+++ b/odl/solvers/nonsmooth/proximal_operators.py
@@ -21,6 +21,7 @@ from future import standard_library
 standard_library.install_aliases()
 from builtins import super
 
+from functools import lru_cache
 import numpy as np
 import scipy.special
 
@@ -224,6 +225,7 @@ def proximal_arg_scaling(prox_factory, scaling):
     if scaling == 0:
         return proximal_const_func(prox_factory(1.0).domain)
 
+    @lru_cache()
     def arg_scaling_prox_factory(sigma):
         """Create proximal for the translation with a given sigma.
 
@@ -295,6 +297,7 @@ def proximal_quadratic_perturbation(prox_factory, a, u=None):
         raise TypeError('`u` must be `None` or a `LinearSpaceElement` '
                         'instance, got {!r}.'.format(u))
 
+    @lru_cache()
     def quadratic_perturbation_prox_factory(sigma):
         """Create proximal for the quadratic perturbation with a given sigma.
 

--- a/odl/solvers/nonsmooth/proximal_operators.py
+++ b/odl/solvers/nonsmooth/proximal_operators.py
@@ -21,7 +21,6 @@ from future import standard_library
 standard_library.install_aliases()
 from builtins import super
 
-from functools import lru_cache
 import numpy as np
 import scipy.special
 
@@ -29,6 +28,7 @@ from odl.operator import (Operator, IdentityOperator, ScalingOperator,
                           ConstantOperator, DiagonalOperator)
 from odl.space import ProductSpace
 from odl.set import LinearSpaceElement
+from odl.util import cache_arguments
 
 
 __all__ = ('combine_proximals', 'proximal_cconj', 'proximal_translation',
@@ -225,7 +225,7 @@ def proximal_arg_scaling(prox_factory, scaling):
     if scaling == 0:
         return proximal_const_func(prox_factory(1.0).domain)
 
-    @lru_cache()
+    @cache_arguments
     def arg_scaling_prox_factory(sigma):
         """Create proximal for the translation with a given sigma.
 
@@ -297,7 +297,7 @@ def proximal_quadratic_perturbation(prox_factory, a, u=None):
         raise TypeError('`u` must be `None` or a `LinearSpaceElement` '
                         'instance, got {!r}.'.format(u))
 
-    @lru_cache()
+    @cache_arguments
     def quadratic_perturbation_prox_factory(sigma):
         """Create proximal for the quadratic perturbation with a given sigma.
 

--- a/odl/space/npy_ntuples.py
+++ b/odl/space/npy_ntuples.py
@@ -494,15 +494,20 @@ def _blas_is_applicable(*args):
 def _lincomb_impl(a, x1, b, x2, out, dtype):
     """Raw linear combination depending on data type."""
 
+    # Define thresholds for when different implementations should be used
+    threshold_small = 100
+    threshold_medium = 50000
+
+    # Convert to native since BLAS needs it
     size = native(x1.size)
 
     # Shortcut for small problems
-    if size < 100:  # small array optimization
+    if size <= threshold_small:  # small array optimization
         out.data[:] = a * x1.data + b * x2.data
         return
 
     # If data is very big, use BLAS if possible
-    if size >= 50000 and _blas_is_applicable(x1, x2, out):
+    if size > threshold_medium and _blas_is_applicable(x1, x2, out):
         axpy, scal, copy = linalg.blas.get_blas_funcs(
             ['axpy', 'scal', 'copy'], arrays=(x1.data, x2.data, out.data))
     else:

--- a/odl/test/solvers/nonsmooth/douglas_rachford_test.py
+++ b/odl/test/solvers/nonsmooth/douglas_rachford_test.py
@@ -95,6 +95,36 @@ def test_primal_dual_l1():
     assert all_almost_equal(x, data_1, places=2)
 
 
+def test_primal_dual_no_operator():
+    """Verify that the correct value is returned when there is no operator.
+
+    Solves the optimization problem
+
+        min_x ||x - data_1||_1
+
+    which has optimum value data_1.
+    """
+
+    # Define the space
+    space = odl.rn(5)
+
+    # Operator
+    L = []
+
+    # Data
+    data_1 = odl.util.testutils.noise_element(space)
+
+    # Proximals
+    f = odl.solvers.L1Norm(space).translated(data_1)
+    g = []
+
+    # Solve with f term dominating
+    x = space.zero()
+    douglas_rachford_pd(x, f, g, L, tau=3.0, sigma=[], niter=10)
+
+    assert all_almost_equal(x, data_1, places=2)
+
+
 def test_primal_dual_with_li():
     """Test for the forward-backward solver with infimal convolution.
 

--- a/odl/trafos/util/ft_utils.py
+++ b/odl/trafos/util/ft_utils.py
@@ -386,7 +386,7 @@ def _interp_kernel_ft(norm_freqs, interp):
     if interp_ == 'nearest':
         pass
     elif interp_ == 'linear':
-        ker_ft **= 2
+        ker_ft *= ker_ft
     else:
         raise ValueError("`interp` '{}' not understood".format(interp))
 

--- a/odl/trafos/util/ft_utils.py
+++ b/odl/trafos/util/ft_utils.py
@@ -536,10 +536,13 @@ def dft_postprocess_data(arr, real_grid, recip_grid, shift, axes,
         freqs = np.linspace(fmin, fmax, num=len_dft)
         stride = real_grid.stride[ax]
 
+        interp_kernel = _interp_kernel_ft(freqs, intp)
+        interp_kernel *= stride
+
         if op == 'multiply':
-            onedim_arr *= stride * _interp_kernel_ft(freqs, intp)
+            onedim_arr *= interp_kernel
         else:
-            onedim_arr /= stride * _interp_kernel_ft(freqs, intp)
+            onedim_arr /= interp_kernel
 
         onedim_arrs.append(onedim_arr.astype(out.dtype, copy=False))
 

--- a/odl/util/numerics.py
+++ b/odl/util/numerics.py
@@ -244,7 +244,7 @@ def fast_1d_tensor_mult(ndarr, onedim_arrs, axes=None, out=None):
         axes[axes < 0] += out.ndim
         axes = list(axes)
 
-    if np.any(np.array(axes) >= out.ndim) or np.any(np.array(axes) < 0):
+    if not all(0 <= ai < out.ndim for ai in axes):
         raise ValueError('`axes` {} out of bounds for {} dimensions'
                          ''.format(axes_in, out.ndim))
 
@@ -269,8 +269,7 @@ def fast_1d_tensor_mult(ndarr, onedim_arrs, axes=None, out=None):
 
         # Get the axis to spare for the final multiplication, the one
         # with the largest stride.
-        axis_order = np.argsort(out.strides)
-        last_ax = axis_order[-1]
+        last_ax = np.argmax(out.strides)
         last_arr = alist[axes.index(last_ax)]
 
         # Build the semi-big array and multiply
@@ -280,14 +279,14 @@ def fast_1d_tensor_mult(ndarr, onedim_arrs, axes=None, out=None):
                 continue
 
             slc = [None] * out.ndim
-            slc[ax] = np.s_[:]
+            slc[ax] = slice(None)
             factor = factor * arr[slc]
 
         out *= factor
 
         # Finally multiply by the remaining 1d array
         slc = [None] * out.ndim
-        slc[last_ax] = np.s_[:]
+        slc[last_ax] = slice(None)
         out *= last_arr[slc]
 
     return out

--- a/odl/util/utility.py
+++ b/odl/util/utility.py
@@ -223,31 +223,55 @@ def with_metaclass(meta, *bases):
     return metaclass('temporary_class', None, {})
 
 
+def cache_arguments(function):
+    """Decorate function to cache the result with given arguments.
+
+    This is equivalent to `functools.lru_cache` with Python 3, and currently
+    does nothing with Python 2 but this may change at some later point.
+
+    Parameters
+    ----------
+    function : `callable`
+        Function that should be wrapped.
+    """
+    try:
+        from functools import lru_cache
+        return lru_cache()(function)
+    except ImportError:
+        return function
+
+
+@cache_arguments
 def is_scalar_dtype(dtype):
     """Return ``True`` if ``dtype`` is a scalar type."""
     return np.issubsctype(dtype, np.number)
 
 
+@cache_arguments
 def is_int_dtype(dtype):
     """Return ``True`` if ``dtype`` is an integer type."""
     return np.issubsctype(dtype, np.integer)
 
 
+@cache_arguments
 def is_floating_dtype(dtype):
     """Return ``True`` if ``dtype`` is a floating point type."""
     return is_real_floating_dtype(dtype) or is_complex_floating_dtype(dtype)
 
 
+@cache_arguments
 def is_real_dtype(dtype):
     """Return ``True`` if ``dtype`` is a real (including integer) type."""
     return is_scalar_dtype(dtype) and not is_complex_floating_dtype(dtype)
 
 
+@cache_arguments
 def is_real_floating_dtype(dtype):
     """Return ``True`` if ``dtype`` is a real floating point type."""
     return np.issubsctype(dtype, np.floating)
 
 
+@cache_arguments
 def is_complex_floating_dtype(dtype):
     """Return ``True`` if ``dtype`` is a complex floating point type."""
     return np.issubsctype(dtype, np.complexfloating)
@@ -840,24 +864,6 @@ class NumpyRandomSeed(object):
         """Called upon exiting ``with`` command."""
         if self.seed is not None:
             np.random.set_state(self.startstate)
-
-
-def cache_arguments(function):
-    """Decorate function to cache the result with given arguments.
-
-    This is equivalent to `functools.lru_cache` with Python 3, and currently
-    does nothing with Python 2 but this may change at some later point.
-
-    Parameters
-    ----------
-    function : `callable`
-        Function that should be wrapped.
-    """
-    try:
-        from functools import lru_cache
-        return lru_cache()(function)
-    except ImportError:
-        return function
 
 
 if __name__ == '__main__':

--- a/odl/util/utility.py
+++ b/odl/util/utility.py
@@ -24,7 +24,7 @@ __all__ = ('array1d_repr', 'array1d_str', 'arraynd_repr', 'arraynd_str',
            'is_real_dtype', 'is_real_floating_dtype',
            'is_complex_floating_dtype', 'real_dtype', 'complex_dtype',
            'conj_exponent', 'as_flat_array', 'writable_array',
-           'run_from_ipython', 'NumpyRandomSeed')
+           'run_from_ipython', 'NumpyRandomSeed', 'cache_arguments')
 
 TYPE_MAP_R2C = {np.dtype(dtype): np.result_type(dtype, 1j)
                 for dtype in np.sctypes['float']}
@@ -840,6 +840,24 @@ class NumpyRandomSeed(object):
         """Called upon exiting ``with`` command."""
         if self.seed is not None:
             np.random.set_state(self.startstate)
+
+
+def cache_arguments(function):
+    """Decorate function to cache the result with given arguments.
+
+    This is equivalent to `functools.lru_cache` with Python 3, and currently
+    does nothing with Python 2 but this may change at some later point.
+
+    Parameters
+    ----------
+    function : `callable`
+        Function that should be wrapped.
+    """
+    try:
+        from functools import lru_cache
+        return lru_cache()(function)
+    except ImportError:
+        return function
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This started out small but in the end i achieved a x2 speedup for small tomographic inversion problems, clearly nice.

Improvements include:

* MInor optimization on hot paths
    * Remove unncessary "isinstance" call
    * Remove repeated "size" etc calls
* Cache some often re-used stuff (like proximals) using `functools.lrc_cache`
* Reduce number of "element" calls by using proper inplace arithmetic in douglas rachford solver
* Performed some (rudimentary) performance tests and we now have three "levels" of lincomb, each optimal for its own case:
    * size < 100: Callback to pure numpy
    * 100 <= size <= 50000: Use blas style arithmetic but without blas
    * 50000 < size: Use blas
* Renamed `_lincomb` to `_lincomb_impl` since the previous did not play well with the spyder profiler