### PR TITLE
Fix release doc refs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,16 +54,17 @@ script:
     - pytest --doctest-modules --cov --cov-report term-missing --pep8 $TRAVIS_BUILD_DIR/odl
     # Invoke also the alternative way of running the unit tests
     - python -c "import odl; odl.test()"
-    # Build the Sphinx doc (only for Python 3.6 and the master branch)
+    # Build the Sphinx doc (only for Python 3.6, master branch, no PR)
+    # To avoid clogging the logs, we redirect stderr to /dev/null
     - if [[ "$TRAVIS_PYTHON_VERSION" == "3.6" && "$TRAVIS_BRANCH" == "master" && "$TRAVIS_PULL_REQUEST" == "false" ]]; then
         cd $TRAVIS_BUILD_DIR/doc/source && python generate_doc.py && cd -;
-        travis-sphinx -n -s $TRAVIS_BUILD_DIR/doc/source build;
+        travis-sphinx -n -s $TRAVIS_BUILD_DIR/doc/source build 2>/dev/null;
       fi
 
 after_success:
     # Push coverage report to coveralls
     - coveralls
-    # Deploy the Sphinx doc to gh-pages (only for Python 3.6 and the master branch)
+    # Deploy the Sphinx doc to gh-pages (only for Python 3.6, master branch, no PR)
     # See https://github.com/Syntaf/travis-sphinx
     - if [[ "$TRAVIS_PYTHON_VERSION" == "3.6" && "$TRAVIS_BRANCH" == "master" && "$TRAVIS_PULL_REQUEST" == "false" ]]; then
         travis-sphinx deploy;

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -78,7 +78,6 @@ def skip(app, what, name, obj, skip, options):
     if name in ['_multiply',
                 '_divide',
                 '_lincomb',
-                '_apply',
                 '_call']:
         return False
     return skip
@@ -90,12 +89,11 @@ def setup(app):
 # Autosummary
 autosummary_generate = glob.glob("./*.rst")
 
-# Default role for ambiguous ':any:' targets
-default_role = 'py:class'
-
 # Stops WARNING: toctree contains reference to nonexisting document
+# (not anymore since Sphinx 1.6)
 numpydoc_show_class_members = True
 numpydoc_show_inherited_class_members = True
+numpydoc_class_members_toctree = True
 
 # Set order to mirror source
 autodoc_member_order = 'bysource'
@@ -146,7 +144,7 @@ pygments_style = 'sphinx'
 # If true, `todo` and `todoList` produce output, else they produce nothing.
 todo_include_todos = False
 
-# Warn on dead links
+# Warn on dead links and other stuff
 nitpicky = True
 nitpick_ignore = [('py:class', 'future.types.newobject.newobject')]
 

--- a/doc/source/dev/release.rst
+++ b/doc/source/dev/release.rst
@@ -13,6 +13,7 @@ Since this is not everyday work and may be done under the stress of a (self-impo
 
 
 .. _dev_rel_release_schedule:
+
 1. Agree on a release schedule
 ------------------------------
 This involves the "what" and "when" of the release process and fixes a feature set that is supposed to be included in the new version.
@@ -23,6 +24,7 @@ The steps are:
 
 
 .. _dev_rel_master_ok:
+
 2. Make sure tests succeed and docs are built properly
 ------------------------------------------------------
 When all required PRs are merged, ensure that the latest ``master`` branch is sane. Travis CI checks every PR, but certain things like CUDA cannot be tested there and must therefore undergo tests on a local machine, for at least Python 2.7 and one version of Python 3.
@@ -68,6 +70,7 @@ When all required PRs are merged, ensure that the latest ``master`` branch is sa
 
 
 .. _dev_rel_release_branch:
+
 3. Make a release branch off ``master``
 ---------------------------------------
 When all tests succeed and the docs are fine, start a release branch.
@@ -86,6 +89,7 @@ When all tests succeed and the docs are fine, start a release branch.
 
 
 .. _dev_rel_bump_master:
+
 4. Bump the ``master`` branch to the next development version
 -------------------------------------------------------------
 To ensure a higher version number for installations from the git master branch, the version number must be increased before merging the release branch.
@@ -111,6 +115,7 @@ To ensure a higher version number for installations from the git master branch, 
 
 
 .. _dev_rel_publish:
+
 5. Compile and publish the release
 ----------------------------------
 Back on the release branch with a ``git checkout release-X.Y.Z``, it is now time to prepare the release documents, increment the version number and make a release on GitHub.
@@ -156,6 +161,7 @@ Back on the release branch with a ``git checkout release-X.Y.Z``, it is now time
     After that, rebase the release branch(es) on the new master and continue.
 
 .. _dev_rel_create_pkgs:
+
 6. Create packages for PyPI and Conda
 -------------------------------------
 The packages should be built on the release branch to make sure that the version information is correct.
@@ -206,6 +212,7 @@ The packages should be built on the release branch to make sure that the version
 
 
 .. _dev_rel_test_pkgs:
+
 7. Test installing the local packages and check them
 ----------------------------------------------------
 Before actually uploading packages to "official" servers, first install the local packages and run the unit tests.
@@ -222,7 +229,7 @@ Before actually uploading packages to "official" servers, first install the loca
     pip install <pkg_filename>
     python -c "import odl; odl.test()"
 
-  .. warn::
+  .. warning::
 
     Make sure that you're not in the repository root directory while testing, since this can confuse the ``import odl`` command.
     The installed package should be tested, not the code repository.
@@ -239,6 +246,7 @@ Before actually uploading packages to "official" servers, first install the loca
 
 
 .. _dev_rel_upload_pkgs:
+
 8. Upload the packages to the official locations
 ------------------------------------------------
 Installing the packages works, now it's time to put them out into the wild.
@@ -273,6 +281,7 @@ Installing the packages works, now it's time to put them out into the wild.
   Talk to the maintainers to get them.
 
 .. _dev_rel_merge_release_pr:
+
 9. Merge the release branch
 ---------------------------
 Now the release branch can finally be merged.


### PR DESCRIPTION
Bad references in docs. I temporarily changed the `.travis.yml` to ensure that the docs are built for this PR, will remove it again when it succeeds.