### PR TITLE
DOC: fix source installation instructions

### DIFF
--- a/doc/source/getting_started/installing_source.rst
+++ b/doc/source/getting_started/installing_source.rst
@@ -20,7 +20,9 @@ Instructions for the impatient:
   .. code-block:: bash
 
     $ cd odl
-    $ pip install --user --editable .
+    $ pip install [--user] --editable .
+
+  Don't use the ``--user`` option together with ``conda``.
 
 - Install the :ref:`extensions you want<Extra dependencies>`.
 


### PR DESCRIPTION
The TL;DR instructions for installation from source were wrong for conda, this fixes them.