### PR TITLE
BUG: Fix wrong axis labels on DiscreteLp.real_space, closes #862

### DIFF
--- a/odl/discr/lp_discr.py
+++ b/odl/discr/lp_discr.py
@@ -396,7 +396,7 @@ class DiscreteLp(DiscretizedSpace):
         dspace = self.dspace.astype(dtype)
         return type(self)(fspace, self.partition, dspace,
                           exponent=self.exponent, interp=self.interp,
-                          order=self.order)
+                          order=self.order, axis_labels=self.axis_labels)
 
     # Overrides for space functions depending on partition
     #


### PR DESCRIPTION
Getting this out of the way.