### PR TITLE
MAINT: unify usage of calls to parent classes, closes #1061

### DIFF
--- a/doc/source/getting_started/code/getting_started_convolution.py
+++ b/doc/source/getting_started/code/getting_started_convolution.py
@@ -20,8 +20,8 @@ class Convolution(odl.Operator):
         # Initialize the Operator class by calling its __init__ method.
         # This sets properties such as domain and range and allows the other
         # operator convenience functions to work.
-        odl.Operator.__init__(self, domain=kernel.space, range=kernel.space,
-                              linear=True)
+        super(Convolution, self).__init__(
+            domain=kernel.space, range=kernel.space, linear=True)
 
     def _call(self, x):
         """Implement calling the operator by calling scipy."""

--- a/doc/source/getting_started/first_steps.rst
+++ b/doc/source/getting_started/first_steps.rst
@@ -54,8 +54,8 @@ and create a wrapping `Operator` for it in ODL.
            # Initialize the Operator class by calling its __init__ method.
            # This sets properties such as domain and range and allows the other
            # operator convenience functions to work.
-           odl.Operator.__init__(self, domain=kernel.space, range=kernel.space,
-                                 linear=True)
+           super(Convolution, self).__init__(
+               domain=kernel.space, range=kernel.space, linear=True)
 
        def _call(self, x):
            """Implement calling the operator by calling scipy."""

--- a/doc/source/guide/code/functional_indepth_example.py
+++ b/doc/source/guide/code/functional_indepth_example.py
@@ -13,8 +13,8 @@ class MyFunctional(odl.solvers.Functional):
         # This comand calls the init of Functional and sets a number of
         # parameters associated with a functional. All but domain have default
         # values if not set.
-        odl.solvers.Functional.__init__(self, space=space, linear=False,
-                                        grad_lipschitz=2)
+        super(MyFunctional, self).__init__(
+            space=space, linear=False, grad_lipschitz=2)
 
         # We need to check that linear_term is in the domain. Then we store the
         # value of linear_term for future use.
@@ -43,8 +43,8 @@ class MyFunctional(odl.solvers.Functional):
 
             def __init__(self):
                 """Initialize a new instance."""
-                super().__init__(domain=functional.domain,
-                                 range=functional.domain)
+                super(MyGradientOperator, self).__init__(
+                    domain=functional.domain, range=functional.domain)
 
             def _call(self, x):
                 """Evaluate the gradient."""
@@ -79,8 +79,8 @@ class MyFunctionalConjugate(odl.solvers.Functional):
 
     def __init__(self, space, y):
         """initialize a new instance."""
-        odl.solvers.Functional.__init__(self, space=space, linear=False,
-                                        grad_lipschitz=2)
+        super(MyFunctionalConjugate, self).__init__(
+            space=space, linear=False, grad_lipschitz=2)
 
         if y not in space:
             raise TypeError('y is not in the domain!')

--- a/doc/source/guide/faq.rst
+++ b/doc/source/guide/faq.rst
@@ -98,27 +98,18 @@ General errors
 Errors related to Python 2/3
 ----------------------------
 
-#. **Q:** I follow your recommendation to call ``super().__init__(domain, range)``
-   in the ``__init__()`` method of ``MyOperator``, but I get the following
-   error::
+#. **Q:** I follow your recommendation to call ``super().__init__(domain, range)`` in the ``__init__()`` method of ``MyOperator``, but I get the following error::
 
-    File <...>, line ..., in __init__
-		super().__init__(dom, ran)
+       File <...>, line ..., in __init__
+		    super().__init__(dom, ran)
 
-	TypeError: super() takes at least 1 argument (0 given)
+	   TypeError: super() takes at least 1 argument (0 given)
 
    What is this error related to and how can I fix it?
 
-   **P:** The ``super()`` function `in Python 2
-   <https://docs.python.org/2/library/functions.html#super>`_ has to
-   be called with a type as first argument, whereas
-   `in Python 3
-   <https://docs.python.org/3/library/functions.html#super>`_, the
-   type argument is optional and usually not needed.
+   **P:** The ``super()`` function `in Python 2 <https://docs.python.org/2/library/functions.html#super>`_ has to be called with a type as first argument, whereas `in Python 3    <https://docs.python.org/3/library/functions.html#super>`_, the type argument is optional and usually not needed.
 
-   **S:** We recommend to include ``from builtins import super`` in your
-   module to backport the new Py3 ``super()`` function. This way, your code
-   will run in both Python 2 and 3.
+   **S:** We recommend to use the explicit ``super(MyOperator, self)`` since it works in both Python 2 and 3.
 
 
 Usage

--- a/doc/source/guide/functional_guide.rst
+++ b/doc/source/guide/functional_guide.rst
@@ -51,7 +51,7 @@ To define your own functional, start by writing::
 
         def __init__(self, space):
             # Sets `Operator.domain` to `space` and `Operator.range` to `space.field`
-            odl.solvers.Functional.__init__(self, space)
+            super(MyFunctional, self).__init__(space)
 
         ...
 

--- a/doc/source/guide/numpy_guide.rst
+++ b/doc/source/guide/numpy_guide.rst
@@ -88,8 +88,8 @@ To solve the above issue, it is often useful to write an `Operator` wrapping Num
    ...
    ...         # Initialize operator base class.
    ...         # This operator maps from the space of vector to the same space and is linear
-   ...         odl.Operator.__init__(self, domain=vector.space, range=vector.space,
-   ...                               linear=True)
+   ...         super(MyConvolution, self).__init__(
+   ...             domain=vector.space, range=vector.space, linear=True)
    ...
    ...     def _call(self, x):
    ...         # The output of an Operator is automatically cast to an ODL vector

--- a/doc/source/guide/operator_guide.rst
+++ b/doc/source/guide/operator_guide.rst
@@ -33,7 +33,7 @@ for a matrix :math:`A\in \mathbb{R}^{n\times m}` as follows::
             self.matrix = matrix
             dom = odl.rn(matrix.shape[1])
             ran = odl.rn(matrix.shape[0])
-            odl.Operator.__init__(self, dom, ran)
+            super(MatVecOperator, self).__init__(dom, ran)
 
 In addition, an `Operator` needs at least one way of
 evaluation, *in-place* or *out-of-place*.

--- a/examples/operator/simple_operator.py
+++ b/examples/operator/simple_operator.py
@@ -5,7 +5,7 @@ import odl
 
 class AddOp(odl.Operator):
     def __init__(self, space, add_this):
-        odl.Operator.__init__(self, domain=space, range=space)
+        super(AddOp, self).__init__(domain=space, range=space)
         self.add_this = add_this
 
     def _call(self, x):

--- a/examples/solvers/deconvolution_1d.py
+++ b/examples/solvers/deconvolution_1d.py
@@ -12,8 +12,8 @@ class Convolution(odl.Operator):
         self.adjkernel = (adjkernel if adjkernel is not None
                           else kernel.space.element(kernel[::-1].copy()))
         self.norm = float(np.sum(np.abs(self.kernel.ntuple)))
-        odl.Operator.__init__(self, domain=kernel.space, range=kernel.space,
-                              linear=True)
+        super(Convolution, self).__init__(
+            domain=kernel.space, range=kernel.space, linear=True)
 
     def _call(self, rhs, out):
         ndimage.convolve(rhs.ntuple.data, self.kernel.ntuple.data,

--- a/examples/solvers/functional_basic_example.py
+++ b/examples/solvers/functional_basic_example.py
@@ -18,8 +18,8 @@ class MyFunctional(odl.solvers.Functional):
         # This comand calls the init of Functional and sets a number of
         # parameters associated with a functional. All but domain have default
         # values if not set.
-        odl.solvers.Functional.__init__(self, space=space, linear=False,
-                                        grad_lipschitz=2)
+        super(MyFunctional, self).__init__(
+            space=space, linear=False, grad_lipschitz=2)
 
     def _call(self, x):
         # This is what is returned when calling my_func(x)

--- a/examples/solvers/pdhg_denoising_ROF_algorithm_comparison.py
+++ b/examples/solvers/pdhg_denoising_ROF_algorithm_comparison.py
@@ -62,7 +62,7 @@ strong_convexity = 1 / reg_param
 
 
 # define callback to store function values
-class CallbackStore(odl.solvers.util.callback.SolverCallback):
+class CallbackStore(odl.solvers.util.callback.Callback):
     def __init__(self):
         self.iteration_count = 0
         self.iteration_counts = []

--- a/examples/solvers/pdhg_denoising_complex.py
+++ b/examples/solvers/pdhg_denoising_complex.py
@@ -69,7 +69,7 @@ callback = (odl.solvers.CallbackPrintIteration() &
 x = op.domain.zero()
 
 # Run algorithm (and display intermediates)
-odl.solvers.chambolle_pock_solver(
+odl.solvers.pdhg(
     x, f, g, op, tau=tau, sigma=sigma, niter=niter, callback=callback)
 
 # Display images

--- a/examples/space/simple_r.py
+++ b/examples/space/simple_r.py
@@ -8,7 +8,7 @@ class Reals(odl.LinearSpace):
     """The real numbers."""
 
     def __init__(self):
-        odl.LinearSpace.__init__(self, field=odl.RealNumbers())
+        super(Reals, self).__init__(field=odl.RealNumbers())
 
     def _inner(self, x1, x2):
         return x1.__val__ * x2.__val__
@@ -32,7 +32,7 @@ class RealNumber(odl.LinearSpaceElement):
     __val__ = None
 
     def __init__(self, space, v):
-        odl.LinearSpaceElement.__init__(self, space=space)
+        super(RealNumber, self).__init__(space=space)
         self.__val__ = v
 
     def __float__(self):

--- a/examples/space/simple_rn.py
+++ b/examples/space/simple_rn.py
@@ -13,7 +13,7 @@ class SimpleRn(FnBase):
     """The real space R^n, non-optimized implmentation."""
 
     def __init__(self, size):
-        FnBase.__init__(self, size, np.float)
+        super(SimpleRn, self).__init__(size, np.float)
 
     def zero(self):
         return self.element(np.zeros(self.size))
@@ -51,7 +51,7 @@ class SimpleRn(FnBase):
 
 class RnVector(FnBaseVector):
     def __init__(self, space, data):
-        FnBaseVector.__init__(self, space)
+        super(RnVector, self).__init__(space)
         self.data = data
 
     def __getitem__(self, index):
@@ -65,7 +65,7 @@ class RnVector(FnBaseVector):
 
 
 r5 = SimpleRn(5)
-#odl.diagnostics.SpaceTest(r5).run_tests()
+# odl.diagnostics.SpaceTest(r5).run_tests()
 
 # Do some tests to compare
 n = 10**7

--- a/odl/contrib/mrc/mrc.py
+++ b/odl/contrib/mrc/mrc.py
@@ -10,7 +10,7 @@
 
 # Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
-from builtins import int, super
+from builtins import int
 
 from collections import OrderedDict
 from itertools import permutations
@@ -470,7 +470,9 @@ class FileReaderMRC(MRCHeaderProperties, FileReaderRawBinaryWithHeader):
                 keys=MRC_SPEC_KEYS,
                 dtype_map=MRC_DTYPE_TO_NPY_DTYPE)
 
-        super().__init__(file, header_fields)
+        # `MRCHeaderProperties` has no `__init__`, so this calls
+        # `FileReaderRawBinaryWithHeader.__init__`
+        super(FileReaderMRC, self).__init__(file, header_fields)
 
     def read_extended_header(self, groupby='field', force_type=''):
         """Read the extended header according to `extended_header_type`.
@@ -610,8 +612,8 @@ extended-mrc-format-not-used-by-2dx
         data : `numpy.ndarray`
             The data read from `file`.
         """
-        data = super().read_data(dstart, dend).reshape(self.data_shape,
-                                                       order='F')
+        data = super(FileReaderMRC, self).read_data(dstart, dend)
+        data = data.reshape(self.data_shape, order='F')
         if swap_axes:
             data = np.transpose(data, axes=self.data_axis_order)
             assert data.shape == self.data_shape

--- a/odl/contrib/solvers/functional/nonlocalmeans_functionals.py
+++ b/odl/contrib/solvers/functional/nonlocalmeans_functionals.py
@@ -10,7 +10,6 @@
 
 # Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
-from builtins import super
 
 import numpy as np
 
@@ -77,7 +76,8 @@ class NLMRegularizer(Functional):
         self.impl = impl
         self.patch_size = patch_size
         self.patch_distance = patch_distance
-        super().__init__(space=space, linear=False, grad_lipschitz=np.nan)
+        super(NLMRegularizer, self).__init__(
+            space=space, linear=False, grad_lipschitz=np.nan)
 
     @property
     def proximal(self):
@@ -85,7 +85,8 @@ class NLMRegularizer(Functional):
 
         class NLMProximal(Operator):
             def __init__(self, stepsize):
-                Operator.__init__(self, func.domain, func.domain, False)
+                super(NLMProximal, self).__init__(
+                    func.domain, func.domain, linear=False)
                 self.stepsize = stepsize
 
             def _call(self, x):

--- a/odl/contrib/tensorflow/operator.py
+++ b/odl/contrib/tensorflow/operator.py
@@ -53,7 +53,7 @@ class TensorflowOperator(odl.Operator):
         else:
             self.sess = sess
 
-        odl.Operator.__init__(self, domain, range, linear=linear)
+        super(TensorflowOperator, self).__init__(domain, range, linear=linear)
 
     def _call(self, x):
         result = self.sess.run(self.output_tensor,

--- a/odl/contrib/tensorflow/space.py
+++ b/odl/contrib/tensorflow/space.py
@@ -24,7 +24,7 @@ class TensorflowSpace(LinearSpace):
     """A space of tensorflow Tensors."""
 
     def __init__(self, shape, name='ODLTensorflowSpace'):
-        LinearSpace.__init__(self, RealNumbers())
+        super(TensorflowSpace, self).__init__(RealNumbers())
         self.shape = tuple(tf.Dimension(si) if not isinstance(si, tf.Dimension)
                            else si
                            for si in shape)
@@ -94,7 +94,7 @@ class TensorflowSpaceElement(LinearSpaceElement):
     """Elements in TensorflowSpace."""
 
     def __init__(self, space, data):
-        LinearSpaceElement.__init__(self, space)
+        super(TensorflowSpaceElement, self).__init__(space)
         self.data = data
 
     @property
@@ -116,7 +116,7 @@ class TensorflowSpaceOperator(Operator):
     """Wrap ODL operator so that it acts on TensorflowSpace elements."""
 
     def __init__(self, domain, range, func, adjoint=None, linear=False):
-        Operator.__init__(self, domain, range, linear)
+        super(TensorflowSpaceOperator, self).__init__(domain, range, linear)
         self.func = func
         self.adjoint_func = adjoint
 

--- a/odl/deform/linearized.py
+++ b/odl/deform/linearized.py
@@ -10,7 +10,6 @@
 
 # Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
-from builtins import super
 
 import numpy as np
 
@@ -188,9 +187,8 @@ class LinDeformFixedTempl(Operator):
                     'partiton ({!r} != {!r})'
                     ''.format(template.space.partition, domain[0].partition))
 
-        super().__init__(domain=domain,
-                         range=self.template.space,
-                         linear=False)
+        super(LinDeformFixedTempl, self).__init__(
+            domain=domain, range=self.template.space, linear=False)
 
     @property
     def template(self):
@@ -339,8 +337,9 @@ class LinDeformFixedDisp(Operator):
                     'partiton ({!r} != {!r})'
                     ''.format(templ_space.partition, space[0].partition))
 
+        super(LinDeformFixedDisp, self).__init__(
+            domain=templ_space, range=templ_space, linear=True)
         self.__displacement = displacement
-        super().__init__(domain=templ_space, range=templ_space, linear=True)
 
     @property
     def displacement(self):

--- a/odl/discr/diff_ops.py
+++ b/odl/discr/diff_ops.py
@@ -10,7 +10,6 @@
 
 # Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
-from builtins import super
 
 import numpy as np
 
@@ -109,8 +108,8 @@ class PartialDerivative(PointwiseTensorFieldOperator):
 
         # Method is affine if nonzero padding is given.
         linear = not (pad_mode == 'constant' and pad_const != 0)
-        super().__init__(domain=space, range=space, base_space=space,
-                         linear=linear)
+        super(PartialDerivative, self).__init__(
+            domain=space, range=space, base_space=space, linear=linear)
         self.axis = int(axis)
         self.dx = space.cell_sides[axis]
 
@@ -286,7 +285,8 @@ class Gradient(PointwiseTensorFieldOperator):
             range = ProductSpace(domain, domain.ndim)
 
         linear = not (pad_mode == 'constant' and pad_const != 0)
-        super().__init__(domain, range, base_space=domain, linear=linear)
+        super(Gradient, self).__init__(
+            domain, range, base_space=domain, linear=linear)
 
         self.method, method_in = str(method).lower(), method
         if method not in _SUPPORTED_DIFF_METHODS:
@@ -467,7 +467,8 @@ class Divergence(PointwiseTensorFieldOperator):
             range = domain[0]
 
         linear = not (pad_mode == 'constant' and pad_const != 0)
-        super().__init__(domain, range, base_space=range, linear=linear)
+        super(Divergence, self).__init__(
+            domain, range, base_space=range, linear=linear)
 
         self.method, method_in = str(method).lower(), method
         if method not in _SUPPORTED_DIFF_METHODS:
@@ -601,8 +602,8 @@ class Laplacian(PointwiseTensorFieldOperator):
         if not isinstance(space, DiscreteLp):
             raise TypeError('`space` {!r} is not a DiscreteLp instance'
                             ''.format(space))
-        super().__init__(domain=space, range=space, base_space=space,
-                         linear=True)
+        super(Laplacian, self).__init__(
+            domain=space, range=space, base_space=space, linear=True)
 
         self.pad_mode, pad_mode_in = str(pad_mode).lower(), pad_mode
         if pad_mode not in _SUPPORTED_PAD_MODES:

--- a/odl/discr/discr_mappings.py
+++ b/odl/discr/discr_mappings.py
@@ -14,7 +14,7 @@ operators.
 
 # Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
-from builtins import str, super, zip
+from builtins import str, zip
 
 from itertools import product
 import numpy as np
@@ -93,7 +93,7 @@ class FunctionSetMapping(Operator):
 
         domain = fset if map_type_ == 'sampling' else dspace
         range = dspace if map_type_ == 'sampling' else fset
-        Operator.__init__(self, domain, range, linear=linear)
+        super(FunctionSetMapping, self).__init__(domain, range, linear=linear)
         self.__partition = partition
 
         if self.is_linear:
@@ -228,8 +228,8 @@ class PointCollocation(FunctionSetMapping):
         rn(6).element([-2.0, -1.0, -3.0, -2.0, -4.0, -3.0])
         """
         linear = isinstance(ip_fset, FunctionSpace)
-        FunctionSetMapping.__init__(self, 'sampling', ip_fset, partition,
-                                    dspace, linear, **kwargs)
+        super(PointCollocation, self).__init__(
+            'sampling', ip_fset, partition, dspace, linear, **kwargs)
 
     def _call(self, func, out=None, **kwargs):
         """Evaluate ``func`` at the grid of this operator.
@@ -379,8 +379,8 @@ class NearestInterpolation(FunctionSetMapping):
         may not be noticable in some situations due to rounding errors.
         """
         linear = isinstance(fset, FunctionSpace)
-        FunctionSetMapping.__init__(self, 'interpolation', fset, partition,
-                                    dspace, linear, **kwargs)
+        super(NearestInterpolation, self).__init__(
+            'interpolation', fset, partition, dspace, linear, **kwargs)
 
         variant = kwargs.pop('variant', 'left')
         self.__variant = str(variant).lower()
@@ -487,8 +487,8 @@ class LinearInterpolation(FunctionSetMapping):
             raise TypeError('`fspace` {!r} is not a `FunctionSpace` '
                             'instance'.format(fspace))
 
-        FunctionSetMapping.__init__(self, 'interpolation', fspace, partition,
-                                    dspace, linear=True, **kwargs)
+        super(LinearInterpolation, self).__init__(
+            'interpolation', fspace, partition, dspace, linear=True, **kwargs)
 
     def _call(self, x, out=None):
         """Create an interpolator from grid values ``x``.
@@ -578,8 +578,8 @@ class PerAxisInterpolation(FunctionSetMapping):
             raise TypeError('`fspace` {!r} is not a `FunctionSpace` '
                             'instance'.format(fspace))
 
-        FunctionSetMapping.__init__(self, 'interpolation', fspace, partition,
-                                    dspace, linear=True, **kwargs)
+        super(PerAxisInterpolation, self).__init__(
+            'interpolation', fspace, partition, dspace, linear=True, **kwargs)
 
         schemes_in = schemes
         if is_string(schemes):
@@ -844,7 +844,8 @@ scipy.interpolate.RegularGridInterpolator.html>`_ class.
         variant : {'left', 'right'}
             Indicates which neighbor to prefer in the interpolation
         """
-        super().__init__(coord_vecs, values, input_type)
+        super(_NearestInterpolator, self).__init__(
+            coord_vecs, values, input_type)
         variant_ = str(variant).lower()
         if variant_ not in ('left', 'right'):
             raise ValueError("variant '{}' not understood".format(variant_))
@@ -978,7 +979,8 @@ class _PerAxisInterpolator(_Interpolator):
             This option has no effect for schemes other than nearest
             neighbor.
         """
-        super().__init__(coord_vecs, values, input_type)
+        super(_PerAxisInterpolator, self).__init__(
+            coord_vecs, values, input_type)
         self.schemes = schemes
         self.nn_variants = nn_variants
 
@@ -1039,9 +1041,10 @@ class _LinearInterpolator(_PerAxisInterpolator):
         input_type : {'array', 'meshgrid'}
             Type of expected input values in ``__call__``
         """
-        super().__init__(coord_vecs, values, input_type,
-                         schemes=['linear'] * len(coord_vecs),
-                         nn_variants=[None] * len(coord_vecs))
+        super(_LinearInterpolator, self).__init__(
+            coord_vecs, values, input_type,
+            schemes=['linear'] * len(coord_vecs),
+            nn_variants=[None] * len(coord_vecs))
 
 
 if __name__ == '__main__':

--- a/odl/discr/discr_ops.py
+++ b/odl/discr/discr_ops.py
@@ -10,7 +10,6 @@
 
 # Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
-from builtins import super
 
 import numpy as np
 
@@ -80,7 +79,8 @@ class Resampling(Operator):
                              '`range.uspace` ({})'
                              ''.format(domain.uspace, range.uspace))
 
-        super().__init__(domain=domain, range=range, linear=True)
+        super(Resampling, self).__init__(
+            domain=domain, range=range, linear=True)
 
     def _call(self, x, out=None):
         """Apply resampling operator.
@@ -313,7 +313,8 @@ class ResizingOperatorBase(Operator):
         # padding mode 'constant' with `pad_const != 0` is not linear
         linear = (self.pad_mode != 'constant' or self.pad_const == 0.0)
 
-        super().__init__(domain, range, linear=linear)
+        super(ResizingOperatorBase, self).__init__(
+            domain, range, linear=linear)
 
     @property
     def offset(self):

--- a/odl/discr/discretization.py
+++ b/odl/discr/discretization.py
@@ -10,7 +10,6 @@
 
 # Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
-from builtins import super
 
 from odl.operator import Operator
 from odl.space.base_ntuples import (NtuplesBase, NtuplesBaseVector,
@@ -109,7 +108,7 @@ class DiscretizedSet(NtuplesBase):
                                  'the undiscretized space {}'
                                  ''.format(interpol.range, uspace))
 
-        super().__init__(dspace.size, dspace.dtype)
+        super(DiscretizedSet, self).__init__(dspace.size, dspace.dtype)
         self.__uspace = uspace
         self.__dspace = dspace
         self.__sampling = sampling
@@ -244,7 +243,7 @@ class DiscretizedSetElement(NtuplesBaseVector):
 
     def __init__(self, space, ntuple):
         """Initialize a new instance."""
-        NtuplesBaseVector.__init__(self, space)
+        super(DiscretizedSetElement, self).__init__(space)
         self.__ntuple = ntuple
 
     @property

--- a/odl/discr/lp_discr.py
+++ b/odl/discr/lp_discr.py
@@ -10,7 +10,7 @@
 
 # Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
-from builtins import super, str
+from builtins import str
 
 import numpy as np
 from numbers import Integral
@@ -143,7 +143,7 @@ class DiscreteLp(DiscretizedSpace):
                 fspace, self.partition, dspace, self.interp_byaxis,
                 order=self.order)
 
-        DiscretizedSpace.__init__(self, fspace, dspace, sampling, interpol)
+        super(DiscreteLp, self).__init__(fspace, dspace, sampling, interpol)
         self.__exponent = float(exponent)
         if (hasattr(self.dspace, 'exponent') and
                 self.exponent != dspace.exponent):
@@ -410,9 +410,9 @@ class DiscreteLp(DiscretizedSpace):
             func_list = _scaling_func_list(bdry_fracs)
 
             x_arr = apply_on_boundary(x, func=func_list, only_once=False)
-            return super()._inner(self.element(x_arr), y)
+            return super(DiscreteLp, self)._inner(self.element(x_arr), y)
         else:
-            return super()._inner(x, y)
+            return super(DiscreteLp, self)._inner(x, y)
 
     def _norm(self, x):
         """Return ``self.norm(x)``."""
@@ -422,9 +422,9 @@ class DiscreteLp(DiscretizedSpace):
             func_list = _scaling_func_list(bdry_fracs, exponent=self.exponent)
 
             x_arr = apply_on_boundary(x, func=func_list, only_once=False)
-            return super()._norm(self.element(x_arr))
+            return super(DiscreteLp, self)._norm(self.element(x_arr))
         else:
-            return super()._norm(x)
+            return super(DiscreteLp, self)._norm(x)
 
     def _dist(self, x, y):
         """Return ``self.dist(x, y)``."""
@@ -436,9 +436,10 @@ class DiscreteLp(DiscretizedSpace):
             arrs = [apply_on_boundary(vec, func=func_list, only_once=False)
                     for vec in (x, y)]
 
-            return super()._dist(self.element(arrs[0]), self.element(arrs[1]))
+            return super(DiscreteLp, self)._dist(
+                self.element(arrs[0]), self.element(arrs[1]))
         else:
-            return super()._dist(x, y)
+            return super(DiscreteLp, self)._dist(x, y)
 
     def __repr__(self):
         """Return ``repr(self)``."""
@@ -566,7 +567,8 @@ class DiscreteLpElement(DiscretizedSpaceElement):
                                  'expected {!r}'
                                  ''.format(self.space.order, out_order))
 
-            super().asarray(out=out.ravel(order=self.space.order))
+            super(DiscreteLpElement, self).asarray(
+                out=out.ravel(order=self.space.order))
             return out
 
     @property
@@ -696,7 +698,7 @@ class DiscreteLpElement(DiscretizedSpaceElement):
                                                self.space.shape))
                 values = values.ravel(order=self.space.order)
 
-            super().__setitem__(indices, values)
+            super(DiscreteLpElement, self).__setitem__(indices, values)
 
     @property
     def ufuncs(self):

--- a/odl/discr/partition.py
+++ b/odl/discr/partition.py
@@ -16,7 +16,7 @@ of partitions of intervals.
 
 # Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
-from builtins import object, range, super, zip
+from builtins import object, range, zip
 
 import numpy as np
 
@@ -57,6 +57,8 @@ class RectPartition(object):
             Spatial points supporting the partition. They must be
             contained in ``intv_prod``.
         """
+        super(RectPartition, self).__init__()
+
         if not isinstance(intv_prod, IntervalProd):
             raise TypeError('{!r} is not an IntervalProd instance'
                             ''.format(intv_prod))
@@ -75,7 +77,6 @@ class RectPartition(object):
             raise ValueError('{} is not contained in {}'
                              ''.format(grid, intv_prod))
 
-        super().__init__()
         self.__set = intv_prod
         self.__grid = grid
 

--- a/odl/operator/default_ops.py
+++ b/odl/operator/default_ops.py
@@ -10,7 +10,6 @@
 
 # Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
-from builtins import super
 
 from copy import copy
 import numpy as np
@@ -61,7 +60,7 @@ class ScalingOperator(Operator):
             raise TypeError('`space` {!r} not a `LinearSpace` or `Field` '
                             'instance'.format(domain))
 
-        super().__init__(domain, domain, linear=True)
+        super(ScalingOperator, self).__init__(domain, domain, linear=True)
         self.__scalar = domain.field.element(scalar)
 
     @property
@@ -158,7 +157,7 @@ class IdentityOperator(ScalingOperator):
         space : `LinearSpace`
             Space of elements which the operator is acting on.
         """
-        super().__init__(space, 1)
+        super(IdentityOperator, self).__init__(space, 1)
 
     def __repr__(self):
         """Return ``repr(self)``."""
@@ -199,7 +198,7 @@ class LinCombOperator(Operator):
         rn(3).element([2.0, 4.0, 6.0])
         """
         domain = ProductSpace(space, space)
-        super().__init__(domain, space, linear=True)
+        super(LinCombOperator, self).__init__(domain, space, linear=True)
         self.a = a
         self.b = b
 
@@ -275,10 +274,11 @@ class MultiplyOperator(Operator):
         if range is None:
             range = multiplicand.space
 
+        super(MultiplyOperator, self).__init__(domain, range, linear=True)
+
         self.__multiplicand = multiplicand
         self.__domain_is_field = isinstance(domain, Field)
         self.__range_is_field = isinstance(range, Field)
-        super().__init__(domain, range, linear=True)
 
     @property
     def multiplicand(self):
@@ -383,10 +383,10 @@ class PowerOperator(Operator):
         >>> op(2.0)
         4.0
         """
-
+        super(PowerOperator, self).__init__(
+            domain, domain, linear=(exponent == 1))
         self.__exponent = float(exponent)
         self.__domain_is_field = isinstance(domain, Field)
-        super().__init__(domain, domain, linear=(exponent == 1))
 
     @property
     def exponent(self):
@@ -477,8 +477,9 @@ class InnerProductOperator(Operator):
         >>> op(r3.element([1, 2, 3]))
         14.0
         """
+        super(InnerProductOperator, self).__init__(
+            vector.space, vector.space.field, linear=True)
         self.__vector = vector
-        super().__init__(vector.space, vector.space.field, linear=True)
 
     @property
     def vector(self):
@@ -566,7 +567,7 @@ class NormOperator(Operator):
         >>> op([3, 4])
         5.0
         """
-        super().__init__(space, RealNumbers(), linear=False)
+        super(NormOperator, self).__init__(space, RealNumbers(), linear=False)
 
     def _call(self, x):
         """Return the norm of ``x``."""
@@ -656,8 +657,9 @@ class DistOperator(Operator):
         >>> op([4, 5])
         5.0
         """
+        super(DistOperator, self).__init__(
+            vector.space, RealNumbers(), linear=False)
         self.__vector = vector
-        super().__init__(vector.space, RealNumbers(), linear=False)
 
     @property
     def vector(self):
@@ -769,7 +771,7 @@ class ConstantOperator(Operator):
 
         self.__constant = range.element(constant)
         linear = self.constant.norm() == 0
-        super().__init__(domain, range, linear=linear)
+        super(ConstantOperator, self).__init__(domain, range, linear=linear)
 
     @property
     def constant(self):
@@ -849,7 +851,7 @@ class ZeroOperator(Operator):
         if range is None:
             range = domain
 
-        super().__init__(domain, range, linear=True)
+        super(ZeroOperator, self).__init__(domain, range, linear=True)
 
     def _call(self, x, out=None):
         """Return the zero vector or assign it to ``out``."""
@@ -923,7 +925,7 @@ class RealPart(Operator):
         """
         real_space = space.real_space
         linear = (space == real_space)
-        Operator.__init__(self, space, real_space, linear=linear)
+        super(RealPart, self).__init__(space, real_space, linear=linear)
 
     def _call(self, x):
         """Return ``self(x)``."""
@@ -1001,8 +1003,11 @@ class RealPart(Operator):
 
 
 class ImagPart(Operator):
+
+    """Operator that extracts the imaginary part of a vector."""
+
     def __init__(self, space):
-        """Operator that extracts the imaginary part of a vector.
+        """Initialize a new instance.
 
         Parameters
         ----------
@@ -1028,7 +1033,7 @@ class ImagPart(Operator):
         """
         real_space = space.real_space
         linear = (space == real_space)
-        Operator.__init__(self, space, real_space, linear=linear)
+        super(ImagPart, self).__init__(space, real_space, linear=linear)
 
     def _call(self, x):
         """Return ``self(x)``."""
@@ -1146,7 +1151,8 @@ class ComplexEmbedding(Operator):
         """
         complex_space = space.complex_space
         self.scalar = complex_space.field.element(scalar)
-        Operator.__init__(self, space, complex_space, linear=True)
+        super(ComplexEmbedding, self).__init__(
+            space, complex_space, linear=True)
 
     def _call(self, x, out):
         """Return ``self(x)``."""
@@ -1284,7 +1290,7 @@ class ComplexModulus(Operator):
         """
         real_space = space.real_space
         linear = (space == real_space)
-        Operator.__init__(self, space, real_space, linear=linear)
+        super(ComplexModulus, self).__init__(space, real_space, linear=linear)
 
     def _call(self, x):
         """Return ``self(x)``."""

--- a/odl/operator/fn_ops.py
+++ b/odl/operator/fn_ops.py
@@ -10,7 +10,7 @@
 
 # Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
-from builtins import super
+
 import numpy as np
 
 from odl.operator.operator import Operator
@@ -85,7 +85,7 @@ class SamplingOperator(Operator):
             self.__indices_flat = self.sampling_points
 
         range = fn(self.indices_flat.size, dtype=domain.dtype)
-        super().__init__(domain, range, linear=True)
+        super(SamplingOperator, self).__init__(domain, range, linear=True)
 
     @property
     def variant(self):
@@ -216,7 +216,8 @@ class WeightedSumSamplingOperator(Operator):
             self.__indices_flat = self.sampling_points
 
         domain = fn(self.indices_flat.size, dtype=range.dtype)
-        super().__init__(domain, range, linear=True)
+        super(WeightedSumSamplingOperator, self).__init__(
+            domain, range, linear=True)
 
     @property
     def variant(self):
@@ -329,7 +330,7 @@ class FlatteningOperator(Operator):
 
         self.__order = order
         range = fn(domain.size, dtype=domain.dtype)
-        super().__init__(domain, range, linear=True)
+        super(FlatteningOperator, self).__init__(domain, range, linear=True)
 
     def _call(self, x, out=None):
         """Collect indices"""
@@ -416,7 +417,8 @@ class FlatteningOperatorAdjoint(Operator):
                             'instance'.format(range))
 
         domain = fn(range.size, dtype=range.dtype)
-        super().__init__(domain, range, linear=True)
+        super(FlatteningOperatorAdjoint, self).__init__(
+            domain, range, linear=True)
 
     def _call(self, x, out=None):
         """Create a new element with the known coefficients."""

--- a/odl/operator/operator.py
+++ b/odl/operator/operator.py
@@ -10,7 +10,7 @@
 
 # Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
-from builtins import object, super
+from builtins import object
 
 import inspect
 from numbers import Number, Integral
@@ -331,12 +331,11 @@ class Operator(object):
         The set this operator maps to
 
     It is **highly** recommended to call
-    ``super().__init__(domain, range)`` (Note: add
-    ``from builtins import super`` in Python 2) in the ``__init__()``
-    method of any subclass, where ``domain`` and ``range`` are the arguments
-    specifying domain and range of the new operator. In that case, the
-    attributes `Operator.domain` and `Operator.range` are automatically
-    provided by the parent class `Operator`.
+    ``super(MyOp, self).__init__(domain, range)``  in the ``__init__()``
+    method of any subclass  ``MyOp``, where ``domain`` and ``range`` are
+    the arguments specifying domain and range of the new operator. In that
+    case, the attributes `Operator.domain` and `Operator.range` are
+    automatically provided by the parent class `Operator`.
 
     In addition, any subclass **must** implement the private method
     `Operator._call()`. It signature determines how it is interpreted:
@@ -1132,8 +1131,9 @@ class OperatorSum(Operator):
                                 'operator domain {!r}'
                                 ''.format(tmp_dom, left.domain))
 
-        super().__init__(left.domain, left.range,
-                         linear=left.is_linear and right.is_linear)
+        super(OperatorSum, self).__init__(
+            left.domain, left.range,
+            linear=left.is_linear and right.is_linear)
         self.__left = left
         self.__right = right
         self.__tmp_ran = tmp_ran
@@ -1249,9 +1249,10 @@ class OperatorVectorSum(Operator):
             raise TypeError('`op.range` {!r} not a LinearSpace instance'
                             ''.format(operator.range))
 
+        super(OperatorVectorSum, self).__init__(
+            operator.domain, operator.range)
         self.__operator = operator
         self.__vector = operator.range.element(vector)
-        super().__init__(operator.domain, operator.range)
 
     @property
     def operator(self):
@@ -1341,8 +1342,9 @@ class OperatorComp(Operator):
                                 'operator domain {!r}'
                                 ''.format(tmp, left.domain))
 
-        super().__init__(right.domain, left.range,
-                         linear=left.is_linear and right.is_linear)
+        super(OperatorComp, self).__init__(
+            right.domain, left.range,
+            linear=left.is_linear and right.is_linear)
         self.__left = left
         self.__right = right
         self.__tmp = tmp
@@ -1471,7 +1473,8 @@ class OperatorPointwiseProduct(Operator):
             raise OpTypeError('operator domains {!r} and {!r} do not match'
                               ''.format(left.domain, right.domain))
 
-        super().__init__(left.domain, left.range, linear=False)
+        super(OperatorPointwiseProduct, self).__init__(
+            left.domain, left.range, linear=False)
         self.__left = left
         self.__right = right
 
@@ -1560,8 +1563,8 @@ class OperatorLeftScalarMult(Operator):
             scalar = scalar * operator.scalar
             operator = operator.operator
 
-        super().__init__(operator.domain, operator.range,
-                         linear=operator.is_linear)
+        super(OperatorLeftScalarMult, self).__init__(
+            operator.domain, operator.range, linear=operator.is_linear)
         self.__operator = operator
         self.__scalar = scalar
 
@@ -1730,7 +1733,8 @@ class OperatorRightScalarMult(Operator):
             scalar = scalar * operator.scalar
             operator = operator.operator
 
-        super().__init__(operator.domain, operator.range, operator.is_linear)
+        super(OperatorRightScalarMult, self).__init__(
+            operator.domain, operator.range, operator.is_linear)
         self.__operator = operator
         self.__scalar = scalar
         self.__tmp = tmp
@@ -1767,7 +1771,7 @@ class OperatorRightScalarMult(Operator):
             return OperatorRightScalarMult(self.operator, self.scalar * other,
                                            self.__tmp)
         else:
-            return super().__rmul__(other)
+            return super(OperatorRightScalarMult, self).__rmul__(other)
 
     @property
     def inverse(self):
@@ -1900,8 +1904,8 @@ class FunctionalLeftVectorMult(Operator):
             raise OpTypeError('range {!r} not is not vector.space.field {!r}'
                               ''.format(functional.range, vector.space.field))
 
-        super().__init__(functional.domain, vector.space,
-                         linear=functional.is_linear)
+        super(FunctionalLeftVectorMult, self).__init__(
+            functional.domain, vector.space, linear=functional.is_linear)
         self.__functional = functional
         self.__vector = vector
 
@@ -1994,8 +1998,8 @@ class OperatorLeftVectorMult(Operator):
             raise OpRangeError('`vector` {!r} not in operator.range {!r}'
                                ''.format(vector, operator.range))
 
-        super().__init__(operator.domain, operator.range,
-                         linear=operator.is_linear)
+        super(OperatorLeftVectorMult, self).__init__(
+            operator.domain, operator.range, linear=operator.is_linear)
         self.__operator = operator
         self.__vector = vector
 
@@ -2110,8 +2114,8 @@ class OperatorRightVectorMult(Operator):
             raise OpDomainError('`vector` {!r} not in operator.domain {!r}'
                                 ''.format(vector.space, operator.domain))
 
-        super().__init__(operator.domain, operator.range,
-                         linear=operator.is_linear)
+        super(OperatorRightVectorMult, self).__init__(
+            operator.domain, operator.range, linear=operator.is_linear)
         self.__operator = operator
         self.__vector = vector
 

--- a/odl/operator/pspace_ops.py
+++ b/odl/operator/pspace_ops.py
@@ -10,7 +10,6 @@
 
 # Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
-from builtins import super
 
 import numpy as np
 from numbers import Integral
@@ -213,7 +212,8 @@ class ProductSpaceOperator(Operator):
         # Set linearity
         linear = all(op.is_linear for op in self.ops.data)
 
-        super().__init__(domain=domain, range=range, linear=linear)
+        super(ProductSpaceOperator, self).__init__(
+            domain=domain, range=range, linear=linear)
 
     def _call(self, x, out=None):
         """Call the operators on the parts of ``x``."""
@@ -501,7 +501,8 @@ class ComponentProjection(Operator):
         ])
         """
         self.__index = index
-        super().__init__(space, space[index], linear=True)
+        super(ComponentProjection, self).__init__(
+            space, space[index], linear=True)
 
     @property
     def index(self):
@@ -594,7 +595,8 @@ class ComponentProjectionAdjoint(Operator):
         ])
         """
         self.__index = index
-        super().__init__(space[index], space, linear=True)
+        super(ComponentProjectionAdjoint, self).__init__(
+            space[index], space, linear=True)
 
     @property
     def index(self):
@@ -694,10 +696,9 @@ class BroadcastOperator(Operator):
 
         self.__operators = operators
         self.__prod_op = ProductSpaceOperator([[op] for op in operators])
-
-        super().__init__(self.prod_op.domain[0],
-                         self.prod_op.range,
-                         self.prod_op.is_linear)
+        super(BroadcastOperator, self).__init__(
+            self.prod_op.domain[0], self.prod_op.range,
+            linear=self.prod_op.is_linear)
 
     @property
     def prod_op(self):
@@ -871,9 +872,9 @@ class ReductionOperator(Operator):
         self.__operators = operators
         self.__prod_op = ProductSpaceOperator([operators])
 
-        super().__init__(self.prod_op.domain,
-                         self.prod_op.range[0],
-                         self.prod_op.is_linear)
+        super(ReductionOperator, self).__init__(
+            self.prod_op.domain, self.prod_op.range[0],
+            linear=self.prod_op.is_linear)
 
     @property
     def prod_op(self):
@@ -1062,10 +1063,9 @@ class DiagonalOperator(ProductSpaceOperator):
         indices = [range(len(operators)), range(len(operators))]
         shape = (len(operators), len(operators))
         op_matrix = scipy.sparse.coo_matrix((operators, indices), shape)
+        super(DiagonalOperator, self).__init__(op_matrix, **kwargs)
 
         self.__operators = tuple(operators)
-
-        super().__init__(op_matrix, **kwargs)
 
     @property
     def operators(self):

--- a/odl/operator/tensor_ops.py
+++ b/odl/operator/tensor_ops.py
@@ -10,7 +10,6 @@
 
 # Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
-from builtins import super
 
 import numpy as np
 
@@ -78,7 +77,8 @@ class PointwiseTensorFieldOperator(Operator):
                                 'nor a nonempty power space of it'
                                 ''.format(range, base_space))
 
-        super().__init__(domain=domain, range=range, linear=linear)
+        super(PointwiseTensorFieldOperator, self).__init__(
+            domain=domain, range=range, linear=linear)
         self.__base_space = base_space
 
     @property
@@ -162,8 +162,9 @@ class PointwiseNorm(PointwiseTensorFieldOperator):
         if not isinstance(vfspace, ProductSpace):
             raise TypeError('`vfspace` {!r} is not a ProductSpace '
                             'instance'.format(vfspace))
-        super().__init__(domain=vfspace, range=vfspace[0],
-                         base_space=vfspace[0], linear=False)
+        super(PointwiseNorm, self).__init__(
+            domain=vfspace, range=vfspace[0], base_space=vfspace[0],
+            linear=False)
 
         # Need to check for product space shape once higher order tensors
         # are implemented
@@ -377,11 +378,13 @@ class PointwiseInnerBase(PointwiseTensorFieldOperator):
             raise TypeError('`vfsoace` {!r} is not a ProductSpace '
                             'instance'.format(vfspace))
         if adjoint:
-            super().__init__(domain=vfspace[0], range=vfspace,
-                             base_space=vfspace[0], linear=True)
+            super(PointwiseInnerBase, self).__init__(
+                domain=vfspace[0], range=vfspace, base_space=vfspace[0],
+                linear=True)
         else:
-            super().__init__(domain=vfspace, range=vfspace[0],
-                             base_space=vfspace[0], linear=True)
+            super(PointwiseInnerBase, self).__init__(
+                domain=vfspace, range=vfspace[0], base_space=vfspace[0],
+                linear=True)
 
         # Bail out if the space is complex but we cannot take the complex
         # conjugate.
@@ -490,8 +493,9 @@ class PointwiseInner(PointwiseInnerBase):
         >>> print(pw_inner(x))
         [[0.0, -7.0]]
         """
-        super().__init__(adjoint=False, vfspace=vfspace, vecfield=vecfield,
-                         weighting=weighting)
+        super(PointwiseInner, self).__init__(
+            adjoint=False, vfspace=vfspace, vecfield=vecfield,
+            weighting=weighting)
 
     @property
     def vecfield(self):
@@ -590,8 +594,9 @@ class PointwiseInnerAdjoint(PointwiseInnerBase):
                 raise ValueError('base space of the range is different from '
                                  'the given scalar space ({!r} != {!r})'
                                  ''.format(vfspace[0], sspace))
-        super().__init__(adjoint=True, vfspace=vfspace, vecfield=vecfield,
-                         weighting=weighting)
+        super(PointwiseInnerAdjoint, self).__init__(
+            adjoint=True, vfspace=vfspace, vecfield=vecfield,
+            weighting=weighting)
 
         # Get weighting from range
         if hasattr(self.range.weighting, 'array'):
@@ -624,7 +629,7 @@ class PointwiseInnerAdjoint(PointwiseInnerBase):
                               weighting=self.weights)
 
 
-# TODO: Optimize this to an optimized operator on its own.
+# TODO: Make this an optimized operator on its own.
 class PointwiseSum(PointwiseInner):
 
     """Take the point-wise sum of a vector field.
@@ -680,7 +685,8 @@ class PointwiseSum(PointwiseInner):
                             'instance'.format(vfspace))
 
         ones = vfspace.one()
-        super().__init__(vfspace, vecfield=ones, weighting=weighting)
+        super(PointwiseSum, self).__init__(
+            vfspace, vecfield=ones, weighting=weighting)
 
 
 class MatrixOperator(Operator):
@@ -801,7 +807,7 @@ class MatrixOperator(Operator):
                             'range data type {!r}.'
                             ''.format(matrix.dtype, range.dtype))
 
-        super().__init__(domain, range, linear=True)
+        super(MatrixOperator, self).__init__(domain, range, linear=True)
 
     @property
     def matrix(self):

--- a/odl/set/domain.py
+++ b/odl/set/domain.py
@@ -10,7 +10,7 @@
 
 # Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
-from builtins import super, zip
+from builtins import zip
 
 import numpy as np
 
@@ -49,6 +49,7 @@ class IntervalProd(Set):
         >>> rbox
         IntervalProd([-1.0, 2.5, 70.0, 80.0], [-0.5, 10.0, 75.0, 90.0])
         """
+        super(IntervalProd, self).__init__()
         self.__min_pt = np.atleast_1d(min_pt).astype('float64')
         self.__max_pt = np.atleast_1d(max_pt).astype('float64')
 
@@ -73,7 +74,6 @@ class IntervalProd(Set):
                                  'end ({} < {})'.format(axis, xmax, xmin))
 
         self.__nondegen_byaxis = (self.min_pt != self.max_pt)
-        super().__init__()
 
     @property
     def min_pt(self):

--- a/odl/set/space.py
+++ b/odl/set/space.py
@@ -976,7 +976,7 @@ class UniversalSpace(LinearSpace):
 
     def __init__(self):
         """Initialize a new instance."""
-        LinearSpace.__init__(self, field=UniversalSet())
+        super(UniversalSpace, self).__init__(field=UniversalSet())
 
     def element(self, inp=None):
         """Dummy element creation method.

--- a/odl/solvers/functional/default_functionals.py
+++ b/odl/solvers/functional/default_functionals.py
@@ -10,7 +10,6 @@
 
 # Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
-from builtins import super
 
 import numpy as np
 from numbers import Integral
@@ -68,8 +67,9 @@ class LpNorm(Functional):
         exponent : float
             Exponent for the norm (``p``).
         """
+        super(LpNorm, self).__init__(
+            space=space, linear=False, grad_lipschitz=np.nan)
         self.exponent = float(exponent)
-        super().__init__(space=space, linear=False, grad_lipschitz=np.nan)
 
     # TODO: update when integration operator is in place: issue #440
     def _call(self, x):
@@ -132,8 +132,8 @@ class LpNorm(Functional):
 
                 def __init__(self):
                     """Initialize a new instance."""
-                    super().__init__(functional.domain, functional.domain,
-                                     linear=False)
+                    super(L1Gradient, self).__init__(
+                        functional.domain, functional.domain, linear=False)
 
                 def _call(self, x):
                     """Apply the gradient operator to the given point."""
@@ -144,6 +144,7 @@ class LpNorm(Functional):
                     return ZeroOperator(self.domain)
 
             return L1Gradient()
+
         elif self.exponent == 2:
             class L2Gradient(Operator):
 
@@ -151,8 +152,8 @@ class LpNorm(Functional):
 
                 def __init__(self):
                     """Initialize a new instance."""
-                    super().__init__(functional.domain, functional.domain,
-                                     linear=False)
+                    super(L2Gradient, self).__init__(
+                        functional.domain, functional.domain, linear=False)
 
                 def _call(self, x):
                     """Apply the gradient operator to the given point.
@@ -166,6 +167,7 @@ class LpNorm(Functional):
                         return x / norm_of_x
 
             return L2Gradient()
+
         else:
             raise NotImplementedError('`gradient` only implemented for p=1 or '
                                       'p=2')
@@ -238,8 +240,10 @@ class GroupL1Norm(Functional):
             raise TypeError('`space` must be a `ProductSpace`')
         if not vfspace.is_power_space:
             raise TypeError('`space.is_power_space` must be `True`')
+
+        super(GroupL1Norm, self).__init__(
+            space=vfspace, linear=False, grad_lipschitz=np.nan)
         self.pointwise_norm = PointwiseNorm(vfspace, exponent)
-        super().__init__(space=vfspace, linear=False, grad_lipschitz=np.nan)
 
     def _call(self, x):
         """Return the group L1-norm of ``x``."""
@@ -280,8 +284,8 @@ class GroupL1Norm(Functional):
 
             def __init__(self):
                 """Initialize a new instance."""
-                super().__init__(functional.domain, functional.domain,
-                                 linear=False)
+                super(GroupL1Gradient, self).__init__(
+                    functional.domain, functional.domain, linear=False)
 
             def _call(self, x):
                 """Return ``self(x)``."""
@@ -375,8 +379,10 @@ class IndicatorGroupL1UnitBall(Functional):
             raise TypeError('`space` must be a `ProductSpace`')
         if not vfspace.is_power_space:
             raise TypeError('`space.is_power_space` must be `True`')
+
+        super(IndicatorGroupL1UnitBall, self).__init__(
+            space=vfspace, linear=False, grad_lipschitz=np.nan)
         self.pointwise_norm = PointwiseNorm(vfspace, exponent)
-        super().__init__(space=vfspace, linear=False, grad_lipschitz=np.nan)
 
     def _call(self, x):
         """Return ``self(x)``."""
@@ -465,7 +471,7 @@ class IndicatorLpUnitBall(Functional):
         exponent : int or infinity
             Specifies wich norm to use.
         """
-        super().__init__(space=space, linear=False)
+        super(IndicatorLpUnitBall, self).__init__(space=space, linear=False)
         self.__norm = LpNorm(space, exponent)
         self.__exponent = float(exponent)
 
@@ -563,7 +569,7 @@ class L1Norm(LpNorm):
         space : `DiscreteLp` or `FnBase`
             Domain of the functional.
         """
-        super().__init__(space=space, exponent=1)
+        super(L1Norm, self).__init__(space=space, exponent=1)
 
     def __repr__(self):
         """Return ``repr(self)``."""
@@ -601,7 +607,7 @@ class L2Norm(LpNorm):
         space : `DiscreteLp` or `FnBase`
             Domain of the functional.
         """
-        super().__init__(space=space, exponent=2)
+        super(L2Norm, self).__init__(space=space, exponent=2)
 
     def __repr__(self):
         """Return ``repr(self)``."""
@@ -639,7 +645,8 @@ class L2NormSquared(Functional):
         space : `DiscreteLp` or `FnBase`
             Domain of the functional.
         """
-        super().__init__(space=space, linear=False, grad_lipschitz=2)
+        super(L2NormSquared, self).__init__(
+            space=space, linear=False, grad_lipschitz=2)
 
     # TODO: update when integration operator is in place: issue #440
     def _call(self, x):
@@ -695,7 +702,8 @@ class ConstantFunctional(Functional):
         constant : element in ``domain.field``
             The constant value of the functional
         """
-        super().__init__(space=space, linear=(constant == 0), grad_lipschitz=0)
+        super(ConstantFunctional, self).__init__(
+            space=space, linear=(constant == 0), grad_lipschitz=0)
         self.__constant = self.range.element(constant)
 
     @property
@@ -751,7 +759,7 @@ class ZeroFunctional(ConstantFunctional):
         space : `LinearSpace`
             Domain of the functional.
         """
-        super().__init__(space=space, constant=0)
+        super(ZeroFunctional, self).__init__(space=space, constant=0)
 
     def __repr__(self):
         """Return ``repr(self)``."""
@@ -778,7 +786,6 @@ class ScalingFunctional(Functional, ScalingOperator):
 
         Examples
         --------
-        >>> import odl
         >>> field = odl.RealNumbers()
         >>> func = ScalingFunctional(field, 3)
         >>> func(5)
@@ -810,7 +817,7 @@ class IdentityFunctional(ScalingFunctional):
         field : `Field`
             Domain of the functional.
         """
-        ScalingFunctional.__init__(self, field, 1.0)
+        super(IdentityFunctional, self).__init__(field, 1.0)
 
 
 class IndicatorBox(Functional):
@@ -852,7 +859,7 @@ class IndicatorBox(Functional):
         >>> func([0, 1, 3])  # one point outside
         inf
         """
-        Functional.__init__(self, space, linear=False)
+        super(IndicatorBox, self).__init__(space, linear=False)
         self.lower = lower
         self.upper = upper
 
@@ -917,7 +924,8 @@ class IndicatorNonnegativity(IndicatorBox):
         >>> func([0, 1, -3])  # one point negative
         inf
         """
-        IndicatorBox.__init__(self, space, lower=0, upper=None)
+        super(IndicatorNonnegativity, self).__init__(
+            space, lower=0, upper=None)
 
     def __repr__(self):
         """Return ``repr(self)``."""
@@ -954,8 +962,8 @@ class IndicatorZero(Functional):
         >>> func([0, 0, 0])
         2
         """
+        super(IndicatorZero, self).__init__(space, linear=False)
         self.__constant = constant
-        super().__init__(space, linear=False)
 
     @property
     def constant(self):
@@ -1084,7 +1092,8 @@ class KullbackLeibler(Functional):
         >>> func(x)
         3.0
         """
-        super().__init__(space=space, linear=False, grad_lipschitz=np.nan)
+        super(KullbackLeibler, self).__init__(
+            space=space, linear=False, grad_lipschitz=np.nan)
 
         if prior is not None and prior not in self.domain:
             raise ValueError('`prior` not in `domain`'
@@ -1137,8 +1146,8 @@ class KullbackLeibler(Functional):
 
             def __init__(self):
                 """Initialize a new instance."""
-                super().__init__(functional.domain, functional.domain,
-                                 linear=False)
+                super(KLGradient, self).__init__(
+                    functional.domain, functional.domain, linear=False)
 
             def _call(self, x):
                 """Apply the gradient operator to the given point.
@@ -1212,7 +1221,8 @@ class KullbackLeiblerConvexConj(Functional):
             distribution. It is assumed to be nonnegative.
             Default: if None it is take as the one-element.
         """
-        super().__init__(space=space, linear=False, grad_lipschitz=np.nan)
+        super(KullbackLeiblerConvexConj, self).__init__(
+            space=space, linear=False, grad_lipschitz=np.nan)
 
         if prior is not None and prior not in self.domain:
             raise ValueError('`prior` not in `domain`'
@@ -1261,8 +1271,8 @@ class KullbackLeiblerConvexConj(Functional):
 
             def __init__(self):
                 """Initialize a new instance."""
-                super().__init__(functional.domain, functional.domain,
-                                 linear=False)
+                super(KLCCGradient, self).__init__(
+                    functional.domain, functional.domain, linear=False)
 
             def _call(self, x):
                 """Apply the gradient operator to the given point.
@@ -1356,7 +1366,8 @@ class KullbackLeiblerCrossEntropy(Functional):
             distribution. It is assumed to be nonnegative.
             Default: if None it is take as the one-element.
         """
-        super().__init__(space=space, linear=False, grad_lipschitz=np.nan)
+        super(KullbackLeiblerCrossEntropy, self).__init__(
+            space=space, linear=False, grad_lipschitz=np.nan)
 
         if prior is not None and prior not in self.domain:
             raise ValueError('`prior` not in `domain`'
@@ -1405,8 +1416,8 @@ class KullbackLeiblerCrossEntropy(Functional):
 
             def __init__(self):
                 """Initialize a new instance."""
-                super().__init__(functional.domain, functional.domain,
-                                 linear=False)
+                super(KLCrossEntropyGradient, self).__init__(
+                    functional.domain, functional.domain, linear=False)
 
             def _call(self, x):
                 """Apply the gradient operator to the given point.
@@ -1483,7 +1494,8 @@ class KullbackLeiblerCrossEntropyConvexConj(Functional):
             distribution. It is assumed to be nonnegative.
             Default: if None it is take as the one-element.
         """
-        super().__init__(space=space, linear=False, grad_lipschitz=np.nan)
+        super(KullbackLeiblerCrossEntropyConvexConj, self).__init__(
+            space=space, linear=False, grad_lipschitz=np.nan)
 
         if prior is not None and prior not in self.domain:
             raise ValueError('`prior` not in `domain`'
@@ -1517,8 +1529,8 @@ class KullbackLeiblerCrossEntropyConvexConj(Functional):
 
             def __init__(self):
                 """Initialize a new instance."""
-                super().__init__(functional.domain, functional.domain,
-                                 linear=False)
+                super(KLCrossEntCCGradient, self).__init__(
+                    functional.domain, functional.domain, linear=False)
 
             def _call(self, x):
                 """Apply the gradient operator to the given point."""
@@ -1626,9 +1638,8 @@ class SeparableSum(Functional):
         domain = ProductSpace(*domains)
         linear = all(func.is_linear for func in functionals)
 
+        super(SeparableSum, self).__init__(space=domain, linear=linear)
         self.__functionals = tuple(functionals)
-
-        super().__init__(space=domain, linear=linear)
 
     def _call(self, x):
         """Return the separable sum evaluated in ``x``."""
@@ -1748,12 +1759,12 @@ class QuadraticForm(Functional):
             raise ValueError('domain of `operator` and space of `vector` need '
                              'to match')
 
+        super(QuadraticForm, self).__init__(
+            space=domain, linear=(operator is None and constant == 0))
+
         self.__operator = operator
         self.__vector = vector
         self.__constant = constant
-
-        super().__init__(space=domain,
-                         linear=(operator is None and constant == 0))
 
         if self.constant not in self.range:
             raise ValueError('`constant` must be an element in the range of '
@@ -1922,7 +1933,8 @@ class NuclearNorm(Functional):
         if (not space.is_power_space or not space[0].is_power_space):
             raise TypeError('`space` must be of the form `FnBase^(nxm)`')
 
-        super().__init__(space=space, linear=False, grad_lipschitz=np.nan)
+        super(NuclearNorm, self).__init__(
+            space=space, linear=False, grad_lipschitz=np.nan)
 
         self.outernorm = LpNorm(self.domain[0][0], exponent=outer_exp)
         self.pwisenorm = PointwiseNorm(self.domain[0],
@@ -2025,7 +2037,8 @@ class NuclearNorm(Functional):
             """Proximal operator of `NuclearNorm`."""
             def __init__(self, sigma):
                 self.sigma = float(sigma)
-                Operator.__init__(self, func.domain, func.domain, linear=False)
+                super(NuclearNormProximal, self).__init__(
+                    func.domain, func.domain, linear=False)
 
             def _call(self, x):
                 """Return ``self(x)``."""
@@ -2149,8 +2162,9 @@ class IndicatorNuclearNormUnitBall(Functional):
         >>> norm(space.one())
         inf
         """
+        super(IndicatorNuclearNormUnitBall, self).__init__(
+            space=space, linear=False, grad_lipschitz=np.nan)
         self.__norm = NuclearNorm(space, outer_exp, singular_vector_exp)
-        super().__init__(space=space, linear=False, grad_lipschitz=np.nan)
 
     def _call(self, x):
         """Return ``self(x)``."""
@@ -2256,10 +2270,10 @@ https://web.stanford.edu/~boyd/papers/pdf/prox_algs.pdf
         >>> l1_norm = odl.solvers.L1Norm(space)
         >>> smoothed_l1 = MoreauEnvelope(l1_norm)
         """
+        super(MoreauEnvelope, self).__init__(
+            space=functional.domain, linear=False)
         self.__functional = functional
         self.__sigma = sigma
-        super().__init__(space=functional.domain,
-                         linear=False)
 
     @property
     def functional(self):

--- a/odl/solvers/functional/derivatives.py
+++ b/odl/solvers/functional/derivatives.py
@@ -119,8 +119,8 @@ class NumericalDerivative(Operator):
         if self.method not in ('backward', 'forward', 'central'):
             raise ValueError("`method` '{}' not understood").format(method_in)
 
-        Operator.__init__(self, operator.domain, operator.range,
-                          linear=True)
+        super(NumericalDerivative, self).__init__(
+            operator.domain, operator.range, linear=True)
 
     def _call(self, dx):
         """Return ``self(x)``."""
@@ -238,8 +238,8 @@ class NumericalGradient(Operator):
         if self.method not in ('backward', 'forward', 'central'):
             raise ValueError("`method` '{}' not understood").format(method_in)
 
-        Operator.__init__(self, functional.domain, functional.domain,
-                          linear=functional.is_linear)
+        super(NumericalGradient, self).__init__(
+            functional.domain, functional.domain, linear=functional.is_linear)
 
     def _call(self, x):
         """Return ``self(x)``."""

--- a/odl/solvers/functional/example_funcs.py
+++ b/odl/solvers/functional/example_funcs.py
@@ -10,7 +10,6 @@
 
 # Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
-from builtins import super
 
 import numpy as np
 
@@ -93,7 +92,8 @@ class RosenbrockFunctional(Functional):
             raise ValueError('`space` must be an `FnBase`')
         if space.size < 2:
             raise ValueError('`space` must be at least two dimensional')
-        super().__init__(space=space, linear=False, grad_lipschitz=np.inf)
+        super(RosenbrockFunctional, self).__init__(
+            space=space, linear=False, grad_lipschitz=np.inf)
 
     def _call(self, x):
         """Return ``self(x)``."""
@@ -116,8 +116,8 @@ class RosenbrockFunctional(Functional):
 
             def __init__(self):
                 """Initialize a new instance."""
-                super().__init__(functional.domain, functional.domain,
-                                 linear=False)
+                super(RosenbrockGradient, self).__init__(
+                    functional.domain, functional.domain, linear=False)
 
             def _call(self, x, out):
                 """Apply the gradient operator to the given point."""

--- a/odl/solvers/nonsmooth/proximal_operators.py
+++ b/odl/solvers/nonsmooth/proximal_operators.py
@@ -23,7 +23,6 @@ Foundations and Trends in Optimization, 1 (2014), pp 127-239.
 
 # Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
-from builtins import super
 
 import numpy as np
 
@@ -569,7 +568,8 @@ def proximal_box_constraint(space, lower=None, upper=None):
             sigma : positive float
                 Step size parameter, not used.
             """
-            super().__init__(domain=space, range=space, linear=False)
+            super(ProxOpBoxConstraint, self).__init__(
+                domain=space, range=space, linear=False)
 
         def _call(self, x, out):
             """Apply the operator to ``x`` and store the result in ``out``."""
@@ -743,8 +743,9 @@ def proximal_l2(space, lam=1, g=None):
             sigma : positive float
                 Step size parameter
             """
+            super(ProximalL2, self).__init__(
+                domain=space, range=space, linear=False)
             self.sigma = float(sigma)
-            super().__init__(domain=space, range=space, linear=False)
 
         def _call(self, x, out):
             """Apply the operator to ``x`` and stores the result in ``out``."""
@@ -846,8 +847,9 @@ def proximal_convex_conj_l2_squared(space, lam=1, g=None):
             sigma : positive float
                 Step size parameter
             """
+            super(ProximalConvexConjL2Squared, self).__init__(
+                domain=space, range=space, linear=g is None)
             self.sigma = float(sigma)
-            super().__init__(domain=space, range=space, linear=g is None)
 
         def _call(self, x, out):
             """Apply the operator to ``x`` and stores the result in ``out``"""
@@ -1021,11 +1023,12 @@ def proximal_convex_conj_l1(space, lam=1, g=None, isotropic=False):
                 Step size parameter
             """
             # sigma is not used
+            super(ProximalConvexConjL1, self).__init__(
+                domain=space, range=space, linear=False)
             self.sigma = float(sigma)
-            super().__init__(domain=space, range=space, linear=False)
 
         def _call(self, x, out):
-            """Apply the operator to ``x`` and stores the result in ``out``."""
+            """Apply the operator to ``x`` and store the result in ``out``."""
 
             # lam * (x - sigma * g) / max(lam, |x - sigma * g|)
 
@@ -1240,8 +1243,9 @@ def proximal_convex_conj_kl(space, lam=1, g=None):
             ----------
             sigma : positive float
             """
+            super(ProximalConvexConjKL, self).__init__(
+                domain=space, range=space, linear=False)
             self.sigma = float(sigma)
-            super().__init__(domain=space, range=space, linear=False)
 
         def _call(self, x, out):
             """Apply the operator to ``x`` and stores the result in ``out``."""
@@ -1376,7 +1380,8 @@ def proximal_convex_conj_kl_cross_entropy(space, lam=1, g=None):
             sigma : positive float
             """
             self.sigma = float(sigma)
-            super().__init__(domain=space, range=space, linear=False)
+            super(ProximalConvexConjKLCrossEntropy, self).__init__(
+                domain=space, range=space, linear=False)
 
         def _call(self, x, out):
             """Apply the operator to ``x`` and stores the result in ``out``."""

--- a/odl/space/fspace.py
+++ b/odl/space/fspace.py
@@ -10,7 +10,6 @@
 
 # Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
-from builtins import super
 
 from inspect import isfunction
 import numpy as np
@@ -222,8 +221,9 @@ class FunctionSetElement(Operator):
             It must return a `FunctionSet.range` element or a
             `numpy.ndarray` of such (vectorized call).
         """
+        super(FunctionSetElement, self).__init__(
+            fset.domain, fset.range, linear=False)
         self.__space = fset
-        super().__init__(self.space.domain, self.space.range, linear=False)
 
         # Determine which type of implementation fcall is
         if isinstance(fcall, FunctionSetElement):
@@ -1188,6 +1188,7 @@ class FunctionSpaceElement(LinearSpaceElement, FunctionSetElement):
     def __repr__(self):
         """Return ``repr(self)``."""
         return 'FunctionSpaceElement'
+
 
 if __name__ == '__main__':
     # pylint: disable=wrong-import-position

--- a/odl/space/npy_ntuples.py
+++ b/odl/space/npy_ntuples.py
@@ -11,7 +11,6 @@
 # Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
 from future.utils import native
-from builtins import super
 
 import ctypes
 from functools import partial
@@ -181,9 +180,8 @@ class NumpyNtuplesVector(NtuplesBaseVector):
 
     def __init__(self, space, data):
         """Initialize a new instance."""
+        super(NumpyNtuplesVector, self).__init__(space)
         self.__data = data
-
-        NtuplesBaseVector.__init__(self, space)
 
     @property
     def data(self):
@@ -1265,7 +1263,7 @@ class NumpyFnVector(FnBaseVector, NumpyNtuplesVector):
         """Return ``self **= other``."""
         try:
             if other == int(other):
-                return super().__ipow__(other)
+                return super(NumpyFnVector, self).__ipow__(other)
         except TypeError:
             pass
 
@@ -1527,8 +1525,9 @@ class NumpyFnMatrixWeighting(MatrixWeighting):
         Depending on the matrix size, this can be rather expensive.
         """
         # TODO: fix dead link `scipy.sparse.spmatrix`
-        super().__init__(matrix, impl='numpy', exponent=exponent,
-                         dist_using_inner=dist_using_inner, **kwargs)
+        super(NumpyFnMatrixWeighting, self).__init__(
+            matrix, impl='numpy', exponent=exponent,
+            dist_using_inner=dist_using_inner, **kwargs)
 
     def inner(self, x1, x2):
         """Calculate the matrix-weighted inner product of two vectors.
@@ -1674,8 +1673,9 @@ class NumpyFnArrayWeighting(ArrayWeighting):
           not define an inner product or norm, respectively. This is not
           checked during initialization.
         """
-        super().__init__(array, impl='numpy', exponent=exponent,
-                         dist_using_inner=dist_using_inner)
+        super(NumpyFnArrayWeighting, self).__init__(
+            array, impl='numpy', exponent=exponent,
+            dist_using_inner=dist_using_inner)
 
     def inner(self, x1, x2):
         """Return the weighted inner product of two vectors.
@@ -1789,8 +1789,9 @@ class NumpyFnConstWeighting(ConstWeighting):
         - The constant must be positive, otherwise it does not define an
           inner product or norm, respectively.
         """
-        super().__init__(constant, impl='numpy', exponent=exponent,
-                         dist_using_inner=dist_using_inner)
+        super(NumpyFnConstWeighting, self).__init__(
+            constant, impl='numpy', exponent=exponent,
+            dist_using_inner=dist_using_inner)
 
     def inner(self, x1, x2):
         """Calculate the constant-weighted inner product of two vectors.
@@ -1893,11 +1894,12 @@ class NumpyFnNoWeighting(NoWeighting, NumpyFnConstWeighting):
             args = args[2:]
 
         if exponent == 2.0 and not dist_using_inner:
-            if not cls._instance:
-                cls._instance = super().__new__(cls, *args, **kwargs)
+            if cls._instance is None:
+                cls._instance = super(NoWeighting, cls).__new__(
+                    cls, *args, **kwargs)
             return cls._instance
         else:
-            return super().__new__(cls, *args, **kwargs)
+            return super(NoWeighting, cls).__new__(cls, *args, **kwargs)
 
     def __init__(self, exponent=2.0, dist_using_inner=False):
         """Initialize a new instance.
@@ -1918,8 +1920,8 @@ class NumpyFnNoWeighting(NoWeighting, NumpyFnConstWeighting):
 
             This option can only be used if ``exponent`` is 2.0.
         """
-        super().__init__(impl='numpy', exponent=exponent,
-                         dist_using_inner=dist_using_inner)
+        super(NumpyFnNoWeighting, self).__init__(
+            impl='numpy', exponent=exponent, dist_using_inner=dist_using_inner)
 
 
 class NumpyFnCustomInner(CustomInner):
@@ -1950,8 +1952,8 @@ class NumpyFnCustomInner(CustomInner):
             for large arrays. On the downside, it will not evaluate to
             exactly zero for equal (but not identical) ``x`` and ``y``.
         """
-        super().__init__(inner, impl='numpy',
-                         dist_using_inner=dist_using_inner)
+        super(NumpyFnCustomInner, self).__init__(
+            inner, impl='numpy', dist_using_inner=dist_using_inner)
 
 
 class NumpyFnCustomNorm(CustomNorm):
@@ -1976,7 +1978,7 @@ class NumpyFnCustomNorm(CustomNorm):
             - ``||s * x|| = |s| * ||x||``
             - ``||x + y|| <= ||x|| + ||y||``
         """
-        super().__init__(norm, impl='numpy')
+        super(NumpyFnCustomNorm, self).__init__(norm, impl='numpy')
 
 
 class NumpyFnCustomDist(CustomDist):
@@ -2002,7 +2004,7 @@ class NumpyFnCustomDist(CustomDist):
             - ``dist(x, y) = dist(y, x)``
             - ``dist(x, y) <= dist(x, z) + dist(z, y)``
         """
-        super().__init__(dist, impl='numpy')
+        super(NumpyFnCustomDist, self).__init__(dist, impl='numpy')
 
 
 if __name__ == '__main__':

--- a/odl/space/pspace.py
+++ b/odl/space/pspace.py
@@ -10,13 +10,13 @@
 
 # Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
-from builtins import range, str, super, zip
+from builtins import range, str, zip
 
 from numbers import Integral
 from itertools import product
 import numpy as np
 
-from odl.set import LinearSpace, LinearSpaceElement, RealNumbers
+from odl.set import LinearSpace, LinearSpaceElement
 from odl.space.weighting import (
     Weighting, ArrayWeighting, ConstWeighting, NoWeighting,
     CustomInner, CustomNorm, CustomDist)
@@ -260,7 +260,7 @@ class ProductSpace(LinearSpace):
         self.__is_power_space = all(spc == self.spaces[0]
                                     for spc in self.spaces[1:])
 
-        super().__init__(field)
+        super(ProductSpace, self).__init__(field)
 
         # Assign weighting
         if weighting is not None:
@@ -619,7 +619,7 @@ class ProductSpaceElement(LinearSpaceElement):
 
     def __init__(self, space, parts):
         """Initialize a new instance."""
-        super().__init__(space)
+        super(ProductSpaceElement, self).__init__(space)
         self.__parts = tuple(parts)
 
     @property
@@ -1083,8 +1083,9 @@ class ProductSpaceArrayWeighting(ArrayWeighting):
           define an inner product or norm, respectively. This is not checked
           during initialization.
         """
-        super().__init__(array, impl='numpy', exponent=exponent,
-                         dist_using_inner=dist_using_inner)
+        super(ProductSpaceArrayWeighting, self).__init__(
+            array, impl='numpy', exponent=exponent,
+            dist_using_inner=dist_using_inner)
 
     def inner(self, x1, x2):
         """Calculate the array-weighted inner product of two elements.
@@ -1201,8 +1202,9 @@ class ProductSpaceConstWeighting(ConstWeighting):
         - The constant must be positive, otherwise it does not define an
           inner product or norm, respectively.
         """
-        super().__init__(constant, impl='numpy', exponent=exponent,
-                         dist_using_inner=dist_using_inner)
+        super(ProductSpaceConstWeighting, self).__init__(
+            constant, impl='numpy', exponent=exponent,
+            dist_using_inner=dist_using_inner)
 
     def inner(self, x1, x2):
         """Calculate the constant-weighted inner product of two elements.
@@ -1324,10 +1326,12 @@ class ProductSpaceNoWeighting(NoWeighting, ProductSpaceConstWeighting):
 
         if exponent == 2.0 and not dist_using_inner:
             if not cls._instance:
-                cls._instance = super().__new__(cls, *args, **kwargs)
+                parent = super(NoWeighting, ProductSpaceNoWeighting)
+                cls._instance = parent.__new__(cls, *args, **kwargs)
             return cls._instance
         else:
-            return super().__new__(cls, *args, **kwargs)
+            return super(NoWeighting, ProductSpaceNoWeighting).__new__(
+                cls, *args, **kwargs)
 
     def __init__(self, exponent=2.0, dist_using_inner=False):
         """Initialize a new instance.
@@ -1348,8 +1352,8 @@ class ProductSpaceNoWeighting(NoWeighting, ProductSpaceConstWeighting):
 
             Can only be used if ``exponent`` is 2.0.
         """
-        super().__init__(impl='numpy', exponent=exponent,
-                         dist_using_inner=dist_using_inner)
+        super(ProductSpaceNoWeighting, self).__init__(
+            impl='numpy', exponent=exponent, dist_using_inner=dist_using_inner)
 
 
 class ProductSpaceCustomInner(CustomInner):
@@ -1383,8 +1387,9 @@ class ProductSpaceCustomInner(CustomInner):
 
             Can only be used if ``exponent`` is 2.0.
         """
-        super().__init__(impl='numpy', inner=inner,
-                         dist_using_inner=dist_using_inner)
+        super(ProductSpaceCustomInner, self).__init__(
+            impl='numpy', inner=inner,
+            dist_using_inner=dist_using_inner)
 
 
 class ProductSpaceCustomNorm(CustomNorm):
@@ -1410,7 +1415,7 @@ class ProductSpaceCustomNorm(CustomNorm):
             - ``||s * x|| = |s| * ||x||``
             - ``||x + y|| <= ||x|| + ||y||``
         """
-        super().__init__(norm, impl='numpy')
+        super(ProductSpaceCustomNorm, self).__init__(norm, impl='numpy')
 
 
 class ProductSpaceCustomDist(CustomDist):
@@ -1436,7 +1441,7 @@ class ProductSpaceCustomDist(CustomDist):
             - ``dist(x, y) = dist(y, x)``
             - ``dist(x, y) <= dist(x, z) + dist(z, y)``
         """
-        super().__init__(dist, impl='numpy')
+        super(ProductSpaceCustomDist, self).__init__(dist, impl='numpy')
 
 
 def _strip_space(x):

--- a/odl/space/weighting.py
+++ b/odl/space/weighting.py
@@ -10,7 +10,6 @@
 
 # Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
-from builtins import super
 
 import numpy as np
 
@@ -260,8 +259,8 @@ class MatrixWeighting(Weighting):
         precomp_mat_pow = kwargs.pop('precomp_mat_pow', False)
         self._cache_mat_pow = bool(kwargs.pop('cache_mat_pow', True))
         self._cache_mat_decomp = bool(kwargs.pop('cache_mat_decomp', False))
-        super().__init__(impl=impl, exponent=exponent,
-                         dist_using_inner=dist_using_inner)
+        super(MatrixWeighting, self).__init__(
+            impl=impl, exponent=exponent, dist_using_inner=dist_using_inner)
 
         # Check and set matrix
         if scipy.sparse.isspmatrix(matrix):
@@ -398,13 +397,14 @@ class MatrixWeighting(Weighting):
         if other is self:
             return True
 
-        return (super().__eq__(other) and
+        return (super(MatrixWeighting, self).__eq__(other) and
                 self.matrix is getattr(other, 'matrix', None))
 
     def __hash__(self):
         """Return ``hash(self)``."""
         # TODO: Better hash for matrix?
-        return super().__hash__() ^ hash(self.matrix.tostring())
+        return hash((super(MatrixWeighting, self).__hash__(),
+                     self.matrix.tobytes()))
 
     def equiv(self, other):
         """Test if other is an equivalent weighting.
@@ -552,8 +552,8 @@ class ArrayWeighting(Weighting):
 
             This option can only be used if ``exponent`` is 2.0.
         """
-        super().__init__(impl=impl, exponent=exponent,
-                         dist_using_inner=dist_using_inner)
+        super(ArrayWeighting, self).__init__(
+            impl=impl, exponent=exponent, dist_using_inner=dist_using_inner)
 
         # We store our "own" data structures as-is to retain Numpy
         # compatibility while avoiding copies. Other things are run through
@@ -595,13 +595,14 @@ class ArrayWeighting(Weighting):
         if other is self:
             return True
 
-        return (super().__eq__(other) and
+        return (super(ArrayWeighting, self).__eq__(other) and
                 self.array is getattr(other, 'array', None))
 
     def __hash__(self):
         """Return ``hash(self)``."""
         # TODO: Better hash for array?
-        return super().__hash__() ^ hash(self.array.tostring())
+        return hash((super(ArrayWeighting, self).__hash__(),
+                     self.array.tobytes()))
 
     def equiv(self, other):
         """Return True if other is an equivalent weighting.
@@ -679,8 +680,8 @@ class ConstWeighting(Weighting):
 
             This option can only be used if ``exponent`` is 2.0.
         """
-        super().__init__(impl=impl, exponent=exponent,
-                         dist_using_inner=dist_using_inner)
+        super(ConstWeighting, self).__init__(
+            impl=impl, exponent=exponent, dist_using_inner=dist_using_inner)
         self._const = float(const)
         if self.const <= 0:
             raise ValueError('expected positive constant, got {}'
@@ -705,12 +706,12 @@ class ConstWeighting(Weighting):
         if other is self:
             return True
 
-        return (super().__eq__(other) and
+        return (super(ConstWeighting, self).__eq__(other) and
                 self.const == getattr(other, 'const', None))
 
     def __hash__(self):
         """Return ``hash(self)``."""
-        return super().__hash__() ^ hash(self.const)
+        return hash((super(ConstWeighting, self).__hash__(), self.const))
 
     def equiv(self, other):
         """Test if other is an equivalent weighting.
@@ -830,8 +831,8 @@ class CustomInner(Weighting):
 
             Can only be used if ``exponent`` is 2.0.
         """
-        super().__init__(impl=impl, exponent=2.0,
-                         dist_using_inner=dist_using_inner)
+        super(CustomInner, self).__init__(
+            impl=impl, exponent=2.0, dist_using_inner=dist_using_inner)
 
         if not callable(inner):
             raise TypeError('`inner` {!r} is not callable'
@@ -852,11 +853,12 @@ class CustomInner(Weighting):
             ``True`` if other is a `CustomInner`
             instance with the same inner product, ``False`` otherwise.
         """
-        return super().__eq__(other) and self.inner == other.inner
+        return (super(CustomInner, self).__eq__(other) and
+                self.inner == other.inner)
 
     def __hash__(self):
         """Return ``hash(self)``."""
-        return super().__hash__() ^ hash(self.inner)
+        return hash((super(CustomInner, self).__hash__(), self.inner))
 
     @property
     def repr_part(self):
@@ -898,7 +900,8 @@ class CustomNorm(Weighting):
         impl : string
             Specifier for the implementation backend
         """
-        super().__init__(impl=impl, exponent=1.0, dist_using_inner=False)
+        super(CustomNorm, self).__init__(
+            impl=impl, exponent=1.0, dist_using_inner=False)
 
         if not callable(norm):
             raise TypeError('`norm` {!r} is not callable'
@@ -923,11 +926,12 @@ class CustomNorm(Weighting):
             ``True`` if other is a `CustomNorm` instance with the same
             norm, ``False`` otherwise.
         """
-        return super().__eq__(other) and self.norm == other.norm
+        return (super(CustomNorm, self).__eq__(other) and
+                self.norm == other.norm)
 
     def __hash__(self):
         """Return ``hash(self)``."""
-        return super().__hash__() ^ hash(self.norm)
+        return hash((super(CustomNorm, self).__hash__(), self.norm))
 
     @property
     def repr_part(self):
@@ -971,7 +975,8 @@ class CustomDist(Weighting):
         impl : string
             Specifier for the implementation backend
         """
-        super().__init__(impl=impl, exponent=1.0, dist_using_inner=False)
+        super(CustomDist, self).__init__(
+            impl=impl, exponent=1.0, dist_using_inner=False)
 
         if not callable(dist):
             raise TypeError('`dist` {!r} is not callable'
@@ -1000,11 +1005,12 @@ class CustomDist(Weighting):
             ``True`` if other is a `CustomDist` instance with the same
             dist, ``False`` otherwise.
         """
-        return super().__eq__(other) and self.dist == other.dist
+        return (super(CustomDist, self).__eq__(other) and
+                self.dist == other.dist)
 
     def __hash__(self):
         """Return ``hash(self)``."""
-        return super().__hash__() ^ hash(self.dist)
+        return hash((super(CustomDist, self).__hash__(), self.dist))
 
     @property
     def repr_part(self):

--- a/odl/test/operator/operator_test.py
+++ b/odl/test/operator/operator_test.py
@@ -7,7 +7,6 @@
 # obtain one at https://mozilla.org/MPL/2.0/.
 
 from __future__ import division
-from builtins import super
 import pytest
 import numpy as np
 import sys
@@ -31,7 +30,7 @@ class MultiplyAndSquareOp(Operator):
         ran = (odl.rn(matrix.shape[0])
                if range is None else range)
 
-        super().__init__(dom, ran)
+        super(MultiplyAndSquareOp, self).__init__(dom, ran)
         self.matrix = matrix
 
     def _call(self, rhs, out=None):
@@ -481,7 +480,7 @@ class SumFunctional(Operator):
     """Sum of elements."""
 
     def __init__(self, domain):
-        super().__init__(domain, domain.field, linear=True)
+        super(SumFunctional, self).__init__(domain, domain.field, linear=True)
 
     def _call(self, x):
         return np.sum(x)
@@ -496,7 +495,7 @@ class ConstantVector(Operator):
     """Vector times a scalar."""
 
     def __init__(self, domain):
-        super().__init__(domain.field, domain, linear=True)
+        super(ConstantVector, self).__init__(domain.field, domain, linear=True)
 
     def _call(self, x):
         return self.range.element(np.ones(self.range.size) * x)
@@ -675,7 +674,8 @@ class SumSquaredFunctional(Operator):
     """Sum of the squared elements."""
 
     def __init__(self, domain):
-        super().__init__(domain, domain.field, linear=False)
+        super(SumSquaredFunctional, self).__init__(
+            domain, domain.field, linear=False)
 
     def _call(self, x):
         return np.sum(x ** 2)

--- a/odl/test/operator/oputils_test.py
+++ b/odl/test/operator/oputils_test.py
@@ -94,7 +94,7 @@ def test_matrix_representation_product_to_product():
     ran_and_dom = ProductSpace(rn, rm)
 
     AB_matrix = np.vstack([np.hstack([A, np.zeros((n, m))]),
-                          np.hstack([np.zeros((m, n)), B])])
+                           np.hstack([np.zeros((m, n)), B])])
     ABop = ProductSpaceOperator([[Aop, 0],
                                  [0, Bop]],
                                 ran_and_dom, ran_and_dom)
@@ -117,7 +117,7 @@ def test_matrix_representation_product_to_product_two():
     ran_and_dom = ProductSpace(rn, 2)
 
     AB_matrix = np.vstack([np.hstack([A, np.zeros((n, n))]),
-                          np.hstack([np.zeros((n, n)), B])])
+                           np.hstack([np.zeros((n, n)), B])])
     ABop = ProductSpaceOperator([[Aop, 0],
                                  [0, Bop]],
                                 ran_and_dom, ran_and_dom)
@@ -148,8 +148,7 @@ def test_matrix_representation_wrong_domain():
         """Small test operator."""
         def __init__(self):
             super(MyOp, self).__init__(
-                domain=ProductSpace(odl.rn(3),
-                                    ProductSpace(odl.rn(3), odl.rn(3))),
+                domain=odl.rn(3) * odl.rn(3) ** 2,
                 range=odl.rn(4),
                 linear=True)
 
@@ -168,8 +167,7 @@ def test_matrix_representation_wrong_range():
         def __init__(self):
             super(MyOp, self).__init__(
                 domain=odl.rn(3),
-                range=ProductSpace(odl.rn(3),
-                                   ProductSpace(odl.rn(3), odl.rn(3))),
+                range=odl.rn(3) * odl.rn(3) ** 2,
                 linear=True)
 
         def _call(self, x, out):

--- a/odl/test/operator/oputils_test.py
+++ b/odl/test/operator/oputils_test.py
@@ -7,9 +7,8 @@
 # obtain one at https://mozilla.org/MPL/2.0/.
 
 from __future__ import division
-from builtins import super
-import pytest
 import numpy as np
+import pytest
 
 import odl
 from odl.operator.oputils import matrix_representation, power_method_opnorm
@@ -129,52 +128,54 @@ def test_matrix_representation_product_to_product_two():
 
 def test_matrix_representation_not_linear_op():
     # Verify that the matrix representation function gives correct error
-    class small_nonlin_op(odl.Operator):
-        """Small nonlinear test operator"""
+    class MyNonLinOp(odl.Operator):
+        """Small nonlinear test operator."""
         def __init__(self):
-            super().__init__(domain=odl.rn(3), range=odl.rn(4), linear=False)
+            super(MyNonLinOp, self).__init__(
+                domain=odl.rn(3), range=odl.rn(4), linear=False)
 
         def _call(self, x):
-            return x
+            return x ** 2
 
-    nonlin_op = small_nonlin_op()
+    nonlin_op = MyNonLinOp()
     with pytest.raises(ValueError):
         matrix_representation(nonlin_op)
 
 
 def test_matrix_representation_wrong_domain():
     # Verify that the matrix representation function gives correct error
-    class small_op(odl.Operator):
-        """Small nonlinear test operator"""
+    class MyOp(odl.Operator):
+        """Small test operator."""
         def __init__(self):
-            super().__init__(domain=ProductSpace(odl.rn(3),
-                                                 ProductSpace(odl.rn(3),
-                                                              odl.rn(3))),
-                             range=odl.rn(4), linear=True)
+            super(MyOp, self).__init__(
+                domain=ProductSpace(odl.rn(3),
+                                    ProductSpace(odl.rn(3), odl.rn(3))),
+                range=odl.rn(4),
+                linear=True)
 
         def _call(self, x, out):
             return odl.rn(np.random.rand(4))
 
-    nonlin_op = small_op()
+    nonlin_op = MyOp()
     with pytest.raises(TypeError):
         matrix_representation(nonlin_op)
 
 
 def test_matrix_representation_wrong_range():
     # Verify that the matrix representation function gives correct error
-    class small_op(odl.Operator):
-        """Small nonlinear test operator"""
+    class MyOp(odl.Operator):
+        """Small test operator."""
         def __init__(self):
-            super().__init__(domain=odl.rn(3),
-                             range=ProductSpace(odl.rn(3),
-                                                ProductSpace(odl.rn(3),
-                                                             odl.rn(3))),
-                             linear=True)
+            super(MyOp, self).__init__(
+                domain=odl.rn(3),
+                range=ProductSpace(odl.rn(3),
+                                   ProductSpace(odl.rn(3), odl.rn(3))),
+                linear=True)
 
         def _call(self, x, out):
             return odl.rn(np.random.rand(4))
 
-    nonlin_op = small_op()
+    nonlin_op = MyOp()
     with pytest.raises(TypeError):
         matrix_representation(nonlin_op)
 

--- a/odl/tomo/backends/stir_bindings.py
+++ b/odl/tomo/backends/stir_bindings.py
@@ -28,7 +28,6 @@ the STIR classes used here.
 
 # Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
-from builtins import super
 
 try:
     import stir
@@ -107,7 +106,8 @@ class ForwardProjectorByBinWrapper(Operator):
                              ''.format(range.shape, proj_shape))
 
         # Set domain, range etc
-        super().__init__(domain, range, True)
+        super(ForwardProjectorByBinWrapper, self).__init__(
+            domain, range, linear=True)
 
         # Read template of the projection
         self.proj_data = proj_data
@@ -206,7 +206,8 @@ class BackProjectorByBinWrapper(Operator):
                              ''.format(range.shape, proj_shape))
 
         # Set range domain
-        super().__init__(domain, range, True)
+        super(BackProjectorByBinWrapper, self).__init__(
+            domain, range, linear=True)
 
         # Read template of the projection
         self.proj_data = proj_data

--- a/odl/tomo/geometry/conebeam.py
+++ b/odl/tomo/geometry/conebeam.py
@@ -10,7 +10,6 @@
 
 # Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
-from builtins import super
 
 import numpy as np
 
@@ -185,8 +184,9 @@ class FanFlatGeometry(DivergentBeamGeometry):
         self.__src_to_det_init = src_to_det_init
         detector = Flat1dDetector(dpart, det_axis_init)
         translation = kwargs.pop('translation', None)
-        super().__init__(ndim=2, motion_part=apart, detector=detector,
-                         translation=translation)
+        super(FanFlatGeometry, self).__init__(
+            ndim=2, motion_part=apart, detector=detector,
+            translation=translation)
 
         self.__src_radius = float(src_radius)
         if self.src_radius < 0:
@@ -713,8 +713,9 @@ class ConeFlatGeometry(DivergentBeamGeometry, AxisOrientedGeometry):
         AxisOrientedGeometry.__init__(self, axis)
         detector = Flat2dDetector(dpart, det_axes_init)
         translation = kwargs.pop('translation', None)
-        super().__init__(ndim=3, motion_part=apart, detector=detector,
-                         translation=translation)
+        super(ConeFlatGeometry, self).__init__(
+            ndim=3, motion_part=apart, detector=detector,
+            translation=translation)
 
         self.__pitch = float(pitch)
         self.__offset_along_axis = float(kwargs.pop('offset_along_axis', 0))

--- a/odl/tomo/geometry/detector.py
+++ b/odl/tomo/geometry/detector.py
@@ -10,7 +10,7 @@
 
 # Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
-from builtins import object, super
+from builtins import object
 
 import numpy as np
 
@@ -170,7 +170,7 @@ class FlatDetector(Detector):
         # TODO: apart from being constant, there is no big simplification
         # in this method compared to parent. Consider removing FlatDetector
         # altogether.
-        return super().surface_measure(self.params.min_pt)
+        return super(FlatDetector, self).surface_measure(self.params.min_pt)
 
 
 class Flat1dDetector(FlatDetector):
@@ -188,7 +188,7 @@ class Flat1dDetector(FlatDetector):
         axis : `array-like`, shape ``(2,)``
             Principal axis of the detector.
         """
-        super().__init__(part)
+        super(Flat1dDetector, self).__init__(part)
         if self.ndim != 1:
             raise ValueError('expected partition to have 1 dimension, '
                              'got {}'.format(self.ndim))
@@ -285,7 +285,7 @@ class Flat2dDetector(FlatDetector):
             Principal axes of the detector, e.g.
             ``[(0, 1, 0), (0, 0, 1)]``.
         """
-        super().__init__(part)
+        super(Flat2dDetector, self).__init__(part)
         if self.ndim != 2:
             raise ValueError('expected partition to have 2 dimensions, '
                              'got {}'.format(self.ndim))
@@ -395,7 +395,7 @@ class CircleSectionDetector(Detector):
         circ_rad : positive float
             Radius of the circle along which the detector is curved.
         """
-        super().__init__(part)
+        super(CircleSectionDetector, self).__init__(part)
         if self.ndim != 1:
             raise ValueError('expected `part` to have 1 dimension, '
                              'got {}'.format(self.ndim))

--- a/odl/tomo/geometry/parallel.py
+++ b/odl/tomo/geometry/parallel.py
@@ -10,7 +10,6 @@
 
 # Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
-from builtins import super
 
 import numpy as np
 
@@ -58,7 +57,8 @@ class ParallelBeamGeometry(Geometry):
             Additional parameters passed on to the ``__init__`` method
             of `Geometry`.
         """
-        super().__init__(ndim, apart, detector, **kwargs)
+        super(ParallelBeamGeometry, self).__init__(
+            ndim, apart, detector, **kwargs)
 
         if self.ndim not in (2, 3):
             raise ValueError('`ndim` must be 2 or 3, got {}'.format(ndim))
@@ -322,8 +322,9 @@ class Parallel2dGeometry(ParallelBeamGeometry):
         # Initialize stuff. Normalization of the detector axis happens in
         # the detector class.
         detector = Flat1dDetector(part=dpart, axis=det_axis_init)
-        super().__init__(ndim=2, apart=apart, detector=detector,
-                         det_pos_init=det_pos_init, translation=translation)
+        super(Parallel2dGeometry, self).__init__(
+            ndim=2, apart=apart, detector=detector, det_pos_init=det_pos_init,
+            translation=translation)
 
         if self.motion_partition.ndim != 1:
             raise ValueError('`apart` dimension {}, expected 1'
@@ -646,8 +647,9 @@ class Parallel3dEulerGeometry(ParallelBeamGeometry):
         # Initialize stuff. Normalization of the detector axes happens in
         # the detector class.
         detector = Flat2dDetector(part=dpart, axes=det_axes_init)
-        super().__init__(ndim=3, apart=apart, detector=detector,
-                         det_pos_init=det_pos_init, translation=translation)
+        super(Parallel3dEulerGeometry, self).__init__(
+            ndim=3, apart=apart, detector=detector, det_pos_init=det_pos_init,
+            translation=translation)
 
         if self.motion_partition.ndim not in (2, 3):
             raise ValueError('`apart` has dimension {}, expected '
@@ -960,8 +962,9 @@ class Parallel3dAxisGeometry(ParallelBeamGeometry, AxisOrientedGeometry):
         # the detector class.
         AxisOrientedGeometry.__init__(self, axis)
         detector = Flat2dDetector(dpart, det_axes_init)
-        super().__init__(ndim=3, apart=apart, detector=detector,
-                         det_pos_init=det_pos_init, translation=translation)
+        super(Parallel3dAxisGeometry, self).__init__(
+            ndim=3, apart=apart, detector=detector, det_pos_init=det_pos_init,
+            translation=translation)
 
         if self.motion_partition.ndim != 1:
             raise ValueError('`apart` has dimension {}, expected 1'

--- a/odl/tomo/geometry/spect.py
+++ b/odl/tomo/geometry/spect.py
@@ -10,7 +10,6 @@
 
 # Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
-from builtins import super
 
 import numpy as np
 
@@ -89,7 +88,8 @@ class ParallelHoleCollimatorGeometry(Parallel3dAxisGeometry):
             kwargs['det_pos_init'] = det_pos_init
         self._orig_to_det_init_arg = orig_to_det_init
 
-        super().__init__(apart, dpart, axis, **kwargs)
+        super(ParallelHoleCollimatorGeometry, self).__init__(
+            apart, dpart, axis, **kwargs)
 
     @classmethod
     def frommatrix(cls, apart, dpart, det_radius, init_matrix):

--- a/odl/tomo/operators/ray_trafo.py
+++ b/odl/tomo/operators/ray_trafo.py
@@ -10,7 +10,7 @@
 
 # Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
-from builtins import str, super
+from builtins import str
 
 import numpy as np
 import warnings
@@ -281,9 +281,11 @@ class RayTransformBase(Operator):
 
         # Finally, initialize the Operator structure
         if variant == 'forward':
-            super().__init__(domain=reco_space, range=proj_space, linear=True)
+            super(RayTransformBase, self).__init__(
+                domain=reco_space, range=proj_space, linear=True)
         elif variant == 'backward':
-            super().__init__(domain=proj_space, range=reco_space, linear=True)
+            super(RayTransformBase, self).__init__(
+                domain=proj_space, range=reco_space, linear=True)
 
     @property
     def impl(self):
@@ -365,8 +367,9 @@ class RayTransform(RayTransformBase):
         and storage order 'C'. Otherwise copies will be needed.
         """
         range = kwargs.pop('range', None)
-        super().__init__(reco_space=domain, proj_space=range,
-                         geometry=geometry, variant='forward', **kwargs)
+        super(RayTransform, self).__init__(
+            reco_space=domain, proj_space=range, geometry=geometry,
+            variant='forward', **kwargs)
 
     def _call_real(self, x_real, out_real):
         """Real-space forward projection for the current set-up.
@@ -470,8 +473,9 @@ class RayBackProjection(RayTransformBase):
         and storage order 'C'. Otherwise copies will be needed.
         """
         domain = kwargs.pop('domain', None)
-        super().__init__(reco_space=range, proj_space=domain,
-                         geometry=geometry, variant='backward', **kwargs)
+        super(RayBackProjection, self).__init__(
+            reco_space=range, proj_space=domain, geometry=geometry,
+            variant='backward', **kwargs)
 
     def _call_real(self, x_real, out_real):
         """Real-space back-projection for the current set-up.

--- a/odl/trafos/fourier.py
+++ b/odl/trafos/fourier.py
@@ -10,7 +10,6 @@
 
 # Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
-from builtins import super
 
 import numpy as np
 
@@ -139,9 +138,11 @@ class DiscreteFourierTransformBase(Operator):
                                            dtype_repr(range.dtype)))
 
         if inverse:
-            super().__init__(range, domain, linear=True)
+            super(DiscreteFourierTransformBase, self).__init__(
+                range, domain, linear=True)
         else:
-            super().__init__(domain, range, linear=True)
+            super(DiscreteFourierTransformBase, self).__init__(
+                domain, range, linear=True)
         self._fftw_plan = None
 
     def _call(self, x, out, **kwargs):
@@ -436,8 +437,9 @@ class DiscreteFourierTransform(DiscreteFourierTransformBase):
         >>> fft.domain.shape
         (2, 3, 4)
         """
-        super().__init__(inverse=False, domain=domain, range=range, axes=axes,
-                         sign=sign, halfcomplex=halfcomplex, impl=impl)
+        super(DiscreteFourierTransform, self).__init__(
+            inverse=False, domain=domain, range=range, axes=axes,
+            sign=sign, halfcomplex=halfcomplex, impl=impl)
 
     def _call_numpy(self, x):
         """Return ``self(x)`` using numpy.
@@ -586,8 +588,9 @@ class DiscreteFourierTransformInverse(DiscreteFourierTransformBase):
         >>> ifft.range.shape
         (2, 3, 4)
         """
-        super().__init__(inverse=True, domain=range, range=domain, axes=axes,
-                         sign=sign, halfcomplex=halfcomplex, impl=impl)
+        super(DiscreteFourierTransformInverse, self).__init__(
+            inverse=True, domain=range, range=domain, axes=axes,
+            sign=sign, halfcomplex=halfcomplex, impl=impl)
 
     def _call_numpy(self, x):
         """Return ``self(x)`` using numpy.
@@ -844,9 +847,11 @@ class FourierTransformBase(Operator):
                                      shift=self.shifts)
 
         if inverse:
-            super().__init__(range, domain, linear=True)
+            super(FourierTransformBase, self).__init__(
+                range, domain, linear=True)
         else:
-            super().__init__(domain, range, linear=True)
+            super(FourierTransformBase, self).__init__(
+                domain, range, linear=True)
         self._fftw_plan = None
 
         # Storing temporaries directly as arrays
@@ -1231,8 +1236,8 @@ class FourierTransform(FourierTransformBase):
           <odlgroup.github.io/odl/math/trafos/fourier_transform.html#adjoint>`_
           for details.
         """
-        super().__init__(inverse=False, domain=domain, range=range,
-                         impl=impl, **kwargs)
+        super(FourierTransform, self).__init__(
+            inverse=False, domain=domain, range=range, impl=impl, **kwargs)
 
     def _preprocess(self, x, out=None):
         """Return the pre-processed version of ``x``.
@@ -1468,9 +1473,8 @@ class FourierTransformInverse(FourierTransformBase):
           <odlgroup.github.io/odl/math/trafos/fourier_transform.html#adjoint>`_
           for details.
         """
-        # TODO: variants wrt placement of 2*pi
-        super().__init__(inverse=True, domain=range, range=domain,
-                         impl=impl, **kwargs)
+        super(FourierTransformInverse, self).__init__(
+            inverse=True, domain=range, range=domain, impl=impl, **kwargs)
 
     def _preprocess(self, x, out=None):
         """Return the pre-processed version of ``x``.

--- a/odl/trafos/wavelet.py
+++ b/odl/trafos/wavelet.py
@@ -10,7 +10,7 @@
 
 # Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
-from builtins import str, super
+from builtins import str
 
 import numpy as np
 
@@ -140,9 +140,11 @@ class WaveletTransformBase(Operator):
         self.__variant = variant
 
         if variant == 'forward':
-            super().__init__(domain=space, range=coeff_space, linear=True)
+            super(WaveletTransformBase, self).__init__(
+                domain=space, range=coeff_space, linear=True)
         else:
-            super().__init__(domain=coeff_space, range=space, linear=True)
+            super(WaveletTransformBase, self).__init__(
+                domain=coeff_space, range=space, linear=True)
 
     @property
     def impl(self):
@@ -295,9 +297,9 @@ class WaveletTransform(WaveletTransformBase):
         >>> decomp.shape
         (16,)
         """
-        super().__init__(space=domain, wavelet=wavelet, nlevels=nlevels,
-                         variant='forward', pad_mode=pad_mode,
-                         pad_const=pad_const, impl=impl)
+        super(WaveletTransform, self).__init__(
+            space=domain, wavelet=wavelet, nlevels=nlevels, variant='forward',
+            pad_mode=pad_mode, pad_const=pad_const, impl=impl)
 
     def _call(self, x):
         """Return wavelet transform of ``x``."""
@@ -328,7 +330,7 @@ class WaveletTransform(WaveletTransformBase):
             return scale * self.inverse
         else:
             # TODO: put adjoint here
-            return super().adjoint
+            return super(WaveletTransform, self).adjoint
 
     @property
     def inverse(self):
@@ -437,9 +439,9 @@ class WaveletTransformInverse(WaveletTransformBase):
         >>> np.allclose(recon, orig_array)
         True
         """
-        super().__init__(space=range, wavelet=wavelet, variant='inverse',
-                         nlevels=nlevels, pad_mode=pad_mode,
-                         pad_const=pad_const, impl=impl)
+        super(WaveletTransformInverse, self).__init__(
+            space=range, wavelet=wavelet, variant='inverse', nlevels=nlevels,
+            pad_mode=pad_mode, pad_const=pad_const, impl=impl)
 
     def _call(self, coeffs):
         """Return the inverse wavelet transform of ``coeffs``."""
@@ -476,7 +478,7 @@ class WaveletTransformInverse(WaveletTransformBase):
             return scale * self.inverse
         else:
             # TODO: put adjoint here
-            return super().adjoint
+            return super(WaveletTransformInverse, self).adjoint
 
     @property
     def inverse(self):

--- a/odl/util/vectorization.py
+++ b/odl/util/vectorization.py
@@ -10,7 +10,6 @@
 
 # Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
-from builtins import super
 
 from functools import wraps
 import numpy as np
@@ -135,7 +134,7 @@ class OptionalArgDecorator(object):
            the stored ``dec_args`` and ``dec_kwargs``.
         """
         # Decorating without arguments: return wrapper w/o args directly
-        instance = super().__new__(cls)
+        instance = super(OptionalArgDecorator, cls).__new__(cls)
 
         if (not kwargs and
                 len(args) == 1 and
@@ -250,6 +249,7 @@ class _NumpyVectorizeWrapper(object):
         vect_kwargs :
             keyword arguments for `numpy.vectorize`
         """
+        super(_NumpyVectorizeWrapper, self).__init__()
         self.func = func
         self.vfunc = None
         self.vect_args = vect_args


### PR DESCRIPTION
Getting this out of the way.

## Caveat
There are some cases when `super()` is the wrong choice, most notably with multiple inheritance and "conflicting" methods. Everything is good as long as a certain method only exists once or things stay nicely in order. However, consider the case of `ScalingFunctional` which I stumbled over while doing this change.

We have `class ScalingFunctional(Functional, ScalingOperator)`, with MRO
```python
[odl.solvers.functional.default_functionals.ScalingFunctional,
 odl.solvers.functional.functional.Functional,
 odl.operator.default_ops.ScalingOperator,
 odl.operator.operator.Operator,
 object]
```
So far, so good. The `__init__` method of `ScalingFunctional` even hardcodes the `__init__` calls to both parent classes, not using `super`. Everything should be fine, or?

**Turns out, no**. The crucial part is the common misconception (also on my part) that in an instance method of a class, `self` always refers to an instance of that class. That's **not** true. In this case, when `Functional.__init__` uses `self`, then `self` is an instance of `ScalingFunctional`. In particular, when using `super` to resolve the MRO, it is still the one of `ScalingFunctional`. 

Hence, when `Functional.__init__` calls `super(Functional, self).__init__(...)`, then the `__init__` method that is called is **not** the one of `Operator` (the only parent of `Functional`), but the one of `ScalingOperator`, because it comes first in the MRO.
We can confirm this by printing `self.__class__.mro()` in  `Functional.__init__`:
```python
[<class 'odl.solvers.functional.default_functionals.ScalingFunctional'>,
 <class 'odl.solvers.functional.functional.Functional'>,
 <class 'odl.operator.default_ops.ScalingOperator'>,
 <class 'odl.operator.operator.Operator'>,
 <class 'object'>]
```

### Conclusion

We have to be careful with multiple inheritance the MRO contains potentially conflicting methods. As [the documentation](https://docs.python.org/3/library/functions.html#super) says, `super` is intended for **collaborative** classes, and this situation is not like that.
Sometimes it's hard to tell who will call what. Two ways to mitigate this are:

1. Don't use `super` in classes that **may** participate in non-collaborative multiple inheritance. That applies mostly to core classes. It may be hard to know in advance which classes will be affected.
2. Avoid non-collaborative multiple inheritance as far as possible. In particular, try to keep the class hierarchy linear if possible.