### PR TITLE
BUG: fix gradient of GroupL1Norm. Also safeguard derivative of PointwiseNorm.

### DIFF
--- a/odl/operator/tensor_ops.py
+++ b/odl/operator/tensor_ops.py
@@ -340,14 +340,15 @@ class PointwiseNorm(PointwiseTensorFieldOperator):
         inner_vf = vf.copy()
 
         for gi in inner_vf:
+            gi *= np.abs(gi) ** (self.exponent - 2)
             if self.exponent >= 2:
-                tmp = vf_pwnorm_fac * np.abs(gi) ** (2 - self.exponent)
                 # Any component that is zero is not divided with
-                nz = (tmp.asarray() != 0)
-                gi[nz] /= tmp[nz]
-
+                nz = (vf_pwnorm_fac.asarray() != 0)
+                gi[nz] /= vf_pwnorm_fac[nz]
             else:
-                gi *= np.abs(gi) ** (self.exponent - 2) / vf_pwnorm_fac
+                # For exponents < 2, there will be a singularity if any
+                # component is zero
+                gi /= vf_pwnorm_fac
 
         return PointwiseInner(self.domain, inner_vf, weighting=self.weights)
 

--- a/odl/operator/tensor_ops.py
+++ b/odl/operator/tensor_ops.py
@@ -341,10 +341,11 @@ class PointwiseNorm(PointwiseTensorFieldOperator):
 
         for gi in inner_vf:
             if self.exponent >= 2:
-                with np.errstate(invalid='ignore', divide='ignore'):
-                    tmp = vf_pwnorm_fac * gi ** (self.exponent - 2)
-                    # Any component that is zero is not divided with
-                    gi /= tmp if not tmp else 1
+                tmp = vf_pwnorm_fac * gi ** (self.exponent - 2)
+                # Any component that is zero is not divided with
+                for i, val in zip(np.arange(len(tmp)), tmp):
+                    if not val == 0.0:
+                        gi[i] /= val
             else:
                 gi /= vf_pwnorm_fac * gi ** (self.exponent - 2)
 

--- a/odl/operator/tensor_ops.py
+++ b/odl/operator/tensor_ops.py
@@ -341,13 +341,13 @@ class PointwiseNorm(PointwiseTensorFieldOperator):
 
         for gi in inner_vf:
             if self.exponent >= 2:
-                tmp = vf_pwnorm_fac * gi ** (self.exponent - 2)
+                tmp = vf_pwnorm_fac * np.abs(gi) ** (2 - self.exponent)
                 # Any component that is zero is not divided with
-                for i, val in zip(np.arange(len(tmp)), tmp):
-                    if not val == 0.0:
-                        gi[i] /= val
+                nz = (tmp.asarray() != 0)
+                gi[nz] /= tmp[nz]
+
             else:
-                gi /= vf_pwnorm_fac * gi ** (self.exponent - 2)
+                gi *= np.abs(gi) ** (self.exponent - 2) / vf_pwnorm_fac
 
         return PointwiseInner(self.domain, inner_vf, weighting=self.weights)
 

--- a/odl/operator/tensor_ops.py
+++ b/odl/operator/tensor_ops.py
@@ -340,14 +340,15 @@ class PointwiseNorm(PointwiseTensorFieldOperator):
         inner_vf = vf.copy()
 
         for gi in inner_vf:
-            gi *= np.abs(gi) ** (self.exponent - 2)
+            gi *= gi.ufuncs.absolute().ufuncs.power(self.exponent - 2)
             if self.exponent >= 2:
                 # Any component that is zero is not divided with
                 nz = (vf_pwnorm_fac.asarray() != 0)
                 gi[nz] /= vf_pwnorm_fac[nz]
             else:
-                # For exponents < 2, there will be a singularity if any
-                # component is zero
+                # For exponents < 2 there will be a singularity if any
+                # component is zero. This reullts in inf or nan. See the
+                # documentation for further details.
                 gi /= vf_pwnorm_fac
 
         return PointwiseInner(self.domain, inner_vf, weighting=self.weights)

--- a/odl/operator/tensor_ops.py
+++ b/odl/operator/tensor_ops.py
@@ -340,7 +340,12 @@ class PointwiseNorm(PointwiseTensorFieldOperator):
         inner_vf = vf.copy()
 
         for gi in inner_vf:
-            gi /= vf_pwnorm_fac * gi ** (self.exponent - 2)
+            if self.exponent >= 2:
+                with np.errstate(invalid='ignore', divide='ignore'):
+                    gi /= vf_pwnorm_fac * gi ** (self.exponent - 2)
+                    gi = np.nan_to_num(x=gi)
+            else:
+                gi /= vf_pwnorm_fac * gi ** (self.exponent - 2)
 
         return PointwiseInner(self.domain, inner_vf, weighting=self.weights)
 

--- a/odl/operator/tensor_ops.py
+++ b/odl/operator/tensor_ops.py
@@ -347,7 +347,7 @@ class PointwiseNorm(PointwiseTensorFieldOperator):
                 gi[nz] /= vf_pwnorm_fac[nz]
             else:
                 # For exponents < 2 there will be a singularity if any
-                # component is zero. This reullts in inf or nan. See the
+                # component is zero. This results in inf or nan. See the
                 # documentation for further details.
                 gi /= vf_pwnorm_fac
 

--- a/odl/operator/tensor_ops.py
+++ b/odl/operator/tensor_ops.py
@@ -342,8 +342,9 @@ class PointwiseNorm(PointwiseTensorFieldOperator):
         for gi in inner_vf:
             if self.exponent >= 2:
                 with np.errstate(invalid='ignore', divide='ignore'):
-                    gi /= vf_pwnorm_fac * gi ** (self.exponent - 2)
-                    gi = np.nan_to_num(x=gi)
+                    tmp = vf_pwnorm_fac * gi ** (self.exponent - 2)
+                    # Any component that is zero is not divided with
+                    gi /= tmp if not tmp else 1
             else:
                 gi /= vf_pwnorm_fac * gi ** (self.exponent - 2)
 

--- a/odl/solvers/functional/default_functionals.py
+++ b/odl/solvers/functional/default_functionals.py
@@ -291,8 +291,11 @@ class GroupL1Norm(Functional):
 
             def _call(self, x):
                 """Return ``self(x)``."""
-                return functional.pointwise_norm.derivative(x).adjoint(
-                    np.sign(functional.pointwise_norm(x)))
+                to_return = functional.pointwise_norm(x)
+                to_return.ufuncs.sign(out=to_return)
+                functional.pointwise_norm.derivative(x).adjoint(to_return,
+                                                                out=to_return)
+                return to_return
 
         return GroupL1Gradient()
 

--- a/odl/solvers/functional/default_functionals.py
+++ b/odl/solvers/functional/default_functionals.py
@@ -289,13 +289,14 @@ class GroupL1Norm(Functional):
                 super(GroupL1Gradient, self).__init__(
                     functional.domain, functional.domain, linear=False)
 
-            def _call(self, x):
+            def _call(self, x, out):
                 """Return ``self(x)``."""
-                to_return = functional.pointwise_norm(x)
-                to_return.ufuncs.sign(out=to_return)
-                functional.pointwise_norm.derivative(x).adjoint(to_return,
-                                                                out=to_return)
-                return to_return
+                pwnorm_x = functional.pointwise_norm(x)
+                pwnorm_x.ufuncs.sign(out=pwnorm_x)
+                functional.pointwise_norm.derivative(x).adjoint(pwnorm_x,
+                                                                out=out)
+
+                return out
 
         return GroupL1Gradient()
 

--- a/odl/solvers/functional/default_functionals.py
+++ b/odl/solvers/functional/default_functionals.py
@@ -291,22 +291,8 @@ class GroupL1Norm(Functional):
 
             def _call(self, x):
                 """Return ``self(x)``."""
-                p = functional.pointwise_norm.exponent
-
-                if functional.pointwise_norm.exponent == 1:
-                    result = np.abs(x)
-                    np.divide(x, result, out=result, where=result != 0)
-                    return result
-                elif functional.pointwise_norm.exponent == 2:
-                    result = functional.pointwise_norm(x)
-                    np.divide(x, result, out=result, where=result != 0)
-                    return result
-                else:
-                    dividend = np.power(np.abs(x), p - 2) * x
-                    divisor = np.power(functional.pointwise_norm(x), p - 1)
-                    np.divide(dividend, divisor, out=divisor,
-                              where=divisor != 0)
-                    return divisor
+                return functional.pointwise_norm.derivative(x).adjoint(
+                    np.sign(functional.pointwise_norm(x)))
 
         return GroupL1Gradient()
 

--- a/odl/test/operator/tensor_ops_test.py
+++ b/odl/test/operator/tensor_ops_test.py
@@ -215,7 +215,7 @@ def test_pointwise_norm_gradient_real(exponent):
     tmp = pwnorm(point).ufuncs.power(1 - exponent)
     v_field = vfspace.element()
     for i in range(len(v_field)):
-        v_field[i] = tmp * point[i] * np.abs(point[i])**(exponent - 2)
+        v_field[i] = tmp * point[i] * np.abs(point[i]) ** (exponent - 2)
     pwinner = odl.PointwiseInner(vfspace, v_field)
     expected_result = pwinner(direction)
 
@@ -235,7 +235,7 @@ def test_pointwise_norm_gradient_real(exponent):
     tmp = pwnorm(point).ufuncs.power(1 - exponent)
     v_field = vfspace.element()
     for i in range(len(v_field)):
-        v_field[i] = tmp * point[i] * np.abs(point[i])**(exponent - 2)
+        v_field[i] = tmp * point[i] * np.abs(point[i]) ** (exponent - 2)
     pwinner = odl.PointwiseInner(vfspace, v_field)
     expected_result = pwinner(direction)
 

--- a/odl/test/operator/tensor_ops_test.py
+++ b/odl/test/operator/tensor_ops_test.py
@@ -224,7 +224,7 @@ def test_pointwise_norm_gradient_real(exponent):
     direction = vfspace.element(test_direction)
     func_pwnorm = pwnorm.derivative(point)
 
-    assert not any(np.isnan(func_pwnorm(direction)))
+    assert not np.isnan(func_pwnorm(direction)).asarray().any()
 
     # 3d
     fspace = odl.uniform_discr([0, 0], [1, 1], (2, 2))
@@ -248,7 +248,7 @@ def test_pointwise_norm_gradient_real(exponent):
     direction = vfspace.element(test_direction)
     func_pwnorm = pwnorm.derivative(point)
 
-    assert not any(np.isnan(func_pwnorm(direction)))
+    assert not np.isnan(func_pwnorm(direction)).asarray().any()
 
 
 # ---- PointwiseInner ----

--- a/odl/test/operator/tensor_ops_test.py
+++ b/odl/test/operator/tensor_ops_test.py
@@ -192,6 +192,65 @@ def test_pointwise_norm_weighted(exponent):
     assert all_almost_equal(out, true_norm)
 
 
+def test_pointwise_norm_gradient_real(exponent):
+    # The operator is not differentiable for exponent 'inf'
+    if exponent == float('inf'):
+        fspace = odl.uniform_discr([0, 0], [1, 1], (2, 2))
+        vfspace = ProductSpace(fspace, 1)
+        pwnorm = PointwiseNorm(vfspace, exponent)
+        point = vfspace.one()
+        with pytest.raises(NotImplementedError):
+            pwnorm.derivative(point)
+        return
+
+    # TODO: implement good tests also for the 'normal behaviour'
+
+    # The gradient is only well-defined in all points if the exponent is >= 2
+    if exponent < 2:
+        pytest.skip('differential of operator has singularity for this '
+                    'exponent')
+
+    # 1d
+    fspace = odl.uniform_discr([0, 0], [1, 1], (2, 2))
+    vfspace = ProductSpace(fspace, 1)
+    pwnorm = PointwiseNorm(vfspace, exponent)
+
+    test_point = np.array([[[0, 0],  # This makes the point singular for p < 2
+                            [1, 2]]])
+    test_direction = np.array([[[1, 2],
+                                [4, 5]]])
+
+    point = vfspace.element(test_point)
+    direction = vfspace.element(test_direction)
+    func_pwnorm = pwnorm.derivative(point)
+
+    assert not any(np.isnan(func_pwnorm(direction)))
+
+    # 3d
+    fspace = odl.uniform_discr([0, 0], [1, 1], (2, 2))
+    vfspace = ProductSpace(fspace, 3)
+    pwnorm = PointwiseNorm(vfspace, exponent)
+
+    test_point = np.array([[[0, 0],  # This makes the point singular for p < 2
+                            [1, 2]],
+                           [[3, 4],
+                            [0, 0]],  # This makes the point singular for p < 2
+                           [[5, 6],
+                            [7, 8]]])
+    test_direction = np.array([[[0, 1],
+                                [2, 3]],
+                               [[4, 5],
+                                [6, 7]],
+                               [[8, 9],
+                                [0, 1]]])
+
+    point = vfspace.element(test_point)
+    direction = vfspace.element(test_direction)
+    func_pwnorm = pwnorm.derivative(point)
+
+    assert not any(np.isnan(func_pwnorm(direction)))
+
+
 # ---- PointwiseInner ----
 
 

--- a/odl/test/operator/tensor_ops_test.py
+++ b/odl/test/operator/tensor_ops_test.py
@@ -203,10 +203,50 @@ def test_pointwise_norm_gradient_real(exponent):
             pwnorm.derivative(point)
         return
 
-    # TODO: implement good tests also for the 'normal behaviour'
+    # 1d
+    fspace = odl.uniform_discr([0, 0], [1, 1], (2, 2))
+    vfspace = ProductSpace(fspace, 1)
+    pwnorm = PointwiseNorm(vfspace, exponent)
 
-    # The gradient is only well-defined in all points if the exponent is >= 2
-    if exponent < 2:
+    point = noise_element(vfspace)
+    direction = noise_element(vfspace)
+
+    # Computing expected result
+    tmp = pwnorm(point).ufuncs.power(1 - exponent)
+    v_field = vfspace.element()
+    for i in range(len(v_field)):
+        v_field[i] = tmp * point[i] * np.abs(point[i])**(exponent - 2)
+    pwinner = odl.PointwiseInner(vfspace, v_field)
+    expected_result = pwinner(direction)
+
+    func_pwnorm = pwnorm.derivative(point)
+
+    assert all_almost_equal(func_pwnorm(direction), expected_result)
+
+    # 3d
+    fspace = odl.uniform_discr([0, 0], [1, 1], (2, 2))
+    vfspace = ProductSpace(fspace, 3)
+    pwnorm = PointwiseNorm(vfspace, exponent)
+
+    point = noise_element(vfspace)
+    direction = noise_element(vfspace)
+
+    # Computing expected result
+    tmp = pwnorm(point).ufuncs.power(1 - exponent)
+    v_field = vfspace.element()
+    for i in range(len(v_field)):
+        v_field[i] = tmp * point[i] * np.abs(point[i])**(exponent - 2)
+    pwinner = odl.PointwiseInner(vfspace, v_field)
+    expected_result = pwinner(direction)
+
+    func_pwnorm = pwnorm.derivative(point)
+    assert all_almost_equal(func_pwnorm(direction), expected_result)
+
+
+def test_pointwise_norm_gradient_real_with_zeros(exponent):
+    # The gradient is only well-defined in points with zeros if the exponent is
+    # >= 2 and < inf
+    if exponent < 2 or exponent == float('inf'):
         pytest.skip('differential of operator has singularity for this '
                     'exponent')
 
@@ -224,7 +264,7 @@ def test_pointwise_norm_gradient_real(exponent):
     direction = vfspace.element(test_direction)
     func_pwnorm = pwnorm.derivative(point)
 
-    assert not np.isnan(func_pwnorm(direction)).asarray().any()
+    assert not np.any(np.isnan(func_pwnorm(direction)))
 
     # 3d
     fspace = odl.uniform_discr([0, 0], [1, 1], (2, 2))
@@ -248,8 +288,7 @@ def test_pointwise_norm_gradient_real(exponent):
     direction = vfspace.element(test_direction)
     func_pwnorm = pwnorm.derivative(point)
 
-    assert not np.isnan(func_pwnorm(direction)).asarray().any()
-
+    assert not np.any(np.isnan(func_pwnorm(direction)))
 
 # ---- PointwiseInner ----
 

--- a/odl/test/solvers/functional/functional_test.py
+++ b/odl/test/solvers/functional/functional_test.py
@@ -49,7 +49,8 @@ def space(request, tspace_impl):
 func_params = ['l1 ', 'l2', 'l2^2', 'constant', 'zero', 'ind_unit_ball_1',
                'ind_unit_ball_2', 'ind_unit_ball_pi', 'ind_unit_ball_inf',
                'product', 'quotient', 'kl', 'kl_cc', 'kl_cross_ent',
-               'kl_cc_cross_ent', 'huber']
+               'kl_cc_cross_ent', 'huber', 'groupl1']
+
 func_ids = [" functional='{}' ".format(p) for p in func_params]
 
 
@@ -93,6 +94,9 @@ def functional(request, space):
         func = odl.solvers.KullbackLeiblerCrossEntropy(space).convex_conj
     elif name == 'huber':
         func = odl.solvers.Huber(space, gamma=0.1)
+    elif name == 'groupl1':
+        space = odl.ProductSpace(space, 3)
+        func = odl.solvers.GroupL1Norm(space)
     else:
         assert False
 


### PR DESCRIPTION
This should fix #950. Also added the group L1 norm to the test suit of functionals.

The commit also contains a safeguarding of the derivative of the `PointwiseNorm`. If I understand correctly, for Lp-spaces with exponent >= 2 the derivative of the pointwise norm exists everywhere and the only issue should be when one gets 0/0 in some points. Ergo the current fix.