### PR TITLE
ENH/BUG: update in fbp to handle unweighted range of ray transform.

### DIFF
--- a/odl/test/largescale/tomo/analytic_slow_test.py
+++ b/odl/test/largescale/tomo/analytic_slow_test.py
@@ -27,6 +27,8 @@ filter_type = simple_fixture(
 frequency_scaling = simple_fixture(
     'frequency_scaling', [0.5, 0.9, 1.0])
 
+weighting = simple_fixture('weighting', ['const', 'none'])
+
 # Find the valid projectors
 # TODO: Add nonuniform once #671 is solved
 projectors = [skip_if_no_astra('par2d astra_cpu uniform'),
@@ -49,7 +51,7 @@ projectors = [pytest.mark.skipif(p.args[0] + largescale, p.args[1])
 
 
 @pytest.fixture(scope="module", params=projectors, ids=projector_ids)
-def projector(request):
+def projector(request, weighting):
 
     n_angles = 500
     dtype = 'float32'
@@ -77,7 +79,8 @@ def projector(request):
     if geom == 'par2d':
         # Reconstruction space
         discr_reco_space = odl.uniform_discr([-20, -20], [20, 20],
-                                             [100, 100], dtype=dtype)
+                                             [100, 100], dtype=dtype,
+                                             weighting=weighting)
 
         # Geometry
         dpart = odl.uniform_partition(-30, 30, 500)
@@ -89,7 +92,8 @@ def projector(request):
     elif geom == 'par3d':
         # Reconstruction space
         discr_reco_space = odl.uniform_discr([-20, -20, -20], [20, 20, 20],
-                                             [100, 100, 100], dtype=dtype)
+                                             [100, 100, 100], dtype=dtype,
+                                             weighting=weighting)
 
         # Geometry
         dpart = odl.uniform_partition([-30, -30], [30, 30], [200, 200])
@@ -101,7 +105,8 @@ def projector(request):
     elif geom == 'cone2d':
         # Reconstruction space
         discr_reco_space = odl.uniform_discr([-20, -20], [20, 20],
-                                             [100, 100], dtype=dtype)
+                                             [100, 100], dtype=dtype,
+                                             weighting=weighting)
 
         # Geometry
         dpart = odl.uniform_partition(-40, 40, 200)
@@ -114,7 +119,8 @@ def projector(request):
     elif geom == 'cone3d':
         # Reconstruction space
         discr_reco_space = odl.uniform_discr([-20, -20, -20], [20, 20, 20],
-                                             [100, 100, 100], dtype=dtype)
+                                             [100, 100, 100], dtype=dtype,
+                                             weighting=weighting)
 
         # Geometry
         dpart = odl.uniform_partition([-50, -50], [50, 50], [200, 200])
@@ -127,7 +133,8 @@ def projector(request):
     elif geom == 'helical':
         # Reconstruction space
         discr_reco_space = odl.uniform_discr([-20, -20, 0], [20, 20, 40],
-                                             [100, 100, 100], dtype=dtype)
+                                             [100, 100, 100], dtype=dtype,
+                                             weighting=weighting)
 
         # Geometry
         # TODO: angles
@@ -174,13 +181,14 @@ def test_fbp_reconstruction(projector):
 
 @skip_if_no_astra_cuda
 @skip_if_no_largescale
-def test_fbp_reconstruction_filters(filter_type, frequency_scaling):
+def test_fbp_reconstruction_filters(filter_type, frequency_scaling, weighting):
     """Validate that the various filters work as expected."""
 
     apart = odl.uniform_partition(0, np.pi, 500)
 
     discr_reco_space = odl.uniform_discr([-20, -20], [20, 20],
-                                         [100, 100], dtype='float32')
+                                         [100, 100], dtype='float32',
+                                         weighting=weighting)
 
     # Geometry
     dpart = odl.uniform_partition(-30, 30, 500)

--- a/odl/tomo/analytic/filtered_back_projection.py
+++ b/odl/tomo/analytic/filtered_back_projection.py
@@ -15,6 +15,7 @@ import numpy as np
 import scipy as sp
 from odl.discr import ResizingOperator
 from odl.trafos import FourierTransform, PYFFTW_AVAILABLE
+from odl.space.weighting import NoWeighting
 
 
 __all__ = ('fbp_op', 'fbp_filter_op', 'tam_danielson_window',
@@ -440,7 +441,12 @@ def fbp_filter_op(ray_trafo, padding=True, filter_type='Ram-Lak',
     ramp_function = fourier.range.element(fourier_filter)
 
     # Create ramp filter via the convolution formula with fourier transforms
-    return fourier.inverse * ramp_function * fourier
+    if isinstance(ray_trafo.range.weighting, NoWeighting):
+        # Compensate for potentially unweighted range of the ray transform
+        weights = ray_trafo.range.cell_volume
+        return weights * fourier.inverse * ramp_function * fourier
+    else:
+        return fourier.inverse * ramp_function * fourier
 
 
 def fbp_op(ray_trafo, padding=True, filter_type='Ram-Lak',

--- a/odl/tomo/analytic/filtered_back_projection.py
+++ b/odl/tomo/analytic/filtered_back_projection.py
@@ -440,13 +440,19 @@ def fbp_filter_op(ray_trafo, padding=True, filter_type='Ram-Lak',
     # Create ramp in the detector direction
     ramp_function = fourier.range.element(fourier_filter)
 
-    # Create ramp filter via the convolution formula with fourier transforms
+    weight = 1
     if isinstance(ray_trafo.range.weighting, NoWeighting):
         # Compensate for potentially unweighted range of the ray transform
-        weights = ray_trafo.range.cell_volume
-        return weights * fourier.inverse * ramp_function * fourier
-    else:
-        return fourier.inverse * ramp_function * fourier
+        weight *= ray_trafo.range.cell_volume
+
+    if isinstance(ray_trafo.domain.weighting, NoWeighting):
+        # Compensate for potentially unweighted domain of the ray transform
+        weight /= ray_trafo.domain.cell_volume
+
+    ramp_function *= weight
+
+    # Create ramp filter via the convolution formula with fourier transforms
+    return fourier.inverse * ramp_function * fourier
 
 
 def fbp_op(ray_trafo, padding=True, filter_type='Ram-Lak',


### PR DESCRIPTION
The `range` of the ray transform "inherits" the weighting (i.e., it is unweighted) from the `domain` if this is unweighted (see commit 12344455 and df30402f4). However, in this case creating an FBP operator will not give an analytic inverse. It needs to be scaled. This is a first draft on this.

Thank you @adler-j for pointing it out.