### PR TITLE
ENH: HaarPSI FOM

### DIFF
--- a/odl/contrib/fom/__init__.py
+++ b/odl/contrib/fom/__init__.py
@@ -8,10 +8,12 @@
 
 from __future__ import absolute_import
 
-__all__ = ()
+__all__ = ('supervised', 'unsupervised', 'util')
 
 from .supervised import *
 __all__ += supervised.__all__
 
 from .unsupervised import *
 __all__ += unsupervised.__all__
+
+from . import util

--- a/odl/contrib/fom/examples/haarpsi.py
+++ b/odl/contrib/fom/examples/haarpsi.py
@@ -1,0 +1,104 @@
+"""Demonstration of the components of the HaarPSI figure of merit."""
+
+import matplotlib.pyplot as plt
+import numpy as np
+import scipy.misc
+from odl.contrib import fom
+
+# --- Generate images --- #
+
+true_image = scipy.misc.ascent().astype('float32')
+
+# Image with false structures
+corrupt1 = true_image.copy()
+corrupt1[100:110, 50:350] = 0  # long narrow hole
+corrupt1[200:204, 60:64] = 180  # small square corrupted
+corrupt1[350:400, 200:250] = 200  # large square corrupted
+
+# Noisy image, using a predictable outcome
+np.random.seed(123)
+corrupt2 = true_image + np.random.uniform(0, 40, true_image.shape)
+corrupt2 = corrupt2.astype('float32')
+
+# Show images
+fig, ax = plt.subplots(ncols=3)
+ax[0].imshow(true_image, cmap='gray')
+ax[0].set_title('original')
+ax[1].imshow(corrupt1, cmap='gray')
+ax[1].set_title('corrupted')
+ax[2].imshow(corrupt2, cmap='gray')
+ax[2].set_title('noisy')
+fig.suptitle('Input images for comparison')
+fig.tight_layout()
+fig.show()
+
+# --- Similarity maps --- #
+
+# Compute similarity maps
+a = 4.2
+c = 100
+sim1_ax0 = fom.util.haarpsi_similarity_map(corrupt1, true_image, axis=0,
+                                           a=a, c=c)
+sim1_ax1 = fom.util.haarpsi_similarity_map(corrupt1, true_image, axis=1,
+                                           a=a, c=c)
+sim2_ax0 = fom.util.haarpsi_similarity_map(corrupt2, true_image, axis=0,
+                                           a=a, c=c)
+sim2_ax1 = fom.util.haarpsi_similarity_map(corrupt2, true_image, axis=1,
+                                           a=a, c=c)
+
+# Show similarity images
+fig, ax = plt.subplots(ncols=2)
+ax[0].imshow(sim1_ax0)
+ax[0].set_title('axis 0')
+ax[1].imshow(sim1_ax1)
+ax[1].set_title('axis 1')
+fig.suptitle('Similarity maps for corrupted image')
+fig.tight_layout()
+fig.show()
+
+fig, ax = plt.subplots(ncols=2)
+ax[0].imshow(sim2_ax0)
+ax[0].set_title('axis 0')
+ax[1].imshow(sim2_ax1)
+ax[1].set_title('axis 1')
+fig.suptitle('Similarity maps for noisy image')
+fig.tight_layout()
+fig.show()
+
+# --- Weight maps --- #
+
+# Compute similarity weight maps
+wmap1_ax0 = fom.util.haarpsi_weight_map(corrupt1, true_image, axis=0)
+wmap1_ax1 = fom.util.haarpsi_weight_map(corrupt1, true_image, axis=1)
+wmap2_ax0 = fom.util.haarpsi_weight_map(corrupt2, true_image, axis=0)
+wmap2_ax1 = fom.util.haarpsi_weight_map(corrupt2, true_image, axis=1)
+
+# Show weight maps
+fig, ax = plt.subplots(ncols=2)
+ax[0].imshow(wmap1_ax0)
+ax[0].set_title('axis 0')
+ax[1].imshow(wmap1_ax1)
+ax[1].set_title('axis 1')
+fig.suptitle('Weight maps for corrupted image')
+fig.tight_layout()
+fig.show()
+
+fig, ax = plt.subplots(ncols=2)
+ax[0].imshow(wmap2_ax0)
+ax[0].set_title('axis 0')
+ax[1].imshow(wmap2_ax1)
+ax[1].set_title('axis 1')
+fig.suptitle('Weight maps for noisy image')
+fig.tight_layout()
+fig.show()
+
+# --- HaarPSI scores --- #
+
+# Compute HaarPSI scores
+score1 = fom.haarpsi(corrupt1, true_image, a, c)
+score2 = fom.haarpsi(corrupt2, true_image, a, c)
+
+print('Similarity score (a = {}, c = {}) for corrupted image: {}'
+      ''.format(a, c, score1))
+print('Similarity score (a = {}, c = {}) for noisy image: {}'
+      ''.format(a, c, score2))

--- a/odl/contrib/fom/examples/supervised_comparison.py
+++ b/odl/contrib/fom/examples/supervised_comparison.py
@@ -28,6 +28,8 @@ range_diff = []
 blur = []
 false_struct = []
 ssim = []
+psnr = []
+haarpsi = []
 
 # Create mask for ROI to evaluate blurring and false structures. Arbitrarily
 # chosen as bone in Shepp-Logan phantom.
@@ -36,53 +38,51 @@ mask = (np.asarray(phantom) == 1)
 for stddev in np.linspace(0.1, 10, 100):
     phantom_noisy = phantom + odl.phantom.white_noise(reco_space,
                                                       stddev=stddev)
-    mse.append(fom.mean_squared_error(phantom_noisy,
-                                      phantom,
-                                      normalized=True))
+    mse.append(
+        fom.mean_squared_error(phantom_noisy, phantom, normalized=True))
 
-    mae.append(fom.mean_absolute_error(phantom_noisy,
-                                       phantom,
-                                       normalized=True))
+    mae.append(
+        fom.mean_absolute_error(phantom_noisy, phantom, normalized=True))
 
-    mvd.append(fom.mean_value_difference(phantom_noisy,
-                                         phantom,
-                                         normalized=True))
+    mvd.append(
+        fom.mean_value_difference(phantom_noisy, phantom, normalized=True))
 
-    std_diff.append(fom.standard_deviation_difference(phantom_noisy,
-                                                      phantom,
-                                                      normalized=True))
+    std_diff.append(
+        fom.standard_deviation_difference(phantom_noisy, phantom,
+                                          normalized=True))
 
-    range_diff.append(fom.range_difference(phantom_noisy,
-                                           phantom,
-                                           normalized=True))
+    range_diff.append(
+        fom.range_difference(phantom_noisy, phantom, normalized=True))
 
-    blur.append(fom.blurring(phantom_noisy,
-                             phantom,
-                             mask,
-                             normalized=True,
+    blur.append(
+        fom.blurring(phantom_noisy, phantom, mask, normalized=True,
+                     smoothness_factor=30))
+
+    false_struct.append(
+        fom.false_structures(phantom_noisy, phantom, mask, normalized=True,
                              smoothness_factor=30))
 
-    false_struct.append(fom.false_structures(phantom_noisy,
-                                             phantom,
-                                             mask,
-                                             normalized=True,
-                                             smoothness_factor=30))
+    ssim.append(
+        fom.ssim(phantom_noisy, phantom, normalized=True))
 
-    ssim.append(fom.ssim(phantom_noisy,
-                         phantom,
-                         normalized=True))
+    psnr.append(
+        fom.psnr(phantom_noisy, phantom, normalize=True))
 
-plt.figure('Figures of merit')
-plt.plot(mse, label='Mean squared error')
-plt.plot(mae, label='Mean absolute error')
-plt.plot(mvd, label='Mean value difference')
-plt.plot(std_diff, label='Standard deviation difference')
-plt.plot(range_diff, label='Range difference')
-plt.plot(blur, label='Blurring')
-plt.plot(false_struct, label='False structures')
-plt.plot(ssim, label='Structural similarity')
+    haarpsi.append(
+        fom.haarpsi(phantom_noisy, phantom))
 
-plt.legend(loc='upper center', bbox_to_anchor=(0.5, -0.15),
-           fancybox=True, shadow=True, ncol=1)
-plt.xlabel('Noise level')
-plt.ylabel('FOM')
+fig, ax = plt.subplots()
+ax.plot(mse, label='MSE')
+ax.plot(mae, label='MAE')
+ax.plot(mvd, label='MVD')
+ax.plot(std_diff, label='SDD')
+ax.plot(range_diff, label='RD')
+ax.plot(blur, label='BLUR')
+ax.plot(false_struct, label='FS')
+ax.plot(ssim, label='SSIM')
+ax.plot(haarpsi, label='HaarPSI')
+plt.legend(loc='center right', fancybox=True, shadow=True, ncol=1)
+ax.set_xlabel('Noise level')
+ax.set_ylabel('FOM')
+plt.title('Figures of merit')
+fig.show()

--- a/odl/contrib/fom/supervised.py
+++ b/odl/contrib/fom/supervised.py
@@ -607,7 +607,7 @@ def psnr(data, ground_truth, normalize=False):
     >>> ground_truth = spc.element([1, 1, 1, 1, 2])
     >>> result = psnr(data, ground_truth)
     >>> print('{:.3f}'.format(result))
-    6.021
+    13.010
 
     If data == ground_truth, the result is positive infinity:
 

--- a/odl/contrib/fom/supervised.py
+++ b/odl/contrib/fom/supervised.py
@@ -6,17 +6,15 @@
 # v. 2.0. If a copy of the MPL was not distributed with this file, You can
 # obtain one at https://mozilla.org/MPL/2.0/.
 
-"""
-Implementation of Figures of Merit (FOMs) for comparing reconstructions with
-a given reference.
-"""
+"""Figures of merit (FOMs) for comparison against a known ground truth."""
 
 import odl
 import numpy as np
 
 __all__ = ('mean_squared_error', 'mean_absolute_error',
            'mean_value_difference', 'standard_deviation_difference',
-           'range_difference', 'blurring', 'false_structures', 'ssim', 'psnr')
+           'range_difference', 'blurring', 'false_structures', 'ssim', 'psnr',
+           'haarpsi')
 
 
 def mean_squared_error(data, ground_truth, mask=None, normalized=False):
@@ -636,7 +634,89 @@ def psnr(data, ground_truth, normalize=False):
     else:
         return 20 * np.log10(max_true) - 10 * np.log10(mse_result)
 
+
+def haarpsi(data, ground_truth, a=4.2, c=None):
+    """Haar-Wavelet based perceptual similarity index FOM.
+
+    This function evaluates the structural similarity between two images
+    based on edge features along the coordinate axes, analyzed with two
+    wavelet filter levels. See
+    `[Rei+2016] <https://arxiv.org/abs/1607.06140>`_ and the Notes section
+    for further details.
+
+    Parameters
+    ----------
+    data : 2D array-like
+        The image to compare to the ground truth.
+    ground_truth : 2D array-like
+        The true image with which to compare ``data``. It must have the
+        same shape as ``data``.
+    a : positive float, optional
+        Parameter in the logistic function. Larger value leads to a
+        steeper curve, thus lowering the threshold for an input to
+        be mapped to an output close to 1. See Notes for details.
+        The default value 4.2 is taken from the referenced paper.
+    c : positive float, optional
+        Constant determining the score of maximally dissimilar values.
+        Smaller constant means higher penalty for dissimilarity.
+        See `haarpsi_similarity_map` for details.
+        For ``None``, the value is chosen as
+        ``3 * sqrt(max(abs(ground_truth)))``.
+
+    Returns
+    -------
+    score : float between 0 and 1
+        The similarity score. See Notes for details.
+
+    See Also
+    --------
+    haarpsi_similarity_map
+    haarpsi_weight_map
+
+    Notes
+    -----
+    For input images :math:`f_1, f_2`, the HaarPSI score is defined as
+
+    .. math::
+        \mathrm{HaarPSI}_{f_1, f_2} =
+        l_a^{-1} \\left(
+        \\frac{
+        \sum_x \sum_{k=1}^2 \mathrm{HS}_{f_1, f_2}^{(k)}(x) \cdot
+        \mathrm{W}_{f_1, f_2}^{(k)}(x)}{
+        \sum_x \sum_{k=1}^2 \mathrm{W}_{f_1, f_2}^{(k)}(x)}
+        \\right)^2
+
+    see `[Rei+2016] <https://arxiv.org/abs/1607.06140>`_ equation (12).
+
+    For the definitions of the constituting functions, see
+
+        - `haarpsi_similarity_map` for :math:`\mathrm{HS}_{f_1, f_2}^{(k)}`,
+        - `haarpsi_weight_map` for :math:`\mathrm{W}_{f_1, f_2}^{(k)}`.
+
+    References
+    ----------
+    [Rei+2016] Reisenhofer, R, Bosse, S, Kutyniok, G, and Wiegand, T.
+    *A Haar Wavelet-Based Perceptual Similarity Index for Image Quality
+    Assessment*. arXiv:1607.06140 [cs], Jul. 2016.
+    """
+    import scipy.special
+    from odl.contrib.fom.util import haarpsi_similarity_map, haarpsi_weight_map
+
+    if c is None:
+        c = 3 * np.sqrt(np.max(np.abs(ground_truth)))
+
+    lsim_horiz = haarpsi_similarity_map(data, ground_truth, axis=0, c=c, a=a)
+    lsim_vert = haarpsi_similarity_map(data, ground_truth, axis=1, c=c, a=a)
+
+    wmap_horiz = haarpsi_weight_map(data, ground_truth, axis=0)
+    wmap_vert = haarpsi_weight_map(data, ground_truth, axis=1)
+
+    numer = np.sum(lsim_horiz * wmap_horiz + lsim_vert * wmap_vert)
+    denom = np.sum(wmap_horiz + wmap_vert)
+
+    return (scipy.special.logit(numer / denom) / a) ** 2
+
+
 if __name__ == '__main__':
-    # pylint: disable=wrong-import-position
     from odl.util.testutils import run_doctests
     run_doctests()

--- a/odl/contrib/fom/test/test_supervised.py
+++ b/odl/contrib/fom/test/test_supervised.py
@@ -1,0 +1,36 @@
+import numpy as np
+import pytest
+import scipy.signal
+import scipy.misc
+import odl
+from odl.contrib.fom.util import filter_image_sep2d
+from odl.util.testutils import simple_fixture
+
+fft_impl_params = [odl.util.testutils.never_skip('numpy'),
+                   odl.util.testutils.skip_if_no_pyfftw('pyfftw')]
+fft_impl = simple_fixture('fft_impl', fft_impl_params,
+                          fmt=" {name} = '{value.args[1]}' ")
+
+
+def filter_image(image, fh, fv):
+    """Reference filtering function using ``scipy.signal.convolve``."""
+    fh, fv = np.asarray(fh), np.asarray(fv)
+    image = scipy.signal.convolve(image, fh[:, None], mode='same')
+    return scipy.signal.convolve(image, fv[None, :], mode='same')
+
+
+def test_filter_image_fft(fft_impl):
+    """Test the FFT filtering function against the real-space variant."""
+    image = np.random.rand(128, 128)
+    image -= np.mean(image)
+
+    for fh, fv in zip([[1, 1], [1, 1, 1], [1, 1, 1, 1]],
+                      [[-1, 1], [-1, 1, 1], [-1, -1, 1, 1]]):
+
+        conv_real = filter_image(image, fh, fv)
+        conv_fft = filter_image_sep2d(image, fh, fv, impl=fft_impl)
+        assert np.allclose(conv_real, conv_fft)
+
+
+if __name__ == '__main__':
+    pytest.main([str(__file__.replace('\\', '/')), '-v'])

--- a/odl/contrib/fom/util.py
+++ b/odl/contrib/fom/util.py
@@ -1,0 +1,394 @@
+# Copyright 2014-2017 The ODL contributors
+#
+# This file is part of ODL.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file, You can
+# obtain one at https://mozilla.org/MPL/2.0/.
+
+"""Utility functions for FOMs."""
+
+import numpy as np
+from odl.trafos.backends import PYFFTW_AVAILABLE
+
+__all__ = ()
+
+
+def filter_image_sep2d(image, fh, fv, impl='numpy', padding=None):
+    """Filter an image with a separable filter.
+
+    Parameters
+    ----------
+    image : 2D array-like
+        The image to be filtered. It must have a real (vs. complex) dtype.
+    fh, fv : 1D array-like
+        Horizontal (axis 0) and vertical (axis 1) filters. Their sizes
+        can be at most the image sizes in the respective axes.
+    impl : {'numpy', 'pyfftw'}, optional
+        FFT backend to use. The ``pyfftw`` backend requires the
+        ``pyfftw`` package to be installed. It is usually significantly
+        faster than the NumPy backend.
+    padding : positive int, optional
+        Amount of zeros added to the left and right of the image in all
+        axes before FFT. This helps avoiding wraparound artifacts due to
+        large boundary values.
+        For ``None``, the padding is computed as ::
+
+            padding = min(max(len(fh), len(fv)) - 1, 64)
+
+        A padding of ``len(filt) - 1`` ensures that errors in FFT-based
+        convolutions are small. At the same time, the padding should not
+        be excessive to retain efficiency.
+
+    Returns
+    -------
+    filtered : 2D `numpy.ndarray`
+        The image filtered horizontally by ``fh`` and vertically by ``fv``.
+        It has the same shape as ``image``, and its dtype is
+        ``np.result_type(image, fh, fv)``.
+    """
+    # TODO: generalize for nD
+    impl, impl_in = str(impl).lower(), impl
+    image = np.asarray(image)
+    if image.ndim != 2:
+        raise ValueError('`image` must be 2-dimensional, got image with '
+                         'ndim={}'.format(image.ndim))
+    if image.size == 0:
+        raise ValueError('`image` cannot have size 0')
+    if not np.issubsctype(image.dtype, np.floating):
+        image = image.astype(float)
+
+    fh = np.asarray(fh).astype(image.dtype)
+    if fh.ndim != 1:
+        raise ValueError('`fh` must be one-dimensional')
+    elif fh.size == 0:
+        raise ValueError('`fh` cannot have size 0')
+    elif fh.size > image.shape[0]:
+        raise ValueError('`fh` can be at most `image.shape[0]`, got '
+                         '{} > {}'.format(fh.size, image.shape[0]))
+
+    fv = np.asarray(fv).astype(image.dtype)
+    if fv.ndim != 1:
+        raise ValueError('`fv` must be one-dimensional')
+    elif fv.size == 0:
+        raise ValueError('`fv` cannot have size 0')
+    elif fv.size > image.shape[0]:
+        raise ValueError('`fv` can be at most `image.shape[1]`, got '
+                         '{} > {}'.format(fv.size, image.shape[1]))
+
+    # Pad image with zeros
+    if padding is None:
+        padding = min(max(len(fh), len(fv)) - 1, 64)
+
+    if padding != 0:
+        image_padded = np.pad(image, padding, mode='constant')
+    else:
+        image_padded = image.copy() if impl == 'pyfftw' else image
+
+    # Prepare filters for the convolution
+    def prepare_for_fft(filt, n_new):
+        """Return padded and shifted filter ready for FFT.
+
+        The filter is padded with zeros to the new size, and then shifted
+        such that such that the middle element of old filter, i.e., the
+        one at index ``(len(filt) - 1) // 2`` ends up at index 0.
+        """
+        mid = (len(filt) - 1) // 2
+        padded = np.zeros(n_new, dtype=filt.dtype)
+        padded[:len(filt) - mid] = filt[mid:]
+        padded[len(padded) - mid:] = filt[:mid]
+        return padded
+
+    fh = prepare_for_fft(fh, image_padded.shape[0])
+    fv = prepare_for_fft(fv, image_padded.shape[1])
+
+    # Perform the multiplication in Fourier space and apply inverse FFT
+    if impl == 'numpy':
+        image_ft = np.fft.rfftn(image_padded)
+        fh_ft = np.fft.fft(fh)
+        fv_ft = np.fft.rfft(fv)
+
+        image_ft *= fh_ft[:, None]
+        image_ft *= fv_ft[None, :]
+        # Important to specify the shape since `irfftn` cannot know the
+        # original shape
+        conv = np.fft.irfftn(image_ft, s=image_padded.shape)
+        if conv.dtype != image.dtype:
+            conv = conv.astype(image.dtype)
+
+    elif impl == 'pyfftw':
+        if not PYFFTW_AVAILABLE:
+            raise ValueError(
+                '`pyfftw` package is not available; you need to install it '
+                'to use the pyfftw backend')
+
+        import pyfftw
+        import multiprocessing
+
+        # Generate output arrays, for half-complex transform of image and
+        # vertical filter, and full FT of the horizontal filter
+        out_img_shape = (image_padded.shape[0], image_padded.shape[1] // 2 + 1)
+        out_img_dtype = np.result_type(image_padded, 1j)
+        out_img = np.empty(out_img_shape, out_img_dtype)
+
+        out_fh_shape = out_img_shape[0]
+        out_fh_dtype = np.result_type(fh, 1j)
+        fh_c = fh.astype(out_fh_dtype)  # need to make this a C2C trafo
+        out_fh = np.empty(out_fh_shape, out_fh_dtype)
+
+        out_fv_shape = out_img_shape[1]
+        out_fv_dtype = np.result_type(fv, 1j)
+        out_fv = np.empty(out_fv_shape, out_fv_dtype)
+
+        # Perform the forward transforms of image and filters. We use
+        # the `FFTW_ESTIMATE` flag to not allow the planner to destroy
+        # the input.
+        plan = pyfftw.FFTW(image_padded, out_img, axes=(0, 1),
+                           direction='FFTW_FORWARD',
+                           flags=['FFTW_ESTIMATE'],
+                           threads=multiprocessing.cpu_count())
+        plan(image_padded, out_img)
+
+        plan = pyfftw.FFTW(fh_c, out_fh, axes=(0,),
+                           direction='FFTW_FORWARD',
+                           flags=['FFTW_ESTIMATE'],
+                           threads=multiprocessing.cpu_count())
+        plan(fh_c, out_fh)
+
+        plan = pyfftw.FFTW(fv, out_fv, axes=(0,),
+                           direction='FFTW_FORWARD',
+                           flags=['FFTW_ESTIMATE'],
+                           threads=multiprocessing.cpu_count())
+        plan(fv, out_fv)
+
+        # Fourier space multiplication
+        out_img *= out_fh[:, None]
+        out_img *= out_fv[None, :]
+
+        # Inverse trafo
+        conv = image_padded  # Overwrite
+        plan = pyfftw.FFTW(out_img.copy(), conv, axes=(0, 1),
+                           direction='FFTW_BACKWARD',
+                           flags=['FFTW_ESTIMATE'],
+                           threads=multiprocessing.cpu_count())
+        plan(out_img, conv)
+
+    else:
+        raise ValueError('unsupported `impl` {!r}'.format(impl_in))
+
+    if padding:
+        return conv[padding:-padding, padding:-padding]
+    else:
+        return conv
+
+
+def haarpsi_similarity_map(img1, img2, axis, c, a):
+    """Local similarity map for directional features along an axis.
+
+    Parameters
+    ----------
+    img1, img2 : array-like
+        The images to compare. They must have equal shape.
+    axis : {0, 1}
+        Direction in which to look for edge similarities.
+    c : positive float
+        Constant determining the score of maximally dissimilar values.
+        Smaller constant means higher penalty for dissimilarity.
+        See Notes for details.
+    a : positive float
+        Parameter in the logistic function. Larger value leads to a
+        steeper curve, thus lowering the threshold for an input to
+        be mapped to an output close to 1. See Notes for details.
+
+    Returns
+    -------
+    local_sim : `numpy.ndarray`
+        Pointwise similarity of directional edge features of ``img1`` and
+        ``img2``, measured using two Haar wavelet detail levels.
+
+    Notes
+    -----
+    For input images :math:`f_1, f_2` this function is defined as
+
+    .. math::
+        \mathrm{HS}_{f_1, f_2}^{(k)}(x) =
+        l_a \\left(
+        \\frac{1}{2} \sum_{j=1}^2
+        S\\left(\\left|g_j^{(k)} \\ast f_1 \\right|(x),
+        \\left|g_j^{(k)} \\ast f_2 \\right|(x), c\\right)
+        \\right),
+
+    see `[Rei+2016] <https://arxiv.org/abs/1607.06140>`_ equation (10).
+    Here, the superscript :math:`(k)` refers to the axis (0 or 1)
+    in which edge features are compared, :math:`l_a` is the logistic
+    function :math:`l_a(x) = (1 + \mathrm{e}^{-a x})^{-1}`, and :math:`S`
+    is the pointwise similarity score
+
+    .. math::
+        S(x, y, c) = \\frac{2xy + c^2}{x^2 + y^2 + c^2},
+
+    Hence, :math:`c` is the :math:`y`-value at which the score
+    drops to :math:`1 / 2` for :math:`x = 0`. In other words, the smaller
+    :math:`c` is chosen, the more dissimilarity is penalized.
+
+    The filters :math:`g_j^{(k)}` are high-pass Haar wavelet filters in the
+    axis :math:`k` and low-pass Haar wavelet filters in the other axes.
+    The index :math:`j` refers to the scaling level of the wavelet.
+    In code, these filters can be computed as ::
+
+        f_lo_level1 = [np.sqrt(2), np.sqrt(2)] # low-pass Haar filter
+        f_hi_level1 = [-np.sqrt(2), np.sqrt(2)] # high-pass Haar filter
+        f_lo_level2 = np.repeat(f_lo_level1, 2)
+        f_hi_level2 = np.repeat(f_hi_level1, 2)
+        f_lo_level3 = np.repeat(f_lo_level2, 2)
+        f_hi_level3 = np.repeat(f_hi_level2, 2)
+        ...
+
+    The logistic function :math:`l_a` transforms values in
+    :math:`[0, \\infty)` to :math:`[1/2, 1)`, where the parameter
+    :math:`a` determines how fast the curve attains values close
+    to 1. Larger :math:`a` means that smaller :math:`x` will yield
+    a value :math:`l_a(x)` close to 1 (and thus result in a higher
+    score). In other words, the larger :math:`a`, the more forgiving
+    the similarity measure.
+
+    References
+    ----------
+    [Rei+2016] Reisenhofer, R, Bosse, S, Kutyniok, G, and Wiegand, T.
+    *A Haar Wavelet-Based Perceptual Similarity Index for Image Quality
+    Assessment*. arXiv:1607.06140 [cs], Jul. 2016.
+    """
+    # TODO: generalize for nD
+    import scipy.special
+    impl = 'pyfftw' if PYFFTW_AVAILABLE else 'numpy'
+
+    # Haar wavelet filters for levels 1 and 2
+    dec_lo_lvl1 = np.array([np.sqrt(2), np.sqrt(2)])
+    dec_lo_lvl2 = np.repeat(dec_lo_lvl1, 2)
+    dec_hi_lvl1 = np.array([-np.sqrt(2), np.sqrt(2)])
+    dec_hi_lvl2 = np.repeat(dec_hi_lvl1, 2)
+
+    if axis == 0:
+        # High-pass in axis 0, low-pass in axis 1
+        fh_lvl1 = dec_hi_lvl1
+        fv_lvl1 = dec_lo_lvl1
+        fh_lvl2 = dec_hi_lvl2
+        fv_lvl2 = dec_lo_lvl2
+    elif axis == 1:
+        # Low-pass in axis 0, high-pass in axis 1
+        fh_lvl1 = dec_lo_lvl1
+        fv_lvl1 = dec_hi_lvl1
+        fh_lvl2 = dec_lo_lvl2
+        fv_lvl2 = dec_hi_lvl2
+    else:
+        raise ValueError('`axis` out of the valid range 0 -> 1')
+
+    # Filter images with level 1 and 2 filters
+    img1_lvl1 = filter_image_sep2d(img1, fh_lvl1, fv_lvl1, impl=impl)
+    img1_lvl2 = filter_image_sep2d(img1, fh_lvl2, fv_lvl2, impl=impl)
+
+    img2_lvl1 = filter_image_sep2d(img2, fh_lvl1, fv_lvl1, impl=impl)
+    img2_lvl2 = filter_image_sep2d(img2, fh_lvl2, fv_lvl2, impl=impl)
+
+    c = float(c)
+
+    def S(x, y):
+        """Return ``(2 * x * y + c ** 2) / (x ** 2 + y ** 2 + c ** 2)``."""
+        num = 2 * x
+        num *= y
+        num += c ** 2
+        denom = x ** 2
+        denom += y ** 2
+        denom += c ** 2
+        frac = num
+        frac /= denom
+        return frac
+
+    # Compute similarity scores for both levels
+    np.abs(img1_lvl1, out=img1_lvl1)
+    np.abs(img2_lvl1, out=img2_lvl1)
+    np.abs(img1_lvl2, out=img1_lvl2)
+    np.abs(img2_lvl2, out=img2_lvl2)
+
+    sim_lvl1 = S(img1_lvl1, img2_lvl1)
+    sim_lvl2 = S(img1_lvl2, img2_lvl2)
+
+    # Return logistic of the mean value
+    sim = sim_lvl1
+    sim += sim_lvl2
+    sim /= 2
+    sim *= a
+    return scipy.special.expit(sim)
+
+
+def haarpsi_weight_map(img1, img2, axis):
+    """Weighting map for directional features along an axis.
+
+    Parameters
+    ----------
+    img1, img2 : array-like
+        The images to compare. They must have equal shape.
+    axis : {0, 1}
+        Direction in which to look for edge similarities.
+
+    Returns
+    -------
+    weight_map : `numpy.ndarray`
+        The pointwise weight map. See Notes for details.
+
+    Notes
+    -----
+    The pointwise weight map of associated with input images :math:`f_1, f_2`
+    and axis :math:`k` is defined
+    as
+
+    .. math::
+        \mathrm{W}_{f_1, f_2}^{(k)}(x) =
+        \max \\left\{
+        \\left|g_3^{(k)} \\ast f_1 \\right|(x),
+        \\left|g_3^{(k)} \\ast f_2 \\right|(x)
+        \\right\},
+
+    see `[Rei+2016] <https://arxiv.org/abs/1607.06140>`_ equations (11)
+    and (13).
+
+    Here, :math:`g_3^{(k)}` is a Haar wavelet filter for scaling level 3
+    that performs high-pass filtering in axis :math:`k` and low-pass
+    filtering in the other axes. Such a filter can be computed as ::
+
+        f_lo_level1 = [np.sqrt(2), np.sqrt(2)] # low-pass Haar filter
+        f_hi_level1 = [-np.sqrt(2), np.sqrt(2)] # high-pass Haar filter
+        f_lo_level3 = np.repeat(f_lo_level1, 4)
+        f_hi_level3 = np.repeat(f_hi_level1, 4)
+
+    References
+    ----------
+    [Rei+2016] Reisenhofer, R, Bosse, S, Kutyniok, G, and Wiegand, T.
+    *A Haar Wavelet-Based Perceptual Similarity Index for Image Quality
+    Assessment*. arXiv:1607.06140 [cs], Jul. 2016.
+    """
+    # TODO: generalize for nD
+    impl = 'pyfftw' if PYFFTW_AVAILABLE else 'numpy'
+
+    # Haar wavelet filters for level 3
+    dec_lo_lvl3 = np.repeat([np.sqrt(2), np.sqrt(2)], 4)
+    dec_hi_lvl3 = np.repeat([-np.sqrt(2), np.sqrt(2)], 4)
+
+    if axis == 0:
+        fh_lvl3 = dec_hi_lvl3
+        fv_lvl3 = dec_lo_lvl3
+    elif axis == 1:
+        fh_lvl3 = dec_lo_lvl3
+        fv_lvl3 = dec_hi_lvl3
+    else:
+        raise ValueError('`axis` out of the valid range 0 -> 1')
+
+    # Filter with level 3 wavelet filter
+    img1_lvl3 = filter_image_sep2d(img1, fh_lvl3, fv_lvl3, impl=impl)
+    img2_lvl3 = filter_image_sep2d(img2, fh_lvl3, fv_lvl3, impl=impl)
+
+    # Return the pointwise maximum of the filtered images
+    np.abs(img1_lvl3, out=img1_lvl3)
+    np.abs(img2_lvl3, out=img2_lvl3)
+
+    return np.maximum(img1_lvl3, img2_lvl3)


### PR DESCRIPTION
Implementation of the HaarPSI figure of merit, also gave me an opportunity to play around with pytorch a bit. Seems to work quite well, one can now use HaarPSI as output layer and (optionally) train its parameters, whether or not that makes sense.

**TODO**
- [x] Add proper example for using HaarPSI
- [x] ~~Make sure the convolution in pytorch does what it should~~ Moved out
- [x] In `contrib/fom`: write `S` function with `c**2` instead of `c`, makes it more intuitive.
- [x] In `contrib/fom`: rename some functions to be HaarPSI-specific
- [x] Use `scipy` functions where applicable
- [x] Simplify kernel FFT manipulation