### PR TITLE
MAINT: remove examples/__init__.py

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ install:
     - conda info -a
 
     # Install dependencies and enter test environment
-    - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION numpy scipy future nomkl sphinx sphinx_rtd_theme pytest pytest-pep8 pytest-cov
+    - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION "numpy<1.13" scipy future nomkl sphinx sphinx_rtd_theme pytest pytest-pep8 pytest-cov
     - source activate test-environment
 
     # Some packages which are only on PyPI, not on conda

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -8,3 +8,4 @@ include test_requirements.txt
 include odl/pytest.ini
 exclude pytest.ini
 recursive-include odl/test test*.py *test.py
+prune examples

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -7,6 +7,7 @@ source:
     git_rev: master  # for testing, put any branch here
     # git_rev: v0.6.0  # release
     # git_rev: a542c12d23da7fa5b92b360a51ea14e4804c58f6  # intermediate bugfix revision
+    # path: ..  # for builds from local source (no download)
 
 build:
     number: 0
@@ -18,13 +19,13 @@ requirements:
         - setuptools
         - nomkl # [not win]
         - future >=0.14
-        - numpy >=1.9
+        - numpy >=1.9,<1.13
         - scipy >=0.14
     run:
         - python
         - future >=0.14
         - nomkl # [not win]
-        - numpy >=1.9
+        - numpy >=1.9,<1.13
         - scipy >=0.14
         - matplotlib
         - pytest >=3.0.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 future >= 0.14
-numpy >= 1.9
+numpy >= 1.9, < 1.13
 scipy >= 0.14
 


### PR DESCRIPTION
Somehow left-over in the source tree. It messes up the package layout quite a bit since examples are installed directly under `site-packages`. This fixes the issue, but an intermediate release is needed so that users can get a fixed package.