### PR TITLE
ENH/BUG: update of unweighted ray transform.

### DIFF
--- a/odl/tomo/operators/ray_trafo.py
+++ b/odl/tomo/operators/ray_trafo.py
@@ -205,7 +205,7 @@ class RayTransformBase(Operator):
             proj_uspace = FunctionSpace(geometry.params, out_dtype=dtype)
 
             if isinstance(reco_space.weighting, NoWeighting):
-                weighting = 1.0
+                weighting = None
             elif (isinstance(reco_space.weighting, ConstWeighting) and
                   np.isclose(reco_space.weighting.const,
                              reco_space.cell_volume)):


### PR DESCRIPTION
If the domain of the ray transform is unweighted, the weighting in the range should not be `1.0` but it should return an unweighted space, i.e., the argument passed should be `None`.