### PR TITLE
Vectorize geometries

### DIFF
--- a/odl/tomo/backends/astra_setup.py
+++ b/odl/tomo/backends/astra_setup.py
@@ -322,7 +322,9 @@ def astra_conebeam_2d_geom_to_vec(geometry):
 
     # Center of detector
     mid_pt = geometry.det_params.mid_pt
-    centers = geometry.det_point_position(angles, mid_pt)
+    # Need to cast `mid_pt` to float since otherwise the empty axis is
+    # not removed
+    centers = geometry.det_point_position(angles, float(mid_pt))
     vectors[:, 2:4] = rot_minus_90.dot(centers.T).T
 
     # Vector from detector pixel 0 to 1

--- a/odl/tomo/backends/astra_setup.py
+++ b/odl/tomo/backends/astra_setup.py
@@ -254,7 +254,8 @@ def astra_conebeam_3d_geom_to_vec(geometry):
     vectors[:, 3:6] = geometry.det_point_position(angles, mid_pt)
 
     # Vectors from detector pixel (0, 0) to (1, 0) and (0, 0) to (0, 1)
-    det_axes = geometry.det_axes(angles)
+    # `det_axes` gives shape (N, 2, 3), swap to get (2, N, 3)
+    det_axes = np.moveaxis(geometry.det_axes(angles), -2, 0)
     px_sizes = geometry.det_partition.cell_sides
     # Swap detector axes to have better memory layout in  projection data.
     # ASTRA produces `(v, theta, u)` layout, and to map to ODL layout
@@ -381,7 +382,8 @@ def astra_parallel_3d_geom_to_vec(geometry):
     vectors[:, 3:6] = geometry.det_point_position(angles, mid_pt)
 
     # Vectors from detector pixel (0, 0) to (1, 0) and (0, 0) to (0, 1)
-    det_axes = geometry.det_axes(angles)
+    # `det_axes` gives shape (N, 2, 3), swap to get (2, N, 3)
+    det_axes = np.moveaxis(geometry.det_axes(angles), -2, 0)
     px_sizes = geometry.det_partition.cell_sides
     # Swap detector axes to have better memory layout in  projection data.
     # ASTRA produces `(v, theta, u)` layout, and to map to ODL layout

--- a/odl/tomo/backends/astra_setup.py
+++ b/odl/tomo/backends/astra_setup.py
@@ -50,7 +50,8 @@ import numpy as np
 
 from odl.discr import DiscreteLp, DiscreteLpElement
 from odl.tomo.geometry import (
-    Geometry, DivergentBeamGeometry, ParallelBeamGeometry, FlatDetector)
+    Geometry, DivergentBeamGeometry, ParallelBeamGeometry,
+    Flat1dDetector, Flat2dDetector)
 from odl.tomo.util.utility import euler_matrix
 
 
@@ -427,7 +428,7 @@ def astra_projection_geometry(geometry):
         raise ValueError('non-uniform detector sampling is not supported')
 
     if (isinstance(geometry, ParallelBeamGeometry) and
-            isinstance(geometry.detector, FlatDetector) and
+            isinstance(geometry.detector, (Flat1dDetector, Flat2dDetector)) and
             geometry.ndim == 2):
         # TODO: change to parallel_vec when available
         det_width = geometry.det_partition.cell_sides[0]
@@ -440,14 +441,14 @@ def astra_projection_geometry(geometry):
                                            angles)
 
     elif (isinstance(geometry, DivergentBeamGeometry) and
-          isinstance(geometry.detector, FlatDetector) and
+          isinstance(geometry.detector, (Flat1dDetector, Flat2dDetector)) and
           geometry.ndim == 2):
         det_count = geometry.detector.size
         vec = astra_conebeam_2d_geom_to_vec(geometry)
         proj_geom = astra.create_proj_geom('fanflat_vec', det_count, vec)
 
     elif (isinstance(geometry, ParallelBeamGeometry) and
-          isinstance(geometry.detector, FlatDetector) and
+          isinstance(geometry.detector, (Flat1dDetector, Flat2dDetector)) and
           geometry.ndim == 3):
         # Swap detector axes (see astra_*_3d_to_vec)
         det_row_count = geometry.det_partition.shape[0]
@@ -457,7 +458,7 @@ def astra_projection_geometry(geometry):
                                            det_col_count, vec)
 
     elif (isinstance(geometry, DivergentBeamGeometry) and
-          isinstance(geometry.detector, FlatDetector) and
+          isinstance(geometry.detector, (Flat1dDetector, Flat2dDetector)) and
           geometry.ndim == 3):
         # Swap detector axes (see astra_*_3d_to_vec)
         det_row_count = geometry.det_partition.shape[0]

--- a/odl/tomo/geometry/conebeam.py
+++ b/odl/tomo/geometry/conebeam.py
@@ -182,7 +182,10 @@ class FanFlatGeometry(DivergentBeamGeometry):
 
         # Initialize stuff
         self.__src_to_det_init = src_to_det_init
-        detector = Flat1dDetector(dpart, det_axis_init)
+        # `check_bounds` is needed for both detector and geometry
+        check_bounds = kwargs.get('check_bounds', True)
+        detector = Flat1dDetector(dpart, axis=det_axis_init,
+                                  check_bounds=check_bounds)
         translation = kwargs.pop('translation', None)
         super(FanFlatGeometry, self).__init__(
             ndim=2, motion_part=apart, detector=detector,
@@ -759,7 +762,10 @@ class ConeFlatGeometry(DivergentBeamGeometry, AxisOrientedGeometry):
         # Initialize stuff
         self.__src_to_det_init = src_to_det_init
         AxisOrientedGeometry.__init__(self, axis)
-        detector = Flat2dDetector(dpart, det_axes_init)
+        # `check_bounds` is needed for both detector and geometry
+        check_bounds = kwargs.get('check_bounds', True)
+        detector = Flat2dDetector(dpart, axes=det_axes_init,
+                                  check_bounds=check_bounds)
         super(ConeFlatGeometry, self).__init__(
             ndim=3, motion_part=apart, detector=detector, **kwargs)
 

--- a/odl/tomo/geometry/conebeam.py
+++ b/odl/tomo/geometry/conebeam.py
@@ -745,11 +745,16 @@ class ConeFlatGeometry(DivergentBeamGeometry, AxisOrientedGeometry):
 
         # Check and normalize `src_to_det_init`. Detector axes are
         # normalized in the detector class.
-        if np.linalg.norm(src_to_det_init) <= 1e-10:
-            raise ValueError('`src_to_det_init` norm {} too close to 0'
-                             ''.format(np.linalg.norm(src_to_det_init)))
+        if np.linalg.norm(src_to_det_init) == 0:
+            raise ValueError('`src_to_det_init` cannot be zero')
         else:
             src_to_det_init /= np.linalg.norm(src_to_det_init)
+
+        # Get stuff out of kwargs, otherwise upstream code complains
+        # about unknown parameters (rightly so)
+        self.__pitch = float(pitch)
+        self.__offset_along_axis = float(kwargs.pop('offset_along_axis', 0))
+        self.__src_radius = float(src_radius)
 
         # Initialize stuff
         self.__src_to_det_init = src_to_det_init
@@ -758,9 +763,7 @@ class ConeFlatGeometry(DivergentBeamGeometry, AxisOrientedGeometry):
         super(ConeFlatGeometry, self).__init__(
             ndim=3, motion_part=apart, detector=detector, **kwargs)
 
-        self.__pitch = float(pitch)
-        self.__offset_along_axis = float(kwargs.pop('offset_along_axis', 0))
-        self.__src_radius = float(src_radius)
+        # Check parameters
         if self.src_radius < 0:
             raise ValueError('source circle radius {} is negative'
                              ''.format(src_radius))

--- a/odl/tomo/geometry/conebeam.py
+++ b/odl/tomo/geometry/conebeam.py
@@ -333,7 +333,7 @@ class FanFlatGeometry(DivergentBeamGeometry):
     def src_position(self, angle):
         """Return the source position at ``angle``.
 
-        For an angle ``phi``, the source position is given by::
+        For an angle ``phi``, the source position is given by ::
 
             src(phi) = translation +
                        rot_matrix(phi) * (-src_rad * src_to_det_init)
@@ -520,7 +520,7 @@ class FanFlatGeometry(DivergentBeamGeometry):
     def __getitem__(self, indices):
         """Return self[indices].
 
-        This is defined by::
+        This is defined by ::
 
             self[indices].partition == self.partition[indices]
 
@@ -949,27 +949,26 @@ class ConeFlatGeometry(DivergentBeamGeometry, AxisOrientedGeometry):
             Unit vectors along which the detector is aligned.
             If ``angle`` is a single parameter, the returned array has
             shape ``(2, 3)``, otherwise
-            ``(2,) + broadcast(*angles).shape + (3,)``.
-            The first axis of length 2 enumerates the detector axes.
+            ``broadcast(*angles).shape + (2, 3)``.
 
         Notes
         -----
-        To get an array that enumerates axis pairs, move the first axis
-        of the array to the second-to-last position::
+        To get an array that enumerates the detector axes in the first
+        dimension, move the second-to-last axis to the first position:
 
             axes = det_axes(angle)
-            axes_enumeration = np.moveaxis(deriv, 0, -2)
+            axes_enumeration = np.moveaxis(deriv, -2, 0)
         """
         # Transpose to take dot along axis 1
         axes = self.rotation_matrix(angle).dot(self.det_axes_init.T)
         # `axes` has shape (a, 3, 2), need to roll the last dimensions
-        # to the first place
-        return np.rollaxis(axes, -1, 0)
+        # to the second-to-last place
+        return np.rollaxis(axes, -1, -2)
 
     def det_refpoint(self, angle):
         """Return the detector reference point position at ``angle``.
 
-        For an angle ``phi``, the detector position is given by::
+        For an angle ``phi``, the detector position is given by ::
 
             det_ref(phi) = translation +
                            rot_matrix(phi) * (det_rad * src_to_det_init) +
@@ -1055,7 +1054,7 @@ class ConeFlatGeometry(DivergentBeamGeometry, AxisOrientedGeometry):
     def src_position(self, angle):
         """Return the source position at ``angle``.
 
-        For an angle ``phi``, the source position is given by::
+        For an angle ``phi``, the source position is given by ::
 
             src(phi) = translation +
                        rot_matrix(phi) * (-src_rad * src_to_det_init) +
@@ -1172,7 +1171,7 @@ class ConeFlatGeometry(DivergentBeamGeometry, AxisOrientedGeometry):
     def __getitem__(self, indices):
         """Return self[indices].
 
-        This is defined by::
+        This is defined by ::
 
             self[indices].partition == self.partition[indices]
 

--- a/odl/tomo/geometry/conebeam.py
+++ b/odl/tomo/geometry/conebeam.py
@@ -17,7 +17,8 @@ from odl.discr import uniform_partition
 from odl.tomo.geometry.detector import Flat1dDetector, Flat2dDetector
 from odl.tomo.geometry.geometry import (
     DivergentBeamGeometry, AxisOrientedGeometry)
-from odl.tomo.util.utility import euler_matrix, transform_system
+from odl.tomo.util.utility import (
+    euler_matrix, transform_system, is_inside_bounds)
 from odl.util import signature_string, indent_rows
 
 
@@ -484,8 +485,7 @@ class FanFlatGeometry(DivergentBeamGeometry):
         squeeze_out = (np.shape(angle) == ())
         angle = np.array(angle, dtype=float, copy=False, ndmin=1)
         if (self.check_bounds and
-                not self.motion_params.contains_all(angle.ravel())):
-            # Allow `angle` with ndim > 1 by checking the raveled array
+                not is_inside_bounds(angle, self.motion_params)):
             raise ValueError('`angle` {} not in the valid range {}'
                              ''.format(angle, self.motion_params))
 

--- a/odl/tomo/geometry/conebeam.py
+++ b/odl/tomo/geometry/conebeam.py
@@ -346,7 +346,7 @@ class FanFlatGeometry(DivergentBeamGeometry):
 
         Returns
         -------
-        pos : `numpy.ndarray`, shape (2,) or (num_params, 2)
+        pos : `numpy.ndarray`, shape (2,) or (num_angles, 2)
             Vector(s) pointing from the origin to the source.
             If ``angle`` is a single parameter, a single vector
             is returned, otherwise a stack of vectors along axis 0.
@@ -410,7 +410,7 @@ class FanFlatGeometry(DivergentBeamGeometry):
 
         Returns
         -------
-        point : `numpy.ndarray`, shape (2,) or (num_params, 2)
+        point : `numpy.ndarray`, shape (2,) or (num_angles, 2)
             Vector(s) pointing from the origin to the detector reference
             point. If ``angle`` is a single parameter, a single vector
             is returned, otherwise a stack of vectors along axis 0.
@@ -471,7 +471,7 @@ class FanFlatGeometry(DivergentBeamGeometry):
 
         Returns
         -------
-        rot : `numpy.ndarray`, shape (2, 2) or (num_params, 2, 2)
+        rot : `numpy.ndarray`, shape (2, 2) or (num_angles, 2, 2)
             The rotation matrix (or matrices) mapping vectors at the
             initial state to the ones in the state defined by ``angle``.
             The rotation is extrinsic, i.e., defined in the "world"
@@ -944,7 +944,7 @@ class ConeFlatGeometry(DivergentBeamGeometry, AxisOrientedGeometry):
             of shape ``(3,)`` is returned, each of which stands for
             a detector axis.
             For multiple angle parameters, the tuple contains 2 arrays
-            of shape ``(num_params, 3)``, i.e., a stack of the respective
+            of shape ``(num_angles, 3)``, i.e., a stack of the respective
             vectors along array axis 0.
 
         Notes
@@ -977,7 +977,7 @@ class ConeFlatGeometry(DivergentBeamGeometry, AxisOrientedGeometry):
 
         Returns
         -------
-        refpt : `numpy.ndarray`, shape (3,) or (num_params, 3)
+        refpt : `numpy.ndarray`, shape (3,) or (num_angles, 3)
             Vector(s) pointing from the origin to the detector reference
             point at ``angle``.
             If ``angle`` is a single parameter, a single vector is
@@ -1052,7 +1052,7 @@ class ConeFlatGeometry(DivergentBeamGeometry, AxisOrientedGeometry):
 
         Returns
         -------
-        pos : `numpy.ndarray`, shape (3,) or (num_params, 3)
+        pos : `numpy.ndarray`, shape (3,) or (num_angles, 3)
             Vector(s) pointing from the origin to the source position
             at ``angle``.
             If ``angle`` is a single parameter, a single vector is

--- a/odl/tomo/geometry/detector.py
+++ b/odl/tomo/geometry/detector.py
@@ -19,7 +19,8 @@ from odl.tomo.util.utility import perpendicular_vector
 from odl.util import indent_rows, signature_string
 
 
-__all__ = ('Detector', 'FlatDetector', 'Flat1dDetector', 'Flat2dDetector',
+__all__ = ('Detector',
+           'Flat1dDetector', 'Flat2dDetector',
            'CircleSectionDetector')
 
 
@@ -147,33 +148,7 @@ class Detector(object):
             raise NotImplementedError('not implemented for ndim >= 3')
 
 
-class FlatDetector(Detector):
-
-    """Abstract class for flat detectors in 2 and 3 dimensions."""
-
-    def surface_measure(self, param=None):
-        """Constant density function of the surface measure.
-
-        Parameters
-        ----------
-        param : `params` element, optional
-            Parameter value where to evaluate the function
-
-        Returns
-        -------
-        measure : float
-            Constant density 1.0
-        """
-        if param not in self.params:
-            raise ValueError('`param` {} not in the valid range '
-                             '{}'.format(param, self.params))
-        # TODO: apart from being constant, there is no big simplification
-        # in this method compared to parent. Consider removing FlatDetector
-        # altogether.
-        return super(FlatDetector, self).surface_measure(self.params.min_pt)
-
-
-class Flat1dDetector(FlatDetector):
+class Flat1dDetector(Detector):
 
     """A 1d line detector aligned with ``axis``."""
 
@@ -269,7 +244,7 @@ class Flat1dDetector(FlatDetector):
         return repr(self)
 
 
-class Flat2dDetector(FlatDetector):
+class Flat2dDetector(Detector):
 
     """A 2d flat panel detector aligned with ``axes``."""
 

--- a/odl/tomo/geometry/detector.py
+++ b/odl/tomo/geometry/detector.py
@@ -622,9 +622,9 @@ class CircleSectionDetector(Detector):
     def surface(self, param):
         """Return the detector surface point corresponding to ``param``.
 
-        The surface point lies on a circle around ``radius * center_dir``
-        through the origin. More precisely, for a parameter ``phi``, the
-        returned point is given by ::
+        The surface point lies on a circle around `center` through the
+        origin. More precisely, for a parameter ``phi``, the returned
+        point is given by ::
 
             surf = radius * ((1 - cos(phi)) * center_dir +
                              sin(phi) * tangent_at_0)

--- a/odl/tomo/geometry/detector.py
+++ b/odl/tomo/geometry/detector.py
@@ -40,14 +40,17 @@ class Detector(object):
     this behavior.
     """
 
-    def __init__(self, partition, check_bounds=True):
+    def __init__(self, partition, space_ndim=None, check_bounds=True):
         """Initialize a new instance.
 
         Parameters
         ----------
         partition : `RectPartition`
-           Partition of the detector parameter set (pixelization).
-           It determines dimension, parameter range and discretization.
+            Partition of the detector parameter set (pixelization).
+            It determines dimension, parameter range and discretization.
+        space_ndim : positive int, optional
+            Number of dimensions of the embedding space.
+            Default: ``partition.ndim + 1``
         check_bounds : bool, optional
             If ``True``, methods computing vectors check input arguments.
             Checks are vectorized and add only a small overhead.
@@ -55,6 +58,14 @@ class Detector(object):
         if not isinstance(partition, RectPartition):
             raise TypeError('`partition` {!r} is not a RectPartition instance'
                             ''.format(partition))
+
+        if space_ndim is None:
+            self.__space_ndim = partition.ndim + 1
+        else:
+            self.__space_ndim = int(space_ndim)
+            if self.space_ndim <= 0:
+                raise ValueError('`space_ndim` must be postitive, got {}'
+                                 ''.format(space_ndim))
 
         self.__partition = partition
         self.__check_bounds = bool(check_bounds)
@@ -85,7 +96,7 @@ class Detector(object):
         This default (``space_ndim = ndim + 1``) can be overridden by
         subclasses.
         """
-        return self.ndim + 1
+        return self.__space_ndim
 
     @property
     def params(self):
@@ -244,7 +255,7 @@ class Detector(object):
 
 class Flat1dDetector(Detector):
 
-    """A 1d line detector aligned with a given axis."""
+    """A 1d line detector aligned with a given axis in 2D space."""
 
     def __init__(self, partition, axis, check_bounds=True):
         """Initialize a new instance.
@@ -269,7 +280,7 @@ class Flat1dDetector(Detector):
         >>> np.allclose(det.surface_normal(0), [0, -1])
         True
         """
-        super(Flat1dDetector, self).__init__(partition, check_bounds)
+        super(Flat1dDetector, self).__init__(partition, 2, check_bounds)
         if self.ndim != 1:
             raise ValueError('`partition` must be 1-dimensional, got ndim={}'
                              ''.format(self.ndim))
@@ -405,7 +416,7 @@ class Flat1dDetector(Detector):
 
 class Flat2dDetector(Detector):
 
-    """A 2d flat panel detector aligned two given axes."""
+    """A 2D flat panel detector aligned two given axes in 3D space."""
 
     def __init__(self, partition, axes, check_bounds=True):
         """Initialize a new instance.
@@ -433,7 +444,7 @@ class Flat2dDetector(Detector):
         >>> det.surface_normal([0, 0])
         array([ 0., -1.,  0.])
         """
-        super(Flat2dDetector, self).__init__(partition, check_bounds)
+        super(Flat2dDetector, self).__init__(partition, 3, check_bounds)
         if self.ndim != 2:
             raise ValueError('`partition` must be 2-dimensional, got ndim={}'
                              ''.format(self.ndim))
@@ -620,7 +631,7 @@ class Flat2dDetector(Detector):
 
 class CircleSectionDetector(Detector):
 
-    """A 1d detector given by a circle section that crosses the origin.
+    """A 1D detector on a circle section crossing the origin in 2D space.
 
     The parametrization is chosen such that parameter (=angle) 0
     corresponds to the origin. Negative param correspond to points
@@ -657,7 +668,7 @@ class CircleSectionDetector(Detector):
         >>> det.tangent_at_0
         array([ 1.,  0.])
         """
-        super(CircleSectionDetector, self).__init__(partition, check_bounds)
+        super(CircleSectionDetector, self).__init__(partition, 2, check_bounds)
         if self.ndim != 1:
             raise ValueError('`partition` must be 1-dimensional, got ndim={}'
                              ''.format(self.ndim))

--- a/odl/tomo/geometry/detector.py
+++ b/odl/tomo/geometry/detector.py
@@ -36,41 +36,34 @@ class Detector(object):
     * optionally a surface measure function.
     """
 
-    def __init__(self, part):
+    def __init__(self, partition, check_bounds=True):
         """Initialize a new instance.
 
         Parameters
         ----------
-        part : `RectPartition`
+        partition : `RectPartition`
            Partition of the detector parameter set (pixelization).
            It determines dimension, parameter range and discretization.
+        check_bounds : bool, optional
+            If ``True``, methods perform sanity checks on provided input
+            parameters.
         """
-        if not isinstance(part, RectPartition):
-            raise TypeError('`part` {!r} is not a RectPartition instance'
-                            ''.format(part))
+        if not isinstance(partition, RectPartition):
+            raise TypeError('`partition` {!r} is not a RectPartition instance'
+                            ''.format(partition))
 
-        self.__partition = part
-
-    def surface(self, param):
-        """Parametrization of the detector reference surface.
-
-        Parameters
-        ----------
-        param : `params` element
-            Parameter value where to evaluate the function.
-
-        Returns
-        -------
-        point :
-            Spatial location of the detector point corresponding to
-            ``param``.
-        """
-        raise NotImplementedError('abstract method')
+        self.__partition = partition
+        self.__check_bounds = bool(check_bounds)
 
     @property
     def partition(self):
         """Partition of the detector parameter set into subsets."""
         return self.__partition
+
+    @property
+    def check_bounds(self):
+        """Whether to check if method parameters are in the valid range."""
+        return self.__check_bounds
 
     @property
     def ndim(self):
@@ -97,21 +90,82 @@ class Detector(object):
         """Total number of pixels."""
         return self.partition.size
 
+    def surface(self, param):
+        """Parametrization of the detector reference surface.
+
+        Parameters
+        ----------
+        param : `array-like`
+            Parameter value(s) at which to evaluate. An array should
+            stack parameters along axis 0.
+
+        Returns
+        -------
+        point : `numpy.ndarray`, shape (ndim,) or (num_params, ndim)
+            Vector(s) pointing from the origin to the detector surface
+            point at ``param``.
+            If ``param`` is a single parameter, a single vector is
+            returned, otherwise a stack of vectors along axis 0.
+        """
+        raise NotImplementedError('abstract method')
+
     def surface_deriv(self, param):
         """Partial derivative(s) of the surface parametrization.
 
         Parameters
         ----------
-        param : `params` element
-            Parameter value where to evaluate the function.
+        param : `array-like`
+            Parameter value(s) at which to evaluate. An array should
+            stack parameters along axis 0.
 
         Returns
         -------
-        deriv :
-            Vector (``ndim=1``) or sequence of vectors corresponding
-            to the partial derivatives at ``param``.
+        deriv : `numpy.ndarray` or tuple
+            If `ndim` is 1, an array of shape ``(ndim,)`` is returned if
+            ``param`` is a single parameter, and an array of shape
+            ``(num_params, ndim)`` for multiple parameters.
+
+            For higher `ndim`, a tuple of length `ndim` is returned,
+            where each entry is as described for the 1D case. The
+            i-th entry corresponds to the i-th partial derivative.
         """
         raise NotImplementedError('abstract method')
+
+    def surface_normal(self, param):
+        """Unit vector perpendicular to the detector surface at ``param``.
+
+        The orientation is chosen as follows:
+
+            - In 2D, the system ``(normal, tangent)`` should be
+              right-handed.
+            - In 3D, the system ``(tangent[0], tangent[1], normal)``
+              should be right-handed.
+
+        Here, ``tangent`` is the return value of `surface_deriv` at
+        ``param``.
+
+        Parameters
+        ----------
+        param : float or `array-like`
+            Parameter value(s) at which to evaluate. An array should stack
+            parameters along axis 0.
+
+        Returns
+        -------
+        normal : `numpy.ndarray`, shape (2,) or (num_params, 2)
+            Unit vector(s) perpendicular to the detector surface at
+            ``param``.
+            If ``param`` is a single parameter, a single vector is
+            returned, otherwise a stack of vectors along axis 0.
+        """
+        if self.ndim == 1:
+            return -perpendicular_vector(self.surface_deriv(param))
+        elif self.ndim == 2:
+            normal = np.cross(*self.surface_deriv(param), axis=-1)
+            normal /= np.linalg.norm(normal, axis=-1, keepdims=True)
+            return normal
+        else:
+            raise NotImplementedError('normal not defined for ndim >= 3')
 
     def surface_measure(self, param):
         """Density function of the surface measure.
@@ -124,120 +178,187 @@ class Detector(object):
 
         Parameters
         ----------
-        param : `params` element
-            Parameter value where to evaluate the function.
+        param : `array-like`
+            Parameter value(s) at which to evaluate. An array should
+            stack parameters along axis 0.
 
         Returns
         -------
-        measure : float
-            The density value at the given parameter.
+        measure : float or `numpy.ndarray`
+            The density value(s) at the given parameter(s).
 
         .. _Arc length:
             https://en.wikipedia.org/wiki/Curve#Lengths_of_curves
         .. _Surface area:
             https://en.wikipedia.org/wiki/Surface_area
         """
-        if param not in self.params:
-            raise ValueError('`param` {} not in the valid range {}'
-                             ''.format(param, self.params))
         if self.ndim == 1:
-            return float(np.linalg.norm(self.surface_deriv(param)))
+            scalar_out = np.isscalar(param)
+            measure = np.linalg.norm(self.surface_deriv(param), axis=-1)
+            if scalar_out:
+                measure = float(measure)
+
+            return measure
+
         elif self.ndim == 2:
-            return float(np.linalg.norm(np.cross(*self.surface_deriv(param))))
+            scalar_out = (np.shape(param) == (2,))
+            deriv = self.surface_deriv(param)
+            cross = np.cross(*deriv, axis=-1)
+            measure = np.linalg.norm(cross, axis=-1)
+            if scalar_out:
+                measure = float(measure)
+
+            return measure
+
         else:
             raise NotImplementedError('not implemented for ndim >= 3')
 
 
 class Flat1dDetector(Detector):
 
-    """A 1d line detector aligned with ``axis``."""
+    """A 1d line detector aligned with a given axis."""
 
-    def __init__(self, part, axis):
+    def __init__(self, partition, axis, check_bounds=True):
         """Initialize a new instance.
 
         Parameters
         ----------
-        part : 1-dim. `RectPartition`
+        partition : 1-dim. `RectPartition`
             Partition of the parameter interval, corresponding to the
             line elements.
         axis : `array-like`, shape ``(2,)``
-            Principal axis of the detector.
-        """
-        super(Flat1dDetector, self).__init__(part)
-        if self.ndim != 1:
-            raise ValueError('expected partition to have 1 dimension, '
-                             'got {}'.format(self.ndim))
+            Fixed axis along which this detector is aligned.
+        check_bounds : bool, optional
+            If ``True``, methods perform sanity checks on provided input
+            parameters.
 
-        if np.linalg.norm(axis) <= 1e-10:
-            raise ValueError('`axis` vector {} too close to zero'
-                             ''.format(axis))
+        Examples
+        --------
+        >>> part = odl.uniform_partition(0, 1, 10)
+        >>> det = Flat1dDetector(part, axis=[1, 0])
+        >>> det.axis
+        array([ 1.,  0.])
+        >>> np.allclose(det.surface_normal(0), [0, -1])
+        True
+        """
+        super(Flat1dDetector, self).__init__(partition, check_bounds)
+        if self.ndim != 1:
+            raise ValueError('`partition` must be 1-dimensional, got ndim={}'
+                             ''.format(self.ndim))
+
+        if np.linalg.norm(axis) == 0:
+            raise ValueError('`axis` cannot be zero')
         self.__axis = np.asarray(axis) / np.linalg.norm(axis)
-        # Let (normal, axis) be positively oriented since the normal will
-        # be the basis for det_to_src.
-        self.__normal = -perpendicular_vector(self.axis)
 
     @property
     def axis(self):
-        """Normalized principal axis of the detector."""
+        """Fixed axis along which this detector is aligned."""
         return self.__axis
 
-    @property
-    def normal(self):
-        """Unit vector perpendicular to the detector.
-
-        Its orientation is chosen such that the system ``axis, normal``
-        is right-handed.
-        """
-        return self.__normal
-
     def surface(self, param):
-        """Parametrization of the (1d) detector reference surface.
+        """Return the detector surface point corresponding to ``param``.
 
-        The reference line segment is chosen to be aligned with the
-        second coordinate axis, such that the parameter value 0 results
-        in the reference point (0, 0).
+        For parameter value ``p``, the surface point is given by ::
+
+            surf = p * axis
 
         Parameters
         ----------
-        param : `params` element
-            Parameter value where to evaluate the function.
+        param : float or `array-like`
+            Parameter value(s) at which to evaluate.
 
         Returns
         -------
-        point : `numpy.ndarray`, shape (2,)
-            The point on the detector surface corresponding to the
-            given parameters.
+        point : `numpy.ndarray`, shape (2,) or (num_params, 2)
+            Vector(s) pointing from the origin to the detector surface
+            point at ``param``.
+            If ``param`` is a single parameter, a single vector is
+            returned, otherwise a stack of vectors along axis 0.
+
+        Examples
+        --------
+        The method works with a single parameter, resulting in a single
+        vector:
+
+        >>> part = odl.uniform_partition(0, 1, 10)
+        >>> det = Flat1dDetector(part, axis=[1, 0])
+        >>> det.surface(0)
+        array([ 0.,  0.])
+        >>> det.surface(1)
+        array([ 1.,  0.])
+
+        It is also vectorized, i.e., it can be called with multiple
+        parameters at once:
+
+        >>> det.surface([0, 1])
+        array([[ 0.,  0.],
+               [ 1.,  0.]])
         """
-        param = float(param)
-        if param not in self.params:
+        squeeze_out = np.isscalar(param)
+        param = np.array(param, dtype=float, copy=False, ndmin=1)
+        if self.check_bounds and not self.params.contains_all(param):
             raise ValueError('`param` {} not in the valid range '
                              '{}'.format(param, self.params))
-        return self.axis * param
+        surf = param[:, None] * self.axis[None, :]
+        if squeeze_out:
+            surf = surf.squeeze()
+
+        return surf
 
     def surface_deriv(self, param=None):
-        """Derivative of the surface parametrization.
+        """Return the surface derivative at ``param``.
+
+        This is a constant function evaluating to `axis` everywhere.
 
         Parameters
         ----------
-        param : `params` element, optional
-            Parameter value where to evaluate the function.
+        param : float or `array-like`
+            Parameter value(s) at which to evaluate.
 
         Returns
         -------
-        derivative : `numpy.ndarray`, shape (2,)
-            The constant derivative.
+        deriv : `numpy.ndarray`, shape (2,) or (num_params, 2)
+            Vector(s) representing the detector surface derivative at
+            ``param``.
+            If ``param`` is a single parameter, a single vector is
+            returned, otherwise a stack of vectors along axis 0.
+
+        Examples
+        --------
+        The method works with a single parameter, resulting in a single
+        vector:
+
+        >>> part = odl.uniform_partition(0, 1, 10)
+        >>> det = Flat1dDetector(part, axis=[1, 0])
+        >>> det.surface_deriv(0)
+        array([ 1.,  0.])
+        >>> det.surface_deriv(1)
+        array([ 1.,  0.])
+
+        It is also vectorized, i.e., it can be called with multiple
+        parameters at once:
+
+        >>> det.surface_deriv([0, 1])
+        array([[ 1.,  0.],
+               [ 1.,  0.]])
         """
-        if param is not None and param not in self.params:
+        squeeze_out = np.isscalar(param)
+        param = np.array(param, dtype=float, copy=False, ndmin=1)
+        if self.check_bounds and not self.params.contains_all(param):
             raise ValueError('`param` {} not in the valid range '
                              '{}'.format(param, self.params))
-        return self.axis
+        if squeeze_out:
+            return self.axis
+        else:
+            return np.vstack([self.axis] * len(param))
 
     def __repr__(self):
         """Return ``repr(self)``."""
-        posargs = [self.partition, self.axis]
-        inner_str = signature_string(posargs, [], sep=[',\n', ', ', ', '])
-        return '{}({})'.format(self.__class__.__name__,
-                               indent_rows(inner_str))
+        posargs = [self.partition]
+        optargs = [('axis', self.axis.tolist(), None)]
+        inner_str = signature_string(posargs, optargs, sep=',\n')
+        return '{}(\n{}\n)'.format(self.__class__.__name__,
+                                   indent_rows(inner_str))
 
     def __str__(self):
         """Return ``str(self)``."""
@@ -246,208 +367,439 @@ class Flat1dDetector(Detector):
 
 class Flat2dDetector(Detector):
 
-    """A 2d flat panel detector aligned with ``axes``."""
+    """A 2d flat panel detector aligned two given axes."""
 
-    def __init__(self, part, axes):
+    def __init__(self, partition, axes, check_bounds=True):
         """Initialize a new instance.
 
         Parameters
         ----------
-        part : 2-dim. `RectPartition`
-            Partition of the parameter interval, corresponding to the
+        partition : 2-dim. `RectPartition`
+            Partition of the parameter rectangle, corresponding to the
             pixels.
-        axes : 2-tuple of `array-like`'s (shape ``(3,)``)
-            Principal axes of the detector, e.g.
-            ``[(0, 1, 0), (0, 0, 1)]``.
+        axes : sequence of `array-like`'s
+            Fixed pair of of unit vectors with which the detector is aligned.
+            The vectors must have shape ``(3,)`` and be linearly
+            independent.
+        check_bounds : bool, optional
+            If ``True``, methods perform sanity checks on provided input
+            parameters.
+
+        Examples
+        --------
+        >>> part = odl.uniform_partition([0, 0], [1, 1], (10, 10))
+        >>> det = Flat2dDetector(part, axes=[(1, 0, 0), (0, 0, 1)])
+        >>> det.axes
+        (array([ 1.,  0.,  0.]), array([ 0.,  0.,  1.]))
+        >>> det.surface_normal([0, 0])
+        array([ 0., -1.,  0.])
         """
-        super(Flat2dDetector, self).__init__(part)
+        super(Flat2dDetector, self).__init__(partition, check_bounds)
         if self.ndim != 2:
-            raise ValueError('expected partition to have 2 dimensions, '
-                             'got {}'.format(self.ndim))
+            raise ValueError('`partition` must be 2-dimensional, got ndim={}'
+                             ''.format(self.ndim))
 
-        for i, a in enumerate(axes):
-            if np.linalg.norm(a) <= 1e-10:
-                raise ValueError('axis vector {} {} too close to zero'
-                                 ''.format(i, axes[i]))
-            if np.shape(a) != (3,):
-                raise ValueError('axis vector {} has shape {}. expected (3,)'
-                                 ''.format(i, np.shape(a)))
+        axes, axes_in = np.asarray(axes, dtype=float), axes
+        if axes.shape != (2, 3):
+            raise ValueError('`axes` must be a sequence of 2 3-dimensional '
+                             'vectors, got {}'.format(axes_in))
+        if np.linalg.norm(np.cross(*axes)) == 0:
+            raise ValueError('`axes` {} are linearly dependent'
+                             ''.format(axes_in))
 
-        self.__axes = tuple(np.asarray(a) / np.linalg.norm(a) for a in axes)
-        self.__normal = np.cross(self.axes[0], self.axes[1])
-
-        if np.linalg.norm(self.normal) <= 1e-4:
-            raise ValueError('`axes` are almost parallel (norm of normal = '
-                             '{})'.format(np.linalg.norm(self.normal)))
+        axes /= np.linalg.norm(axes, axis=1, keepdims=True)
+        self.__axes = tuple(axes)
 
     @property
     def axes(self):
-        """Normalized principal axes of this detector as a 2-tuple."""
+        """Fixed 2-tuple of unit vectors with which the detector is aligned."""
         return self.__axes
 
-    @property
-    def normal(self):
-        """Unit vector perpendicular to this detector.
-
-        The orientation is chosen such that the triple
-        ``axes[0], axes[1], normal`` form a right-hand system.
-        """
-        return self.__normal
-
     def surface(self, param):
-        """Parametrization of the 2d detector reference surface.
+        """Return the detector surface point corresponding to ``param``.
 
-        The reference plane segment is chosen to be aligned with the
-        second and third coordinate axes, in this order, such that
-        the parameter value (0, 0) results in the reference (0, 0, 0).
+        For parameter value ``p``, the surface point is given by ::
 
-        Parameters
-        ----------
-        param : `params` element
-            Parameter value where to evaluate the function.
-
-        Returns
-        -------
-        point : `numpy.ndarray`, shape (3,)
-            The point on the detector surface corresponding to the
-            given parameters.
-        """
-        if param not in self.params:
-            raise ValueError('`param` {} not in the valid range '
-                             '{}'.format(param, self.params))
-
-        return sum(float(p) * ax for p, ax in zip(param, self.axes))
-
-    def surface_deriv(self, param=None):
-        """Derivative of the surface parametrization.
+            surf = p[0] * axes[0] + p[1] * axes[1]
 
         Parameters
         ----------
-        param : `params` element, optional
-            Parameter value where to evaluate the function.
+        param : `array-like`
+            Parameter value(s) at which to evaluate. A 2D array should stack
+            parameters along axis 0.
 
         Returns
         -------
-        derivatives : 2-tuple of `numpy.ndarray`'s (shape ``(3,)``)
-            The constant partial derivatives given by the detector axes.
+        point : `numpy.ndarray`, shape (3,) or (num_params, 3)
+            Vector(s) pointing from the origin to the detector surface
+            point at ``param``.
+            If ``param`` is a single parameter, a single vector is
+            returned, otherwise a stack of vectors along axis 0.
+
+        Examples
+        --------
+        The method works with a single parameter, resulting in a single
+        vector:
+
+        >>> part = odl.uniform_partition([0, 0], [1, 1], (10, 10))
+        >>> det = Flat2dDetector(part, axes=[(1, 0, 0), (0, 0, 1)])
+        >>> det.surface([0, 0])
+        array([ 0.,  0.,  0.])
+        >>> det.surface([0, 1])
+        array([ 0.,  0.,  1.])
+        >>> det.surface([1, 1])
+        array([ 1.,  0.,  1.])
+
+        It is also vectorized, i.e., it can be called with multiple
+        parameters at once:
+
+        >>> det.surface([[0, 0], [0, 1], [1, 1]])
+        array([[ 0.,  0.,  0.],
+               [ 0.,  0.,  1.],
+               [ 1.,  0.,  1.]])
         """
-        if param is not None and param not in self.params:
+        squeeze_out = (np.shape(param) == (2,))
+        # Need to transpose (IntervalProd.contains_all expects first axis
+        # to be spatial component, second axis parameter enumeration)
+        param, param_in = (np.array(param, dtype=float, copy=False, ndmin=2).T,
+                           param)
+        if self.check_bounds and not self.params.contains_all(param):
             raise ValueError('`param` {} not in the valid range '
-                             '{}'.format(param, self.params))
-        return self.axes
+                             '{}'.format(param_in, self.params))
+
+        surf = sum(ax[None, :] * p[:, None]
+                   for p, ax in zip(param, self.axes))
+        if squeeze_out:
+            surf = surf.squeeze()
+
+        return surf
+
+    def surface_deriv(self, param):
+        """Return the surface derivative at ``param``.
+
+        This is a constant function evaluating to `axes` everywhere.
+
+        Parameters
+        ----------
+        param : `array-like`
+            Parameter value(s) at which to evaluate. A 2D array should
+            stack parameters along axis 0.
+
+        Returns
+        -------
+        deriv : 2-tuple of `numpy.ndarray`
+            The i-th entry is an array representing the surface derivative
+            vector(s) at ``param`` with respect to the i-th coordinate.
+            If ``param`` is a single parameter, each entry is an array
+            of shape ``(3,)``, otherwise each entry is a stack of vectors
+            along axis 0, i.e., an array of shape ``(num_params, 3)``.
+
+        Examples
+        --------
+        The method works with a single parameter, resulting in a 2-tuple
+        of vectors:
+
+        >>> part = odl.uniform_partition([0, 0], [1, 1], (10, 10))
+        >>> det = Flat2dDetector(part, axes=[(1, 0, 0), (0, 0, 1)])
+        >>> det.surface_deriv([0, 0])
+        (array([ 1.,  0.,  0.]), array([ 0.,  0.,  1.]))
+        >>> det.surface_deriv([1, 1])
+        (array([ 1.,  0.,  0.]), array([ 0.,  0.,  1.]))
+
+        It is also vectorized, i.e., it can be called with multiple
+        parameters at once:
+
+        >>> deriv = det.surface_deriv([[0, 0], [1, 1]])
+        >>> deriv[0]
+        array([[ 1.,  0.,  0.],
+               [ 1.,  0.,  0.]])
+        >>> deriv[1]
+        array([[ 0.,  0.,  1.],
+               [ 0.,  0.,  1.]])
+        """
+        squeeze_out = (np.shape(param) == (2,))
+        # Need to transpose (IntervalProd expects first axis to be spatial
+        # component, not parameter enumeration)
+        param, param_in = (np.array(param, dtype=float, copy=False, ndmin=2).T,
+                           param)
+        if self.check_bounds and not self.params.contains_all(param):
+            raise ValueError('`param` {} not in the valid range '
+                             '{}'.format(param_in, self.params))
+
+        if squeeze_out:
+            return self.axes
+        else:
+            return tuple(np.vstack([ax] * param.shape[1]) for ax in self.axes)
 
     def __repr__(self):
         """Return ``repr(self)``."""
-        inner_fstr = '\n    {!r},\n    {!r}'
-        inner_str = inner_fstr.format(self.partition, self.axes)
-        return '{}({})'.format(self.__class__.__name__, inner_str)
+        posargs = [self.partition]
+        optargs = [('axes', tuple(ax.tolist() for ax in self.axes), None)]
+        inner_str = signature_string(posargs, optargs, sep=',\n')
+        return '{}(\n{}\n)'.format(self.__class__.__name__,
+                                   indent_rows(inner_str))
 
     def __str__(self):
         """Return ``str(self)``."""
-        # TODO: prettify
-        inner_fstr = '\n    {},\n    {}'
-        inner_str = inner_fstr.format(self.partition, self.axes)
-        return '{}({})'.format(self.__class__.__name__, inner_str)
+        return repr(self)
 
 
 class CircleSectionDetector(Detector):
 
-    """A 1d detector given by a section of a circle.
+    """A 1d detector given by a circle section that crosses the origin.
 
-    The reference circular section is part of a circle with radius ``r``,
-    which is shifted by the vector ``(-r, 0)`` such that the parameter
-    value 0 results in the detector reference point ``(0, 0)``.
+    The parametrization is chosen such that parameter (=angle) 0
+    corresponds to the origin. Negative angles correspond to points
+    "left" of the line from circle center to origin, positive angles
+    to points on the "right" of that line.
     """
 
-    def __init__(self, part, circ_rad):
+    def __init__(self, partition, center, check_bounds=True):
         """Initialize a new instance.
 
         Parameters
         ----------
-        part : 1-dim. `RectPartition`
+        partition : 1-dim. `RectPartition`
             Partition of the parameter interval, corresponding to the
-            angle sections along the line.
-        circ_rad : positive float
-            Radius of the circle along which the detector is curved.
-        """
-        super(CircleSectionDetector, self).__init__(part)
-        if self.ndim != 1:
-            raise ValueError('expected `part` to have 1 dimension, '
-                             'got {}'.format(self.ndim))
+            angular sections along the line.
+        center : `array-like`, shape ``(2,)``
+            Center point of the circle, cannot be zero. Larger distance
+            to the origin results in less curvature.
+        check_bounds : bool, optional
+            If ``True``, methods perform sanity checks on provided input
+            parameters.
 
-        self.__circ_rad, circ_rad_in = float(circ_rad), circ_rad
-        if self.circ_rad <= 0:
-            raise ValueError('`circ_rad` {} is not positive'
-                             ''.format(circ_rad_in))
+        Examples
+        --------
+        Initialize a detector with circle radius 2 and extending to
+        90 degrees on both sides of the origin (a half circle).
+
+        >>> part = odl.uniform_partition(-np.pi / 2, np.pi / 2, 10)
+        >>> det = CircleSectionDetector(part, center=[0, -2])
+        >>> det.radius
+        2.0
+        >>> det.center_dir
+        array([ 0., -1.])
+        >>> det.tangent_at_0
+        array([ 1.,  0.])
+        """
+        super(CircleSectionDetector, self).__init__(partition, check_bounds)
+        if self.ndim != 1:
+            raise ValueError('`partition` must be 1-dimensional, got ndim={}'
+                             ''.format(self.ndim))
+
+        self.__center = np.asarray(center, dtype=float)
+        if self.center.shape != (2,):
+            raise ValueError('`center` must have shape (2,), got {}'
+                             ''.format(self.center.shape))
+        if np.linalg.norm(self.center) == 0:
+            raise ValueError('`center` cannot be zero')
 
     @property
-    def circ_rad(self):
-        """Circle radius of this detector."""
-        return self.__circ_rad
+    def center(self):
+        """Center point of the circle."""
+        return self.__center
+
+    @property
+    def radius(self):
+        """Curvature radius the detector."""
+        return np.linalg.norm(self.center)
+
+    @property
+    def center_dir(self):
+        """Unit vector from the origin to the center of the circle."""
+        return self.center / self.radius
+
+    @property
+    def tangent_at_0(self):
+        """Unit vector tangent to the circle at ``param=0``.
+
+        The direction is chosen such that the circle is traversed clockwise
+        for growing angle parameter.
+        """
+        return perpendicular_vector(self.center_dir)
 
     def surface(self, param):
-        """Parametrization of the detector reference surface.
+        """Return the detector surface point corresponding to ``param``.
+
+        The surface point lies on a circle around ``radius * center_dir``
+        through the origin. More precisely, for a parameter ``phi``, the
+        returned point is given by ::
+
+            surf = radius * ((1 - cos(phi)) * center_dir +
+                             sin(phi) * tangent_at_0)
+
+        In particular, ``phi=0`` yields the origin ``(0, 0)``.
 
         Parameters
         ----------
-        param : `params` element
-            Parameter value where to evaluate the function.
-        """
-        if param in self.params or self.params.contains_all(param):
-            return (self.circ_rad *
-                    np.array([np.cos(param) - 1, np.sin(param)]).T)
-        else:
-            raise ValueError('`param` value(s) {} not in the valid range '
-                             '{}'.format(param, self.params))
-
-    def surface_deriv(self, param):
-        """Partial derivative(s) of the surface parametrization.
-
-        Parameters
-        ----------
-        param : `params` element
-            Parameter value where to evaluate the function.
-        """
-        if param in self.params or self.params.contains_all(param):
-            return self.circ_rad * np.array([-np.sin(param), np.cos(param)]).T
-        else:
-            raise ValueError('`param` value(s) {} not in the valid range '
-                             '{}'.format(param, self.params))
-
-    def surface_measure(self, param):
-        """Constant density function of the surface measure.
-
-        Parameters
-        ----------
-        param : `params` element
-            Parameter value where to evaluate the function.
+        param : float or `array-like`
+            Parameter value(s) at which to evaluate.
 
         Returns
         -------
-        measure : float
-            The constant density ``r``, equal to the length of the
-            tangent to the detector circle at any point.
+        point : `numpy.ndarray`, shape (2,) or (num_params, 2)
+            Vector(s) pointing from the origin to the detector surface
+            point at ``param``.
+            If ``param`` is a single parameter, a single vector is
+            returned, otherwise a stack of vectors along axis 0.
+
+        Examples
+        --------
+        The method works with a single parameter, resulting in a single
+        vector:
+
+        >>> part = odl.uniform_partition(-np.pi / 2, np.pi / 2, 10)
+        >>> det = CircleSectionDetector(part, center=[0, -2])
+        >>> det.surface(0)
+        array([ 0.,  0.])
+        >>> det.surface(-np.pi / 2)
+        array([-2., -2.])
+        >>> det.surface(np.pi / 2)
+        array([ 2., -2.])
+
+        It is also vectorized, i.e., it can be called with multiple
+        parameters at once:
+
+        >>> det.surface([-np.pi / 2, 0, np.pi / 2])
+        array([[-2., -2.],
+               [ 0.,  0.],
+               [ 2., -2.]])
         """
-        if param in self.params:
-            return self.circ_rad
-        elif self.params.contains_all(param):
-            return self.circ_rad * np.ones_like(param, dtype=float)
-        else:
-            raise ValueError('`param` value(s) {} not in the valid range '
+        squeeze_out = np.isscalar(param)
+        param = np.array(param, dtype=float, copy=False, ndmin=1)
+        if self.check_bounds and not self.params.contains_all(param):
+            raise ValueError('`param` {} not in the valid range '
                              '{}'.format(param, self.params))
+        surf = ((1 - np.cos(param))[:, None] * self.center_dir[None, :] +
+                np.sin(param)[:, None] * self.tangent_at_0[None, :])
+        surf *= self.radius
+        if squeeze_out:
+            surf = surf.squeeze()
+
+        return surf
+
+    def surface_deriv(self, param):
+        """Return the surface derivative at ``param``.
+
+        The derivative at parameter ``phi`` is given by ::
+
+            deriv = radius * (sin(phi) * center_dir + cos(phi) * tangent_at_0)
+
+        Parameters
+        ----------
+        param : float or `array-like`
+            Parameter value(s) at which to evaluate.
+
+        Returns
+        -------
+        deriv : `numpy.ndarray`, shape (2,) or (num_params, 2)
+            Vector(s) representing the detector surface derivative at
+            ``param``.
+            If ``param`` is a single parameter, a single vector is
+            returned, otherwise a stack of vectors along axis 0.
+
+        See Also
+        --------
+        surface
+
+        Examples
+        --------
+        The method works with a single parameter, resulting in a single
+        vector:
+
+        >>> part = odl.uniform_partition(-np.pi / 2, np.pi / 2, 10)
+        >>> det = CircleSectionDetector(part, center=[0, -2])
+        >>> det.surface_deriv(0)
+        array([ 2.,  0.])
+        >>> np.allclose(det.surface_deriv(-np.pi / 2), [0, 2])
+        True
+        >>> np.allclose(det.surface_deriv(np.pi / 2), [0, -2])
+        True
+
+        It is also vectorized, i.e., it can be called with multiple
+        parameters at once:
+
+        >>> deriv = det.surface_deriv([-np.pi / 2, 0, np.pi / 2])
+        >>> np.allclose(deriv, [[0, 2],
+        ...                     [2, 0],
+        ...                     [0, -2]])
+        True
+        """
+        squeeze_out = np.isscalar(param)
+        param = np.array(param, dtype=float, copy=False, ndmin=1)
+        if self.check_bounds and not self.params.contains_all(param):
+            raise ValueError('`param` {} not in the valid range '
+                             '{}'.format(param, self.params))
+        deriv = (np.sin(param)[:, None] * self.center_dir[None, :] +
+                 np.cos(param)[:, None] * self.tangent_at_0[None, :])
+        deriv *= self.radius
+        if squeeze_out:
+            deriv = deriv.squeeze()
+
+        return deriv
+
+    def surface_measure(self, param):
+        """Return the arc length measure at ``param``.
+
+        This is a constant function evaluating to `radius` everywhere.
+
+        Parameters
+        ----------
+        param : float or `array-like`
+            Parameter value(s) at which to evaluate.
+
+        Returns
+        -------
+        deriv : float or `numpy.ndarray`
+            Constant value(s) of the arc length measure at ``param``.
+            If ``param`` is a single parameter, a float is returned,
+            otherwise a vector of the same length as ``param``.
+
+        See Also
+        --------
+        surface
+        surface_deriv
+
+        Examples
+        --------
+        The method works with a single parameter, resulting in a float:
+
+        >>> part = odl.uniform_partition(-np.pi / 2, np.pi / 2, 10)
+        >>> det = CircleSectionDetector(part, center=[0, -2])
+        >>> det.surface_measure(0)
+        2.0
+        >>> det.surface_measure(np.pi / 2)
+        2.0
+
+        It is also vectorized, i.e., it can be called with multiple
+        parameters at once:
+
+        >>> det.surface_measure([0, np.pi / 2])
+        array([ 2.,  2.])
+        """
+        scalar_out = np.isscalar(param)
+        param = np.array(param, dtype=float, copy=False, ndmin=1)
+        if self.check_bounds and not self.params.contains_all(param):
+            raise ValueError('`param` {} not in the valid range '
+                             '{}'.format(param, self.params))
+
+        if scalar_out:
+            return self.radius
+        else:
+            return self.radius * np.ones(param.shape[0])
 
     def __repr__(self):
         """Return ``repr(self)``."""
-        inner_fstr = '\n    {!r},\n    {}'
-        inner_str = inner_fstr.format(self.partition, self.circ_rad)
-        return '{}({})'.format(self.__class__.__name__, inner_str)
+        posargs = [self.partition]
+        optargs = [('center', self.center.tolist(), None)]
+        inner_str = signature_string(posargs, optargs, sep=',\n')
+        return '{}(\n{}\n)'.format(self.__class__.__name__,
+                                   indent_rows(inner_str))
 
     def __str__(self):
         """Return ``str(self)``."""
-        # TODO: prettify
-        inner_fstr = '\n    {},\n    {}'
-        inner_str = inner_fstr.format(self.partition, self.circ_rad)
-        return '{}({})'.format(self.__class__.__name__, inner_str)
+        return repr(self)
 
 
 if __name__ == '__main__':

--- a/odl/tomo/geometry/detector.py
+++ b/odl/tomo/geometry/detector.py
@@ -15,7 +15,7 @@ from builtins import object
 import numpy as np
 
 from odl.discr import RectPartition
-from odl.tomo.util.utility import perpendicular_vector
+from odl.tomo.util import perpendicular_vector, is_inside_bounds
 from odl.util import indent_rows, signature_string
 
 
@@ -171,6 +171,7 @@ class Detector(object):
             - ``param.shape + (space_ndim,)`` if `ndim` is 1,
             - ``param.shape[:-1] + (space_ndim,)`` otherwise.
         """
+        # Checking is done by `surface_deriv`
         if self.ndim == 1 and self.space_ndim == 2:
             return -perpendicular_vector(self.surface_deriv(param))
         elif self.ndim == 2 and self.space_ndim == 3:
@@ -215,6 +216,7 @@ class Detector(object):
         .. _Surface area:
             https://en.wikipedia.org/wiki/Surface_area
         """
+        # Checking is done by `surface_deriv`
         if self.ndim == 1:
             scalar_out = (np.shape(param) == ())
             measure = np.linalg.norm(self.surface_deriv(param), axis=-1)
@@ -324,8 +326,7 @@ class Flat1dDetector(Detector):
         """
         squeeze_out = (np.shape(param) == ())
         param = np.array(param, dtype=float, copy=False, ndmin=1)
-        if self.check_bounds and not self.params.contains_all(param.ravel()):
-            # Allow `param` with ndim > 1 by checking the raveled array
+        if self.check_bounds and not is_inside_bounds(param, self.params):
             raise ValueError('`param` {} not in the valid range '
                              '{}'.format(param, self.params))
 
@@ -377,8 +378,7 @@ class Flat1dDetector(Detector):
         """
         squeeze_out = (np.shape(param) == ())
         param = np.array(param, dtype=float, copy=False, ndmin=1)
-        if self.check_bounds and not self.params.contains_all(param.ravel()):
-            # Allow `param` with ndim > 1 by checking the raveled array
+        if self.check_bounds and not is_inside_bounds(param, self.params):
             raise ValueError('`param` {} not in the valid range '
                              '{}'.format(param, self.params))
         if squeeze_out:
@@ -510,14 +510,9 @@ class Flat2dDetector(Detector):
         param_in = param
         param = tuple(np.array(p, dtype=float, copy=False, ndmin=1)
                       for p in param)
-        if self.check_bounds:
-            # Flesh out and flatten to check bounds
-            bcast_param = np.broadcast_arrays(*param)
-            stacked_param = np.vstack(bcast_param)
-            flat_param = stacked_param.reshape(self.ndim, -1)
-            if not self.params.contains_all(flat_param):
-                raise ValueError('`param` {} not in the valid range '
-                                 '{}'.format(param_in, self.params))
+        if self.check_bounds and not is_inside_bounds(param, self.params):
+            raise ValueError('`param` {} not in the valid range '
+                             '{}'.format(param_in, self.params))
 
         # Compute outer product of the i-th spatial component of the
         # parameter and sum up the contributions
@@ -594,14 +589,9 @@ class Flat2dDetector(Detector):
         param_in = param
         param = tuple(np.array(p, dtype=float, copy=False, ndmin=1)
                       for p in param)
-        if self.check_bounds:
-            # Flesh out and flatten to check bounds
-            bcast_param = np.broadcast_arrays(*param)
-            stacked_param = np.vstack(bcast_param)
-            flat_param = stacked_param.reshape(self.ndim, -1)
-            if not self.params.contains_all(flat_param):
-                raise ValueError('`param` {} not in the valid range '
-                                 '{}'.format(param_in, self.params))
+        if self.check_bounds and not is_inside_bounds(param, self.params):
+            raise ValueError('`param` {} not in the valid range '
+                             '{}'.format(param_in, self.params))
 
         if squeeze_out:
             return self.axes
@@ -754,8 +744,7 @@ class CircleSectionDetector(Detector):
         """
         squeeze_out = (np.shape(param) == ())
         param = np.array(param, dtype=float, copy=False, ndmin=1)
-        if self.check_bounds and not self.params.contains_all(param.ravel()):
-            # Allow `param` with ndim > 1 by checking the raveled array
+        if self.check_bounds and not is_inside_bounds(param, self.params):
             raise ValueError('`param` {} not in the valid range '
                              '{}'.format(param, self.params))
 
@@ -820,8 +809,7 @@ class CircleSectionDetector(Detector):
         """
         squeeze_out = (np.shape(param) == ())
         param = np.array(param, dtype=float, copy=False, ndmin=1)
-        if self.check_bounds and not self.params.contains_all(param.ravel()):
-            # Allow `param` with ndim > 1 by checking the raveled array
+        if self.check_bounds and not is_inside_bounds(param, self.params):
             raise ValueError('`param` {} not in the valid range '
                              '{}'.format(param, self.params))
 
@@ -880,7 +868,7 @@ class CircleSectionDetector(Detector):
         """
         scalar_out = (np.shape(param) == ())
         param = np.array(param, dtype=float, copy=False, ndmin=1)
-        if self.check_bounds and not self.params.contains_all(param):
+        if self.check_bounds and not is_inside_bounds(param, self.params):
             raise ValueError('`param` {} not in the valid range '
                              '{}'.format(param, self.params))
 

--- a/odl/tomo/geometry/geometry.py
+++ b/odl/tomo/geometry/geometry.py
@@ -420,11 +420,11 @@ class DivergentBeamGeometry(Geometry):
             infinity).
             The shape of the returned array is as follows:
 
-            - ``mparam`` and ``dparam`` single: ``(ndim,)``
-            - ``mparam`` single, ``dparam`` stack: ``(num_dparams, ndim)``
-            - ``mparam`` stack, ``dparam`` single: ``(num_mparams, ndim)``
-            - ``mparam`` and ``dparam`` stacks:
-              ``(num_mparam, num_dparams, ndim)``
+            - ``angle`` and ``dparam`` single: ``(ndim,)``
+            - ``angle`` single, ``dparam`` stack: ``(num_dparams, ndim)``
+            - ``angle`` stack, ``dparam`` single: ``(num_angles, ndim)``
+            - ``angle`` and ``dparam`` stacks:
+              ``(num_angle, num_dparams, ndim)``
 
         Examples
         --------

--- a/odl/tomo/geometry/geometry.py
+++ b/odl/tomo/geometry/geometry.py
@@ -358,13 +358,13 @@ class AxisOrientedGeometry(object):
         axis : `array-like`, shape ``(3,)``
             Vector defining the fixed rotation axis of this geometry.
         """
-        axis, axis_in = np.asarray(axis, dtype=float), axis
+        axis = np.asarray(axis, dtype=float)
         if axis.shape != (3,):
             raise ValueError('`axis.shape` must be (3,), got {}'
                              ''.format(axis.shape))
 
-        if np.linalg.norm(axis) <= 1e-10:
-            raise ValueError('`axis` {} too close to zero'.format(axis_in))
+        if np.linalg.norm(axis) == 0:
+            raise ValueError('`axis` cannot be zero')
 
         self.__axis = axis / np.linalg.norm(axis)
 

--- a/odl/tomo/geometry/geometry.py
+++ b/odl/tomo/geometry/geometry.py
@@ -16,7 +16,7 @@ import numpy as np
 
 from odl.discr import RectPartition
 from odl.tomo.geometry.detector import Detector
-from odl.tomo.util import axis_rotation_matrix
+from odl.tomo.util import axis_rotation_matrix, is_inside_bounds
 
 
 __all__ = ('Geometry', 'DivergentBeamGeometry', 'AxisOrientedGeometry')
@@ -610,7 +610,7 @@ class AxisOrientedGeometry(object):
         squeeze_out = (np.shape(angle) == ())
         angle = np.array(angle, dtype=float, copy=False, ndmin=1)
         if (self.check_bounds and
-                not self.motion_params.contains_all(angle.ravel())):
+                not is_inside_bounds(angle, self.motion_params)):
             raise ValueError('`angle` {} not in the valid range {}'
                              ''.format(angle, self.motion_params))
 

--- a/odl/tomo/geometry/parallel.py
+++ b/odl/tomo/geometry/parallel.py
@@ -54,8 +54,7 @@ class ParallelBeamGeometry(Geometry):
         det_pos_init : `array-like`
             Initial position of the detector reference point.
         kwargs :
-            Additional parameters passed on to the ``__init__`` method
-            of `Geometry`.
+            Further parameters passed on to `Geometry`.
         """
         super(ParallelBeamGeometry, self).__init__(
             ndim, apart, detector, **kwargs)
@@ -82,10 +81,10 @@ class ParallelBeamGeometry(Geometry):
             return self.motion_grid.points()
 
     def det_refpoint(self, angle):
-        """Return the position of the detector ref. point at ``angles``.
+        """Return the position(s) of the detector ref. point at ``angle``.
 
         The reference point is given by a rotation of the initial
-        position by ``angles``.
+        position by ``angle``.
 
         For an angle ``phi``, the detector position is given by ::
 
@@ -97,14 +96,17 @@ class ParallelBeamGeometry(Geometry):
 
         Parameters
         ----------
-        angle : float
-            Parameter describing the detector rotation, must be
-            contained in `motion_params`.
+        angle : float or `array-like`
+            Angle(s) in radians describing the counter-clockwise
+            rotation of the detector.
 
         Returns
         -------
-        point : `numpy.ndarray`, shape (`ndim`,)
-            The reference point for the given parameter.
+        refpt : `numpy.ndarray`, shape (ndim,) or (num_params, ndim)
+            Vector(s) pointing from the origin to the detector reference
+            point at ``angle``.
+            If ``angle`` is a single parameter, a single vector is
+            returned, otherwise a stack of vectors along axis 0.
 
         Examples
         --------
@@ -119,6 +121,15 @@ class ParallelBeamGeometry(Geometry):
         >>> np.allclose(geom.det_refpoint(np.pi / 2), [-1, 0])
         True
 
+        The method is vectorized, i.e., it can be called with multiple
+        angles at once:
+
+        >>> points = geom.det_refpoint([0, np.pi])
+        >>> np.allclose(points[0], [0, 1])
+        True
+        >>> np.allclose(points[1], [0, -1])
+        True
+
         In 3d with single rotation axis ``e_z``, we have the same situation,
         except that the vectors have a third component equal to 0:
 
@@ -130,56 +141,46 @@ class ParallelBeamGeometry(Geometry):
         >>> np.allclose(geom.det_refpoint(np.pi / 2), [-1, 0, 0])
         True
         """
-        if angle not in self.motion_params:
-            raise ValueError('`angle` {} not in the valid range {}'
-                             ''.format(angle, self.motion_params))
+        squeeze_out = np.isscalar(angle)
+        angle = np.array(angle, dtype=float, copy=False, ndmin=1)
+
         rot_part = self.rotation_matrix(angle).dot(
             self.det_pos_init - self.translation)
-        return self.translation + rot_part
+        refpoint = self.translation[None, :] + rot_part
+        if squeeze_out:
+            refpoint = refpoint.squeeze()
 
-    def det_to_src(self, angles, dpar, normalized=True):
+        return refpoint
+
+    def det_to_src(self, angle, dparam):
         """Direction from a detector location to the source.
 
         In parallel geometry, this function is independent of the
-        detector parameter.
-
-        Since the (virtual) source is infinitely far away, only the
-        normalized version is valid.
+        detector parameter since the (virtual) source is infinitely
+        far away.
 
         Parameters
         ----------
-        angles : float
-            Euler angles given in radians, must be contained
-            in this geometry's `motion_params`
-        dpar : float
-            Detector parameters, must be contained in this
-            geometry's `det_params`
-        normalized : bool, optional
-            If ``True``, return the normalized version of the vector.
-            For parallel geometry, this is the only sensible option.
+        angle : `array-like`
+            One or several (Euler) angles in radians at which to
+            evaluate. An array should stack parameters along axis 0.
+        dparam : `array-like`
+            Detector parameter(s) at which to evaluate. An array should
+            stack parameters along axis 0.
 
         Returns
         -------
-        vec : `numpy.ndarray`, shape (`ndim`,)
-            Unit vector pointing from the detector to the source
-
-        Raises
-        ------
-        NotImplementedError
-            if ``normalized=False`` is given, since this case is not
-            well defined.
+        vec : `numpy.ndarray`, shape (ndim,) or (num_params, ndim)
+            Unit vector(s) pointing from the detector to the source.
+            If both ``angle`` and ``dparam`` are single parameters, a single
+            vector is returned, otherwise a stack of vectors along axis 0.
         """
-        if angles not in self.motion_params:
-            raise ValueError('`angles` {} not in the valid range {}'
-                             ''.format(angles, self.motion_params))
-        if dpar not in self.det_params:
-            raise ValueError('`dpar` {} not in the valid range '
-                             '{}'.format(dpar, self.det_params))
-        if not normalized:
-            raise NotImplementedError('non-normalized detector to source is '
-                                      'not available in parallel case')
+        if self.check_bounds:
+            if not self.det_params.contains_all(dparam):
+                raise ValueError('`dparam` {} not in the valid range '
+                                 '{}'.format(dparam, self.det_params))
 
-        return self.rotation_matrix(angles).dot(self.detector.normal)
+        return self.rotation_matrix(angle).dot(self.detector.normal)
 
 
 class Parallel2dGeometry(ParallelBeamGeometry):
@@ -220,6 +221,11 @@ class Parallel2dGeometry(ParallelBeamGeometry):
             Global translation of the geometry. This is added last in any
             method that computes an absolute vector, e.g., `det_refpoint`,
             and also shifts the center of rotation.
+            Default: ``(0, 0)``
+        check_bounds : bool, optional
+            If ``True``, methods perform sanity checks on provided input
+            parameters.
+            Default: ``True``
 
         Notes
         -----
@@ -324,19 +330,14 @@ class Parallel2dGeometry(ParallelBeamGeometry):
         detector = Flat1dDetector(part=dpart, axis=det_axis_init)
         super(Parallel2dGeometry, self).__init__(
             ndim=2, apart=apart, detector=detector, det_pos_init=det_pos_init,
-            translation=translation)
+            translation=translation, **kwargs)
 
         if self.motion_partition.ndim != 1:
             raise ValueError('`apart` dimension {}, expected 1'
                              ''.format(self.motion_partition.ndim))
 
-        # Make sure there are no leftover kwargs
-        if kwargs:
-            raise TypeError('got unexpected keyword arguments {}'
-                            ''.format(kwargs))
-
     @classmethod
-    def frommatrix(cls, apart, dpart, init_matrix):
+    def frommatrix(cls, apart, dpart, init_matrix, **kwargs):
         """Create an instance of `Parallel2dGeometry` using a matrix.
 
         This alternative constructor uses a matrix to rotate and
@@ -355,6 +356,8 @@ class Parallel2dGeometry(ParallelBeamGeometry):
             determine the new vectors. If present, the third column acts
             as a translation after the initial transformation.
             The resulting ``det_axis_init`` will be normalized.
+        kwargs :
+            Further keyword arguments passed to the class constructor.
 
         Returns
         -------
@@ -406,9 +409,9 @@ class Parallel2dGeometry(ParallelBeamGeometry):
         # Use the standard constructor with these vectors
         det_pos, det_axis = transformed_vecs
         if translation.size == 0:
-            kwargs = {}
+            pass
         else:
-            kwargs = {'translation': translation}
+            kwargs['translation'] = translation
 
         return cls(apart, dpart, det_pos,
                    det_axis_init=det_axis, **kwargs)
@@ -419,11 +422,25 @@ class Parallel2dGeometry(ParallelBeamGeometry):
         return self.detector.axis
 
     def det_axis(self, angle):
-        """Return the detector axis at ``angle``."""
+        """Return the detector axis (axes) at ``angle``.
+
+        Parameters
+        ----------
+        angle : float or `array-like`
+            Angle(s) in radians describing the counter-clockwise
+            rotation of the detector.
+
+        Returns
+        -------
+        axis : `numpy.ndarray`, shape (2,) or (num_params, 2)
+            Unit vector(s) along which the detector is aligned.
+            If ``angle`` is a single parameter, a single vector is
+            returned, otherwise a stack of vectors along axis 0.
+        """
         return self.rotation_matrix(angle).dot(self.det_axis_init)
 
     def rotation_matrix(self, angle):
-        """Return the rotation matrix for ``angle``.
+        """Return the rotation matrix to the system state at ``angle``.
 
         For an angle ``phi``, the matrix is given by ::
 
@@ -432,22 +449,32 @@ class Parallel2dGeometry(ParallelBeamGeometry):
 
         Parameters
         ----------
-        angle : float
-            Rotation angle given in radians, must be contained in
-            this geometry's `motion_params`
+        angle : float or `array-like`
+            Angle(s) in radians describing the counter-clockwise
+            rotation of the detector.
 
         Returns
         -------
-        rot : `numpy.ndarray`, shape (2, 2)
-            The rotation matrix mapping the standard basis vectors in
-            the fixed ("lab") coordinate system to the basis vectors of
-            the local coordinate system of the detector reference point,
-            expressed in the fixed system.
+        rot : `numpy.ndarray`, shape (2, 2) or (num_params, 2, 2)
+            The rotation matrix (or matrices) mapping vectors at the
+            initial state to the ones in the state defined by ``angle``.
+            The rotation is extrinsic, i.e., defined in the "world"
+            coordinate system.
+            If ``angle`` is a single parameter, a single matrix is
+            returned, otherwise a stack of matrices along axis 0.
         """
-        if angle not in self.motion_params:
+        squeeze_out = np.isscalar(angle)
+        angle = np.array(angle, dtype=float, copy=False, ndmin=1)
+        if (self.check_bounds and
+                not self.motion_params.contains_all(angle)):
             raise ValueError('`angle` {} not in the valid range {}'
                              ''.format(angle, self.motion_params))
-        return euler_matrix(angle)
+
+        matrix = euler_matrix(angle)
+        if squeeze_out:
+            matrix = matrix.squeeze()
+
+        return matrix
 
     def __repr__(self):
         """Return ``repr(self)``."""
@@ -546,6 +573,11 @@ class Parallel3dEulerGeometry(ParallelBeamGeometry):
             Global translation of the geometry. This is added last in any
             method that computes an absolute vector, e.g., `det_refpoint`,
             and also shifts the center of rotation.
+            Default: ``(0, 0, 0)``
+        check_bounds : bool, optional
+            If ``True``, methods perform sanity checks on provided input
+            parameters.
+            Default: ``True``
 
         Notes
         -----
@@ -649,19 +681,14 @@ class Parallel3dEulerGeometry(ParallelBeamGeometry):
         detector = Flat2dDetector(part=dpart, axes=det_axes_init)
         super(Parallel3dEulerGeometry, self).__init__(
             ndim=3, apart=apart, detector=detector, det_pos_init=det_pos_init,
-            translation=translation)
+            translation=translation, **kwargs)
 
         if self.motion_partition.ndim not in (2, 3):
             raise ValueError('`apart` has dimension {}, expected '
                              '2 or 3'.format(self.motion_partition.ndim))
 
-        # Make sure there are no leftover kwargs
-        if kwargs:
-            raise TypeError('got unexpected keyword arguments {}'
-                            ''.format(kwargs))
-
     @classmethod
-    def frommatrix(cls, apart, dpart, init_matrix):
+    def frommatrix(cls, apart, dpart, init_matrix, **kwargs):
         """Create an instance of `Parallel3dEulerGeometry` using a matrix.
 
         This alternative constructor uses a matrix to rotate and
@@ -681,6 +708,8 @@ class Parallel3dEulerGeometry(ParallelBeamGeometry):
             determine the new vectors. If present, the fourth column acts
             as a translation after the initial transformation.
             The resulting ``det_axes_init`` will be normalized.
+        kwargs :
+            Further keyword arguments passed to the class constructor.
 
         Returns
         -------
@@ -734,9 +763,9 @@ class Parallel3dEulerGeometry(ParallelBeamGeometry):
         # Use the standard constructor with these vectors
         det_pos, det_axis_0, det_axis_1 = transformed_vecs
         if translation.size == 0:
-            kwargs = {}
+            pass
         else:
-            kwargs = {'translation': translation}
+            kwargs['translation'] = translation
 
         return cls(apart, dpart, det_pos,
                    det_axes_init=[det_axis_0, det_axis_1],
@@ -748,31 +777,80 @@ class Parallel3dEulerGeometry(ParallelBeamGeometry):
         return self.detector.axes
 
     def det_axes(self, angles):
-        """Return the detector axes tuple at ``angle``."""
-        return tuple(self.rotation_matrix(angles).dot(axis)
-                     for axis in self.det_axes_init)
-
-    def rotation_matrix(self, angles):
-        """Matrix defining the intrinsic rotation for ``angles``.
+        """Return the detector axes tuple at ``angles``.
 
         Parameters
         ----------
         angles : `array-like`
-            Angles in radians defining the rotation, must be contained
-            in this geometry's ``motion_params``
+            Euler angles in radians describing the rotation of the detector.
+            If multiple angle pairs (or triplets) are given, they must be
+            stacked along axis 0.
 
         Returns
         -------
-        rot : `numpy.ndarray`, shape ``(3, 3)``
-            Rotation matrix from the initial configuration of detector
-            position and axes (all angles zero) to the configuration at
-            ``angles``. The rotation is extrinsic, i.e., expressed in the
-            "world" coordinate system.
+        axes : tuple of `numpy.ndarray`'s
+            Unit vector(s) along which the detector is aligned.
+            If ``angles`` is a single pair (or triplet) of Euler angles,
+            a tuple of 2 arrays of shape ``(3,)`` is returned, each of
+            which stands for a detector axis.
+            For multiple angle parameters, the tuple contains 2 arrays
+            of shape ``(num_params, 3)``, i.e., a stack of the respective
+            vectors along array axis 0.
+
+        Notes
+        -----
+        To get a sequence of axi pairs one can, e.g., do the following::
+
+            axis_arrays = geometry.det_axes(angles)
+            list_of_axis_pairs = list(zip(*axis_arrays))
         """
-        if angles not in self.motion_params:
+        return tuple(self.rotation_matrix(angles).dot(axis)
+                     for axis in self.det_axes_init)
+
+    def rotation_matrix(self, angles):
+        """Return the rotation matrix to the system state at ``angles``.
+
+        Parameters
+        ----------
+        angles : `array-like`
+            Euler angles in radians describing the rotation of the detector.
+            If multiple angle pairs (or triplets) are given, they must be
+            stacked along axis 0.
+
+        Returns
+        -------
+        rot : `numpy.ndarray`, shape (3, 3) or (num_params, 3, 3)
+            The rotation matrix (or matrices) mapping vectors at the
+            initial state to the ones in the state defined by ``angles``.
+            The rotation is extrinsic, i.e., defined in the "world"
+            coordinate system.
+            If ``angles`` is a pair (or triplet) of Euler angles, a single
+            matrix is returned, otherwise a stack of matrices along axis 0.
+        """
+        squeeze_out = (np.shape(angles) == (self.motion_params.ndim,))
+        angles = np.array(angles, dtype=float, copy=False, ndmin=2)
+
+        # Need custom check here until #861 is in because arrays are
+        # assumed to be flat in the "point enumeration" axis
+        # TODO: replace when #861 is in
+        def all_contained():
+            if angles.ndim != 2:
+                return False
+
+            mins = np.min(angles, axis=1)
+            maxs = np.max(angles, axis=1)
+            return (np.all(mins >= self.motion_params.min_pt) and
+                    np.all(maxs <= self.motion_params.max_pt))
+
+        if self.check_bounds and not all_contained():
             raise ValueError('`angles` {} not in the valid range {}'
                              ''.format(angles, self.motion_params))
-        return euler_matrix(*angles)
+
+        matrix = euler_matrix(*angles.T)
+        if squeeze_out:
+            matrix = matrix.squeeze()
+
+        return matrix
 
     def __repr__(self):
         """Return ``repr(self)``."""
@@ -842,6 +920,11 @@ class Parallel3dAxisGeometry(ParallelBeamGeometry, AxisOrientedGeometry):
             Global translation of the geometry. This is added last in any
             method that computes an absolute vector, e.g., `det_refpoint`,
             and also shifts the axis of rotation.
+            Default: ``(0, 0, 0)``
+        check_bounds : bool, optional
+            If ``True``, methods perform sanity checks on provided input
+            parameters.
+            Default: ``True``
 
         Notes
         -----
@@ -976,7 +1059,7 @@ class Parallel3dAxisGeometry(ParallelBeamGeometry, AxisOrientedGeometry):
                             ''.format(kwargs))
 
     @classmethod
-    def frommatrix(cls, apart, dpart, init_matrix):
+    def frommatrix(cls, apart, dpart, init_matrix, **kwargs):
         """Create an instance of `Parallel3dAxisGeometry` using a matrix.
 
         This alternative constructor uses a matrix to rotate and
@@ -995,6 +1078,8 @@ class Parallel3dAxisGeometry(ParallelBeamGeometry, AxisOrientedGeometry):
             determine the new vectors. If present, the fourth column acts
             as a translation after the initial transformation.
             The resulting ``det_axes_init`` will be normalized.
+        kwargs :
+            Further keyword arguments passed to the class constructor.
 
         Returns
         -------
@@ -1050,9 +1135,9 @@ class Parallel3dAxisGeometry(ParallelBeamGeometry, AxisOrientedGeometry):
         # Use the standard constructor with these vectors
         axis, det_pos, det_axis_0, det_axis_1 = transformed_vecs
         if translation.size == 0:
-            kwargs = {}
+            pass
         else:
-            kwargs = {'translation': translation}
+            kwargs['translation'] = translation
 
         return cls(apart, dpart, axis,
                    det_pos_init=det_pos,
@@ -1064,9 +1149,34 @@ class Parallel3dAxisGeometry(ParallelBeamGeometry, AxisOrientedGeometry):
         """Initial axes of the detector."""
         return self.detector.axes
 
-    def det_axes(self, angles):
-        """Return the detector axes tuple at ``angle``."""
-        return tuple(self.rotation_matrix(angles).dot(axis)
+    def det_axes(self, angle):
+        """Return the detector axes tuple at ``angle``.
+
+        Parameters
+        ----------
+        angles : float or `array-like`
+            Angle(s) in radians describing the counter-clockwise rotation
+            of the detector around `axis`.
+
+        Returns
+        -------
+        axes : tuple of `numpy.ndarray`'s
+            Unit vector(s) along which the detector is aligned.
+            If ``angle`` is a single parameter, a tuple of 2 arrays
+            of shape ``(3,)`` is returned, each of which stands for
+            a detector axis.
+            For multiple angle parameters, the tuple contains 2 arrays
+            of shape ``(num_params, 3)``, i.e., a stack of the respective
+            vectors along array axis 0.
+
+        Notes
+        -----
+        To get a sequence of axi pairs one can, e.g., do the following::
+
+            axis_arrays = geometry.det_axes(angles)
+            list_of_axis_pairs = list(zip(*axis_arrays))
+        """
+        return tuple(self.rotation_matrix(angle).dot(axis)
                      for axis in self.det_axes_init)
 
     def __repr__(self):

--- a/odl/tomo/geometry/parallel.py
+++ b/odl/tomo/geometry/parallel.py
@@ -333,8 +333,11 @@ class Parallel2dGeometry(ParallelBeamGeometry):
         det_pos_init += translation
 
         # Initialize stuff. Normalization of the detector axis happens in
-        # the detector class.
-        detector = Flat1dDetector(dpart, axis=det_axis_init)
+        # the detector class. `check_bounds` is needed for both detector
+        # and geometry.
+        check_bounds = kwargs.get('check_bounds', True)
+        detector = Flat1dDetector(dpart, axis=det_axis_init,
+                                  check_bounds=check_bounds)
         super(Parallel2dGeometry, self).__init__(
             ndim=2, apart=apart, detector=detector, det_pos_init=det_pos_init,
             translation=translation, **kwargs)
@@ -683,9 +686,12 @@ class Parallel3dEulerGeometry(ParallelBeamGeometry):
                                  dtype=float)
         det_pos_init += translation
 
-        # Initialize stuff. Normalization of the detector axes happens in
-        # the detector class.
-        detector = Flat2dDetector(dpart, axes=det_axes_init)
+        # Initialize stuff. Normalization of the detector axis happens in
+        # the detector class. `check_bounds` is needed for both detector
+        # and geometry.
+        check_bounds = kwargs.get('check_bounds', True)
+        detector = Flat2dDetector(dpart, axes=det_axes_init,
+                                  check_bounds=check_bounds)
         super(Parallel3dEulerGeometry, self).__init__(
             ndim=3, apart=apart, detector=detector, det_pos_init=det_pos_init,
             translation=translation, **kwargs)
@@ -1049,9 +1055,12 @@ class Parallel3dAxisGeometry(ParallelBeamGeometry, AxisOrientedGeometry):
         det_pos_init += translation
 
         # Initialize stuff. Normalization of the detector axis happens in
-        # the detector class.
+        # the detector class. `check_bounds` is needed for both detector
+        # and geometry.
         AxisOrientedGeometry.__init__(self, axis)
-        detector = Flat2dDetector(dpart, det_axes_init)
+        check_bounds = kwargs.get('check_bounds', True)
+        detector = Flat2dDetector(dpart, axes=det_axes_init,
+                                  check_bounds=check_bounds)
         super(Parallel3dAxisGeometry, self).__init__(
             ndim=3, apart=apart, detector=detector, det_pos_init=det_pos_init,
             translation=translation)

--- a/odl/tomo/geometry/parallel.py
+++ b/odl/tomo/geometry/parallel.py
@@ -141,8 +141,14 @@ class ParallelBeamGeometry(Geometry):
         >>> np.allclose(geom.det_refpoint(np.pi / 2), [-1, 0, 0])
         True
         """
-        squeeze_out = np.isscalar(angle)
-        angle = np.array(angle, dtype=float, copy=False, ndmin=1)
+        if self.motion_params.ndim == 1:
+            squeeze_out = np.isscalar(angle)
+            nd = 1
+        else:
+            squeeze_out = (np.shape(angle) == (self.motion_params.ndim,))
+            nd = 2
+
+        angle = np.array(angle, dtype=float, copy=False, ndmin=nd)
 
         rot_part = self.rotation_matrix(angle).dot(
             self.det_pos_init - self.translation)
@@ -180,7 +186,8 @@ class ParallelBeamGeometry(Geometry):
                 raise ValueError('`dparam` {} not in the valid range '
                                  '{}'.format(dparam, self.det_params))
 
-        return self.rotation_matrix(angle).dot(self.detector.normal)
+        return self.rotation_matrix(angle).dot(
+            self.detector.surface_normal(dparam))
 
 
 class Parallel2dGeometry(ParallelBeamGeometry):
@@ -327,7 +334,7 @@ class Parallel2dGeometry(ParallelBeamGeometry):
 
         # Initialize stuff. Normalization of the detector axis happens in
         # the detector class.
-        detector = Flat1dDetector(part=dpart, axis=det_axis_init)
+        detector = Flat1dDetector(dpart, axis=det_axis_init)
         super(Parallel2dGeometry, self).__init__(
             ndim=2, apart=apart, detector=detector, det_pos_init=det_pos_init,
             translation=translation, **kwargs)
@@ -678,7 +685,7 @@ class Parallel3dEulerGeometry(ParallelBeamGeometry):
 
         # Initialize stuff. Normalization of the detector axes happens in
         # the detector class.
-        detector = Flat2dDetector(part=dpart, axes=det_axes_init)
+        detector = Flat2dDetector(dpart, axes=det_axes_init)
         super(Parallel3dEulerGeometry, self).__init__(
             ndim=3, apart=apart, detector=detector, det_pos_init=det_pos_init,
             translation=translation, **kwargs)

--- a/odl/tomo/geometry/parallel.py
+++ b/odl/tomo/geometry/parallel.py
@@ -339,8 +339,9 @@ class Parallel2dGeometry(ParallelBeamGeometry):
         detector = Flat1dDetector(dpart, axis=det_axis_init,
                                   check_bounds=check_bounds)
         super(Parallel2dGeometry, self).__init__(
-            ndim=2, apart=apart, detector=detector, det_pos_init=det_pos_init,
-            translation=translation, **kwargs)
+            ndim=2, apart=apart, detector=detector,
+            det_pos_init=det_pos_init, translation=translation,
+            **kwargs)
 
         if self.motion_partition.ndim != 1:
             raise ValueError('`apart` dimension {}, expected 1'
@@ -693,8 +694,9 @@ class Parallel3dEulerGeometry(ParallelBeamGeometry):
         detector = Flat2dDetector(dpart, axes=det_axes_init,
                                   check_bounds=check_bounds)
         super(Parallel3dEulerGeometry, self).__init__(
-            ndim=3, apart=apart, detector=detector, det_pos_init=det_pos_init,
-            translation=translation, **kwargs)
+            ndim=3, apart=apart, detector=detector,
+            det_pos_init=det_pos_init, translation=translation,
+            **kwargs)
 
         if self.motion_partition.ndim not in (2, 3):
             raise ValueError('`apart` has dimension {}, expected '
@@ -1062,17 +1064,13 @@ class Parallel3dAxisGeometry(ParallelBeamGeometry, AxisOrientedGeometry):
         detector = Flat2dDetector(dpart, axes=det_axes_init,
                                   check_bounds=check_bounds)
         super(Parallel3dAxisGeometry, self).__init__(
-            ndim=3, apart=apart, detector=detector, det_pos_init=det_pos_init,
-            translation=translation)
+            ndim=3, apart=apart, detector=detector,
+            det_pos_init=det_pos_init, translation=translation,
+            **kwargs)
 
         if self.motion_partition.ndim != 1:
             raise ValueError('`apart` has dimension {}, expected 1'
                              ''.format(self.motion_partition.ndim))
-
-        # Make sure there are no leftover kwargs
-        if kwargs:
-            raise TypeError('got unexpected keyword arguments {}'
-                            ''.format(kwargs))
 
     @classmethod
     def frommatrix(cls, apart, dpart, init_matrix, **kwargs):

--- a/odl/tomo/geometry/parallel.py
+++ b/odl/tomo/geometry/parallel.py
@@ -954,16 +954,15 @@ class Parallel3dEulerGeometry(ParallelBeamGeometry):
             Unit vector(s) along which the detector is aligned.
             If ``angles`` is a single pair (or triplet) of Euler angles,
             the returned array has shape ``(2, 3)``, otherwise
-            is ``(2,) + broadcast(*angles).shape + (3,)``.
-            The first axis of length 2 enumerates the detector axes.
+            ``broadcast(*angles).shape + (2, 3)``.
 
         Notes
         -----
-        To get an array that enumerates axis pairs, move the first axis
-        of the array to the second-to-last position::
+        To get an array that enumerates the detector axes in the first
+        dimension, move the second-to-last axis to the first position:
 
-            axes = det_axes(angles)
-            axes_enumeration = np.moveaxis(deriv, 0, -2)
+            axes = det_axes(angle)
+            axes_enumeration = np.moveaxis(deriv, -2, 0)
 
         Examples
         --------
@@ -986,25 +985,25 @@ class Parallel3dEulerGeometry(ParallelBeamGeometry):
         different shapes and will be broadcast against each other to
         determine the final shape:
 
-        >>> # First array for the first Euler angle, second array for second
+        >>> # The first axis enumerates the angles
         >>> np.allclose(geom.det_axes(([0, np.pi / 2], [0, 0])),
         ...             [[[1, 0, 0],
-        ...               [0, 1, 0]],
-        ...              [[0, 0, 1],
+        ...               [0, 0, 1]],
+        ...              [[0, 1, 0],
         ...               [0, 0, 1]]])
         True
         >>> # Pairs of Euler angles in a (4, 5) array each
         >>> geom.det_axes((np.zeros((4, 5)), np.zeros((4, 5)))).shape
-        (2, 4, 5, 3)
+        (4, 5, 2, 3)
         >>> # Using broadcasting for "outer product" type result
         >>> geom.det_axes((np.zeros((4, 1)), np.zeros((1, 5)))).shape
-        (2, 4, 5, 3)
+        (4, 5, 2, 3)
         """
         # Transpose to take dot along axis 1
         axes = self.rotation_matrix(angles).dot(self.det_axes_init.T)
         # `axes` has shape (a, 3, 2), need to roll the last dimensions
-        # to the first place
-        return np.rollaxis(axes, -1, 0)
+        # to the second to last place
+        return np.rollaxis(axes, -1, -2)
 
     def rotation_matrix(self, angles):
         """Return the rotation matrix to the system state at ``angles``.
@@ -1344,7 +1343,7 @@ class Parallel3dAxisGeometry(ParallelBeamGeometry, AxisOrientedGeometry):
 
         Parameters
         ----------
-        angles : float or `array-like`
+        angle : float or `array-like`
             Angle(s) in radians describing the counter-clockwise rotation
             of the detector around `axis`.
 
@@ -1354,16 +1353,15 @@ class Parallel3dAxisGeometry(ParallelBeamGeometry, AxisOrientedGeometry):
             Unit vectors along which the detector is aligned.
             If ``angle`` is a single parameter, the returned array has
             shape ``(2, 3)``, otherwise
-            ``(2,) + broadcast(*angles).shape + (3,)``.
-            The first axis of length 2 enumerates the detector axes.
+            ``broadcast(*angle).shape + (2, 3)``.
 
         Notes
         -----
-        To get an array that enumerates axis pairs, move the first axis
-        of the array to the second-to-last position::
+        To get an array that enumerates the detector axes in the first
+        dimension, move the second-to-last axis to the first position:
 
             axes = det_axes(angle)
-            axes_enumeration = np.moveaxis(deriv, 0, -2)
+            axes_enumeration = np.moveaxis(deriv, -2, 0)
 
         Examples
         --------
@@ -1385,18 +1383,18 @@ class Parallel3dAxisGeometry(ParallelBeamGeometry, AxisOrientedGeometry):
 
         >>> np.allclose(geom.det_axes([0, np.pi / 2]),
         ...             [[[1, 0, 0],
-        ...               [0, 1, 0]],
-        ...              [[0, 0, 1],
+        ...               [0, 0, 1]],
+        ...              [[0, 1, 0],
         ...               [0, 0, 1]]])
         True
         >>> geom.det_axes(np.zeros((4, 5))).shape
-        (2, 4, 5, 3)
+        (4, 5, 2, 3)
         """
         # Transpose to take dot along axis 1
         axes = self.rotation_matrix(angle).dot(self.det_axes_init.T)
         # `axes` has shape (a, 3, 2), need to roll the last dimensions
-        # to the first place
-        return np.rollaxis(axes, -1, 0)
+        # to the second to last place
+        return np.rollaxis(axes, -1, -2)
 
     def __repr__(self):
         """Return ``repr(self)``."""
@@ -1427,7 +1425,7 @@ class Parallel3dAxisGeometry(ParallelBeamGeometry, AxisOrientedGeometry):
     def __getitem__(self, indices):
         """Return self[indices].
 
-        This is defined by::
+        This is defined by ::
 
             self[indices].partition == self.partition[indices]
 

--- a/odl/tomo/geometry/spect.py
+++ b/odl/tomo/geometry/spect.py
@@ -41,6 +41,9 @@ class ParallelHoleCollimatorGeometry(Parallel3dAxisGeometry):
             Radius of the circular detector orbit.
         axis : `array-like`, shape ``(3,)``, optional
             Vector defining the fixed rotation axis of this geometry.
+
+        Other Parameters
+        ----------------
         orig_to_det_init : `array-like`, shape ``(3,)``, optional
             Vector pointing towards the initial position of the detector
             reference point. The default depends on ``axis``, see Notes.
@@ -52,6 +55,11 @@ class ParallelHoleCollimatorGeometry(Parallel3dAxisGeometry):
             Global translation of the geometry. This is added last in any
             method that computes an absolute vector, e.g., `det_refpoint`,
             and also shifts the axis of rotation.
+            Default: ``(0, 0, 0)``
+        check_bounds : bool, optional
+            If ``True``, methods perform sanity checks on provided input
+            parameters.
+            Default: ``True``
 
         Notes
         -----
@@ -92,7 +100,7 @@ class ParallelHoleCollimatorGeometry(Parallel3dAxisGeometry):
             apart, dpart, axis, **kwargs)
 
     @classmethod
-    def frommatrix(cls, apart, dpart, det_radius, init_matrix):
+    def frommatrix(cls, apart, dpart, det_radius, init_matrix, **kwargs):
         """Create a `ParallelHoleCollimatorGeometry` using a matrix.
 
         This alternative constructor uses a matrix to rotate and
@@ -113,6 +121,8 @@ class ParallelHoleCollimatorGeometry(Parallel3dAxisGeometry):
             determine the new vectors. If present, the fourth column acts
             as a translation after the initial transformation.
             The resulting ``det_axes_init`` will be normalized.
+        kwargs :
+            Further keyword arguments passed to the class constructor.
 
         Returns
         -------
@@ -143,9 +153,9 @@ class ParallelHoleCollimatorGeometry(Parallel3dAxisGeometry):
         # Use the standard constructor with these vectors
         axis, orig_to_det, det_axis_0, det_axis_1 = transformed_vecs
         if translation.size == 0:
-            kwargs = {}
+            pass
         else:
-            kwargs = {'translation': translation}
+            kwargs['translation'] = translation
 
         return cls(apart, dpart, det_radius, axis,
                    orig_to_det_init=orig_to_det,

--- a/odl/tomo/geometry/spect.py
+++ b/odl/tomo/geometry/spect.py
@@ -152,9 +152,7 @@ class ParallelHoleCollimatorGeometry(Parallel3dAxisGeometry):
 
         # Use the standard constructor with these vectors
         axis, orig_to_det, det_axis_0, det_axis_1 = transformed_vecs
-        if translation.size == 0:
-            pass
-        else:
+        if translation.size != 0:
             kwargs['translation'] = translation
 
         return cls(apart, dpart, det_radius, axis,


### PR DESCRIPTION
~~Incomplete~~ PR for vectorization of geometry methods.

### TODO:
- [x] Propagate `check_bounds` to detectors
- [x] Update doc for detectors
- [x] Improve `repr` of detectors
- [x] Decide on what to do with nonsense parameters (e.g. `normalized` when only one choice is valid, but the parameter is there for API consistency)
      **Solution:** I removed `normalized` from `ParallelGeometry.det_to_src`, can't seem to remember what other cases I had in mind.
- [x] Replace `super()` calls
      **Solution:** I did like suggested n #1061 
- [x] Check if the custom `all_contained()` is really needed, seems fishy
      **Solution:** Turned out a simple transpose did the job
- [x] Fix methods depending on two variables (as in 56393e6)
- [x] ~~Add unit tests~~ Have already a bunch of doctests, and ASTRA vec geometry generation already uses vectorization, should be good enough?