### PR TITLE
MAINT: Change references to be local in doc

### DIFF
--- a/doc/source/refs.rst
+++ b/doc/source/refs.rst
@@ -2,36 +2,6 @@
 
 References
 ==========
-
-.. [BB1988] Barzilai, J, and Borwein, J M. *Two-point step size
-   gradient methods*. IMA Journal of Numerical Analysis, 8 (1988),
-   pp 141--148.
-
-.. [BC2011] Bauschke, H H, and Combettes, P L. *Convex analysis and
-   monotone operator theory in Hilbert spaces*. Springer, 2011.
-
-.. [BC2015] Bot, R I, and Csetnek, E R. *On the convergence rate of
-   a forward-backward type primal-dual splitting algorithm for convex
-   optimization problems*. Optimization, 64.1 (2015), pp 5--23.
-
-.. [BH2013] Bot, R I, and Hendrich, C. *A Douglas-Rachford type
-   primal-dual method for solving inclusions with mixtures of
-   composite and parallel-sum type monotone operators*. SIAM Journal
-   on Optimization, 23.4 (2013), pp 2541--2565.
-
-.. [Bro1965] Broyden, C G. *A class of methods for solving nonlinear
-   simultaneous equations*. Mathematics of computation, 33 (1965),
-   pp 577--593.
-
-.. [BV2004] Boyd, S, and Vandenberghe, L. *Convex optimization*.
-   Cambridge university press, 2004.
-
-.. [Che+2015] Cheng, A, Henderson, R, Mastronarde, D, Ludtke, S J,
-   Schoenmakers, R H M, Short, J, Marabini, R, Dallakyan, S, Agard, D,
-   and Winn, M. *MRC2014: Extensions to the MRC format header for electron
-   cryo-microscopy and tomography*. Journal of Structural Biology,
-   129 (2015), pp 146--150.
-
 .. [CP2011a] Chambolle, A and Pock, T. *A First-Order
    Primal-Dual Algorithm for Convex Problems with Applications to
    Imaging*. Journal of Mathematical Imaging and Vision, 40 (2011),
@@ -42,42 +12,12 @@ References
    optimization*. 2011 IEEE International Conference on Computer Vision
    (ICCV), 2011, pp 1762-1769.
 
-.. [CP2011c] Combettes, P L, and Pesquet, J-C. *Proximal splitting
-   methods in signal processing.* In:  Bauschke, H H, Burachik, R S,
-   Combettes, P L, Elser, V, Luke, D R, and Wolkowicz, H. Fixed-point
-   algorithms for inverse problems in science and engineering, Springer,
-   2011.
-
-.. [GNS2009] Griva, I, Nash, S G, and Sofer, A. *Linear and nonlinear
-   optimization*. Siam, 2009.
-
-.. [Hei+2016] Heide, F et al. *ProxImaL: Efficient Image Optimization using
-   Proximal Algorithms*. ACM Transactions on Graphics (TOG), 2016.
-
-.. [KP2015] Komodakis, N, and Pesquet, J-C. *Playing with Duality: An overview
-   of recent primal-dual approaches for solving large-scale optimization
-   problems*. IEEE Signal Processing Magazine, 32.6 (2015), pp 31--54.
-
-.. [Kva1991] Kvaalen, E. *A faster Broyden method*. BIT Numerical
-   Mathematics 31 (1991), pp 369--372.
-
-.. [Lue1969] Luenberger, D G. *Optimization by vector space methods*. Wiley,
-   1969.
-
-.. [Okt2015] Oktem, O. *Mathematics of electron tomography*. In:
-   Scherzer, O. Handbook of Mathematical Methods in Imaging.
-   Springer, 2015, pp 937--1031.
-
 .. [PB2014] Parikh, N, and Boyd, S. *Proximal Algorithms*.
    Foundations and Trends in Optimization, 1 (2014), pp 127-239.
 
 .. [Pre+2007] Press, W H, Teukolsky, S A, Vetterling, W T, and Flannery, B P.
    *Numerical Recipes in C - The Art of Scientific Computing* (Volume 3).
    Cambridge University Press, 2007.
-
-.. [Ray1997] Raydan, M. *The Barzilai and Borwein method for the
-   large scale unconstrained minimization problem*. SIAM J. Optim.,
-   7 (1997), pp 26--33.
 
 .. [Roc1970] Rockafellar, R. T. *Convex analysis*. Princeton
    University Press, 1970.
@@ -90,11 +30,3 @@ References
 .. [SW1971] Stein, E, and Weiss, G.
    *Introduction to Fourier Analysis on Euclidean Spaces*.
    Princeton University Press, 1971.
-
-.. [Val2014] Valkonen, T.
-   *A primal-dual hybrid gradient method for non-linear operators with
-   applications to MRI*. Inverse Problems, 30 (2014).
-
-.. [Du+2016] J. Duran, M. Moeller, C. Sbert, and D. Cremers.
-   *Collaborative Total Variation: A General Framework for Vectorial TV Models*
-   SIAM Journal of Imaging Sciences 9(1): 116--151, 2016.

--- a/odl/contrib/mrc/mrc.py
+++ b/odl/contrib/mrc/mrc.py
@@ -431,7 +431,7 @@ class FileReaderMRC(MRCHeaderProperties, FileReaderRawBinaryWithHeader):
     """Reader for the MRC file format.
 
     By default, the MRC2014 format is used, see `print_mrc_2014_spec` for
-    details. See also [Che+2015]_ or the `explanations on the CCP4 homepage
+    details. See also [Che+2015] or the `explanations on the CCP4 homepage
     <http://www.ccpem.ac.uk/mrc_format/mrc2014.php>`_ for the
     text of the specification.
 
@@ -624,7 +624,7 @@ class FileWriterMRC(MRCHeaderProperties, FileWriterRawBinaryWithHeader):
 
     """Writer for the MRC file format.
 
-    See [Che+2015]_ or the `explanations on the CCP4 homepage
+    See [Che+2015] or the `explanations on the CCP4 homepage
     <http://www.ccpem.ac.uk/mrc_format/mrc2014.php>`_ for the
     text of the specification.
 
@@ -712,13 +712,13 @@ def mrc_header_from_params(shape, dtype, kind, **kwargs):
     dmin, dmax : float, optional
         Minimum and maximum values of the data, used for header entries
         ``'dmin'`` and ``'dmax'``, resp.
-        Default: 1.0, 0.0. These values indicate according to [Che+2015]_
+        Default: 1.0, 0.0. These values indicate according to [Che+2015]
         that the values are considered as undetermined.
     dmean, rms : float, optional
         Mean and variance of the data, used for header entries ``'dmean'``
         and ``'rms'``, resp.
         Default: ``min(dmin, dmax) - 1, -1.0``. These values indicate
-        according to [Che+2015]_ that the values are considered as
+        according to [Che+2015] that the values are considered as
         undetermined.
     mrc_version : 2-tuple of int, optional
         Version identifier for the MRC file, used for the ``'nversion'``

--- a/odl/operator/oputils.py
+++ b/odl/operator/oputils.py
@@ -397,6 +397,8 @@ def as_proximal_lang_operator(op, norm_bound=None):
     This is intended to be used with the `ProxImaL language solvers.
     <https://github.com/comp-imaging/proximal>`_
 
+    For documentation on the proximal language (ProxImaL) see [Hei+2016].
+
     Parameters
     ----------
     op : `Operator`
@@ -419,9 +421,9 @@ def as_proximal_lang_operator(op, norm_bound=None):
 
     References
     ----------
-    For documentation on the proximal language (ProxImaL) see [Hei+2016]_.
+    [Hei+2016] Heide, F et al. *ProxImaL: Efficient Image Optimization using
+    Proximal Algorithms*. ACM Transactions on Graphics (TOG), 2016.
     """
-
     # TODO: use out parameter once "as editable array" is added
 
     def forward(inp, out):

--- a/odl/solvers/functional/default_functionals.py
+++ b/odl/solvers/functional/default_functionals.py
@@ -490,9 +490,17 @@ class IndicatorLpUnitBall(Functional):
         The convex conjugate functional of an ``Lp`` norm, ``p < infty`` is the
         indicator function on the unit ball defined by the corresponding dual
         norm ``q``, given by ``1/p + 1/q = 1`` and where ``q = infty`` if
-        ``p = 1`` [Roc1970]_. By the Fenchel-Moreau theorem, the convex
+        ``p = 1`` [Roc1970]. By the Fenchel-Moreau theorem, the convex
         conjugate functional of indicator function on the unit ball in ``Lq``
-        is the corresponding Lp-norm [BC2011]_.
+        is the corresponding Lp-norm [BC2011].
+
+        References
+        ----------
+        [Roc1970] Rockafellar, R. T. *Convex analysis*. Princeton
+        University Press, 1970.
+
+        [BC2011] Bauschke, H H, and Combettes, P L. *Convex analysis and
+        monotone operator theory in Hilbert spaces*. Springer, 2011.
         """
         if self.exponent == np.inf:
             return L1Norm(self.domain)
@@ -969,7 +977,12 @@ class IndicatorZero(Functional):
         Notes
         -----
         By the Fenchel-Moreau theorem the convex conjugate is the constant
-        functional [BC2011]_ with the constant value of -`constant`.
+        functional [BC2011] with the constant value of -`constant`.
+
+        References
+        ----------
+        [BC2011] Bauschke, H H, and Combettes, P L. *Convex analysis and
+        monotone operator theory in Hilbert spaces*. Springer, 2011.
         """
         return ConstantFunctional(self.domain, -self.constant)
 
@@ -1859,13 +1872,13 @@ class NuclearNorm(Functional):
     :math:`\mathbb{R}^{\min(n, m)}`.
 
     For a detailed description of its properties, e.g, its proximal, convex
-    conjugate and more, see [Du+2016]_.
+    conjugate and more, see [Du+2016].
 
     References
     ----------
-    J. Duran, M. Moeller, C. Sbert, and D. Cremers. Collaborative Total
-    Variation: A General Framework for Vectorial TV Models, SIAM Journal of
-    Imaging Sciences 9(1): 116--151, 2016.
+    [Du+2016] J. Duran, M. Moeller, C. Sbert, and D. Cremers.
+    *Collaborative Total Variation: A General Framework for Vectorial TV
+    Models* SIAM Journal of Imaging Sciences 9(1): 116--151, 2016.
     """
 
     def __init__(self, space, outer_exp=1, singular_vector_exp=2):
@@ -2092,13 +2105,13 @@ class IndicatorNuclearNormUnitBall(Functional):
     norm, that is, 0 if the nuclear norm is less than 1, and infinity else.
 
     For a detailed description of its properties, e.g, its proximal, convex
-    conjugate and more, see [Du+2016]_.
+    conjugate and more, see [Du+2016].
 
     References
     ----------
-    J. Duran, M. Moeller, C. Sbert, and D. Cremers. Collaborative Total
-    Variation: A General Framework for Vectorial TV Models, SIAM Journal of
-    Imaging Sciences 9(1): 116--151, 2016.
+    [Du+2016] J. Duran, M. Moeller, C. Sbert, and D. Cremers.
+    *Collaborative Total Variation: A General Framework for Vectorial TV
+    Models* SIAM Journal of Imaging Sciences 9(1): 116--151, 2016.
     """
 
     def __init__(self, space, outer_exp=1, singular_vector_exp=2):

--- a/odl/solvers/functional/functional.py
+++ b/odl/solvers/functional/functional.py
@@ -136,15 +136,19 @@ class Functional(Operator):
 
         The concept is also known as the Legendre transformation.
 
-        References
-        ----------
-        Wikipedia article on `Convex conjugate
-        <https://en.wikipedia.org/wiki/Convex_conjugate>`_.
-
-        Wikipedia article on `Legendre transformation
+        For literature references see, e.g., [Lue1969], [Roc1970], the
+        wikipedia article on `Convex conjugate
+        <https://en.wikipedia.org/wiki/Convex_conjugate>`_ or the wikipedia
+        article on the `Legendre transformation
         <https://en.wikipedia.org/wiki/Legendre_transformation>`_.
 
-        For literature references see, e.g., [Lue1969]_, [Roc1970]_.
+        References
+        ----------
+        [Lue1969] Luenberger, D G. *Optimization by vector space methods*.
+        Wiley, 1969.
+
+        [Roc1970] Rockafellar, R. T. *Convex analysis*. Princeton
+        University Press, 1970.
         """
         return FunctionalDefaultConvexConjugate(self)
 
@@ -794,7 +798,14 @@ class FunctionalTranslation(Functional):
         .. math::
             (f( . - y))^* (x) = f^*(x) + <y, x>.
 
-        For reference on the identity used, see [KP2015]_.
+        For reference on the identity used, see [KP2015].
+
+        References
+        ----------
+        [KP2015] Komodakis, N, and Pesquet, J-C. *Playing with Duality: An
+        overview of recent primal-dual approaches for solving large-scale
+        optimization problems*. IEEE Signal Processing Magazine, 32.6 (2015),
+        pp 31--54.
         """
         return FunctionalLinearPerturb(
             self.functional.convex_conj,
@@ -885,7 +896,14 @@ proximal_quadratic_perturbation
         .. math::
             (f(x) + <y, x>)^* (x) = f^*(x - y).
 
-        For reference on the identity used, see [KP2015]_.
+        For reference on the identity used, see [KP2015].
+
+        References
+        ----------
+        [KP2015] Komodakis, N, and Pesquet, J-C. *Playing with Duality: An
+        overview of recent primal-dual approaches for solving large-scale
+        optimization problems*. IEEE Signal Processing Magazine, 32.6 (2015),
+        pp 31--54.
         """
         return self.functional.convex_conj.translated(
             self.linear_term)

--- a/odl/solvers/nonsmooth/chambolle_pock.py
+++ b/odl/solvers/nonsmooth/chambolle_pock.py
@@ -9,8 +9,7 @@
 """First-order primal-dual algorithm developed by Chambolle and Pock.
 
 The Chambolle-Pock algorithm is a flexible method well suited for
-non-smooth convex optimization problems in imaging. It was first
-proposed in [CP2011a]_.
+non-smooth convex optimization problems in imaging.
 """
 
 # Imports for common Python 2/3 codebase
@@ -126,6 +125,15 @@ def chambolle_pock_solver(x, f, g, L, tau, sigma, niter, **kwargs):
     :math:`F((x_1, x_2)) = \|x_1\|_2^2 + \|x_2\|_1`, :math:`G(x)=0`. See the
     examples folder for more information on how to do this.
 
+    For a more detailed documentation see :ref:`chambolle_pock`.
+
+    References on the algorithm can be found in [CP2011a] and [CP2011b].
+
+    This implementation of the CP algorithm is along the lines of
+    [Sid+2012].
+
+    The non-linear case is analyzed in [Val2014].
+
     See Also
     --------
     odl.solvers.nonsmooth.douglas_rachford.douglas_rachford_pd :
@@ -137,20 +145,24 @@ def chambolle_pock_solver(x, f, g, L, tau, sigma, niter, **kwargs):
 
     References
     ----------
-    For a more detailed documentation see :ref:`chambolle_pock`.
+    [CP2011a] Chambolle, A and Pock, T. *A First-Order
+    Primal-Dual Algorithm for Convex Problems with Applications to
+    Imaging*. Journal of Mathematical Imaging and Vision, 40 (2011),
+    pp 120-145.
 
-    References on the Chambolle-Pock algorithm can be found in [CP2011a]_ and
-    [CP2011b]_.
+    [CP2011b] Chambolle, A and Pock, T. *Diagonal
+    preconditioning for first order primal-dual algorithms in convex
+    optimization*. 2011 IEEE International Conference on Computer Vision
+    (ICCV), 2011, pp 1762-1769.
 
-    This implementation of the CP algorithm is along the lines of
-    [Sid+2012]_.
+    [Sid+2012] Sidky, E Y, Jorgensen, J H, and Pan, X.
+    *Convex optimization problem prototyping for image reconstruction in
+    computed tomography with the Chambolle-Pock algorithm*. Physics in
+    Medicine and Biology, 57 (2012), pp 3065-3091.
 
-    For more on convex analysis including convex conjugates and
-    resolvent operators see [Roc1970]_.
-
-    For more on proximal operators and algorithms see [PB2014]_.
-
-    The non-linear case is analyzed in [Val2014]_.
+    [Val2014] Valkonen, T.
+    *A primal-dual hybrid gradient method for non-linear operators with
+    applications to MRI*. Inverse Problems, 30 (2014).
     """
     # Forward operator
     if not isinstance(L, Operator):

--- a/odl/solvers/nonsmooth/douglas_rachford.py
+++ b/odl/solvers/nonsmooth/douglas_rachford.py
@@ -38,6 +38,8 @@ def douglas_rachford_pd(x, f, g, L, tau, sigma, niter,
 
         (g @ l)(x) = inf_y g(y) + l(x - y)
 
+    For references on the algorithm, see algorithm 3.1 in [BH2013].
+
     Parameters
     ----------
     x : `LinearSpaceElement`
@@ -114,7 +116,10 @@ def douglas_rachford_pd(x, f, g, L, tau, sigma, niter,
 
     References
     ----------
-    For references on the algorithm, see algorithm 3.1 in [BH2013]_.
+    [BH2013] Bot, R I, and Hendrich, C. *A Douglas-Rachford type
+    primal-dual method for solving inclusions with mixtures of
+    composite and parallel-sum type monotone operators*. SIAM Journal
+    on Optimization, 23.4 (2013), pp 2541--2565.
     """
 
     # Problem size

--- a/odl/solvers/nonsmooth/forward_backward.py
+++ b/odl/solvers/nonsmooth/forward_backward.py
@@ -93,8 +93,8 @@ def forward_backward_pd(x, f, g, L, h, tau, sigma, niter,
     gradient, :math:`\\eta > 0`.
 
     The optional operators :math:`\\nabla l_i^*` need to be
-    :math:`\\nu_i`-Lipschitz continuous. Note that in the reference
-    [BC2015]_, the condition is formulated as :math:`l_i` being proper, lower
+    :math:`\\nu_i`-Lipschitz continuous. Note that in the paper, the condition
+    is formulated as :math:`l_i` being proper, lower
     semicontinuous, and :math:`\\nu_i^{-1}`-strongly convex, which implies that
     :math:`l_i^*` have :math:`\\nu_i`-Lipschitz continuous gradients.
 
@@ -116,6 +116,10 @@ def forward_backward_pd(x, f, g, L, h, tau, sigma, niter,
     where, if the simpler problem is considered, all :math:`\\nu_i` can be
     considered to be :math:`\\infty`.
 
+    For reference on the forward-backward primal-dual algorithm, see [BC2015].
+
+    For more on proximal operators and algorithms see [PB2014].
+
     See Also
     --------
     odl.solvers.nonsmooth.chambolle_pock.chambolle_pock_solver :
@@ -127,12 +131,12 @@ def forward_backward_pd(x, f, g, L, h, tau, sigma, niter,
 
     References
     ----------
-    For reference on the forward-backward primal-dual algorithm, see [BC2015]_.
+    [BC2015] Bot, R I, and Csetnek, E R. *On the convergence rate of
+    a forward-backward type primal-dual splitting algorithm for convex
+    optimization problems*. Optimization, 64.1 (2015), pp 5--23.
 
-    For more on convex analysis including convex conjugates and
-    resolvent operators see [Roc1970]_.
-
-    For more on proximal operators and algorithms see [PB2014]_.
+    [PB2014] Parikh, N, and Boyd, S. *Proximal Algorithms*.
+    Foundations and Trends in Optimization, 1 (2014), pp 127-239.
     """
 
     # Problem size

--- a/odl/solvers/nonsmooth/proximal_operators.py
+++ b/odl/solvers/nonsmooth/proximal_operators.py
@@ -13,7 +13,13 @@ provided for convenience.
 
 For more details see :ref:`proximal_operators` and references therein. For
 more details on proximal operators including how to evaluate the proximal
-operator of a variety of functions see [PB2014]_. """
+operator of a variety of functions see [PB2014].
+
+References
+----------
+[PB2014] Parikh, N, and Boyd, S. *Proximal Algorithms*.
+Foundations and Trends in Optimization, 1 (2014), pp 127-239.
+"""
 
 # Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
@@ -120,7 +126,15 @@ def proximal_cconj(prox_factory):
     Note that since :math:`(F^*)^* = F`, this can be used to get the proximal
     of the original function from the proximal of the convex conjugate.
 
-    For reference on the Moreau identity, see [CP2011c]_.
+    For reference on the Moreau identity, see [CP2011c].
+
+    References
+    ----------
+    [CP2011c] Combettes, P L, and Pesquet, J-C. *Proximal splitting
+    methods in signal processing.* In:  Bauschke, H H, Burachik, R S,
+    Combettes, P L, Elser, V, Luke, D R, and Wolkowicz, H. Fixed-point
+    algorithms for inverse problems in science and engineering, Springer,
+    2011.
     """
     def cconj_prox_factory(sigma):
         """Create proximal for the dual with a given sigma.
@@ -167,7 +181,15 @@ def proximal_translation(prox_factory, y):
 
     where :math:`y` is the translation, and :math:`\\sigma` is the step size.
 
-    For reference on the identity used, see [CP2011c]_.
+    For reference on the identity used, see [CP2011c].
+
+    References
+    ----------
+    [CP2011c] Combettes, P L, and Pesquet, J-C. *Proximal splitting
+    methods in signal processing.* In:  Bauschke, H H, Burachik, R S,
+    Combettes, P L, Elser, V, Luke, D R, and Wolkowicz, H. Fixed-point
+    algorithms for inverse problems in science and engineering, Springer,
+    2011.
     """
 
     def translation_prox_factory(sigma):
@@ -218,7 +240,15 @@ def proximal_arg_scaling(prox_factory, scaling):
     where :math:`scal` is the scaling parameter, and :math:`\\sigma` is the
     step size.
 
-    For reference on the identity used, see [CP2011c]_.
+    For reference on the identity used, see [CP2011c].
+
+    References
+    ----------
+    [CP2011c] Combettes, P L, and Pesquet, J-C. *Proximal splitting
+    methods in signal processing.* In:  Bauschke, H H, Burachik, R S,
+    Combettes, P L, Elser, V, Luke, D R, and Wolkowicz, H. Fixed-point
+    algorithms for inverse problems in science and engineering, Springer,
+    2011.
     """
 
     scaling = float(scaling)
@@ -283,9 +313,17 @@ def proximal_quadratic_perturbation(prox_factory, a, u=None):
     :math:`u` is the space element defining the linear functional, and
     :math:`\\sigma` is the step size.
 
-    For reference on the identity used, see [CP2011c]_. Note that this identity
+    For reference on the identity used, see [CP2011c]. Note that this identity
     is not the exact one given in the reference, but was recalculated for
     arbitrary step lengths.
+
+    References
+    ----------
+    [CP2011c] Combettes, P L, and Pesquet, J-C. *Proximal splitting
+    methods in signal processing.* In:  Bauschke, H H, Burachik, R S,
+    Combettes, P L, Elser, V, Luke, D R, and Wolkowicz, H. Fixed-point
+    algorithms for inverse problems in science and engineering, Springer,
+    2011.
     """
 
     a = float(a)
@@ -365,7 +403,15 @@ def proximal_composition(proximal, operator, mu):
     The function cannot verify that the operator is unitary, the user needs
     to verify this.
 
-    For reference on the identity used, see [CP2011c]_.
+    For reference on the identity used, see [CP2011c].
+
+    References
+    ----------
+    [CP2011c] Combettes, P L, and Pesquet, J-C. *Proximal splitting
+    methods in signal processing.* In:  Bauschke, H H, Burachik, R S,
+    Combettes, P L, Elser, V, Luke, D R, and Wolkowicz, H. Fixed-point
+    algorithms for inverse problems in science and engineering, Springer,
+    2011.
     """
 
     def proximal_composition_factory(sigma):
@@ -1078,11 +1124,17 @@ def proximal_l1(space, lam=1, g=None, isotropic=False):
         F(x) = \\lambda \| \|x - g\|_2 \|_1
 
     The proximal can be calculated using the Moreau equality (also known as
-    Moreau decomposition or Moreau identity). See for example [BC2011]_.
+    Moreau decomposition or Moreau identity). See for example [BC2011].
 
     See Also
     --------
     proximal_cconj_l1 : proximal for convex conjugate
+
+
+    References
+    ----------
+    [BC2011] Bauschke, H H, and Combettes, P L. *Convex analysis and
+    monotone operator theory in Hilbert spaces*. Springer, 2011.
     """
     # TODO: optimize
     prox_cc_l1 = proximal_cconj_l1(space, lam=lam, g=g, isotropic=isotropic)

--- a/odl/solvers/smooth/gradient.py
+++ b/odl/solvers/smooth/gradient.py
@@ -41,10 +41,10 @@ def steepest_descent(f, x, line_search=1.0, maxiter=1000, tol=1e-16,
     :math:`f(x) = \infty` for :math:`x\\not\\in C`, or by providing a
     ``projection`` function that projects the iterates on :math:`C`.
 
-    The algorithm is described in [BV2004]_, section 9.3--9.4
+    The algorithm is described in [BV2004], section 9.3--9.4
     (`book available online
     <http://stanford.edu/~boyd/cvxbook/bv_cvxbook.pdf>`_),
-    [GNS2009]_, Section 12.2, and wikipedia
+    [GNS2009], Section 12.2, and wikipedia
     `Gradient_descent
     <https://en.wikipedia.org/wiki/Gradient_descent>`_.
 
@@ -74,6 +74,14 @@ def steepest_descent(f, x, line_search=1.0, maxiter=1000, tol=1e-16,
         Optimized solver for the case ``f(x) = ||Ax - b||_2^2``
     odl.solvers.iterative.iterative.conjugate_gradient :
         Optimized solver for the case ``f(x) = x^T Ax - 2 x^T b``
+
+    References
+    ----------
+    [BV2004] Boyd, S, and Vandenberghe, L. *Convex optimization*.
+    Cambridge university press, 2004.
+
+    [GNS2009] Griva, I, Nash, S G, and Sofer, A. *Linear and nonlinear
+    optimization*. Siam, 2009.
     """
     grad = f.gradient
     if x not in grad.domain:

--- a/odl/solvers/smooth/newton.py
+++ b/odl/solvers/smooth/newton.py
@@ -149,10 +149,10 @@ def newtons_method(f, x, line_search=1.0, maxiter=1000, tol=1e-16,
     of finding a root of a function.
 
     The algorithm is well-known and there is a vast literature about it.
-    Among others, the method is described in [BV2004]_, Sections 9.5
+    Among others, the method is described in [BV2004], Sections 9.5
     and 10.2 (`book available online
     <http://stanford.edu/~boyd/cvxbook/bv_cvxbook.pdf>`_),
-    [GNS2009]_,  Section 2.7 for solving nonlinear equations and Section
+    [GNS2009],  Section 2.7 for solving nonlinear equations and Section
     11.3 for its use in minimization, and wikipedia on `Newton's_method
     <https://en.wikipedia.org/wiki/Newton's_method>`_.
 
@@ -189,6 +189,14 @@ def newtons_method(f, x, line_search=1.0, maxiter=1000, tol=1e-16,
         for computing the search direction.
     callback : callable, optional
         Object executing code per iteration, e.g. plotting each iterate
+
+    References
+    ----------
+    [BV2004] Boyd, S, and Vandenberghe, L. *Convex optimization*.
+    Cambridge university press, 2004.
+
+    [GNS2009] Griva, I, Nash, S G, and Sofer, A. *Linear and nonlinear
+    optimization*. Siam, 2009.
     """
     # TODO: update doc
     grad = f.gradient
@@ -265,7 +273,7 @@ def bfgs_method(f, x, line_search=1.0, maxiter=1000, tol=1e-15, num_store=None,
     implementation uses the rank-one BFGS update schema where the
     inverse of the Hessian is recalculated in each iteration.
 
-    The algorithm is described in [GNS2009]_, Section 12.3 and in the
+    The algorithm is described in [GNS2009], Section 12.3 and in the
     `BFGS Wikipedia article
     <https://en.wikipedia.org/wiki/Broyden%E2%80%93Fletcher%E2%80%93\
 Goldfarb%E2%80%93Shanno_algorithm>`_
@@ -293,6 +301,11 @@ Goldfarb%E2%80%93Shanno_algorithm>`_
         Default: Identity on ``f.domain``
     callback : callable, optional
         Object executing code per iteration, e.g. plotting each iterate.
+
+    References
+    ----------
+    [GNS2009] Griva, I, Nash, S G, and Sofer, A. *Linear and nonlinear
+    optimization*. Siam, 2009.
     """
     grad = f.gradient
     if x not in grad.domain:
@@ -370,7 +383,7 @@ def broydens_method(f, x, line_search=1.0, impl='first', maxiter=1000,
 
     using a Newton-type update scheme with approximate Hessian.
 
-    The algorithm is described in [Bro1965]_ and [Kva1991]_, and in a
+    The algorithm is described in [Bro1965] and [Kva1991], and in a
     `Wikipedia article
     <https://en.wikipedia.org/wiki/Broyden's_method>`_.
 
@@ -397,6 +410,15 @@ def broydens_method(f, x, line_search=1.0, impl='first', maxiter=1000,
         Default: Identity on ``f.domain``
     callback : callable, optional
         Object executing code per iteration, e.g. plotting each iterate.
+
+    References
+    ----------
+    [Bro1965] Broyden, C G. *A class of methods for solving nonlinear
+    simultaneous equations*. Mathematics of computation, 33 (1965),
+    pp 577--593.
+
+    [Kva1991] Kvaalen, E. *A faster Broyden method*. BIT Numerical
+    Mathematics 31 (1991), pp 369--372.
     """
     grad = f.gradient
     if x not in grad.domain:

--- a/odl/solvers/util/steplen.py
+++ b/odl/solvers/util/steplen.py
@@ -54,12 +54,20 @@ class BacktrackingLineSearch(LineSearch):
     This methods approximately finds the longest step length fulfilling
     the Armijo-Goldstein condition.
 
-    The line search algorithm is described in [BV2004]_, page 464
+    The line search algorithm is described in [BV2004], page 464
     (`book available online
     <http://stanford.edu/~boyd/cvxbook/bv_cvxbook.pdf>`_) and
-    [GNS2009]_, pages 378--379. See also
+    [GNS2009], pages 378--379. See also
     `Backtracking_line_search
     <https://en.wikipedia.org/wiki/Backtracking_line_search>`_.
+
+    References
+    ----------
+    [BV2004] Boyd, S, and Vandenberghe, L. *Convex optimization*.
+    Cambridge university press, 2004.
+
+    [GNS2009] Griva, I, Nash, S G, and Sofer, A. *Linear and nonlinear
+    optimization*. Siam, 2009.
     """
 
     def __init__(self, function, tau=0.5, discount=0.01, alpha=1.0,

--- a/odl/trafos/util/ft_utils.py
+++ b/odl/trafos/util/ft_utils.py
@@ -421,7 +421,7 @@ def dft_postprocess_data(arr, real_grid, recip_grid, shift, axes,
         for 'shift=True'  : xi_bar[k] = -pi + pi * (2*k) / N
         for 'shift=False' : xi_bar[k] = -pi + pi * (2*k+1) / N
 
-    See [Pre+2007]_, Section 13.9 "Computing Fourier Integrals Using
+    See [Pre+2007], Section 13.9 "Computing Fourier Integrals Using
     the FFT" for a similar approach.
 
     Parameters
@@ -456,6 +456,12 @@ def dft_postprocess_data(arr, real_grid, recip_grid, shift, axes,
     out : `numpy.ndarray`
         Result of the post-processing. If ``out`` was given, the returned
         object is a reference to it.
+
+    References
+    ----------
+    [Pre+2007] Press, W H, Teukolsky, S A, Vetterling, W T, and Flannery, B P.
+    *Numerical Recipes in C - The Art of Scientific Computing* (Volume 3).
+    Cambridge University Press, 2007.
     """
     arr = np.asarray(arr)
     if is_real_floating_dtype(arr.dtype):


### PR DESCRIPTION
Now fixed all of this for the code doc. I guess we maybe want to kill `refs.rst` totally and move all references into the specific files?