### PR TITLE
MAINT: make imports even more lazy to speed up import time

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -9,10 +9,10 @@ omit =
     */__init__.py
     odl/diagnostics/*
     odl/util/*
-    
+
     # Omit until coveralls supports cuda.
     odl/space/cu_ntuples.py
-    
+
     # Omit until coveralls supports pywt.
     odl/trafos/wavelet.py
 
@@ -41,7 +41,6 @@ exclude_lines =
 
     # Skip imports and __all__
     import *
-    standard_library.install_aliases()
     __all__
 
     # Decorators

--- a/odl/contrib/mrc/mrc.py
+++ b/odl/contrib/mrc/mrc.py
@@ -10,8 +10,6 @@
 
 # Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import int, super
 
 from collections import OrderedDict

--- a/odl/contrib/mrc/uncompr_bin.py
+++ b/odl/contrib/mrc/uncompr_bin.py
@@ -10,8 +10,6 @@
 
 # Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import int, object, open
 
 from collections import OrderedDict

--- a/odl/contrib/solvers/functional/nonlocalmeans_functionals.py
+++ b/odl/contrib/solvers/functional/nonlocalmeans_functionals.py
@@ -10,8 +10,6 @@
 
 # Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import super
 
 import numpy as np

--- a/odl/contrib/tensorflow/layer.py
+++ b/odl/contrib/tensorflow/layer.py
@@ -11,8 +11,6 @@
 # Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
 from builtins import range, str
-from future import standard_library
-standard_library.install_aliases()
 
 import numpy as np
 import uuid

--- a/odl/contrib/tensorflow/operator.py
+++ b/odl/contrib/tensorflow/operator.py
@@ -10,8 +10,6 @@
 
 # Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
-from future import standard_library
-standard_library.install_aliases()
 
 import tensorflow as tf
 import numpy as np

--- a/odl/contrib/tensorflow/space.py
+++ b/odl/contrib/tensorflow/space.py
@@ -10,8 +10,6 @@
 
 # Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
-from future import standard_library
-standard_library.install_aliases()
 
 import tensorflow as tf
 from odl.set import LinearSpace, LinearSpaceElement, RealNumbers

--- a/odl/contrib/theano/layer.py
+++ b/odl/contrib/theano/layer.py
@@ -10,9 +10,7 @@
 
 # Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
-from future import standard_library
 from future.utils import native
-standard_library.install_aliases()
 
 import theano
 import numpy as np

--- a/odl/deform/linearized.py
+++ b/odl/deform/linearized.py
@@ -10,8 +10,6 @@
 
 # Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import super
 
 import numpy as np

--- a/odl/diagnostics/examples.py
+++ b/odl/diagnostics/examples.py
@@ -10,8 +10,6 @@
 
 # Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
-from future import standard_library
-standard_library.install_aliases()
 
 from itertools import product
 

--- a/odl/diagnostics/operator.py
+++ b/odl/diagnostics/operator.py
@@ -10,8 +10,6 @@
 
 # Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import object
 
 import numpy as np

--- a/odl/diagnostics/space.py
+++ b/odl/diagnostics/space.py
@@ -10,8 +10,6 @@
 
 # Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import object
 
 from copy import copy, deepcopy

--- a/odl/discr/diff_ops.py
+++ b/odl/discr/diff_ops.py
@@ -10,8 +10,6 @@
 
 # Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import super
 
 import numpy as np

--- a/odl/discr/discr_mappings.py
+++ b/odl/discr/discr_mappings.py
@@ -14,8 +14,6 @@ operators.
 
 # Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import str, super, zip
 
 from itertools import product

--- a/odl/discr/discr_ops.py
+++ b/odl/discr/discr_ops.py
@@ -10,13 +10,11 @@
 
 # Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import super
 
 import numpy as np
 
-from odl.discr import DiscreteLp, uniform_partition, nonuniform_partition
+from odl.discr import DiscreteLp, uniform_partition
 from odl.operator import Operator
 from odl.set import IntervalProd
 from odl.space import FunctionSpace, fn

--- a/odl/discr/discretization.py
+++ b/odl/discr/discretization.py
@@ -10,8 +10,6 @@
 
 # Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import super
 
 from odl.operator import Operator

--- a/odl/discr/grid.py
+++ b/odl/discr/grid.py
@@ -14,16 +14,14 @@ space with a certain structure which is exploited to minimize storage.
 
 # Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
-from future import standard_library
-standard_library.install_aliases()
-from builtins import super, range, str, zip
+from builtins import range, str, zip
 
 import numpy as np
 
 from odl.set import Set, IntervalProd
 from odl.util import (
     normalized_index_expression, normalized_scalar_param_list, safe_int_conv,
-    array1d_repr, array1d_str, signature_string, indent_rows)
+    array1d_repr, signature_string, indent_rows)
 
 
 __all__ = ('RectGrid', 'uniform_grid', 'uniform_grid_fromintv')
@@ -160,6 +158,8 @@ class RectGrid(Set):
         Ordering is only relevant when the point array is actually created;
         the grid itself is independent of this ordering.
         """
+        super(RectGrid, self).__init__()
+
         vecs = tuple(np.atleast_1d(vec).astype('float64')
                      for vec in coord_vectors)
         for i, vec in enumerate(vecs):

--- a/odl/discr/lp_discr.py
+++ b/odl/discr/lp_discr.py
@@ -10,8 +10,6 @@
 
 # Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import super, str
 
 import numpy as np

--- a/odl/discr/partition.py
+++ b/odl/discr/partition.py
@@ -16,8 +16,6 @@ of partitions of intervals.
 
 # Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import object, range, super, zip
 
 import numpy as np

--- a/odl/operator/default_ops.py
+++ b/odl/operator/default_ops.py
@@ -10,11 +10,8 @@
 
 # Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import super
 
-import numpy as np
 from copy import copy
 import numpy as np
 

--- a/odl/operator/fn_ops.py
+++ b/odl/operator/fn_ops.py
@@ -10,8 +10,6 @@
 
 # Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import super
 import numpy as np
 

--- a/odl/operator/operator.py
+++ b/odl/operator/operator.py
@@ -10,9 +10,6 @@
 
 # Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
-from future import standard_library
-from future.utils import raise_from
-standard_library.install_aliases()
 from builtins import object, super
 
 import inspect
@@ -672,10 +669,10 @@ class Operator(object):
         if x not in self.domain:
             try:
                 x = self.domain.element(x)
-            except (TypeError, ValueError) as err:
-                raise_from(OpDomainError(
+            except (TypeError, ValueError):
+                raise OpDomainError(
                     'unable to cast {!r} to an element of '
-                    'the domain {!r}'.format(x, self.domain)), err)
+                    'the domain {!r}'.format(x, self.domain))
 
         if out is not None:  # In-place evaluation
             if out not in self.range:
@@ -700,11 +697,10 @@ class Operator(object):
             if out not in self.range:
                 try:
                     out = self.range.element(out)
-                except (TypeError, ValueError) as err:
-                    new_exc = OpRangeError(
+                except (TypeError, ValueError):
+                    raise OpRangeError(
                         'unable to cast {!r} to an element of '
                         'the range {!r}'.format(out, self.range))
-                    raise_from(new_exc, err)
         return out
 
     def norm(self, estimate=False, **kwargs):
@@ -2233,6 +2229,7 @@ class OpNotImplementedError(NotImplementedError):
     These are raised when a method in `LinearSpace` that has not been
     defined in a specific space is called.
     """
+
 
 if __name__ == '__main__':
     # pylint: disable=wrong-import-position

--- a/odl/operator/oputils.py
+++ b/odl/operator/oputils.py
@@ -10,9 +10,7 @@
 
 # Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
-from future import standard_library
-from future.utils import raise_from, native
-standard_library.install_aliases()
+from future.utils import native
 
 import numpy as np
 
@@ -198,10 +196,9 @@ def power_method_opnorm(op, xstart=None, maxiter=100, rtol=1e-05, atol=1e-08,
     if xstart is None:
         try:
             x = op.domain.one()  # TODO: random? better choice?
-        except AttributeError as exc:
-            raise_from(
-                ValueError('`xstart` must be defined in case the '
-                           'operator domain has no `one()`'), exc)
+        except AttributeError:
+            raise ValueError('`xstart` must be defined in case the '
+                             'operator domain has no `one()`')
     else:
         # copy to ensure xstart is not modified
         x = op.domain.element(xstart).copy()
@@ -290,6 +287,9 @@ def as_scipy_operator(op):
     `NumpyFn` this incurs no significant overhead. If the space type is
     ``CudaFn`` or some other nonlocal type, the overhead is significant.
     """
+    # Lazy import to improve `import odl` time
+    import scipy.sparse
+
     if not op.is_linear:
         raise ValueError('`op` needs to be linear')
 
@@ -312,7 +312,6 @@ def as_scipy_operator(op):
     def rmatvec(v):
         return as_flat_array(op.adjoint(v))
 
-    import scipy.sparse.linalg
     return scipy.sparse.linalg.LinearOperator(shape=shape,
                                               matvec=matvec,
                                               rmatvec=rmatvec,

--- a/odl/operator/pspace_ops.py
+++ b/odl/operator/pspace_ops.py
@@ -10,12 +10,9 @@
 
 # Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import super
 
 import numpy as np
-import scipy as sp
 from numbers import Integral
 
 from odl.operator.operator import Operator
@@ -144,6 +141,8 @@ class ProductSpaceOperator(Operator):
             [1.0, 2.0, 3.0]
         ])
         """
+        # Lazy import to improve `import odl` time
+        import scipy.sparse
 
         # Validate input data
         if domain is not None:
@@ -161,7 +160,7 @@ class ProductSpaceOperator(Operator):
                 raise NotImplementedError('weighted spaces not supported')
 
         # Convert ops to sparse representation
-        self.ops = sp.sparse.coo_matrix(operators)
+        self.ops = scipy.sparse.coo_matrix(operators)
 
         if not all(isinstance(op, Operator) for op in self.ops.data):
             raise TypeError('`operators` {!r} must be a matrix of Operators'
@@ -298,6 +297,9 @@ class ProductSpaceOperator(Operator):
             [0.0, 0.0, 0.0]
         ])
         """
+        # Lazy import to improve `import odl` time
+        import scipy.sparse
+
         # Short circuit optimization
         if self.is_linear:
             return self
@@ -306,7 +308,7 @@ class ProductSpaceOperator(Operator):
                                                               self.ops.col)]
         indices = [self.ops.row, self.ops.col]
         shape = self.ops.shape
-        deriv_matrix = sp.sparse.coo_matrix((deriv_ops, indices), shape)
+        deriv_matrix = scipy.sparse.coo_matrix((deriv_ops, indices), shape)
         return ProductSpaceOperator(deriv_matrix, self.domain, self.range)
 
     @property
@@ -346,10 +348,13 @@ class ProductSpaceOperator(Operator):
             [1.0, 2.0, 3.0]
         ])
         """
+        # Lazy import to improve `import odl` time
+        import scipy.sparse
+
         adjoint_ops = [op.adjoint for op in self.ops.data]
         indices = [self.ops.col, self.ops.row]  # Swap col/row -> transpose
         shape = (self.ops.shape[1], self.ops.shape[0])
-        adj_matrix = sp.sparse.coo_matrix((adjoint_ops, indices), shape)
+        adj_matrix = scipy.sparse.coo_matrix((adjoint_ops, indices), shape)
         return ProductSpaceOperator(adj_matrix, self.range, self.domain)
 
     def __getitem__(self, index):
@@ -1046,6 +1051,9 @@ class DiagonalOperator(ProductSpaceOperator):
         >>> op.operators
         (IdentityOperator(rn(3)), IdentityOperator(rn(3)))
         """
+        # Lazy import to improve `import odl` time
+        import scipy.sparse
+
         if (len(operators) == 2 and
                 isinstance(operators[0], Operator) and
                 isinstance(operators[1], Integral)):
@@ -1053,7 +1061,7 @@ class DiagonalOperator(ProductSpaceOperator):
 
         indices = [range(len(operators)), range(len(operators))]
         shape = (len(operators), len(operators))
-        op_matrix = sp.sparse.coo_matrix((operators, indices), shape)
+        op_matrix = scipy.sparse.coo_matrix((operators, indices), shape)
 
         self.__operators = tuple(operators)
 

--- a/odl/operator/tensor_ops.py
+++ b/odl/operator/tensor_ops.py
@@ -10,18 +10,14 @@
 
 # Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import super
 
 import numpy as np
-import scipy
 
 from odl.operator import Operator
-from odl.set import RealNumbers, ComplexNumbers, LinearSpace
+from odl.set import RealNumbers, ComplexNumbers
 from odl.space import ProductSpace, fn
 from odl.space.base_ntuples import FnBase
-from odl.space.npy_ntuples import NumpyFn
 from odl.util import writable_array, signature_string, indent_rows
 
 
@@ -762,7 +758,9 @@ class MatrixOperator(Operator):
         >>> op(op.domain.one())
         rn(4).element([13.0, 7.0, 0.0, 5.0])
         """
-        # TODO: fix dead link `scipy.sparse.spmatrix`
+        # Lazy import to improve `import odl` time
+        import scipy.sparse
+
         if scipy.sparse.isspmatrix(matrix):
             self.__matrix = matrix
         else:
@@ -813,6 +811,8 @@ class MatrixOperator(Operator):
     @property
     def matrix_issparse(self):
         """Whether the representing matrix is sparse or not."""
+        # Lazy import to improve `import odl` time
+        import scipy.sparse
         return scipy.sparse.isspmatrix(self.matrix)
 
     @property
@@ -844,7 +844,10 @@ class MatrixOperator(Operator):
         -------
         inverse : `MatrixOperator`
         """
-        if self.matrix_issparse:
+        # Lazy import to improve `import odl` time
+        import scipy.sparse
+
+        if scipy.sparse.issparse(self.matrix):
             dense_matrix = self.matrix.toarray()
         else:
             dense_matrix = self.matrix
@@ -852,7 +855,7 @@ class MatrixOperator(Operator):
                               domain=self.range, range=self.domain)
 
     def _call(self, x, out=None):
-        """Raw apply method on input, writing to given output."""
+        """Return ``self(x[, out])``."""
         if out is None:
             return self.range.element(self.matrix.dot(x))
         else:
@@ -895,6 +898,7 @@ class MatrixOperator(Operator):
     def __str__(self):
         """Return ``str(self)``."""
         return repr(self)
+
 
 if __name__ == '__main__':
     # pylint: disable=wrong-import-position

--- a/odl/phantom/emission.py
+++ b/odl/phantom/emission.py
@@ -10,8 +10,6 @@
 
 # Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
-from future import standard_library
-standard_library.install_aliases()
 
 from odl.phantom.geometric import ellipsoid_phantom
 from odl.phantom.phantom_utils import cylinders_from_ellipses

--- a/odl/phantom/geometric.py
+++ b/odl/phantom/geometric.py
@@ -10,8 +10,6 @@
 
 # Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
-from future import standard_library
-standard_library.install_aliases()
 
 import numpy as np
 

--- a/odl/phantom/misc_phantoms.py
+++ b/odl/phantom/misc_phantoms.py
@@ -10,8 +10,6 @@
 
 # Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
-from future import standard_library
-standard_library.install_aliases()
 
 import numpy as np
 import sys

--- a/odl/phantom/noise.py
+++ b/odl/phantom/noise.py
@@ -10,8 +10,6 @@
 
 # Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
-from future import standard_library
-standard_library.install_aliases()
 
 import numpy as np
 from odl.util import as_flat_array, NumpyRandomSeed

--- a/odl/phantom/phantom_utils.py
+++ b/odl/phantom/phantom_utils.py
@@ -10,8 +10,6 @@
 
 # Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
-from future import standard_library
-standard_library.install_aliases()
 
 import numpy as np
 

--- a/odl/phantom/transmission.py
+++ b/odl/phantom/transmission.py
@@ -10,8 +10,6 @@
 
 # Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
-from future import standard_library
-standard_library.install_aliases()
 
 from odl.discr import DiscreteLp
 from odl.phantom.geometric import ellipsoid_phantom

--- a/odl/set/domain.py
+++ b/odl/set/domain.py
@@ -11,9 +11,6 @@
 # Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
 from builtins import super, zip
-from future import standard_library
-from future.utils import raise_from
-standard_library.install_aliases()
 
 import numpy as np
 
@@ -326,10 +323,9 @@ class IntervalProd(Set):
         try:
             return (self.approx_contains(other.min(), atol) and
                     self.approx_contains(other.max(), atol))
-        except AttributeError as err:
-            raise_from(
-                AttributeError('cannot test {!r} without `min` and `max` '
-                               'methods'.format(other)), err)
+        except AttributeError:
+            raise AttributeError('cannot test {!r} without `min` and `max` '
+                                 'methods'.format(other))
 
     def contains_all(self, other, atol=0.0):
         """Return ``True`` if all points defined by ``other`` are contained.

--- a/odl/set/sets.py
+++ b/odl/set/sets.py
@@ -11,9 +11,7 @@
 # Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
 from builtins import int, object, str, zip
-from future import standard_library
 from past.builtins import basestring
-standard_library.install_aliases()
 
 from numbers import Integral, Real, Complex
 import numpy as np

--- a/odl/set/space.py
+++ b/odl/set/space.py
@@ -10,9 +10,7 @@
 
 # Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
-from builtins import object, range, str
-from future import standard_library
-standard_library.install_aliases()
+from builtins import object, range
 
 import numpy as np
 

--- a/odl/solvers/functional/default_functionals.py
+++ b/odl/solvers/functional/default_functionals.py
@@ -10,20 +10,15 @@
 
 # Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import super
 
 import numpy as np
-import scipy
 from numbers import Integral
 
 from odl.solvers.functional.functional import Functional
 from odl.space import ProductSpace
 from odl.operator import (Operator, ConstantOperator, ZeroOperator,
                           ScalingOperator, DiagonalOperator, PointwiseNorm)
-from odl.solvers.functional.functional import (
-    Functional, FunctionalDefaultConvexConjugate)
 from odl.solvers.nonsmooth.proximal_operators import (
     proximal_l1, proximal_convex_conj_l1, proximal_l2, proximal_convex_conj_l2,
     proximal_l2_squared, proximal_const_func, proximal_box_constraint,
@@ -1109,6 +1104,9 @@ class KullbackLeibler(Functional):
         If any components of ``x`` is non-positive, the value is positive
         infinity.
         """
+        # Lazy import to improve `import odl` time
+        import scipy.special
+
         if self.prior is None:
             tmp = ((x - 1 - np.log(x)).inner(self.domain.one()))
         else:
@@ -1234,6 +1232,9 @@ class KullbackLeiblerConvexConj(Functional):
         If any components of ``x`` is larger than or equal to 1, the value is
         positive infinity.
         """
+        # Lazy import to improve `import odl` time
+        import scipy.special
+
         if self.prior is None:
             tmp = -1.0 * (np.log(1 - x)).inner(self.domain.one())
         else:
@@ -1375,6 +1376,9 @@ class KullbackLeiblerCrossEntropy(Functional):
         If any components of ``x`` is non-positive, the value is positive
         infinity.
         """
+        # Lazy import to improve `import odl` time
+        import scipy.special
+
         if self.prior is None:
             tmp = (1 - x + scipy.special.xlogy(x, x)).inner(self.domain.one())
         else:

--- a/odl/solvers/functional/derivatives.py
+++ b/odl/solvers/functional/derivatives.py
@@ -10,8 +10,6 @@
 
 # Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
-from future import standard_library
-standard_library.install_aliases()
 
 import numpy as np
 

--- a/odl/solvers/functional/example_funcs.py
+++ b/odl/solvers/functional/example_funcs.py
@@ -10,8 +10,6 @@
 
 # Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import super
 
 import numpy as np

--- a/odl/solvers/functional/functional.py
+++ b/odl/solvers/functional/functional.py
@@ -8,8 +8,6 @@
 
 # Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import super
 
 import numpy as np

--- a/odl/solvers/iterative/iterative.py
+++ b/odl/solvers/iterative/iterative.py
@@ -10,8 +10,6 @@
 
 # Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
-from future import standard_library
-standard_library.install_aliases()
 
 from odl.operator import IdentityOperator, OperatorComp, OperatorSum
 from odl.util import normalized_scalar_param_list

--- a/odl/solvers/iterative/statistical.py
+++ b/odl/solvers/iterative/statistical.py
@@ -10,8 +10,6 @@
 
 # Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
-from future import standard_library
-standard_library.install_aliases()
 
 import numpy as np
 

--- a/odl/solvers/nonsmooth/chambolle_pock.py
+++ b/odl/solvers/nonsmooth/chambolle_pock.py
@@ -14,8 +14,6 @@ non-smooth convex optimization problems in imaging.
 
 # Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
-from future import standard_library
-standard_library.install_aliases()
 
 import numpy as np
 

--- a/odl/solvers/nonsmooth/douglas_rachford.py
+++ b/odl/solvers/nonsmooth/douglas_rachford.py
@@ -10,8 +10,6 @@
 
 # Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
-from future import standard_library
-standard_library.install_aliases()
 
 from odl.operator import Operator
 

--- a/odl/solvers/nonsmooth/forward_backward.py
+++ b/odl/solvers/nonsmooth/forward_backward.py
@@ -11,8 +11,6 @@
 
 # Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
-from future import standard_library
-standard_library.install_aliases()
 
 from odl.operator import Operator
 

--- a/odl/solvers/nonsmooth/proximal_gradient_solvers.py
+++ b/odl/solvers/nonsmooth/proximal_gradient_solvers.py
@@ -10,9 +10,6 @@
 
 # Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
-from future import standard_library
-standard_library.install_aliases()
-
 
 import numpy as np
 

--- a/odl/solvers/nonsmooth/proximal_operators.py
+++ b/odl/solvers/nonsmooth/proximal_operators.py
@@ -23,12 +23,9 @@ Foundations and Trends in Optimization, 1 (2014), pp 127-239.
 
 # Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import super
 
 import numpy as np
-import scipy.special
 
 from odl.operator import (Operator, IdentityOperator, ScalingOperator,
                           ConstantOperator, DiagonalOperator)
@@ -1380,6 +1377,8 @@ def proximal_convex_conj_kl_cross_entropy(space, lam=1, g=None):
 
         def _call(self, x, out):
             """Apply the operator to ``x`` and stores the result in ``out``."""
+            # Lazy import to improve `import odl` time
+            import scipy.special
 
             if g is None:
                 # If g is None, it is taken as the one element

--- a/odl/solvers/smooth/gradient.py
+++ b/odl/solvers/smooth/gradient.py
@@ -10,11 +10,9 @@
 
 # Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
-from future import standard_library
-standard_library.install_aliases()
-
 
 import numpy as np
+
 from odl.solvers.util import ConstantLineSearch
 
 

--- a/odl/solvers/smooth/newton.py
+++ b/odl/solvers/smooth/newton.py
@@ -10,8 +10,6 @@
 
 # Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
-from future import standard_library
-standard_library.install_aliases()
 
 import numpy as np
 from odl.solvers.util import ConstantLineSearch

--- a/odl/solvers/smooth/nonlinear_cg.py
+++ b/odl/solvers/smooth/nonlinear_cg.py
@@ -10,9 +10,6 @@
 
 # Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
-from future import standard_library
-standard_library.install_aliases()
-
 
 from odl.solvers.util import ConstantLineSearch
 

--- a/odl/solvers/util/callback.py
+++ b/odl/solvers/util/callback.py
@@ -10,14 +10,13 @@
 
 # Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
-from future import standard_library
-standard_library.install_aliases()
 
 import warnings
 import time
 import os
 import copy
 import numpy as np
+
 from odl.util import signature_string
 
 __all__ = ('Callback', 'CallbackStore', 'CallbackApply',

--- a/odl/solvers/util/steplen.py
+++ b/odl/solvers/util/steplen.py
@@ -10,8 +10,6 @@
 
 # Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
-from future import standard_library
-standard_library.install_aliases()
 
 import numpy as np
 

--- a/odl/space/base_ntuples.py
+++ b/odl/space/base_ntuples.py
@@ -10,8 +10,6 @@
 
 # Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import int
 
 import numpy as np

--- a/odl/space/entry_points.py
+++ b/odl/space/entry_points.py
@@ -23,15 +23,11 @@ NumpyNtuples : Numpy based implementation of `NtuplesBase`
 
 # Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
-from future import standard_library
-standard_library.install_aliases()
 
-from pkg_resources import iter_entry_points
 from odl.space.npy_ntuples import NumpyNtuples, NumpyFn
 
 __all__ = ('ntuples_impl_names', 'fn_impl_names',
            'ntuples_impl', 'fn_impl')
-
 
 IS_INITIALIZED = False
 NTUPLES_IMPLS = {'numpy': NumpyNtuples}
@@ -42,6 +38,8 @@ def _initialize_if_needed():
     """Initialize ``NTUPLES_IMPLS`` and ``FN_IMPLS`` if not already done."""
     global IS_INITIALIZED, NTUPLES_IMPLS, FN_IMPLS
     if not IS_INITIALIZED:
+        # pkg_resources has long import time
+        from pkg_resources import iter_entry_points
         for entry_point in iter_entry_points(group='odl.space', name=None):
             try:
                 module = entry_point.load()
@@ -90,7 +88,7 @@ def ntuples_impl(impl):
 
     try:
         return NTUPLES_IMPLS[impl]
-    except:
+    except KeyError:
         raise ValueError("key '{}' does not correspond to a valid ntuples "
                          "implmentation".format(impl))
 
@@ -120,6 +118,6 @@ def fn_impl(impl):
 
     try:
         return FN_IMPLS[impl]
-    except:
+    except KeyError:
         raise ValueError("key '{}' does not correspond to a valid fn "
                          "implmentation".format(impl))

--- a/odl/space/fspace.py
+++ b/odl/space/fspace.py
@@ -10,8 +10,6 @@
 
 # Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import super
 
 from inspect import isfunction

--- a/odl/space/npy_ntuples.py
+++ b/odl/space/npy_ntuples.py
@@ -10,9 +10,7 @@
 
 # Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
-from future import standard_library
 from future.utils import native
-standard_library.install_aliases()
 from builtins import super
 
 import ctypes

--- a/odl/space/pspace.py
+++ b/odl/space/pspace.py
@@ -11,8 +11,6 @@
 # Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
 from builtins import range, str, super, zip
-from future import standard_library
-standard_library.install_aliases()
 
 from numbers import Integral
 from itertools import product

--- a/odl/space/space_utils.py
+++ b/odl/space/space_utils.py
@@ -10,8 +10,6 @@
 
 # Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
-from future import standard_library
-standard_library.install_aliases()
 
 __all__ = ('vector', 'ntuples', 'fn', 'cn', 'rn')
 

--- a/odl/tomo/analytic/filtered_back_projection.py
+++ b/odl/tomo/analytic/filtered_back_projection.py
@@ -8,11 +8,8 @@
 
 # Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
-from future import standard_library
-standard_library.install_aliases()
 
 import numpy as np
-import scipy as sp
 from odl.discr import ResizingOperator
 from odl.trafos import FourierTransform, PYFFTW_AVAILABLE
 from odl.space.weighting import NoWeighting
@@ -180,12 +177,15 @@ def tam_danielson_window(ray_trafo, smoothing_width=0.05, n_half_rot=1):
 
     # Create window function
     def window_fcn(x):
+        # Lazy import to improve `import odl` time
+        import scipy.special
+
         x_along_axis = axis_proj[0] * x[1] + axis_proj[1] * x[2]
         if smoothing_width != 0:
             lower_wndw = 0.5 * (
-                1 + sp.special.erf((x_along_axis - lower_proj) / width))
+                1 + scipy.special.erf((x_along_axis - lower_proj) / width))
             upper_wndw = 0.5 * (
-                1 + sp.special.erf((upper_proj - x_along_axis) / width))
+                1 + scipy.special.erf((upper_proj - x_along_axis) / width))
         else:
             lower_wndw = (x_along_axis >= lower_proj)
             upper_wndw = (x_along_axis <= upper_proj)

--- a/odl/tomo/backends/astra_cpu.py
+++ b/odl/tomo/backends/astra_cpu.py
@@ -10,8 +10,6 @@
 
 # Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
-from future import standard_library
-standard_library.install_aliases()
 
 try:
     import astra

--- a/odl/tomo/backends/astra_cuda.py
+++ b/odl/tomo/backends/astra_cuda.py
@@ -10,11 +10,8 @@
 
 # Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
-from future import standard_library
-standard_library.install_aliases()
 
 import numpy as np
-from pkg_resources import parse_version
 try:
     import astra
     ASTRA_CUDA_AVAILABLE = astra.astra.use_cuda()
@@ -342,6 +339,9 @@ def astra_cuda_bp_scaling_factor(proj_space, reco_space, geometry):
     Behavior of ASTRA changes slightly between versions, so we keep
     track of it and adapt the scaling accordingly.
     """
+    # Lazy import due to long import time
+    from pkg_resources import parse_version
+
     # Angular integration weighting factor
     # angle interval weight by approximate cell volume
     angle_extent = geometry.motion_partition.extent

--- a/odl/tomo/backends/astra_setup.py
+++ b/odl/tomo/backends/astra_setup.py
@@ -25,23 +25,23 @@ ODL geometry representation to ASTRA's data structures, including:
 
 # Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
-from future import standard_library
-standard_library.install_aliases()
 
-from pkg_resources import parse_version
 try:
     import astra
     ASTRA_AVAILABLE = True
     try:
         # Available from 1.8 on
         ASTRA_VERSION = astra.__version__
+        _maj, _min = [int(n) for n in ASTRA_VERSION.split('.')]
     except AttributeError:
-        astra_ver_num = astra.astra.version()
-        ASTRA_VERSION = '.'.join([str(astra_ver_num // 100),
-                                  str(astra_ver_num % 100)])
+        _maj = astra.astra.version() // 100
+        _min = astra.astra.version() % 100
+        ASTRA_VERSION = '.'.join([str(_maj), str(_min)])
 
-    if parse_version(ASTRA_VERSION) < parse_version('1.7'):
+    # Don't import pkg_resources only for this, it's slow
+    if (_maj, _min) < (1, 7):
         raise RuntimeError('ASTRA version < 1.7 not supported, please update')
+
 except ImportError:
     ASTRA_AVAILABLE = False
     ASTRA_VERSION = ''
@@ -52,7 +52,6 @@ from odl.discr import DiscreteLp, DiscreteLpElement
 from odl.tomo.geometry import (
     Geometry, DivergentBeamGeometry, ParallelBeamGeometry, FlatDetector)
 from odl.tomo.util.utility import euler_matrix
-from odl.util.utility import pkg_supports
 
 
 __all__ = ('ASTRA_AVAILABLE', 'ASTRA_VERSION', 'astra_supports',
@@ -110,6 +109,7 @@ def astra_supports(feature):
         ``True`` if the currently imported version of ASTRA supports the
         feature in question, ``False`` otherwise.
     """
+    from odl.util.utility import pkg_supports
     return pkg_supports(feature, ASTRA_VERSION, ASTRA_FEATURES)
 
 

--- a/odl/tomo/backends/skimage_radon.py
+++ b/odl/tomo/backends/skimage_radon.py
@@ -11,7 +11,7 @@
 from odl.discr import uniform_discr_frompartition, uniform_partition
 import numpy as np
 try:
-    from skimage.transform import radon, iradon
+    import skimage
     SKIMAGE_AVAILABLE = True
 except ImportError:
     SKIMAGE_AVAILABLE = False
@@ -78,6 +78,9 @@ def skimage_radon_forward(volume, geometry, range, out=None):
     sinogram : ``range`` element
         Sinogram given by the projection.
     """
+    # Lazy import due to significant import time
+    from skimage.transform import radon
+
     # Check basic requirements. Fully checking should be in wrapper
     assert volume.shape[0] == volume.shape[1]
 
@@ -120,6 +123,9 @@ def skimage_radon_back_projector(sinogram, geometry, range, out=None):
     sinogram : ``range`` element
         Sinogram given by the projection.
     """
+    # Lazy import due to significant import time
+    from skimage.transform import iradon
+
     theta = skimage_theta(geometry)
     skimage_range = skimage_sinogram_space(geometry, range, sinogram.space)
 

--- a/odl/tomo/backends/stir_bindings.py
+++ b/odl/tomo/backends/stir_bindings.py
@@ -28,8 +28,6 @@ the STIR classes used here.
 
 # Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import super
 
 try:

--- a/odl/tomo/geometry/conebeam.py
+++ b/odl/tomo/geometry/conebeam.py
@@ -10,13 +10,11 @@
 
 # Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import super
 
 import numpy as np
 
-from odl.discr import uniform_partition, nonuniform_partition
+from odl.discr import uniform_partition
 from odl.tomo.geometry.detector import Flat1dDetector, Flat2dDetector
 from odl.tomo.geometry.geometry import (
     DivergentBeamGeometry, AxisOrientedGeometry)

--- a/odl/tomo/geometry/detector.py
+++ b/odl/tomo/geometry/detector.py
@@ -10,8 +10,6 @@
 
 # Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import object, super
 
 import numpy as np

--- a/odl/tomo/geometry/geometry.py
+++ b/odl/tomo/geometry/geometry.py
@@ -10,8 +10,6 @@
 
 # Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import object
 
 import numpy as np

--- a/odl/tomo/geometry/parallel.py
+++ b/odl/tomo/geometry/parallel.py
@@ -10,13 +10,11 @@
 
 # Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import super
 
 import numpy as np
 
-from odl.discr import uniform_partition, nonuniform_partition
+from odl.discr import uniform_partition
 from odl.tomo.geometry.detector import Flat1dDetector, Flat2dDetector
 from odl.tomo.geometry.geometry import Geometry, AxisOrientedGeometry
 from odl.tomo.util import euler_matrix, transform_system

--- a/odl/tomo/geometry/spect.py
+++ b/odl/tomo/geometry/spect.py
@@ -10,13 +10,10 @@
 
 # Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import super
 
 import numpy as np
 
-from odl.tomo.geometry.geometry import AxisOrientedGeometry
 from odl.tomo.geometry.parallel import Parallel3dAxisGeometry
 from odl.tomo.util.utility import transform_system
 from odl.util import signature_string, indent_rows

--- a/odl/tomo/operators/ray_trafo.py
+++ b/odl/tomo/operators/ray_trafo.py
@@ -10,8 +10,6 @@
 
 # Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import str, super
 
 import numpy as np

--- a/odl/tomo/util/testutils.py
+++ b/odl/tomo/util/testutils.py
@@ -8,8 +8,6 @@
 
 # Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
-from future import standard_library
-standard_library.install_aliases()
 
 __all__ = ('skip_if_no_astra', 'skip_if_no_astra_cuda', 'skip_if_no_skimage')
 

--- a/odl/tomo/util/utility.py
+++ b/odl/tomo/util/utility.py
@@ -8,8 +8,6 @@
 
 # Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
-from future import standard_library
-standard_library.install_aliases()
 
 import numpy as np
 

--- a/odl/trafos/backends/pyfftw_bindings.py
+++ b/odl/trafos/backends/pyfftw_bindings.py
@@ -15,13 +15,9 @@ Fourier transforms.
 
 # Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import range
-from future.utils import raise_from
 
 from multiprocessing import cpu_count
-from pkg_resources import parse_version
 import warnings
 import numpy as np
 from odl.util import (
@@ -29,13 +25,14 @@ from odl.util import (
 try:
     import pyfftw
     PYFFTW_AVAILABLE = True
-    if parse_version(pyfftw.__version__) < parse_version('0.10.4'):
+except ImportError:
+    PYFFTW_AVAILABLE = False
+else:
+    _maj, _min, _patch = [int(n) for n in pyfftw.__version__.split('.')[:3]]
+    if (_maj, _min, _patch) < (0, 10, 4):
         warnings.warn('PyFFTW < 0.10.4 is known to cause problems with some '
                       'ODL functionality, see issue #1002.',
                       RuntimeWarning)
-except ImportError:
-    PYFFTW_AVAILABLE = False
-
 
 __all__ = ('pyfftw_call', 'PYFFTW_AVAILABLE')
 
@@ -249,11 +246,10 @@ def _pyfftw_check_args(arr_in, arr_out, axes, halfcomplex, direction):
         if halfcomplex:
             try:
                 out_shape[axes[-1]] = arr_in.shape[axes[-1]] // 2 + 1
-            except IndexError as err:
-                raise_from(IndexError('axis index {} out of range for array '
-                                      'with {} axes'
-                                      ''.format(axes[-1], arr_in.ndim)),
-                           err)
+            except IndexError:
+                raise IndexError('axis index {} out of range for array '
+                                 'with {} axes'
+                                 ''.format(axes[-1], arr_in.ndim))
 
         if arr_out.shape != tuple(out_shape):
             raise ValueError('expected output shape {}, got {}'
@@ -278,10 +274,9 @@ def _pyfftw_check_args(arr_in, arr_out, axes, halfcomplex, direction):
             try:
                 in_shape[axes[-1]] = arr_out.shape[axes[-1]] // 2 + 1
             except IndexError as err:
-                raise_from(IndexError('axis index {} out of range for array '
-                                      'with {} axes'
-                                      ''.format(axes[-1], arr_out.ndim)),
-                           err)
+                raise IndexError('axis index {} out of range for array '
+                                 'with {} axes'
+                                 ''.format(axes[-1], arr_out.ndim))
 
         if arr_in.shape != tuple(in_shape):
             raise ValueError('expected input shape {}, got {}'

--- a/odl/trafos/backends/pywt_bindings.py
+++ b/odl/trafos/backends/pywt_bindings.py
@@ -15,8 +15,6 @@ of built-in wavelet filters.
 
 # Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
-from future import standard_library
-standard_library.install_aliases()
 
 from itertools import product
 import numpy as np

--- a/odl/trafos/fourier.py
+++ b/odl/trafos/fourier.py
@@ -10,8 +10,6 @@
 
 # Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import super
 
 import numpy as np

--- a/odl/trafos/util/ft_utils.py
+++ b/odl/trafos/util/ft_utils.py
@@ -10,8 +10,6 @@
 
 # Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import range
 
 import numpy as np

--- a/odl/trafos/wavelet.py
+++ b/odl/trafos/wavelet.py
@@ -10,8 +10,6 @@
 
 # Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import str, super
 
 import numpy as np
@@ -19,7 +17,7 @@ import numpy as np
 from odl.discr import DiscreteLp
 from odl.operator import Operator
 from odl.trafos.backends.pywt_bindings import (
-    PYWT_AVAILABLE, PAD_MODES_ODL2PYWT,
+    PYWT_AVAILABLE,
     pywt_pad_mode, pywt_wavelet, pywt_flat_coeff_size, pywt_coeff_shapes,
     pywt_max_nlevels, pywt_flat_array_from_coeffs, pywt_coeffs_from_flat_array,
     pywt_multi_level_decomp, pywt_multi_level_recon)

--- a/odl/ufunc_ops/ufunc_ops.py
+++ b/odl/ufunc_ops/ufunc_ops.py
@@ -10,23 +10,22 @@
 
 # Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
-from future import standard_library
-standard_library.install_aliases()
 
 import numpy as np
 from odl.set import LinearSpace, RealNumbers, Field
 from odl.space import ProductSpace, fn
 from odl.operator import Operator, MultiplyOperator
-from odl.util.utility import is_int_dtype
-from odl.util.ufuncs import UFUNCS
 from odl.solvers import (Functional, ScalingFunctional, FunctionalQuotient,
-                         ConstantFunctional, IdentityFunctional)
+                         ConstantFunctional)
+from odl.util import is_int_dtype
+from odl.util.ufuncs import UFUNCS
 
 __all__ = ()
 
 
 def _is_integer_only_ufunc(name):
     return 'shift' in name or 'bitwise' in name or name == 'invert'
+
 
 LINEAR_UFUNCS = ['negative', 'rad2deg', 'deg2rad', 'add', 'subtract']
 

--- a/odl/util/graphics.py
+++ b/odl/util/graphics.py
@@ -10,8 +10,6 @@
 
 # Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
-from future import standard_library
-standard_library.install_aliases()
 
 import numpy as np
 import warnings

--- a/odl/util/normalize.py
+++ b/odl/util/normalize.py
@@ -10,8 +10,6 @@
 
 # Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
-from future import standard_library
-standard_library.install_aliases()
 
 import numpy as np
 

--- a/odl/util/numerics.py
+++ b/odl/util/numerics.py
@@ -10,8 +10,6 @@
 
 # Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
-from future import standard_library
-standard_library.install_aliases()
 
 import numpy as np
 

--- a/odl/util/pytest_plugins.py
+++ b/odl/util/pytest_plugins.py
@@ -9,8 +9,6 @@
 """Test configuration file."""
 
 from __future__ import print_function, division, absolute_import
-from future import standard_library
-standard_library.install_aliases()
 
 import numpy as np
 import operator

--- a/odl/util/testutils.py
+++ b/odl/util/testutils.py
@@ -10,17 +10,14 @@
 
 # Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import int, object
+from future.moves.itertools import zip_longest
 
-from itertools import zip_longest
 import numpy as np
 import sys
 import os
 import warnings
 from time import time
-from pkg_resources import parse_version
 from odl.util.utility import run_from_ipython
 
 
@@ -677,6 +674,7 @@ def run_doctests(skip_if=False, **kwargs):
         function.
     """
     from doctest import testmod, NORMALIZE_WHITESPACE, SKIP
+    from pkg_resources import parse_version
     import odl
     import numpy as np
 

--- a/odl/util/ufuncs.py
+++ b/odl/util/ufuncs.py
@@ -25,8 +25,6 @@ is used to re-wrap the data into the appropriate space.
 
 # Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
-from future import standard_library
-standard_library.install_aliases()
 
 import numpy as np
 import re

--- a/odl/util/utility.py
+++ b/odl/util/utility.py
@@ -10,13 +10,10 @@
 
 # Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
-from future import standard_library
-standard_library.install_aliases()
 
 from functools import wraps
 from collections import OrderedDict
 import numpy as np
-from pkg_resources import parse_requirements
 
 
 __all__ = ('array1d_repr', 'array1d_str', 'arraynd_repr', 'arraynd_str',
@@ -800,6 +797,8 @@ def pkg_supports(feature, pkg_version, pkg_feat_dict):
     >>> pkg_supports('feat5', '1.0', feat_dict)
     False
     """
+    from pkg_resources import parse_requirements
+
     feature = str(feature)
     pkg_version = str(pkg_version)
     supp_versions = pkg_feat_dict.get(feature, None)

--- a/odl/util/vectorization.py
+++ b/odl/util/vectorization.py
@@ -10,8 +10,6 @@
 
 # Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import super
 
 from functools import wraps


### PR DESCRIPTION
I did some import profiling and identified the main culprits regarding `import odl`. I write the list for reference, to avoid costly imports in the future:

- `scipy.linalg`, `scipy.sparse` and `scipy.special`: each one no large contribution, but together maybe 100 ms.
  Solution: lazy import. Usage is rare anyway.
- `skimage.transform`: takes almost 200 ms.
  Solution: `import skimage` at top level to set `SKIMAGE_AVAILABLE`,  import `radon, iradon` lazily. Big speedup.
- `future.standard_library.install_aliases()`: Does too much stuff, takes 50 to 100 ms. And adds annoying warnings in Spyder that shadow real warnings (e.g. unused imports).
  Solution: removed
- `pkg_resources`: Surprisingly, this one takes over 200 ms!
  Solution: I changed the version checks at module level to a simple homebrew solution and import lazily otherwise. 

The whole set of changes brings `import odl` down to 250 to 350 ms, which can almost be called snappy 🐊 .