### PR TITLE
Fix: avoid improper casts from complex to float when solving complex-valued problems

### DIFF
--- a/examples/solvers/chambolle_pock_denoising.py
+++ b/examples/solvers/chambolle_pock_denoising.py
@@ -29,13 +29,13 @@ space = odl.uniform_discr([0, 0], shape, shape)
 orig = space.element(image)
 
 # Add noise
-image += np.random.normal(0, 0.1, shape)
+image += 0.1 * odl.phantom.white_noise(orig.space)
 
 # Data of noisy image
 noisy = space.element(image)
 
 # Gradient operator
-gradient = odl.Gradient(space, method='forward')
+gradient = odl.Gradient(space)
 
 # Matrix of operators
 op = odl.BroadcastOperator(odl.IdentityOperator(space), gradient)

--- a/examples/solvers/chambolle_pock_denoising_complex.py
+++ b/examples/solvers/chambolle_pock_denoising_complex.py
@@ -11,13 +11,12 @@ For further details and a description of the solution method used, see
 """
 
 import numpy as np
-import scipy
+import scipy.misc
 import odl
 
 # Read test image: use only every second pixel, convert integer to float,
 # and rotate to get the image upright
-dtype = np.complex64
-image = np.rot90(scipy.misc.ascent()[::1, ::1], 3).astype(dtype)
+image = np.rot90(scipy.misc.ascent()[::1, ::1], 3).astype('float32')
 image = image + 1j*image.T
 shape = image.shape
 
@@ -25,20 +24,16 @@ shape = image.shape
 image /= image.real.max()
 
 # Discretized spaces
-space = odl.uniform_discr([0, 0], shape, shape, dtype=dtype)
+space = odl.uniform_discr([0, 0], shape, shape, dtype='complex64')
 
 # Original image
 orig = space.element(image)
 
 # Add noise
-image += (np.random.normal(0, 0.05, shape) +
-          1j*np.random.normal(0, 0.05, shape))
-
-# Data of noisy image
-noisy = space.element(image)
+noisy = image + 0.05 * odl.phantom.white_noise(orig.space)
 
 # Gradient operator
-gradient = odl.Gradient(space, method='forward')
+gradient = odl.Gradient(space)
 
 # Matrix of operators
 op = odl.BroadcastOperator(odl.IdentityOperator(space), gradient)

--- a/examples/solvers/chambolle_pock_denoising_complex.py
+++ b/examples/solvers/chambolle_pock_denoising_complex.py
@@ -1,0 +1,83 @@
+"""Total variation denoising of complex data using the Chambolle-Pock solver.
+
+Solves the optimization problem
+
+    min_{x}  1/2 ||x - g||_2^2 + lam || |grad(x)| ||_1
+
+Where ``grad`` the spatial gradient and ``g`` is given noisy data.
+
+For further details and a description of the solution method used, see
+:ref:`chambolle_pock` in the ODL documentation.
+"""
+
+import numpy as np
+import scipy
+import odl
+
+# Read test image: use only every second pixel, convert integer to float,
+# and rotate to get the image upright
+dtype = np.complex64
+image = np.rot90(scipy.misc.ascent()[::1, ::1], 3).astype(dtype)
+image = image + 1j*image.T
+shape = image.shape
+
+# Rescale max to 1
+image /= image.real.max()
+
+# Discretized spaces
+space = odl.uniform_discr([0, 0], shape, shape, dtype=dtype)
+
+# Original image
+orig = space.element(image)
+
+# Add noise
+image += (np.random.normal(0, 0.05, shape) +
+          1j*np.random.normal(0, 0.05, shape))
+
+# Data of noisy image
+noisy = space.element(image)
+
+# Gradient operator
+gradient = odl.Gradient(space, method='forward')
+
+# Matrix of operators
+op = odl.BroadcastOperator(odl.IdentityOperator(space), gradient)
+
+# Set up the functionals
+
+# l2-squared data matching
+l2_norm = odl.solvers.L2NormSquared(space).translated(noisy)
+
+# Isotropic TV-regularization: l1-norm of grad(x)
+l1_norm = 0.15 * odl.solvers.L1Norm(gradient.range)
+
+# Make separable sum of functionals, order must correspond to the operator K
+f = odl.solvers.SeparableSum(l2_norm, l1_norm)
+
+g = odl.solvers.ZeroFunctional(op.domain)
+
+# --- Select solver parameters and solve using Chambolle-Pock --- #
+
+
+# Estimated operator norm, add 10 percent to ensure ||K||_2^2 * sigma * tau < 1
+op_norm = 1.1 * odl.power_method_opnorm(op, xstart=noisy)
+
+niter = 200  # Number of iterations
+tau = 1.0 / op_norm  # Step size for the primal variable
+sigma = 1.0 / op_norm  # Step size for the dual variable
+
+# Optional: pass callback objects to solver
+callback = (odl.solvers.CallbackPrintIteration() &
+            odl.solvers.CallbackShow(step=5))
+
+# Starting point
+x = op.domain.zero()
+
+# Run algorithm (and display intermediates)
+odl.solvers.chambolle_pock_solver(
+    x, f, g, op, tau=tau, sigma=sigma, niter=niter, callback=callback)
+
+# Display images
+orig.show(title='original image')
+noisy.show(title='noisy image')
+x.show(title='reconstruction', force_show=True)

--- a/odl/discr/diff_ops.py
+++ b/odl/discr/diff_ops.py
@@ -802,7 +802,12 @@ def finite_diff(f, axis, dx=1.0, method='forward', out=None, **kwargs):
     if pad_mode not in _SUPPORTED_PAD_MODES:
         raise ValueError('`pad_mode` {} not understood'
                          ''.format(pad_mode))
-    pad_const = float(kwargs.pop('pad_const', 0))
+
+    pad_const = kwargs.pop('pad_const', 0)
+    if np.iscomplexobj(f):
+        pad_const = complex(pad_const)
+    else:
+        pad_const = float(pad_const)
 
     if out is None:
         out = np.empty_like(f_arr)

--- a/odl/discr/diff_ops.py
+++ b/odl/discr/diff_ops.py
@@ -804,10 +804,7 @@ def finite_diff(f, axis, dx=1.0, method='forward', out=None, **kwargs):
                          ''.format(pad_mode))
 
     pad_const = kwargs.pop('pad_const', 0)
-    if np.iscomplexobj(f):
-        pad_const = complex(pad_const)
-    else:
-        pad_const = float(pad_const)
+    pad_const = f.dtype.type(pad_const)
 
     if out is None:
         out = np.empty_like(f_arr)

--- a/odl/solvers/functional/functional.py
+++ b/odl/solvers/functional/functional.py
@@ -924,12 +924,10 @@ class FunctionalQuadraticPerturb(Functional):
 
         self.__functional = func
         quadratic_coeff = func.domain.field.element(quadratic_coeff)
-        if np.iscomplexobj(quadratic_coeff):
-            if quadratic_coeff.imag != 0:
-                raise ValueError(
-                    "Complex-valued quadratic coeff is not supported.")
-            quadratic_coeff = quadratic_coeff.real
-        self.__quadratic_coeff = quadratic_coeff
+        if quadratic_coeff.imag != 0:
+            raise ValueError(
+                "Complex-valued quadratic coeff is not supported.")
+        self.__quadratic_coeff = quadratic_coeff.real
 
         if linear_term is not None:
             self.__linear_term = func.domain.element(linear_term)

--- a/odl/solvers/functional/functional.py
+++ b/odl/solvers/functional/functional.py
@@ -923,7 +923,13 @@ class FunctionalQuadraticPerturb(Functional):
                             ''.format(func))
 
         self.__functional = func
-        self.__quadratic_coeff = func.domain.field.element(quadratic_coeff)
+        quadratic_coeff = func.domain.field.element(quadratic_coeff)
+        if np.iscomplexobj(quadratic_coeff):
+            if quadratic_coeff.imag != 0:
+                raise ValueError(
+                    "Complex-valued quadratic coeff is not supported.")
+            quadratic_coeff = quadratic_coeff.real
+        self.__quadratic_coeff = quadratic_coeff
 
         if linear_term is not None:
             self.__linear_term = func.domain.element(linear_term)

--- a/odl/solvers/nonsmooth/proximal_operators.py
+++ b/odl/solvers/nonsmooth/proximal_operators.py
@@ -250,7 +250,10 @@ def proximal_arg_scaling(prox_factory, scaling):
     2011.
     """
 
-    scaling = float(scaling)
+    if scaling.imag != 0:
+        raise ValueError("complex scaling not supported.")
+    else:
+        scaling = float(scaling.real)
     if scaling == 0:
         return proximal_const_func(prox_factory(1.0).domain)
 


### PR DESCRIPTION
I am a new user to ODL and wanted to try a simple example with complex-valued data.  As a first step, I tried creating a complex-valued image equivalent of  `chambolle_pock_denoising.py`.   The modified example is included here as 019bf0d.  It may not be worth keeping this example as it is very similar to the real-valued case, but I have included it here for now so you can see the problem that inspired the fixes in this PR.

Commits 1 and 3 are changes that were necessary to avoid errors from calling `float()` on arguments that may be complex-valued (i.e.  `TypeError: can't convert complex to float`)

The `gradient` operator was apparently passing a complex-valued `pad_const` to `finite_diff`.  I have changed the cast from `float()` to `complex()` for the case where the data input to `finite_diff` is complex-valued.

A minimal example that fails prior to this PR, but succeeds afterward is:
```
import numpy as np
import odl
odl.discr.diff_ops.finite_diff(np.arange(8., dtype=np.complex64), axis=0, pad_const=0+0j)
```

28de98a ensures that `quadratic_coeff` ends up real-valued (the users can pass a complex-valued input as long as the imaginary part is 0).  The error with `quadratic_coeff` being complex also occurs for the existing example at `examples/solvers/douglas_rachford_pd_mri.py`.  That example also runs successfully when using the changes proposed in this PR.

Another TypeError in the L1 proximal operator where the step size, `sigma` also had complex type.  I propose taking the `abs` of the step size so that it is guaranteed to be real-valued.  I have attempted to replicate this behaviour across the various other proximal operators as well.

Being new to ODL, there very well may be better alternative solutions to each of these, but hopefully this is helpful!