### PR TITLE
DOC: Correct typos in the documentation and error messages.

### DIFF
--- a/odl/solvers/iterative/iterative.py
+++ b/odl/solvers/iterative/iterative.py
@@ -76,7 +76,7 @@ def landweber(op, x, rhs, niter, omega=1, projection=None, callback=None):
         x_{k+1} = x_k -
                   \omega \ \partial \mathcal{A}(x)^* (\mathcal{A}(x_k) - y),
 
-    where :math:`\partial \mathcal{A}(x)` is the Frechet derivativ
+    where :math:`\partial \mathcal{A}(x)` is the Frechet derivative
     of :math:`\mathcal{A}` at :math:`x` and :math:`\omega` is a
     relaxation parameter. For linear problems, a choice
     :math:`0 < \omega < 2/\\lVert \mathcal{A}^2\\rVert` guarantees
@@ -471,7 +471,7 @@ def kaczmarz(ops, x, rhs, niter, omega=1, projection=None, random=False,
     """
     domain = ops[0].domain
     if any(domain != opi.domain for opi in ops):
-        raise ValueError('`opi[i].domain` are not all equal')
+        raise ValueError('domains of `ops` are not all equal')
 
     if x not in domain:
         raise TypeError('`x` {!r} is not in the domain of `ops` {!r}'

--- a/odl/solvers/nonsmooth/proximal_operators.py
+++ b/odl/solvers/nonsmooth/proximal_operators.py
@@ -1280,8 +1280,8 @@ def proximal_convex_conj_kl(space, lam=1, g=None):
 def proximal_convex_conj_kl_cross_entropy(space, lam=1, g=None):
     """Proximal factory of the convex conjugate of cross entropy KL divergence.
 
-    Function returning the proximal facotry of the convex conjugate of the
-    functional F, where F is the corss entorpy Kullback-Leibler (KL)
+    Function returning the proximal factory of the convex conjugate of the
+    functional F, where F is the cross entropy Kullback-Leibler (KL)
     divergence given by::
 
         F(x) = sum_i (x_i ln(pos(x_i)) - x_i ln(g_i) + g_i - x_i) + ind_P(x)


### PR DESCRIPTION
While reading through a part ODL I noticed some typos which should be corrected.