### PR TITLE
WIP: implement __array_ufunc__, closes #225

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ install:
     - conda info -a
 
     # Install dependencies and enter test environment
-    - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION "numpy<1.13" scipy future nomkl sphinx sphinx_rtd_theme pytest pytest-pep8 pytest-cov
+    - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION numpy scipy future nomkl sphinx sphinx_rtd_theme pytest pytest-pep8 pytest-cov
     - source activate test-environment
 
     # Some packages which are only on PyPI, not on conda

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -19,13 +19,13 @@ requirements:
         - setuptools
         - nomkl # [not win]
         - future >=0.14
-        - numpy >=1.9,<1.13
+        - numpy >=1.9
         - scipy >=0.14
     run:
         - python
         - future >=0.14
         - nomkl # [not win]
-        - numpy >=1.9,<1.13
+        - numpy >=1.9
         - scipy >=0.14
         - matplotlib
         - pytest >=3.0.3

--- a/odl/discr/lp_discr.py
+++ b/odl/discr/lp_discr.py
@@ -694,14 +694,252 @@ class DiscreteLpElement(DiscretizedSpaceElement):
 
             super().__setitem__(indices, values)
 
-    @property
-    def ufuncs(self):
-        """`DiscreteLpUfuncs`, access to numpy style ufuncs.
+    def __array_ufunc__(self, ufunc, method, *inputs, **kwargs):
+        """Interface to Numpy's ufunc machinery.
+
+        This method is called by Numpy version 1.13 and higher as a single
+        point for the ufunc dispatch logic. An object implementing
+        ``__array_ufunc__`` takes over control when a `numpy.ufunc` is
+        called on it, allowing it to use custom implementations and
+        output types.
+
+        This includes handling of in-place arithmetic like
+        ``npy_array += custom_obj_with_array_ufunc``: In this case,
+        the custom object's ``__array_ufunc__`` takes precedence over the
+        `numpy.ndarray` implementation. It will be called with
+        ``npy_array`` as ``out`` argument, which will ensure that the
+        returned object is a Numpy array. For this to work properly,
+        ``__array_ufunc__`` has to accept Numpy arrays as ``out`` arguments.
+
+        See the `corresponding NEP`_ and the `interface documentation`_
+        for further details. See also the `general documentation on
+        Numpy ufuncs`_.
+
+        .. note::
+            This basic implementation casts inputs and
+            outputs to Numpy arrays and evaluates ``ufunc`` on those.
+            For `numpy.ndarray` based data storage, this incurs no
+            significant overhead compared to direct usage of Numpy arrays.
+
+            For other (in particular non-local) implementations, e.g.,
+            GPU arrays or distributed memory, overhead is significant due
+            to copies to CPU main memory. In those classes, the
+            ``__array_ufunc__`` mechanism should be overridden to use
+            native implementations if possible.
+
+        .. note::
+            When using operations that alter the shape (like ``reduce``),
+            or the data type (can be any of the methods),
+            the resulting array is wrapped in a space of the same
+            type as ``self.space``, however **only** using the minimal
+            set of parameters ``size`` and ``dtype``. If more properties
+            are supposed to be propagated, this method must be overridden.
+
+        Parameters
+        ----------
+        ufunc : `numpy.ufunc`
+            Ufunc that should be called on ``self``.
+        method : str
+            Method on ``ufunc`` that should be called on ``self``.
+            Possible values:
+
+            ``'__call__'``, ``'accumulate'``, ``'at'``, ``'reduce'``
+
+        input1, ..., inputN:
+            Positional arguments to ``ufunc.method``.
+        kwargs:
+            Keyword arguments to ``ufunc.method``.
+
+        Returns
+        -------
+        ufunc_result : `DiscreteLpElement`, `numpy.ndarray` or tuple
+            Result of the ufunc evaluation. If no ``out`` keyword argument
+            was given, the result is an `NtuplesBaseVector` or a tuple
+            of such, depending on the number of outputs of ``ufunc``.
+            If ``out`` was provided, the returned object or sequence members
+            refer(s) to ``out``.
 
         Examples
         --------
-        >>> X = uniform_discr(0, 1, 2)
-        >>> x = X.element([1, -2])
+        We apply `numpy.add` to ODL vectors, also with the optional
+        ``out`` parameter:
+
+        >>> rn = odl.rn(3)
+        >>> x = rn.element([1, 2, 3])
+        >>> y = rn.element([-1, -2, -3])
+        >>> np.add(x, y)
+        rn(3).element([0.0, 0.0, 0.0])
+        >>> out = rn.element()
+        >>> result = np.add(x, y, out=out)
+        >>> out
+        rn(3).element([0.0, 0.0, 0.0])
+        >>> result is out
+        True
+
+        The ``add.accumulate`` method retains the original shape and
+        ``dtype``. We can override the latter with the ``dtype``
+        parameter:
+
+        >>> x = rn.element([1, 2, 3])
+        >>> np.add.accumulate(x)
+        rn(3).element([1.0, 3.0, 6.0])
+        >>> np.add.accumulate(x, dtype=complex)
+        cn(3).element([(1+0j), (3+0j), (6+0j)])
+
+        The ``add.at`` method operates in-place. Here we add the second
+        operand ``[5, 10]`` to ``x`` at indices ``[0, 2]``:
+
+        >>> x = rn.element([1, 2, 3])
+        >>> np.add.at(x, [0, 2], [5, 10])
+        >>> x
+        rn(3).element([6.0, 2.0, 13.0])
+
+        Using ``add.reduce`` produces a scalar, which can be avoided by
+        using ``keepdims=True``:
+
+        >>> x = rn.element([1, 2, 3])
+        >>> np.add.reduce(x)
+        6.0
+        >>> np.add.reduce(x, keepdims=True)
+        rn(1).element([6.0])
+
+        References
+        ----------
+        .. _corresponding NEP:
+           https://github.com/numpy/numpy/blob/master/doc/neps/\
+ufunc-overrides.rst
+
+        .. _interface documentation:
+           https://github.com/charris/numpy/blob/master/doc/source/reference/\
+arrays.classes.rst#special-attributes-and-methods
+
+        .. _general documentation on Numpy ufuncs:
+           https://docs.scipy.org/doc/numpy/reference/ufuncs.html
+
+        .. _reduceat documentation:
+           https://docs.scipy.org/doc/numpy/reference/generated/\
+numpy.ufunc.reduceat.html
+        """
+        # Unwrap out if provided. The output parameters are all wrapped
+        # in one tuple, even if there is only one.
+        out_tuple = kwargs.pop('out', ())
+
+        # We allow our own element type and `numpy.ndarray` objects as `out`
+        if not all(isinstance(out, (type(self), np.ndarray)) or out is None
+                   for out in out_tuple):
+            return NotImplemented
+
+        out = out1 = out2 = None
+        if len(out_tuple) == 1:
+            out = out_tuple[0]
+        elif len(out_tuple) == 2:
+            out1 = out_tuple[0]
+            out2 = out_tuple[1]
+
+        # Use some of the kwargs for `writable_array`
+        # TODO: propagate `order` when tensors are available
+        out_dtype = kwargs.get('dtype', None)
+        out_order = kwargs.get('order', None)
+
+        """
+        fspace, partition, dspace, exponent=2.0,
+                 interp='nearest'
+                 order
+                 axis_labels
+        """
+
+        # Need new space for ufunc if dtype or order were changed
+        if ((out_dtype is None or out_dtype == self.dtype) and
+                (out_order is None or out_order == self.order)):
+            out_space = self.space
+        else:
+            # TODO: create space with new dtype and order
+            out_space = self.space.astype()
+
+        # Need to filter for `keepdims` since it's invalid (happening below)
+        keepdims = kwargs.pop('keepdims', False)
+
+        if method == '__call__':
+            if ufunc.nout == 1:
+                # TODO: call into self.ntuple.__array_ufunc__
+                if out is None:
+                    out = out_space.element()
+                with writable_array(out, **array_kwargs) as out_arr:
+                    kwargs['out'] = (out_arr,)
+                    ufunc(*inputs, **kwargs)
+                return out
+
+            elif ufunc.nout == 2:
+                if out1 is None:
+                    out1 = out_space.element()
+                if out2 is None:
+                    out2 = out_space.element()
+                out1_ctx = writable_array(out1, **array_kwargs)
+                out2_ctx = writable_array(out2, **array_kwargs)
+                with out1_ctx as out1_arr, out2_ctx as out2_arr:
+                    kwargs['out'] = (out1_arr, out2_arr)
+                    ufunc(*inputs, **kwargs)
+                return out1, out2
+
+            else:
+                raise NotImplementedError('nout = {} not supported'
+                                          ''.format(ufunc.nout))
+
+        elif method == 'outer':
+            # Not supported at the moment since we need spaces of vector-
+            # valued functions for that.
+            # We have to raise since returning `NotImplemented` will
+            # fall back to native Numpy, resulting in a `numpy.ndarray`.
+            # TODO: add when vector-valued functions are available
+            raise NotImplementedError('`outer` currently not supported')
+        elif method == 'reduceat':
+            # Makes no sense since there is no way to determine in which
+            # space the result should live, except in special cases when
+            # axes are being completely collapsed or don't change size.
+            raise ValueError('`reduceat` not supported')
+        elif method == 'reduce' and keepdims:
+            raise ValueError(
+                '`keepdims=True` cannot be used in `reduce` since there is '
+                'no unique function domain for the collapsed axes')
+        else:
+            if out is None:
+                result = getattr(ufunc, method)(*inputs, **kwargs)
+                if np.isscalar(result):
+                    # This occurs for `reduce` with all axes
+                    return result
+                elif result is None:
+                    # Happens for in-place operations, currently only `at`
+                    return
+                else:
+                    # Wrap result in an appropriate space
+                    # TODO: use `shape` and `order` when tensors are available
+                    result_space = type(self.space)(result.size, result.dtype)
+                    return result_space.element(result.ravel())
+            else:
+                with writable_array(out) as out_arr:
+                    kwargs['out'] = (out_arr,)
+                getattr(ufunc, method)(*inputs, **kwargs)
+
+    # Old ufuncs interface, will be deprecated when Numpy 1.13 becomes minimum
+
+    @property
+    def ufuncs(self):
+        """Access to Numpy style universal functions.
+
+        .. note::
+            This interface is will be deprecated when Numpy 1.13 becomes
+            the minimum required version. Use Numpy ufuncs directly, e.g.,
+            ``np.sqrt(x)`` instead of ``x.ufuncs.sqrt()``.
+
+        Notes
+        -----
+        These ufuncs use optimized implementations for `dspace` if
+        available and incur no significant extra overhead.
+
+        Examples
+        --------
+        >>> space = uniform_discr(0, 1, 2)
+        >>> x = space.element([1, -2])
         >>> x.ufuncs.absolute()
         uniform_discr(0.0, 1.0, 2).element([1.0, 2.0])
 
@@ -722,18 +960,13 @@ class DiscreteLpElement(DiscretizedSpaceElement):
 
         Also supports out parameter
 
-        >>> y = X.element([3, 4])
-        >>> out = X.element()
+        >>> y = space.element([3, 4])
+        >>> out = space.element()
         >>> result = x.ufuncs.add(y, out=out)
         >>> result
         uniform_discr(0.0, 1.0, 2).element([4.0, 2.0])
         >>> result is out
         True
-
-        Notes
-        -----
-        These are optimized to use the underlying ntuple space and incur no
-        overhead unless these do.
         """
         return DiscreteLpUfuncs(self)
 

--- a/odl/space/base_ntuples.py
+++ b/odl/space/base_ntuples.py
@@ -404,10 +404,10 @@ class NtuplesBaseVector(with_metaclass(ABCMeta, object)):
         output types.
 
         This includes handling of in-place arithmetic like
-        ``npy_array += custom_obj_with_array_ufunc``: In this case,
-        the custom object's ``__array_ufunc__`` takes precedence over the
+        ``npy_array += custom_obj``. In this case, the custom object's
+        ``__array_ufunc__`` takes precedence over the baseline
         `numpy.ndarray` implementation. It will be called with
-        ``npy_array`` as ``out`` argument, which will ensure that the
+        ``npy_array`` as ``out`` argument, which ensures that the
         returned object is a Numpy array. For this to work properly,
         ``__array_ufunc__`` has to accept Numpy arrays as ``out`` arguments.
 
@@ -550,21 +550,21 @@ numpy.ufunc.reduceat.html
             out1 = out_tuple[0]
             out2 = out_tuple[1]
 
-        # Use some of the kwargs for `writable_array`
-        # TODO: propagate `order` when tensors are available
-        array_kwargs = {}
-        out_dtype = kwargs.get('dtype', None)
-        if out_dtype is not None:
-            array_kwargs['dtype'] = out_dtype
-
-        # Need new space for ufunc if dtype was changed
-        # TODO: use `shape` and `order` when tensors are available
-        if out_dtype is None or out_dtype == self.dtype:
-            out_space = self.space
-        else:
-            out_space = type(self.space)(self.size, out_dtype)
-
         if method == '__call__':
+            # Use some of the kwargs for `writable_array`
+            # TODO: propagate `order` when tensors are available
+            array_kwargs = {}
+            out_dtype = kwargs.get('dtype', None)
+            if out_dtype is not None:
+                array_kwargs['dtype'] = out_dtype
+
+            # Need new space for ufunc if dtype was changed
+            # TODO: use `shape` and `order` when tensors are available
+            if out_dtype is None or out_dtype == self.dtype:
+                out_space = self.space
+            else:
+                out_space = type(self.space)(self.size, out_dtype)
+
             if ufunc.nout == 1:
                 if out is None:
                     out = out_space.element()

--- a/odl/space/npy_ntuples.py
+++ b/odl/space/npy_ntuples.py
@@ -429,9 +429,17 @@ class NumpyNtuplesVector(NtuplesBaseVector):
         else:
             self.data[indices] = values
 
+    # Old ufuncs interface, will be deprecated when Numpy 1.13 becomes minimum
+
     @property
     def ufuncs(self):
         """`NumpyNtuplesUfuncs`, access to numpy style ufuncs.
+
+        .. note::
+            This interface is deprecated and will be removed as soon
+            as Numpy 1.13 becomes the minimum required version.
+            Use Numpy ufuncs directly, e.g., ``np.sqrt(x)`` instead of
+            ``x.ufuncs.sqrt()``.
 
         Examples
         --------

--- a/odl/util/pytest_plugins.py
+++ b/odl/util/pytest_plugins.py
@@ -18,7 +18,8 @@ import os
 
 import odl
 from odl.trafos.backends import PYFFTW_AVAILABLE, PYWT_AVAILABLE
-from odl.util import dtype_repr
+from odl.util.utility import dtype_repr
+from odl.util.testutils import simple_fixture
 
 try:
     from pytest import fixture
@@ -118,44 +119,8 @@ def scalar_dtype(request):
     return request.param
 
 
-ufunc_params = odl.util.ufuncs.UFUNCS
-ufunc_ids = [' ufunc = {} '.format(p[0]) for p in ufunc_params]
-
-
-@fixture(scope="module", ids=ufunc_ids, params=ufunc_params)
-def ufunc(request):
-    """Tuple with information on a ufunc.
-
-    Returns
-    -------
-    name : str
-        Name of the ufunc.
-    n_in : int
-        Number of input values of the ufunc.
-    n_out : int
-        Number of output values of the ufunc.
-    doc : str
-        Docstring for the ufunc.
-    """
-    return request.param
-
-
-reduction_params = odl.util.ufuncs.REDUCTIONS
-reduction_ids = [' reduction = {} '.format(p[0]) for p in reduction_params]
-
-
-@fixture(scope="module", ids=reduction_ids, params=reduction_params)
-def reduction(request):
-    """Tuple with information on a reduction.
-
-    Returns
-    -------
-    name : str
-        Name of the reduction.
-    doc : str
-        Docstring for the reduction.
-    """
-    return request.param
+ufunc = simple_fixture('ufunc', [p[0] for p in odl.util.ufuncs.UFUNCS])
+reduction = simple_fixture('reduction', ['sum', 'prod', 'min', 'max'])
 
 arithmetic_op_par = [operator.add,
                      operator.truediv,

--- a/odl/util/utility.py
+++ b/odl/util/utility.py
@@ -243,8 +243,8 @@ def cache_arguments(function):
 
 @cache_arguments
 def is_scalar_dtype(dtype):
-    """Return ``True`` if ``dtype`` is a scalar type."""
-    return np.issubsctype(dtype, np.number)
+    """Return ``True`` if ``dtype`` is a scalar type (number or bool)."""
+    return np.issubsctype(dtype, np.number) or np.issubsctype(dtype, np.bool)
 
 
 @cache_arguments

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 future >= 0.14
-numpy >= 1.9, < 1.13
+numpy >= 1.9
 scipy >= 0.14
 


### PR DESCRIPTION
This is a work-in-progress PR for the new interface. Would be nice to get some high-level input before I put a lot of work into fixing the details.

I chose to move most of the logic in `odl.util.ufuncs` to the `__array_ufunc__` method and retail the old interface as a wrapper around the new one, together with a deprecation warning. The warnings become very annoying over time, so I'll try to find a way to only print the warning once. Probably some module global flag.

The `ntuples_test` suite goes green, but probably we need more detailed tests now that we can use more parameters in the ufuncs (e.g. `dtype`) which require creating a new space.