### PR TITLE
add TGV denoising example and modify the TGV tomography example

### DIFF
--- a/examples/solvers/chambolle_pock_denoising_tgv.py
+++ b/examples/solvers/chambolle_pock_denoising_tgv.py
@@ -1,11 +1,11 @@
-"""Total generalized variation tomography using the Chambolle-Pock solver.
+"""Total generalized variation denoising using the Chambolle-Pock solver.
 
 Solves the optimization problem
 
-    min_x ||Ax - d||_2^2 + TGV_2(x)
+    min_x ||x - d||_2^2 + TGV_2(x)
 
-Where ``A`` is a parallel beam forward projector and ``d`` is given noisy data.
-TGV_2 is the second order total generalized variation of ``x``, defined as
+Where ``d`` is given noisy data TGV_2 is the second order total generalized
+variation of ``x``, defined as
 
     TGV_2(x) = min_y lam_1 ||Gx - y||_1 + lam_2 ||Ey||_1
 
@@ -17,7 +17,7 @@ of the vector y_i at location i.
 
 The problem is rewritten as
 
-    min_{x, y} ||Ax - g||_2^2 +  lam_1 ||Gx - y||_1 + lam_2 ||Ey||_1
+    min_{x, y} ||x - d||_2^2 +  lam_1 ||Gx - y||_1 + lam_2 ||Ey||_1
 
 which can then be solved with the Chambolle-Pock method.
 
@@ -31,20 +31,18 @@ on Imaging Sciences, 8(4):2851-2886, 2015.
 import numpy as np
 import odl
 
+
 # %%
-# --- Set up the forward operator (ray transform) --- #
+# --- Set up the forward operator (identity) --- #
 
 # Reconstruction space: discretized functions on the rectangle
-# [-20, 20]^2 with 100 samples per dimension.
-n = 100
-U = odl.uniform_discr(
-    min_pt=[-20, -20], max_pt=[20, 20], shape=[n, n], dtype='float32')
-
-# Make a parallel beam geometry with flat detector
-geometry = odl.tomo.parallel_beam_geometry(U)
+# [-20, 20]^2 with 300 samples per dimension.
+n = 300
+U = odl.uniform_discr(min_pt=[-20, -20], max_pt=[20, 20], shape=[n, n],
+                      dtype='float32')
 
 # Create the forward operator
-A = odl.tomo.RayTransform(U, geometry)
+A = odl.IdentityOperator(U)
 
 # %%
 # --- Generate artificial data --- #
@@ -52,7 +50,7 @@ A = odl.tomo.RayTransform(U, geometry)
 # Create phantom
 #phantom = odl.phantom.shepp_logan(U, modified=True)
 
-m = 25
+m = 75
 
 e1 = np.linspace(0, 1, n)
 e2 = np.ones([n, 1])
@@ -114,7 +112,7 @@ g = odl.solvers.ZeroFunctional(domain)
 l2_norm = odl.solvers.L2NormSquared(A.range).translated(data)
 
 # parameters
-alpha = 4e-1
+alpha = 1e-1
 beta = 1
 
 # The l1-norms scaled by regularization paramters

--- a/examples/solvers/chambolle_pock_denoising_tgv.py
+++ b/examples/solvers/chambolle_pock_denoising_tgv.py
@@ -48,7 +48,7 @@ A = odl.IdentityOperator(U)
 def phantom_func(pts):
     x, y = pts
     sign = ((x < -10) | (x > 10) | (y < -10) | (y > 10)) * 3 - 2
-    return (x / 20.0) * sign
+    return 0.5 * ((x / 20.0) * sign + 1)
 
 phantom = U.element(phantom_func)
 phantom.show(title='Phantom')
@@ -113,14 +113,13 @@ f = odl.solvers.SeparableSum(l2_norm, l1_norm_1, l1_norm_2)
 # Estimated operator norm, add 10 percent to ensure ||K||_2^2 * sigma * tau < 1
 op_norm = 1.1 * odl.power_method_opnorm(op)
 
-niter = 100  # Number of iterations
+niter = 200  # Number of iterations
 tau = 1.0 / op_norm  # Step size for the primal variable
 sigma = 1.0 / op_norm  # Step size for the dual variable
-gamma = 0.5
 
 # Optionally pass callback to the solver to display intermediate results
 callback = (odl.solvers.CallbackPrintIteration() &
-            odl.solvers.CallbackShow('iterates', step=10, indices=0))
+            odl.solvers.CallbackShow(step=10, indices=0))
 
 # Choose a starting point
 x = op.domain.zero()

--- a/examples/solvers/chambolle_pock_tomography_tgv.py
+++ b/examples/solvers/chambolle_pock_tomography_tgv.py
@@ -1,13 +1,13 @@
-"""Total generalized variation tomography using the Chambolle-Pock solver.
+"""Total Generalized Variation tomography using the Chambolle-Pock solver.
 
 Solves the optimization problem
 
-    min_x ||Ax - d||_2^2 + TGV_2(x)
+    min_x ||Ax - d||_2^2 + alpha * TGV_2(x)
 
 Where ``A`` is a parallel beam forward projector and ``d`` is given noisy data.
 TGV_2 is the second order total generalized variation of ``x``, defined as
 
-    TGV_2(x) = min_y lam_1 ||Gx - y||_1 + lam_2 ||Ey||_1
+    TGV_2(x) = min_y ||Gx - y||_1 + beta ||Ey||_1
 
 where ``G`` is the spatial gradient operating on the scalar-field ``x`` and
 ``E`` is the symmetrized gradient operating on the vector-field ``y``.
@@ -17,7 +17,7 @@ of the vector y_i at location i.
 
 The problem is rewritten as
 
-    min_{x, y} ||Ax - g||_2^2 +  lam_1 ||Gx - y||_1 + lam_2 ||Ey||_1
+    min_{x, y} ||Ax - d||_2^2 + alpha ||Gx - y||_1 + alpha * beta ||Ey||_1
 
 which can then be solved with the Chambolle-Pock method.
 
@@ -31,14 +31,12 @@ on Imaging Sciences, 8(4):2851-2886, 2015.
 import numpy as np
 import odl
 
-# %%
 # --- Set up the forward operator (ray transform) --- #
 
 # Reconstruction space: discretized functions on the rectangle
 # [-20, 20]^2 with 100 samples per dimension.
-n = 100
 U = odl.uniform_discr(
-    min_pt=[-20, -20], max_pt=[20, 20], shape=[n, n], dtype='float32')
+    min_pt=[-20, -20], max_pt=[20, 20], shape=[100, 100], dtype='float32')
 
 # Make a parallel beam geometry with flat detector
 geometry = odl.tomo.parallel_beam_geometry(U)
@@ -46,24 +44,15 @@ geometry = odl.tomo.parallel_beam_geometry(U)
 # Create the forward operator
 A = odl.tomo.RayTransform(U, geometry)
 
-# %%
 # --- Generate artificial data --- #
 
 # Create phantom
-#phantom = odl.phantom.shepp_logan(U, modified=True)
+def phantom_func(pts):
+    x, y = pts
+    sign = ((x < -10) | (x > 10) | (y < -10) | (y > 10)) * 3 - 2
+    return (x / 20.0) * sign
 
-m = 25
-
-e1 = np.linspace(0, 1, n)
-e2 = np.ones([n, 1])
-x = np.outer(e1, e2)
-
-e1 = np.linspace(1, 0, n-2*m)
-e2 = np.ones([n-2*m, 1])
-x[m:-m, m:-m] = np.outer(e1, e2)
-
-phantom = U.element(x)
-
+phantom = U.element(phantom_func)
 phantom.show(title='Phantom')
 
 # Create sinogram of forward projected phantom with noise
@@ -72,25 +61,24 @@ data += odl.phantom.white_noise(A.range) * np.mean(data) * 0.1
 
 data.show(title='Simulated data (Sinogram)')
 
-# %%
 # --- Set up the inverse problem --- #
 
 # Initialize gradient operator
 G = odl.Gradient(U, method='forward', pad_mode='symmetric')
 V = G.range
 
-Dx = odl.discr.diff_ops.PartialDerivative(U, 0, method='backward',
-                                          pad_mode='symmetric')
-Dy = odl.discr.diff_ops.PartialDerivative(U, 1, method='backward',
-                                          pad_mode='symmetric')
+Dx = odl.PartialDerivative(U, 0, method='backward', pad_mode='symmetric')
+Dy = odl.PartialDerivative(U, 1, method='backward', pad_mode='symmetric')
 
+# Create symmetrized operator and weighted space.
+# TODO: As the weighted space is currently not supported in ODL we find a
+# workaround.
 #W = odl.ProductSpace(U, 3, weighting=[1, 1, 2])
 #sym_gradient = odl.operator.ProductSpaceOperator(
 #    [[Dx, 0], [0, Dy], [0.5*Dy, 0.5*Dx]], range=W)
-
-W = odl.ProductSpace(U, 4)
 E = odl.operator.ProductSpaceOperator(
-    [[Dx, 0], [0, Dy], [0.5*Dy, 0.5*Dx], [0.5*Dy, 0.5*Dx]], range=W)
+    [[Dx, 0], [0, Dy], [0.5*Dy, 0.5*Dx], [0.5*Dy, 0.5*Dx]])
+W = E.range
 
 # Create the domain of the problem, given by the reconstruction space and the
 # range of the gradient on the reconstruction space.
@@ -108,8 +96,6 @@ op = odl.BroadcastOperator(
 # Do not use the g functional, set it to zero.
 g = odl.solvers.ZeroFunctional(domain)
 
-# Create functionals for the dual variable
-
 # l2-squared data matching
 l2_norm = odl.solvers.L2NormSquared(A.range).translated(data)
 
@@ -124,9 +110,7 @@ l1_norm_2 = alpha * beta * odl.solvers.L1Norm(W)
 # Combine functionals, order must correspond to the operator K
 f = odl.solvers.SeparableSum(l2_norm, l1_norm_1, l1_norm_2)
 
-# %%
 # --- Select solver parameters and solve using Chambolle-Pock --- #
-
 
 # Estimated operator norm, add 10 percent to ensure ||K||_2^2 * sigma * tau < 1
 op_norm = 1.1 * odl.power_method_opnorm(op)
@@ -147,7 +131,6 @@ x = op.domain.zero()
 odl.solvers.chambolle_pock_solver(x, f, g, op, tau=tau, sigma=sigma,
                                   niter=niter, callback=callback)
 
-# %%
 # Display images
 x[0].show(title='TGV reconstruction')
 x[1].show(title='Derivatives', force_show=True)

--- a/examples/solvers/chambolle_pock_tomography_tgv.py
+++ b/examples/solvers/chambolle_pock_tomography_tgv.py
@@ -50,7 +50,7 @@ A = odl.tomo.RayTransform(U, geometry)
 def phantom_func(pts):
     x, y = pts
     sign = ((x < -10) | (x > 10) | (y < -10) | (y > 10)) * 3 - 2
-    return (x / 20.0) * sign
+    return 0.5 * ((x / 20.0) * sign + 1)
 
 phantom = U.element(phantom_func)
 phantom.show(title='Phantom')
@@ -118,11 +118,10 @@ op_norm = 1.1 * odl.power_method_opnorm(op)
 niter = 100  # Number of iterations
 tau = 1.0 / op_norm  # Step size for the primal variable
 sigma = 1.0 / op_norm  # Step size for the dual variable
-gamma = 0.5
 
 # Optionally pass callback to the solver to display intermediate results
 callback = (odl.solvers.CallbackPrintIteration() &
-            odl.solvers.CallbackShow('iterates', step=10, indices=0))
+            odl.solvers.CallbackShow(step=10, indices=0))
 
 # Choose a starting point
 x = op.domain.zero()


### PR DESCRIPTION
- changed TGV example to match the definition of Bredies and Holler
- added phantom that is suitable for TGV. This may be added as a separate phantom to ODL