### PR TITLE
BUG: First solution to misdefined KL distance

### DIFF
--- a/odl/solvers/functional/default_functionals.py
+++ b/odl/solvers/functional/default_functionals.py
@@ -1202,7 +1202,7 @@ class KullbackLeiblerConvexConj(Functional):
             return np.inf
 
         i = self.__target_greater_zero
-        obj_value = -np.sum(self.target[i]*np.log(1-x[i]))
+        obj_value = -np.sum(self.target[i] * np.log(1 - x[i]))
 
         if np.isnan(obj_value):
             # In this case, some element was one while the target was
@@ -1502,7 +1502,8 @@ class KullbackLeiblerCrossEntropyConvexConj(Functional):
 proximal_cconj_kl_cross_entropy :
             `proximal factory` for convex conjugate of the KL cross entropy.
         """
-        return proximal_cconj_kl_cross_entropy(space=self.domain, g=self.target)
+        return proximal_cconj_kl_cross_entropy(space=self.domain,
+                                               g=self.target)
 
     @property
     def convex_conj(self):

--- a/odl/solvers/functional/default_functionals.py
+++ b/odl/solvers/functional/default_functionals.py
@@ -1062,7 +1062,7 @@ class KullbackLeibler(Functional):
     @property
     def target(self):
         """The target in the Kullback-Leibler functional."""
-        return self.target
+        return self.__target
 
     # TODO: update when integration operator is in place: issue #440
     def _call(self, x):

--- a/odl/solvers/functional/default_functionals.py
+++ b/odl/solvers/functional/default_functionals.py
@@ -1056,7 +1056,8 @@ class KullbackLeibler(Functional):
                              ''.format(prior, self.domain))
 
         self.__prior = prior
-        self.__prior_greater_zero = np.greater(self.prior, 0)
+        self.__prior_greater_zero = \
+            self.domain.element(np.greater(self.prior, 0))
         self.__convex_conj = None
 
     @property
@@ -1502,8 +1503,7 @@ class KullbackLeiblerCrossEntropyConvexConj(Functional):
 proximal_cconj_kl_cross_entropy :
             `proximal factory` for convex conjugate of the KL cross entropy.
         """
-        return proximal_cconj_kl_cross_entropy(space=self.domain,
-                                               g=self.prior)
+        return proximal_cconj_kl_cross_entropy(space=self.domain, g=self.prior)
 
     @property
     def convex_conj(self):

--- a/odl/test/solvers/functional/functional_test.py
+++ b/odl/test/solvers/functional/functional_test.py
@@ -98,9 +98,9 @@ def functional(request, space):
         divisor = odl.solvers.functional.ConstantFunctional(space, 2)
         func = odl.solvers.functional.FunctionalQuotient(dividend, divisor)
     elif name == 'kl':
-        func = odl.solvers.functional.KullbackLeibler(space)
+        func = odl.solvers.functional.KullbackLeibler(space, space.one())
     elif name == 'kl_cc':
-        func = odl.solvers.KullbackLeibler(space).convex_conj
+        func = odl.solvers.KullbackLeibler(space, space.one()).convex_conj
     elif name == 'kl_cross_ent':
         func = odl.solvers.functional.KullbackLeiblerCrossEntropy(space)
     elif name == 'kl_cc_cross_ent':


### PR DESCRIPTION
This commit contains a few changes:
- change name of variable from "prior" to "target". I am not sure if target is the best way to put it, but I find prior certainly misleading. In the context of PET imaging, it should be called "data" but this may be different for other applications and usages.
- "prior"/"target" should be non-optional. It does not make much sense to have it optional. If the "target" is constant 1, then this becomes x - log(x) which may be interesting in itself but not what one would be looking for under the term "Kullback Leibler".
- The actual important change in here is the redefinition of the KL divergence to include the definition 0 log(0) := 0 and NOT 0 log(0) := infty. This has implications also for the convex conjugate. The proximal operators don't need to be changed interestingly.
