### PR TITLE
MAINT: Change entry_points to be lazy

### DIFF
--- a/odl/discr/discretization.py
+++ b/odl/discr/discretization.py
@@ -565,10 +565,6 @@ def dspace_type(space, impl, dtype=None):
         Space type selected after the space's field, the backend and
         the data type
     """
-    spacetype_map = {RealNumbers: fn_impl,
-                     ComplexNumbers: fn_impl,
-                     type(None): ntuples_impl}
-
     field_type = type(getattr(space, 'field', None))
 
     if dtype is None:
@@ -592,13 +588,16 @@ def dspace_type(space, impl, dtype=None):
         raise TypeError('non-scalar data type {!r} cannot be combined with '
                         'a `LinearSpace`'.format(dtype))
 
-    try:
-        stype = spacetype_map[field_type](impl)
-    except KeyError:
+    if field_type in (RealNumbers, ComplexNumbers):
+        spacetype = fn_impl
+    elif field_type == type(None):
+        spacetype = ntuples_impl
+    else:
         raise NotImplementedError('no corresponding data space available '
                                   'for space {!r} and implementation {!r}'
                                   ''.format(space, impl))
-    return stype
+
+    return spacetype(impl)
 
 
 if __name__ == '__main__':

--- a/odl/discr/discretization.py
+++ b/odl/discr/discretization.py
@@ -17,7 +17,7 @@ from builtins import super
 from odl.operator import Operator
 from odl.space.base_ntuples import (NtuplesBase, NtuplesBaseVector,
                                     FnBase, FnBaseVector)
-from odl.space import FunctionSet, FN_IMPLS, NTUPLES_IMPLS
+from odl.space import FunctionSet, fn_impl, ntuples_impl
 from odl.set import RealNumbers, ComplexNumbers, LinearSpace
 from odl.util import (
     arraynd_repr, arraynd_str,
@@ -565,9 +565,9 @@ def dspace_type(space, impl, dtype=None):
         Space type selected after the space's field, the backend and
         the data type
     """
-    spacetype_map = {RealNumbers: FN_IMPLS,
-                     ComplexNumbers: FN_IMPLS,
-                     type(None): NTUPLES_IMPLS}
+    spacetype_map = {RealNumbers: fn_impl,
+                     ComplexNumbers: fn_impl,
+                     type(None): ntuples_impl}
 
     field_type = type(getattr(space, 'field', None))
 
@@ -592,9 +592,9 @@ def dspace_type(space, impl, dtype=None):
         raise TypeError('non-scalar data type {!r} cannot be combined with '
                         'a `LinearSpace`'.format(dtype))
 
-    stype = spacetype_map[field_type].get(impl, None)
-
-    if stype is None:
+    try:
+        stype = spacetype_map[field_type](impl)
+    except KeyError:
         raise NotImplementedError('no corresponding data space available '
                                   'for space {!r} and implementation {!r}'
                                   ''.format(space, impl))

--- a/odl/discr/discretization.py
+++ b/odl/discr/discretization.py
@@ -566,6 +566,7 @@ def dspace_type(space, impl, dtype=None):
         the data type
     """
     field_type = type(getattr(space, 'field', None))
+    none_type = type(None)
 
     if dtype is None:
         pass
@@ -590,7 +591,7 @@ def dspace_type(space, impl, dtype=None):
 
     if field_type in (RealNumbers, ComplexNumbers):
         spacetype = fn_impl
-    elif field_type == type(None):
+    elif field_type is none_type:
         spacetype = ntuples_impl
     else:
         raise NotImplementedError('no corresponding data space available '

--- a/odl/discr/lp_discr.py
+++ b/odl/discr/lp_discr.py
@@ -25,7 +25,7 @@ from odl.discr.discr_mappings import (
 from odl.discr.partition import (
     RectPartition, uniform_partition_fromintv, uniform_partition)
 from odl.set import RealNumbers, ComplexNumbers, IntervalProd
-from odl.space import FunctionSpace, ProductSpace, FN_IMPLS
+from odl.space import FunctionSpace, ProductSpace, fn_impl
 from odl.space.weighting import Weighting, NoWeighting, ConstWeighting
 from odl.util import (
     apply_on_boundary, is_real_dtype, is_complex_floating_dtype,
@@ -1215,7 +1215,7 @@ def uniform_discr_fromintv(interval, shape, exponent=2.0, interp='nearest',
     """
     dtype = kwargs.pop('dtype', None)
     if dtype is None:
-        dtype = FN_IMPLS[impl].default_dtype()
+        dtype = fn_impl(impl).default_dtype()
 
     fspace = FunctionSpace(interval, out_dtype=dtype)
     return uniform_discr_fromspace(fspace, shape, exponent, interp, impl,

--- a/odl/space/entry_points.py
+++ b/odl/space/entry_points.py
@@ -12,8 +12,6 @@ External packages can add implementations of `NtuplesBase` and `FnBase` by
 hooking into the setuptools entry point ``'odl.space'`` and exposing the
 methods ``ntuples_impls`` and ``fn_impls``.
 
-Notes
------
 This is used with functions such as `rn`, `fn` and `uniform_discr` in order
 to allow arbitrary implementations.
 
@@ -36,16 +34,14 @@ __all__ = ('ntuples_impl_names', 'fn_impl_names',
 
 
 IS_INITIALIZED = False
-NTUPLES_IMPLS = {}
-FN_IMPLS = {}
+NTUPLES_IMPLS = {'numpy': NumpyNtuples}
+FN_IMPLS = {'numpy': NumpyFn}
 
 
 def _initialize_if_needed():
     """Initialize ``NTUPLES_IMPLS`` and ``FN_IMPLS`` if not already done."""
     global IS_INITIALIZED, NTUPLES_IMPLS, FN_IMPLS
     if not IS_INITIALIZED:
-        NTUPLES_IMPLS = {'numpy': NumpyNtuples}
-        FN_IMPLS = {'numpy': NumpyFn}
         for entry_point in iter_entry_points(group='odl.space', name=None):
             try:
                 module = entry_point.load()
@@ -69,7 +65,7 @@ def fn_impl_names():
 
 
 def ntuples_impl(impl):
-    """Class corresponding to key.
+    """N-tuples class corresponding to key.
 
     Parameters
     ----------
@@ -81,17 +77,16 @@ def ntuples_impl(impl):
     ntuples_imple : `type`
         Class inheriting from `NtuplesBase`.
     """
-    if impl == 'numpy':
+    if impl != 'numpy':
         # Shortcut to improve "import odl" times since most users do not use
         # non-numpy backend.
-        return NumpyNtuples
-    else:
         _initialize_if_needed()
-        return NTUPLES_IMPLS[impl]
+
+    return NTUPLES_IMPLS[impl]
 
 
 def fn_impl(impl):
-    """Class corresponding to key.
+    """Fn class corresponding to key.
 
     Parameters
     ----------
@@ -103,10 +98,9 @@ def fn_impl(impl):
     ntuples_imple : `type`
         Class inheriting from `FnBase`.
     """
-    if impl == 'numpy':
+    if impl != 'numpy':
         # Shortcut to improve "import odl" times since most users do not use
         # non-numpy backend.
-        return NumpyFn
-    else:
         _initialize_if_needed()
-        return FN_IMPLS[impl]
+
+    return FN_IMPLS[impl]

--- a/odl/space/entry_points.py
+++ b/odl/space/entry_points.py
@@ -45,23 +45,24 @@ def _initialize_if_needed():
         for entry_point in iter_entry_points(group='odl.space', name=None):
             try:
                 module = entry_point.load()
-                NTUPLES_IMPLS.update(module.ntuples_impls())
-                FN_IMPLS.update(module.fn_impls())
             except ImportError:
                 pass
+            else:
+                NTUPLES_IMPLS.update(module.ntuples_impls())
+                FN_IMPLS.update(module.fn_impls())
         IS_INITIALIZED = True
 
 
 def ntuples_impl_names():
-    """A list of strings with valid ntuples implementation names."""
+    """A tuple of strings with valid ntuples implementation names."""
     _initialize_if_needed()
-    return list(NTUPLES_IMPLS.keys())
+    return tuple(NTUPLES_IMPLS.keys())
 
 
 def fn_impl_names():
-    """A list of strings with valid fn implementation names."""
+    """A tuple of strings with valid fn implementation names."""
     _initialize_if_needed()
-    return list(FN_IMPLS.keys())
+    return tuple(FN_IMPLS.keys())
 
 
 def ntuples_impl(impl):
@@ -74,15 +75,24 @@ def ntuples_impl(impl):
 
     Returns
     -------
-    ntuples_imple : `type`
+    ntuples_impl : `type`
         Class inheriting from `NtuplesBase`.
+
+    Raises
+    ------
+    ValueError
+        If ``impl`` is not a valid name of a ntuples imlementation.
     """
     if impl != 'numpy':
         # Shortcut to improve "import odl" times since most users do not use
         # non-numpy backend.
         _initialize_if_needed()
 
-    return NTUPLES_IMPLS[impl]
+    try:
+        return NTUPLES_IMPLS[impl]
+    except:
+        raise ValueError("key '{}' does not correspond to a valid ntuples "
+                         "implmentation".format(impl))
 
 
 def fn_impl(impl):
@@ -95,12 +105,21 @@ def fn_impl(impl):
 
     Returns
     -------
-    ntuples_imple : `type`
+    fn_impl : `type`
         Class inheriting from `FnBase`.
+
+    Raises
+    ------
+    ValueError
+        If ``impl`` is not a valid name of a fn imlementation.
     """
     if impl != 'numpy':
         # Shortcut to improve "import odl" times since most users do not use
         # non-numpy backend.
         _initialize_if_needed()
 
-    return FN_IMPLS[impl]
+    try:
+        return FN_IMPLS[impl]
+    except:
+        raise ValueError("key '{}' does not correspond to a valid fn "
+                         "implmentation".format(impl))

--- a/odl/space/space_utils.py
+++ b/odl/space/space_utils.py
@@ -18,7 +18,7 @@ __all__ = ('vector', 'ntuples', 'fn', 'cn', 'rn')
 import numpy as np
 
 from odl.set import RealNumbers, ComplexNumbers
-from odl.space.entry_points import NTUPLES_IMPLS, FN_IMPLS
+from odl.space.entry_points import ntuples_impl, fn_impl
 from odl.util import (
     is_real_floating_dtype, is_complex_floating_dtype, is_scalar_dtype)
 
@@ -35,8 +35,8 @@ def vector(array, dtype=None, impl='numpy'):
         Set the data type of the vector manually with this option.
         By default, the space type is inferred from the input data.
     impl : string, optional
-        The backend to use. See `odl.space.entry_points.NTUPLES_IMPLS` and
-        `odl.space.entry_points.FN_IMPLS` for available options.
+        The backend to use. See `odl.space.entry_points.ntuples_impl_names` and
+        `odl.space.entry_points.fn_impl_names` for available options.
 
     Returns
     -------
@@ -106,7 +106,7 @@ def ntuples(size, dtype, impl='numpy', **kwargs):
 
         Only complex floating-point data types are allowed.
     impl : string, optional
-        The backend to use. See `odl.space.entry_points.NTUPLES_IMPLS` for
+        The backend to use. See `odl.space.entry_points.ntuples_impl_names` for
         available options.
     kwargs :
         Extra keyword arguments to pass to the implmentation.
@@ -119,7 +119,7 @@ def ntuples(size, dtype, impl='numpy', **kwargs):
     --------
     fn : n-tuples over a field with arbitrary scalar data type.
     """
-    return NTUPLES_IMPLS[impl](size, dtype, **kwargs)
+    return ntuples_impl(impl)(size, dtype, **kwargs)
 
 
 def fn(size, dtype=None, impl='numpy', **kwargs):
@@ -138,7 +138,7 @@ def fn(size, dtype=None, impl='numpy', **kwargs):
         Default: default of the implementation given by calling
         ``default_dtype()`` on the `FnBase` implementation.
     impl : string, optional
-        The backend to use. See `odl.space.entry_points.FN_IMPLS` for
+        The backend to use. See `odl.space.entry_points.fn_impl_names` for
         available options.
     kwargs :
         Extra keyword arguments to pass to the implmentation.
@@ -151,14 +151,12 @@ def fn(size, dtype=None, impl='numpy', **kwargs):
     --------
     ntuples : n-tuples over a field with arbitrary data type.
     """
-    fn_impl = FN_IMPLS[impl]
+    fn_cls = fn_impl(impl)
 
     if dtype is None:
         dtype = fn_impl.default_dtype()
 
-    fn = fn_impl(size, dtype, **kwargs)
-
-    return fn
+    return fn_cls(size, dtype=dtype, **kwargs)
 
 
 def cn(size, dtype=None, impl='numpy', **kwargs):
@@ -179,7 +177,7 @@ def cn(size, dtype=None, impl='numpy', **kwargs):
         Default: default of the implementation given by calling
         ``default_dtype(ComplexNumbers())`` on the `FnBase` implementation.
     impl : string, optional
-        The backend to use. See `odl.space.entry_points.FN_IMPLS` for
+        The backend to use. See `odl.space.entry_points.fn_impl_names` for
         available options.
     kwargs :
         Extra keyword arguments to pass to the implmentation.
@@ -192,12 +190,12 @@ def cn(size, dtype=None, impl='numpy', **kwargs):
     --------
     fn : n-tuples over a field with arbitrary scalar data type.
     """
-    cn_impl = FN_IMPLS[impl]
+    cn_cls = fn_impl(impl)
 
     if dtype is None:
-        dtype = cn_impl.default_dtype(ComplexNumbers())
+        dtype = cn_cls.default_dtype(ComplexNumbers())
 
-    cn = cn_impl(size, dtype, **kwargs)
+    cn = cn_cls(size, dtype, **kwargs)
 
     if not cn.is_cn:
         raise TypeError('data type {!r} not a complex floating-point type.'
@@ -222,7 +220,7 @@ def rn(size, dtype=None, impl='numpy', **kwargs):
         Default: default of the implementation given by calling
         ``default_dtype(RealNumbers())`` on the `FnBase` implementation.
     impl : string, optional
-        The backend to use. See `odl.space.entry_points.FN_IMPLS` for
+        The backend to use. See `odl.space.entry_points.fn_impl_names` for
         available options.
     kwargs :
         Extra keyword arguments to pass to the implmentation.
@@ -235,7 +233,7 @@ def rn(size, dtype=None, impl='numpy', **kwargs):
     --------
     fn : n-tuples over a field with arbitrary scalar data type.
     """
-    rn_impl = FN_IMPLS[impl]
+    rn_impl = fn_impl(impl)
 
     if dtype is None:
         dtype = rn_impl.default_dtype(RealNumbers())

--- a/odl/test/deform/linearized_deform_test.py
+++ b/odl/test/deform/linearized_deform_test.py
@@ -32,7 +32,7 @@ def space(request, ndim, interp, dtype, fn_impl):
     Generates example spaces with various implementations, dimensions, dtypes
     and interpolations.
     """
-    if np.dtype(dtype) not in odl.FN_IMPLS[fn_impl].available_dtypes():
+    if np.dtype(dtype) not in odl.fn_impl(fn_impl).available_dtypes():
         pytest.skip('dtype not available for this backend')
 
     return odl.uniform_discr([-1] * ndim, [1] * ndim, [20] * ndim,

--- a/odl/test/discr/discr_ops_test.py
+++ b/odl/test/discr/discr_ops_test.py
@@ -104,7 +104,7 @@ def test_resizing_op_raise():
 
 
 def test_resizing_op_properties(fn_impl, padding):
-    dtypes = [dt for dt in odl.FN_IMPLS[fn_impl].available_dtypes()
+    dtypes = [dt for dt in odl.fn_impl(fn_impl).available_dtypes()
               if is_scalar_dtype(dt)]
 
     pad_mode, pad_const = padding
@@ -143,7 +143,7 @@ def test_resizing_op_properties(fn_impl, padding):
 
 
 def test_resizing_op_call(fn_impl):
-    dtypes = [dt for dt in odl.FN_IMPLS[fn_impl].available_dtypes()
+    dtypes = [dt for dt in odl.fn_impl(fn_impl).available_dtypes()
               if is_scalar_dtype(dt)]
 
     for dtype in dtypes:
@@ -194,7 +194,7 @@ def test_resizing_op_deriv(padding):
 
 def test_resizing_op_inverse(padding, fn_impl):
     pad_mode, pad_const = padding
-    dtypes = [dt for dt in odl.FN_IMPLS[fn_impl].available_dtypes()
+    dtypes = [dt for dt in odl.fn_impl(fn_impl).available_dtypes()
               if is_scalar_dtype(dt)]
 
     for dtype in dtypes:
@@ -212,7 +212,7 @@ def test_resizing_op_inverse(padding, fn_impl):
 
 def test_resizing_op_adjoint(padding, fn_impl):
     pad_mode, pad_const = padding
-    dtypes = [dt for dt in odl.FN_IMPLS[fn_impl].available_dtypes()
+    dtypes = [dt for dt in odl.fn_impl(fn_impl).available_dtypes()
               if is_real_floating_dtype(dt)]
 
     for dtype in dtypes:

--- a/odl/util/pytest_plugins.py
+++ b/odl/util/pytest_plugins.py
@@ -95,7 +95,7 @@ def pytest_ignore_collect(path, config):
 
 # --- Reusable fixtures ---
 
-fn_impl_params = odl.FN_IMPLS.keys()
+fn_impl_params = odl.fn_impl_names()
 fn_impl_ids = [" impl = '{}' ".format(p) for p in fn_impl_params]
 
 
@@ -104,7 +104,7 @@ def fn_impl(request):
     """String with an available `FnBase` implementation name."""
     return request.param
 
-ntuples_impl_params = odl.NTUPLES_IMPLS.keys()
+ntuples_impl_params = odl.ntuples_impl_names()
 ntuples_impl_ids = [" impl = '{}' ".format(p) for p in ntuples_impl_params]
 
 


### PR DESCRIPTION
This PR does two things:

* Changes `entry_points` to being lazy, meaning that we don't go looking for backends before it is really needed. This reduces import time noticably.

* Fixes the circular import problem in https://github.com/odlgroup/odlcuda/issues/19