### PR TITLE
BUG: fix broken colorbar ticks

### DIFF
--- a/odl/util/graphics.py
+++ b/odl/util/graphics.py
@@ -428,7 +428,7 @@ def show_discrete_data(values, grid, title=None, method='',
                 # If it exists and we should update it
                 csub.colorbar.set_clim(minval, maxval)
                 csub.colorbar.set_ticks(ticks)
-                csub.colorbar.set_ticklabels([fmt.format(*ticks)])
+                csub.colorbar.set_ticklabels([fmt % t for t in ticks])
                 csub.colorbar.draw_all()
 
     # Set title of window


### PR DESCRIPTION
An earlier fix broke the ticks in the updated figures.