### PR TITLE
ENH: Add support for vector-valued stepsizes for SeparableSum proximal

### DIFF
--- a/odl/phantom/noise.py
+++ b/odl/phantom/noise.py
@@ -14,7 +14,8 @@ import numpy as np
 from odl.util import NumpyRandomSeed
 
 
-__all__ = ('white_noise', 'poisson_noise', 'salt_pepper_noise')
+__all__ = ('white_noise', 'poisson_noise', 'salt_pepper_noise',
+           'uniform_noise')
 
 
 def white_noise(space, mean=0, stddev=1, seed=None):

--- a/odl/solvers/functional/default_functionals.py
+++ b/odl/solvers/functional/default_functionals.py
@@ -651,8 +651,8 @@ class L2NormSquared(Functional):
     >>> space = odl.rn(3)
     >>> f = odl.solvers.L2NormSquared(space)
     >>> x = space.one()
-    >>> f.proximal([0.5, 1.0, 1.5])(x)
-    rn(3).element([ 0.5       ,  0.33333333,  0.25      ])
+    >>> f.proximal([0.5, 1.5, 2.0])(x)
+    rn(3).element([ 0.5 ,  0.25,  0.2 ])
     """
 
     def __init__(self, space):

--- a/odl/solvers/functional/default_functionals.py
+++ b/odl/solvers/functional/default_functionals.py
@@ -561,6 +561,14 @@ class L1Norm(LpNorm):
 
     .. math::
         \| x \|_1 = \\int_\Omega |x(t)| dt.
+
+    The `proximal` factory allows using vector-valued stepsizes:
+
+    >>> space = odl.rn(3)
+    >>> f = odl.solvers.L1Norm(space)
+    >>> x = space.one()
+    >>> f.proximal([0.5, 1.0, 1.5])(x)
+    rn(3).element([ 0.5,  0. ,  0. ])
     """
 
     def __init__(self, space):
@@ -637,6 +645,14 @@ class L2NormSquared(Functional):
 
     .. math::
         \| x \|_2^2 = \\int_\Omega |x(t)|^2 dt.
+
+    The `proximal` factory allows using vector-valued stepsizes:
+
+    >>> space = odl.rn(3)
+    >>> f = odl.solvers.L2NormSquared(space)
+    >>> x = space.one()
+    >>> f.proximal([0.5, 1.0, 1.5])(x)
+    rn(3).element([ 0.5       ,  0.33333333,  0.25      ])
     """
 
     def __init__(self, space):
@@ -1594,8 +1610,17 @@ class SeparableSum(Functional):
         [\mathrm{prox}_{\\sigma f_1}(x_1),
          \mathrm{prox}_{\\sigma f_2}(x_2),
          ...,
-         \mathrm{prox}_{\\sigma f_n}(x_n)]
+         \mathrm{prox}_{\\sigma f_n}(x_n)].
 
+    If :math:`\\sigma = (\\sigma_1, \\sigma_2, \\ldots, \\sigma_n)` is a list
+    of positive `float`s, then it distributes, too:
+
+    .. math::
+        \mathrm{prox}_{\\sigma h}(x_1, x_2, ..., x_n) =
+        [\mathrm{prox}_{\\sigma_1 f_1}(x_1),
+         \mathrm{prox}_{\\sigma_2 f_2}(x_2),
+         ...,
+         \mathrm{prox}_{\\sigma_n f_n}(x_n)].
     """
 
     def __init__(self, *functionals):
@@ -1616,6 +1641,15 @@ class SeparableSum(Functional):
         >>> l1 = odl.solvers.L1Norm(space)
         >>> l2 = odl.solvers.L2Norm(space)
         >>> f_sum = odl.solvers.SeparableSum(l1, l2)
+
+        The `proximal` factory allows using vector-valued stepsizes:
+
+        >>> x = f_sum.domain.one()
+        >>> f_sum.proximal([0.5, 2.0])(x)
+        ProductSpace(rn(3), 2).element([
+            [ 0.5,  0.5,  0.5],
+            [ 0.,  0.,  0.]
+        ])
 
         Create functional ``f([x1, ... ,xn]) = \sum_i ||xi||_1``:
 

--- a/odl/solvers/functional/functional.py
+++ b/odl/solvers/functional/functional.py
@@ -116,6 +116,41 @@ class Functional(Operator):
         given optimization problem take a `proximal factory` as input,
         i.e., a function returning a proximal operator. See for example
         `forward_backward_pd`.
+
+        In general, the step length :math:`\\sigma` is expected to be a
+        positive float, but certain functionals might accept more types of
+        objects as a stepsize:
+
+        * If a functional is a `SeparableSum`, then, instead of a positive
+        float, one may call the `proximal factory` with a list of positive
+        floats, and the stepsize are applied to each component individually.
+
+        * For certain special functionals like `l1_norm` and `l2_norm_squared`,
+        which are not implemented as a `SeparableSum`, the proximal factory
+        will accept a `space.element`, where `space` is the domain of the
+        functional. Its components must be strictly positive floats.
+
+        A stepsize like :math:`(\\sigma_1, \\ldots, \\sigma_n)`  coincides
+        with a matrix-valued distance according to Section XV.4 of _[HL1993]
+        and the rule
+
+        .. math::
+            M = \\mathrm{diag}(\\sigma_1^{-1}, \\ldots, \\sigma_n^{-1})
+
+        or the Bregman-proximal according to _[E1993] and the rule
+
+        .. math::
+            h(x) = \langle x, M x \rangle.
+
+        References
+        ----------
+        [HL1993] Hiriart-Urruty J-B, and Lemaréchal C. *Convex analysis and
+        minimization algorithms II. Advanced theory and bundle methods.*
+        Springer, 1993.
+
+        [E1993] Eckstein J. *Nonlinear proximal point algorithms using Bregman
+        functions, with applications to convex programming.* Mathematics of
+        Operations Research, 18.1 (1993), pp 202--226.
         """
         raise NotImplementedError(
             'no proximal operator implemented for functional {!r}'

--- a/odl/solvers/functional/functional.py
+++ b/odl/solvers/functional/functional.py
@@ -1,3 +1,5 @@
+# coding=utf-8
+
 # Copyright 2014-2017 The ODL contributors
 #
 # This file is part of ODL.

--- a/odl/solvers/functional/functional.py
+++ b/odl/solvers/functional/functional.py
@@ -127,10 +127,10 @@ class Functional(Operator):
         float, one may call the `proximal factory` with a list of positive
         floats, and the stepsize are applied to each component individually.
 
-        * For certain special functionals like `l1_norm` and `l2_norm_squared`,
+        * For certain special functionals like `L1Norm` and `L2NormSquared`,
         which are not implemented as a `SeparableSum`, the proximal factory
-        will accept a `space.element`, where `space` is the domain of the
-        functional. Its components must be strictly positive floats.
+        will accept an argument which is `element-like` regarding the domain
+        of the functional. Its components must be strictly positive floats.
 
         A stepsize like :math:`(\\sigma_1, \\ldots, \\sigma_n)`  coincides
         with a matrix-valued distance according to Section XV.4 of _[HL1993]

--- a/odl/solvers/nonsmooth/proximal_operators.py
+++ b/odl/solvers/nonsmooth/proximal_operators.py
@@ -159,9 +159,8 @@ def proximal_convex_conj(prox_factory):
 
         mult_inner = MultiplyOperator(1.0 / sigma, domain=space, range=space)
         mult_outer = MultiplyOperator(sigma, domain=space, range=space)
-        result = IdentityOperator(space) \
-            - OperatorComp(OperatorComp(
-                mult_outer, prox_factory(1.0 / sigma)), mult_inner)
+        result = IdentityOperator(space) - OperatorComp(OperatorComp(
+            mult_outer, prox_factory(1.0 / sigma)), mult_inner)
         return result
 
     return convex_conj_prox_factory

--- a/odl/solvers/nonsmooth/proximal_operators.py
+++ b/odl/solvers/nonsmooth/proximal_operators.py
@@ -77,15 +77,19 @@ def combine_proximals(*factory_list):
 
         Parameters
         ----------
-        sigma : positive float
-            Step size parameter
+        sigma : positive float or list of positive floats
+            Step size parameter(s), if a list, the length must match the length of the `factory_list`
+        
 
         Returns
         -------
         diag_op : `DiagonalOperator`
         """
+        if np.isscalar(sigma):
+            sigma = [sigma]*len(factory_list)
+
         return DiagonalOperator(
-            *[factory(sigma) for factory in factory_list])
+            *[factory(sigmai) for (sigmai,factory) in zip(sigma, factory_list)])
 
     return diag_op_factory
 

--- a/odl/solvers/nonsmooth/proximal_operators.py
+++ b/odl/solvers/nonsmooth/proximal_operators.py
@@ -896,6 +896,9 @@ def proximal_convex_conj_l2_squared(space, lam=1, g=None):
                     sig.multiply(g, out=out)
                     out.lincomb(1.0, x, -1.0, out=out)
                     out.divide(1 + 0.5 / lam * sig, out=out)
+            else:
+                raise RuntimeError('Error in ProximalConvexConjL2Squared: sig '
+                                   'is neither a scalar nor a space element.')
 
     return ProximalConvexConjL2Squared
 

--- a/odl/solvers/nonsmooth/proximal_operators.py
+++ b/odl/solvers/nonsmooth/proximal_operators.py
@@ -158,8 +158,8 @@ def proximal_convex_conj(prox_factory):
 
         mult_inner = MultiplyOperator(1.0 / sigma, domain=space, range=space)
         mult_outer = MultiplyOperator(sigma, domain=space, range=space)
-        result = IdentityOperator(space) \
-            - mult_outer * prox_factory(1.0 / sigma) * mult_inner
+        result = (IdentityOperator(space) -
+                  mult_outer * prox_factory(1.0 / sigma) * mult_inner)
         return result
 
     return convex_conj_prox_factory

--- a/odl/solvers/nonsmooth/proximal_operators.py
+++ b/odl/solvers/nonsmooth/proximal_operators.py
@@ -885,11 +885,11 @@ def proximal_convex_conj_l2_squared(space, lam=1, g=None):
                                 -sig / (1 + 0.5 * sig / lam), g)
             elif sig in space:
                 if g is None:
-                    x.divide(1 + 0.5 / lam * sig, out)
+                    x.divide(1 + 0.5 / lam * sig, out=out)
                 else:
-                    sig.multiply(g, out)
-                    out.lincomb(1.0, x, -1.0, out)
-                    out.divide(1 + 0.5 / lam * sig, out)
+                    sig.multiply(g, out=out)
+                    out.lincomb(1.0, x, -1.0, out=out)
+                    out.divide(1 + 0.5 / lam * sig, out=out)
 
     return ProximalConvexConjL2Squared
 
@@ -973,8 +973,8 @@ def proximal_l2_squared(space, lam=1, g=None):
                     x.divide(1.0 + 2.0 * sig * lam, out=out)
                 else:
                     sig.multiply(2.0 * lam * g, out=out)
-                    out.lincomb(1.0, x, 1.0, out)
-                    out.divide(1.0 + 2 * sig * lam, out)
+                    out.lincomb(1.0, x, 1.0, out=out)
+                    out.divide(1.0 + 2 * sig * lam, out=out)
 
     return ProximalL2Squared
 

--- a/odl/solvers/nonsmooth/proximal_operators.py
+++ b/odl/solvers/nonsmooth/proximal_operators.py
@@ -24,10 +24,9 @@ Foundations and Trends in Optimization, 1 (2014), pp 127-239.
 from __future__ import print_function, division, absolute_import
 import numpy as np
 
-from odl.operator import (
-    Operator, IdentityOperator, ScalingOperator, ConstantOperator,
-    DiagonalOperator, PointwiseNorm)
-from odl.set.space import LinearSpaceElement
+from odl.operator import (Operator, IdentityOperator, ScalingOperator,
+                          ConstantOperator, DiagonalOperator, PointwiseNorm,
+                          OperatorComp, MultiplyOperator)
 from odl.space import ProductSpace
 from odl.util import cache_arguments
 
@@ -153,10 +152,14 @@ def proximal_convex_conj(prox_factory):
         """
         if np.isscalar(sigma):
             sigma = float(sigma)
+            prox_other = sigma * prox_factory(1.0 / sigma) * (1.0 / sigma)
+            return IdentityOperator(prox_other.domain) - prox_other
         else:
-            sigma = prox_factory.domain.element(sigma)
-        prox_other = sigma * prox_factory(1.0 / sigma) * (1.0 / sigma)
-        return IdentityOperator(prox_other.domain) - prox_other
+            space = prox_factory(sigma).domain
+            sigma = space.element(sigma)
+            return IdentityOperator(space) - OperatorComp(OperatorComp(
+                MultiplyOperator(sigma), prox_factory(1.0 / sigma)),
+                MultiplyOperator(1.0 / sigma))
 
     return convex_conj_prox_factory
 

--- a/odl/solvers/nonsmooth/proximal_operators.py
+++ b/odl/solvers/nonsmooth/proximal_operators.py
@@ -28,7 +28,7 @@ from odl.operator import (Operator, IdentityOperator, ScalingOperator,
                           ConstantOperator, DiagonalOperator, PointwiseNorm,
                           OperatorComp, MultiplyOperator)
 from odl.space import ProductSpace
-from odl.util import cache_arguments
+from odl.set import LinearSpaceElement
 
 
 __all__ = ('combine_proximals', 'proximal_convex_conj', 'proximal_translation',
@@ -269,7 +269,6 @@ def proximal_arg_scaling(prox_factory, scaling):
     if scaling == 0:
         return proximal_const_func(prox_factory(1.0).domain)
 
-    @cache_arguments
     def arg_scaling_prox_factory(sigma):
         """Create proximal for the translation with a given sigma.
 
@@ -349,7 +348,6 @@ def proximal_quadratic_perturbation(prox_factory, a, u=None):
         raise TypeError('`u` must be `None` or a `LinearSpaceElement` '
                         'instance, got {!r}.'.format(u))
 
-    @cache_arguments
     def quadratic_perturbation_prox_factory(sigma):
         """Create proximal for the quadratic perturbation with a given sigma.
 

--- a/odl/solvers/nonsmooth/proximal_operators.py
+++ b/odl/solvers/nonsmooth/proximal_operators.py
@@ -28,7 +28,7 @@ from odl.operator import (Operator, IdentityOperator, ScalingOperator,
                           ConstantOperator, DiagonalOperator, PointwiseNorm,
                           OperatorComp, MultiplyOperator)
 from odl.space import ProductSpace
-from odl.set import LinearSpaceElement
+from odl.set.space import LinearSpaceElement
 
 
 __all__ = ('combine_proximals', 'proximal_convex_conj', 'proximal_translation',

--- a/odl/solvers/nonsmooth/proximal_operators.py
+++ b/odl/solvers/nonsmooth/proximal_operators.py
@@ -282,11 +282,11 @@ def proximal_arg_scaling(prox_factory, scaling):
             the step size
         """
         scaling_square = scaling * scaling
-# TODO Catch division by zero errors. The following doesn't work:
-#        if not scaling_square > 0 * scaling:
-#            raise NotImplementedError("Proximal scaling: "
-#                                      "Vector-valued scaling "
-#                                      "with zeros not yet supported.")
+#       TODO Catch division by zero errors. The following doesn't work:
+#       if not scaling_square > 0 * scaling:
+#           raise NotImplementedError("Proximal scaling: "
+#                                     "Vector-valued scaling "
+#                                     "with zeros not yet supported.")
         prox = prox_factory(sigma * scaling_square)
         space = prox.domain
         mult_inner = MultiplyOperator(scaling, domain=space, range=space)

--- a/odl/solvers/nonsmooth/proximal_operators.py
+++ b/odl/solvers/nonsmooth/proximal_operators.py
@@ -1032,7 +1032,10 @@ def proximal_convex_conj_l1(space, lam=1, g=None):
             """
             super(ProximalConvexConjL1, self).__init__(
                 domain=space, range=space, linear=False)
-            self.sigma = float(sigma)
+            if np.isscalar(sigma):
+                self.sigma = float(sigma)
+            else:
+                self.sigma = space.element(sigma)
 
         def _call(self, x, out):
             """Return ``self(x, out=out)``."""

--- a/odl/solvers/nonsmooth/proximal_operators.py
+++ b/odl/solvers/nonsmooth/proximal_operators.py
@@ -234,7 +234,7 @@ def proximal_arg_scaling(prox_factory, scaling):
         accepted by prox_factory. It may not contain any nonzero imaginary
         parts. If it is a scalar, it may be zero, in which case the
         resulting proxmial operator is the identity. If not a scalar,
-        it may not contain any nonzero components.
+        it may not contain any zero components.
 
     Returns
     -------
@@ -273,10 +273,15 @@ def proximal_arg_scaling(prox_factory, scaling):
     #   the others.
     # Since these checks are computationally expensive, we do not execute them
     # unconditionally, but only if the scaling factor is a scalar:
-    if np.isscalar(scaling) and scaling.imag != 0:
-        raise ValueError("complex scaling not supported.")
-    if np.isscalar(scaling) and scaling == 0:
-        return proximal_const_func(prox_factory(1.0).domain)
+    if np.isscalar(scaling):
+        if scaling == 0:
+            return proximal_const_func(prox_factory(1.0).domain)
+        elif scaling.imag != 0:
+            raise ValueError("Complex scaling not supported.")
+        else:
+            scaling = float(scaling)
+    else:
+        scaling = np.asarray(scaling)
 
     def arg_scaling_prox_factory(sigma):
         """Create proximal for the translation with a given sigma.

--- a/odl/solvers/nonsmooth/proximal_operators.py
+++ b/odl/solvers/nonsmooth/proximal_operators.py
@@ -26,7 +26,7 @@ import numpy as np
 
 from odl.operator import (Operator, IdentityOperator, ScalingOperator,
                           ConstantOperator, DiagonalOperator, PointwiseNorm,
-                          OperatorComp, MultiplyOperator)
+                          MultiplyOperator)
 from odl.space import ProductSpace
 from odl.set.space import LinearSpaceElement
 
@@ -158,8 +158,8 @@ def proximal_convex_conj(prox_factory):
 
         mult_inner = MultiplyOperator(1.0 / sigma, domain=space, range=space)
         mult_outer = MultiplyOperator(sigma, domain=space, range=space)
-        result = IdentityOperator(space) - OperatorComp(OperatorComp(
-            mult_outer, prox_factory(1.0 / sigma)), mult_inner)
+        result = IdentityOperator(space) \
+            - mult_outer * prox_factory(1.0 / sigma) * mult_inner
         return result
 
     return convex_conj_prox_factory
@@ -297,7 +297,7 @@ def proximal_arg_scaling(prox_factory, scaling):
         space = prox.domain
         mult_inner = MultiplyOperator(scaling, domain=space, range=space)
         mult_outer = MultiplyOperator(1 / scaling, domain=space, range=space)
-        return OperatorComp(OperatorComp(mult_outer, prox), mult_inner)
+        return mult_outer * prox * mult_inner
 
     return arg_scaling_prox_factory
 

--- a/odl/solvers/nonsmooth/proximal_operators.py
+++ b/odl/solvers/nonsmooth/proximal_operators.py
@@ -89,7 +89,7 @@ def combine_proximals(*factory_list):
 
         return DiagonalOperator(
             *[factory(sigmai)
-              for (sigmai, factory) in zip(sigma, factory_list)])
+              for sigmai, factory in zip(sigma, factory_list)])
 
     return diag_op_factory
 

--- a/odl/solvers/nonsmooth/proximal_operators.py
+++ b/odl/solvers/nonsmooth/proximal_operators.py
@@ -78,8 +78,8 @@ def combine_proximals(*factory_list):
         Parameters
         ----------
         sigma : positive float or list of positive floats
-            Step size parameter(s), if a list, the length must match the length of the `factory_list`
-        
+            Step size parameter(s), if a list, the length must match
+            the length of the `factory_list`
 
         Returns
         -------
@@ -89,7 +89,8 @@ def combine_proximals(*factory_list):
             sigma = [sigma]*len(factory_list)
 
         return DiagonalOperator(
-            *[factory(sigmai) for (sigmai,factory) in zip(sigma, factory_list)])
+            *[factory(sigmai)
+              for (sigmai, factory) in zip(sigma, factory_list)])
 
     return diag_op_factory
 

--- a/odl/solvers/nonsmooth/proximal_operators.py
+++ b/odl/solvers/nonsmooth/proximal_operators.py
@@ -78,7 +78,7 @@ def combine_proximals(*factory_list):
         ----------
         sigma : positive float or sequence of positive floats
             Step size parameter(s), if a sequence, the length must match
-            the length of the `factory_list`
+            the length of the ``factory_list``.
 
         Returns
         -------
@@ -142,10 +142,9 @@ def proximal_convex_conj(prox_factory):
 
         Parameters
         ----------
-        sigma : positive float or componentwise positive space element
-                or list of positive floats
-            Step size parameter. Can be non-float if `prox_factory`
-            supports that.
+        sigma : positive float or array-like
+            Step size parameter. Can be a pointwise positive space element or
+            a sequence of positive floats if `prox_factory` supports that.
 
         Returns
         -------
@@ -868,9 +867,9 @@ def proximal_convex_conj_l2_squared(space, lam=1, g=None):
 
             Parameters
             ----------
-            sigma : positive float and pointwise positive space.element
-                Step size parameter. If not a float, then it is assumed to be
-                a vector which contains stepsizes for each point.
+            sigma : positive float or pointwise positive space.element
+                Step size parameter. If scalar, it contains a global stepsize,
+                otherwise the space.element defines a stepsize for each point.
             """
             super(ProximalConvexConjL2Squared, self).__init__(
                 domain=space, range=space, linear=g is None)
@@ -957,8 +956,9 @@ def proximal_l2_squared(space, lam=1, g=None):
 
             Parameters
             ----------
-            sigma : positive float
-                Step size parameter
+            sigma : positive float or pointwise positive space.element
+                Step size parameter. If scalar, it contains a global stepsize,
+                otherwise the space.element defines a stepsize for each point.
             """
             super(ProximalL2Squared, self).__init__(
                 domain=space, range=space, linear=g is None)
@@ -1077,8 +1077,9 @@ def proximal_convex_conj_l1(space, lam=1, g=None):
 
             Parameters
             ----------
-            sigma : positive float
-                Step size parameter.
+            sigma : positive float or pointwise positive space.element
+                Step size parameter. If scalar, it contains a global stepsize,
+                otherwise the space.element defines a stepsize for each point.
             """
             super(ProximalConvexConjL1, self).__init__(
                 domain=space, range=space, linear=False)
@@ -1292,8 +1293,9 @@ def proximal_l1(space, lam=1, g=None):
 
             Parameters
             ----------
-            sigma : positive float
-                Step size parameter.
+            sigma : positive float or pointwise positive space.element
+                Step size parameter. If scalar, it contains a global stepsize,
+                otherwise the space.element defines a stepsize for each point.
             """
             super(ProximalL1, self).__init__(
                 domain=space, range=space, linear=False)

--- a/odl/solvers/nonsmooth/proximal_operators.py
+++ b/odl/solvers/nonsmooth/proximal_operators.py
@@ -142,8 +142,10 @@ def proximal_convex_conj(prox_factory):
 
         Parameters
         ----------
-        sigma : positive float
-            Step size parameter
+        sigma : positive float or componentwise positive space element
+                or list of positive floats
+            Step size parameter. Can be non-float if `prox_factory`
+            supports that.
 
         Returns
         -------
@@ -850,8 +852,9 @@ def proximal_convex_conj_l2_squared(space, lam=1, g=None):
 
             Parameters
             ----------
-            sigma : positive float
-                Step size parameter
+            sigma : positive float and componentwise positive space.element
+                Step size parameter. If not a float, then it is assumed to be
+                a vector which contains stepsizes for each component.
             """
             super(ProximalConvexConjL2Squared, self).__init__(
                 domain=space, range=space, linear=g is None)

--- a/odl/solvers/nonsmooth/proximal_operators.py
+++ b/odl/solvers/nonsmooth/proximal_operators.py
@@ -374,7 +374,10 @@ def proximal_quadratic_perturbation(prox_factory, a, u=None):
         prox = proximal_arg_scaling(prox_factory, const)(sigma)
         if u is not None:
             return (const * prox *
-                    (ScalingOperator(u.space, const) - sigma * const * u))
+                    (MultiplyOperator(const,
+                                      domain=u.space,
+                                      range=u.space) -
+                     sigma * const * u))
         else:
             return const * prox * const
 

--- a/odl/solvers/nonsmooth/proximal_operators.py
+++ b/odl/solvers/nonsmooth/proximal_operators.py
@@ -76,8 +76,8 @@ def combine_proximals(*factory_list):
 
         Parameters
         ----------
-        sigma : positive float or list of positive floats
-            Step size parameter(s), if a list, the length must match
+        sigma : positive float or sequence of positive floats
+            Step size parameter(s), if a sequence, the length must match
             the length of the `factory_list`
 
         Returns
@@ -230,7 +230,7 @@ def proximal_arg_scaling(prox_factory, scaling):
     prox_factory : callable
         A factory function that, when called with a step size, returns the
         proximal operator of ``F``
-    scaling : float or list of floats or space element
+    scaling : float or sequence of floats or space element
         Scaling parameter. The permissible types depent on the stepsizes
         accepted by prox_factory.
 
@@ -861,9 +861,9 @@ def proximal_convex_conj_l2_squared(space, lam=1, g=None):
 
             Parameters
             ----------
-            sigma : positive float and componentwise positive space.element
+            sigma : positive float and pointwise positive space.element
                 Step size parameter. If not a float, then it is assumed to be
-                a vector which contains stepsizes for each component.
+                a vector which contains stepsizes for each point.
             """
             super(ProximalConvexConjL2Squared, self).__init__(
                 domain=space, range=space, linear=g is None)

--- a/odl/test/solvers/functional/default_functionals_test.py
+++ b/odl/test/solvers/functional/default_functionals_test.py
@@ -515,23 +515,21 @@ def test_moreau_envelope_l2_sq(space, sigma):
     assert all_almost_equal(smoothed_l2_sq.gradient(x),
                             x * 2 / (1 + 2 * sigma))
 
-def test_weighted_proximal():
-    """Test for the weighted proximal of a SeparableSum functional."""
 
-    space = odl.space.rn(2)
+def test_weighted_proximal(space):
+    """Test for the weighted proximal of a SeparableSum functional."""
 
     l1 = odl.solvers.L1Norm(space)
     l2 = odl.solvers.L2Norm(space)
-
-    x = space.one()
-    y = space.one()
-
     func = odl.solvers.SeparableSum(l1, l2)
+
+    x = func.domain.one()
 
     sigma = [0.5, 1.0]
 
-    prox = func.proximal(sigma)([x, y])
-    assert all_almost_equal(prox, [l1.proximal(0.5)(x), l2.proximal(1.0)(y)])
+    prox = func.proximal(sigma)(x)
+    assert all_almost_equal(prox, [l1.proximal(sigma[0])(x[0]),
+                                   l2.proximal(sigma[1])(x[1])])
 
 if __name__ == '__main__':
     odl.util.test_file(__file__)

--- a/odl/test/solvers/functional/default_functionals_test.py
+++ b/odl/test/solvers/functional/default_functionals_test.py
@@ -555,7 +555,8 @@ def test_weighted_proximal_L2_norm_squared(space):
 
     # Check if the subdifferential inequalities are satisfied.
     # p = prox_{sigma * f}(x) iff (x - p)/sigma = grad f(p)
-    assert all_almost_equal(func.gradient(p1), space.divide(x - p1, sigma))
+    assert all_almost_equal(func.gradient(p1),
+                            (x - p1) / sigma)
 
 
 def test_weighted_proximal_L1_norm(space):

--- a/odl/test/solvers/functional/default_functionals_test.py
+++ b/odl/test/solvers/functional/default_functionals_test.py
@@ -554,7 +554,7 @@ def test_weighted_proximal_L2_norms_squared(space):
     assert all_almost_equal(p1, p2)
 
     # Check if the subdifferential inequalities are satisfied.
-    # p = prox_{σf}(x) ⇔ (x - p)/σ = ∇f(p)
+    # p = prox_{sigma * f}(x) iff (x - p)/sigma = grad f(p)
     assert all_almost_equal(func.gradient(p1), space.divide(x - p1, sigma))
 
 

--- a/odl/test/solvers/functional/default_functionals_test.py
+++ b/odl/test/solvers/functional/default_functionals_test.py
@@ -515,6 +515,23 @@ def test_moreau_envelope_l2_sq(space, sigma):
     assert all_almost_equal(smoothed_l2_sq.gradient(x),
                             x * 2 / (1 + 2 * sigma))
 
+def test_weighted_proximal():
+    """Test for the weighted proximal of a SeparableSum functional."""
+
+    space = odl.space.rn(2)
+
+    l1 = odl.solvers.L1Norm(space)
+    l2 = odl.solvers.L2Norm(space)
+
+    x = space.one()
+    y = space.one()
+
+    func = odl.solvers.SeparableSum(l1, l2)
+
+    sigma = [0.5, 1.0]
+
+    prox = func.proximal(sigma)([x, y])
+    assert all_almost_equal(prox, [l1.proximal(0.5)(x), l2.proximal(1.0)(y)])
 
 if __name__ == '__main__':
     odl.util.test_file(__file__)

--- a/odl/test/solvers/functional/default_functionals_test.py
+++ b/odl/test/solvers/functional/default_functionals_test.py
@@ -583,7 +583,7 @@ def test_weighted_proximal_L1_norm(space):
 
     # Check if the subdifferential inequalities are satisfied.
     # p = prox_{sigma * f}(x) iff (x - p)/sigma = grad f(p)
-    assert all_almost_equal(func.gradient(p1), space.divide(x - p1, sigma))
+    assert all_almost_equal(func.gradient(p1), (x - p1) / sigma)
 
 
 if __name__ == '__main__':

--- a/odl/test/solvers/functional/default_functionals_test.py
+++ b/odl/test/solvers/functional/default_functionals_test.py
@@ -559,8 +559,8 @@ def test_weighted_proximal_L2_norm_squared(space):
                             (x - p_ip) / sigma)
 
 
-def test_weighted_proximal_L1_norm(space):
-    """Test for the weighted proximal of the L1 norm"""
+def test_weighted_proximal_L1_norm_far(space):
+    """Test for the weighted proximal of the L1 norm away from zero"""
 
     # Define the functional on the space.
     func = odl.solvers.L1Norm(space)
@@ -584,6 +584,34 @@ def test_weighted_proximal_L1_norm(space):
     # Check if the subdifferential inequalities are satisfied.
     # p = prox_{sigma * f}(x) iff (x - p)/sigma = grad f(p)
     assert all_almost_equal(func.gradient(p_ip), (x - p_ip) / sigma)
+
+
+def test_weighted_proximal_L1_norm_close(space):
+    """Test for the weighted proximal of the L1 norm near zero"""
+
+    # Set the space.
+    space = odl.rn(5)
+
+    # Define the functional on the space.
+    func = odl.solvers.L1Norm(space)
+
+    # Set the stepsize.
+    sigma = [0.1, 0.2, 0.5, 1.0, 2.0]
+
+    # Set the starting point.
+    x = 0.5 * space.one()
+
+    # Calculate the proximal point in-place and out-of-place
+    p_ip = space.element()
+    func.proximal(sigma)(x, out=p_ip)
+    p_oop = func.proximal(sigma)(x)
+
+    # Both should contain the same vector now.
+    assert all_almost_equal(p_ip, p_oop)
+
+    # Check if this equals the expected result.
+    expected_result = [0.4, 0.3, 0.0, 0.0, 0.0]
+    assert all_almost_equal(expected_result, p_ip)
 
 
 if __name__ == '__main__':

--- a/odl/test/solvers/functional/default_functionals_test.py
+++ b/odl/test/solvers/functional/default_functionals_test.py
@@ -540,7 +540,7 @@ def test_weighted_proximal_L2_norm_squared(space):
 
     # Set the stepsize as a random element of the spaces
     # with elements between 1 and 10.
-    sigma = odl.phantom.noise.uniform_noise(space, 1, 10)
+    sigma = odl.phantom.uniform_noise(space, 1, 10)
 
     # Start at the one vector.
     x = space.one()

--- a/odl/test/solvers/functional/default_functionals_test.py
+++ b/odl/test/solvers/functional/default_functionals_test.py
@@ -516,7 +516,7 @@ def test_moreau_envelope_l2_sq(space, sigma):
                             x * 2 / (1 + 2 * sigma))
 
 
-def test_weighted_proximal(space):
+def test_weighted_separablesum(space):
     """Test for the weighted proximal of a SeparableSum functional."""
 
     l1 = odl.solvers.L1Norm(space)
@@ -546,17 +546,17 @@ def test_weighted_proximal_L2_norm_squared(space):
     x = space.one()
 
     # Calculate the proximal point in-place and out-of-place
-    p1 = space.element()
-    func.proximal(sigma)(x, out=p1)
-    p2 = func.proximal(sigma)(x)
+    p_ip = space.element()
+    func.proximal(sigma)(x, out=p_ip)
+    p_oop = func.proximal(sigma)(x)
 
     # Both should contain the same vector now.
-    assert all_almost_equal(p1, p2)
+    assert all_almost_equal(p_ip, p_oop)
 
     # Check if the subdifferential inequalities are satisfied.
     # p = prox_{sigma * f}(x) iff (x - p)/sigma = grad f(p)
-    assert all_almost_equal(func.gradient(p1),
-                            (x - p1) / sigma)
+    assert all_almost_equal(func.gradient(p_ip),
+                            (x - p_ip) / sigma)
 
 
 def test_weighted_proximal_L1_norm(space):
@@ -573,17 +573,17 @@ def test_weighted_proximal_L1_norm(space):
     # at the result.
     x = 100 * space.one()
 
-    # Calculate the proximal point inline and non-inline
-    p1 = space.element()
-    func.proximal(sigma)(x, out=p1)
-    p2 = func.proximal(sigma)(x)
+    # Calculate the proximal point in-place and out-of-place
+    p_ip = space.element()
+    func.proximal(sigma)(x, out=p_ip)
+    p_oop = func.proximal(sigma)(x)
 
     # Both should contain the same vector now.
-    assert all_almost_equal(p1, p2)
+    assert all_almost_equal(p_ip, p_oop)
 
     # Check if the subdifferential inequalities are satisfied.
     # p = prox_{sigma * f}(x) iff (x - p)/sigma = grad f(p)
-    assert all_almost_equal(func.gradient(p1), (x - p1) / sigma)
+    assert all_almost_equal(func.gradient(p_ip), (x - p_ip) / sigma)
 
 
 if __name__ == '__main__':

--- a/odl/test/solvers/functional/default_functionals_test.py
+++ b/odl/test/solvers/functional/default_functionals_test.py
@@ -545,7 +545,7 @@ def test_weighted_proximal_L2_norm_squared(space):
     # Start at the one vector.
     x = space.one()
 
-    # Calculate the proximal point inline and non-inline
+    # Calculate the proximal point in-place and out-of-place
     p1 = space.element()
     func.proximal(sigma)(x, out=p1)
     p2 = func.proximal(sigma)(x)
@@ -569,7 +569,7 @@ def test_weighted_proximal_L1_norm(space):
     # with elements between 1 and 10.
     sigma = odl.phantom.noise.uniform_noise(space, 1, 10)
 
-    # Start for away from zero so that the L1 norm will be differentiable
+    # Start far away from zero so that the L1 norm will be differentiable
     # at the result.
     x = 100 * space.one()
 
@@ -583,7 +583,6 @@ def test_weighted_proximal_L1_norm(space):
 
     # Check if the subdifferential inequalities are satisfied.
     # p = prox_{sigma * f}(x) iff (x - p)/sigma = grad f(p)
-    print(func.gradient(p1))
     assert all_almost_equal(func.gradient(p1), space.divide(x - p1, sigma))
 
 

--- a/odl/test/solvers/functional/default_functionals_test.py
+++ b/odl/test/solvers/functional/default_functionals_test.py
@@ -532,7 +532,7 @@ def test_weighted_proximal(space):
                                    l2.proximal(sigma[1])(x[1])])
 
 
-def test_weighted_proximal_L2_norms_squared(space):
+def test_weighted_proximal_L2_norm_squared(space):
     """Test for the weighted proximal of the squared L2 norm"""
 
     # Define the functional on the space.
@@ -555,6 +555,34 @@ def test_weighted_proximal_L2_norms_squared(space):
 
     # Check if the subdifferential inequalities are satisfied.
     # p = prox_{sigma * f}(x) iff (x - p)/sigma = grad f(p)
+    assert all_almost_equal(func.gradient(p1), space.divide(x - p1, sigma))
+
+
+def test_weighted_proximal_L1_norm(space):
+    """Test for the weighted proximal of the L1 norm"""
+
+    # Define the functional on the space.
+    func = odl.solvers.L1Norm(space)
+
+    # Set the stepsize as a random element of the spaces
+    # with elements between 1 and 10.
+    sigma = odl.phantom.noise.uniform_noise(space, 1, 10)
+
+    # Start for away from zero so that the L1 norm will be differentiable
+    # at the result.
+    x = 100 * space.one()
+
+    # Calculate the proximal point inline and non-inline
+    p1 = space.element()
+    func.proximal(sigma)(x, out=p1)
+    p2 = func.proximal(sigma)(x)
+
+    # Both should contain the same vector now.
+    assert all_almost_equal(p1, p2)
+
+    # Check if the subdifferential inequalities are satisfied.
+    # p = prox_{sigma * f}(x) iff (x - p)/sigma = grad f(p)
+    print(func.gradient(p1))
     assert all_almost_equal(func.gradient(p1), space.divide(x - p1, sigma))
 
 

--- a/odl/test/solvers/nonsmooth/proximal_operator_test.py
+++ b/odl/test/solvers/nonsmooth/proximal_operator_test.py
@@ -220,22 +220,28 @@ def test_proximal_convconj_l2_sq_wo_data():
     lam = 2
     prox_factory = proximal_convex_conj_l2_squared(space, lam=lam)
 
-    # Initialize the proximal operator
-    sigma = 0.25
+    # Initialize the proximal operators
+    sigma = 0.25 * space.one()
+    sigmav = sigma * space.one()
     prox = prox_factory(sigma)
+    proxv = prox_factory(sigmav)
 
     assert isinstance(prox, odl.Operator)
+    assert isinstance(proxv, odl.Operator)
 
-    # Allocate output element
+    # Allocate output elements
     x_out = space.element()
+    x_out2 = space.element()
 
     # Optimal point returned by the proximal operator
     prox(x, x_out)
+    proxv(x, x_out2)
 
     # Explicit computation: x / (1 + sigma / (2 * lambda))
     x_verify = x / (1 + sigma / (2 * lam))
 
     assert all_almost_equal(x_out, x_verify, HIGH_ACC)
+    assert all_almost_equal(x_out2, x_verify, HIGH_ACC)
 
 
 def test_proximal_convconj_l2_sq_with_data():

--- a/odl/test/solvers/nonsmooth/proximal_operator_test.py
+++ b/odl/test/solvers/nonsmooth/proximal_operator_test.py
@@ -231,17 +231,17 @@ def test_proximal_convconj_l2_sq_wo_data():
 
     # Allocate output elements
     x_out = space.element()
-    x_out2 = space.element()
+    x_outv = space.element()
 
     # Optimal point returned by the proximal operator
     prox(x, x_out)
-    proxv(x, x_out2)
+    proxv(x, x_outv)
 
     # Explicit computation: x / (1 + sigma / (2 * lambda))
     x_verify = x / (1 + sigma / (2 * lam))
 
     assert all_almost_equal(x_out, x_verify, HIGH_ACC)
-    assert all_almost_equal(x_out2, x_verify, HIGH_ACC)
+    assert all_almost_equal(x_outv, x_verify, HIGH_ACC)
 
 
 def test_proximal_convconj_l2_sq_with_data():


### PR DESCRIPTION
This commit changes the generation of the proximal factory for the class
SeparableSum so that it is possible to choose a stepsize per summand
instead of one stepsize for all. A simple test checks the code.