### PR TITLE
ENH: improve printing of spaces and vectors, closes #1196

### DIFF
--- a/odl/deform/linearized.py
+++ b/odl/deform/linearized.py
@@ -149,7 +149,7 @@ class LinDeformFixedTempl(Operator):
         >>> op = LinDeformFixedTempl(template)
         >>> disp_field = [[0, 0, 0, -0.2, 0]]
         >>> print(op(disp_field))
-        [0.0, 0.0, 1.0, 1.0, 0.0]
+        [ 0.,  0.,  1.,  1.,  0.]
 
         The result depends on the chosen interpolation. With 'linear'
         interpolation and an offset equal to half the distance between two
@@ -160,7 +160,7 @@ class LinDeformFixedTempl(Operator):
         >>> op = LinDeformFixedTempl(template)
         >>> disp_field = [[0, 0, 0, -0.1, 0]]
         >>> print(op(disp_field))
-        [0.0, 0.0, 1.0, 0.5, 0.0]
+        [ 0. ,  0. ,  1. ,  0.5,  0. ]
         """
         space = getattr(template, 'space', None)
         if not isinstance(space, DiscreteLp):
@@ -301,7 +301,7 @@ class LinDeformFixedDisp(Operator):
         >>> op = LinDeformFixedDisp(disp_field)
         >>> template = [0, 0, 1, 0, 0]
         >>> print(op([0, 0, 1, 0, 0]))
-        [0.0, 0.0, 1.0, 1.0, 0.0]
+        [ 0.,  0.,  1.,  1.,  0.]
 
         The result depends on the chosen interpolation. With 'linear'
         interpolation and an offset equal to half the distance between two
@@ -312,7 +312,7 @@ class LinDeformFixedDisp(Operator):
         >>> op = LinDeformFixedDisp(disp_field)
         >>> template = [0, 0, 1, 0, 0]
         >>> print(op(template))
-        [0.0, 0.0, 1.0, 0.5, 0.0]
+        [ 0. ,  0. ,  1. ,  0.5,  0. ]
         """
         space = getattr(displacement, 'space', None)
         if not isinstance(space, ProductSpace):

--- a/odl/discr/diff_ops.py
+++ b/odl/discr/diff_ops.py
@@ -97,10 +97,11 @@ class PartialDerivative(PointwiseTensorFieldOperator):
         ...               [ 0.,  2.,  4.,  6.,  8.]])
         >>> discr = odl.uniform_discr([0, 0], [2, 1], f.shape)
         >>> par_deriv = PartialDerivative(discr, axis=0, pad_mode='order1')
-        >>> par_div_f = par_deriv(f)
-        >>> print(par_div_f)
-        [[0.0, 1.0, 2.0, 3.0, 4.0],
-         [0.0, 1.0, 2.0, 3.0, 4.0]]
+        >>> par_deriv(f)
+        uniform_discr([ 0.,  0.], [ 2.,  1.], (2, 5)).element(
+            [[ 0.,  1.,  2.,  3.,  4.],
+             [ 0.,  1.,  2.,  3.,  4.]]
+        )
         """
         if not isinstance(space, DiscreteLp):
             raise TypeError('`space` {!r} is not a DiscreteLp instance'
@@ -252,20 +253,26 @@ class Gradient(PointwiseTensorFieldOperator):
         >>> f = discr.element(data)
         >>> grad = Gradient(discr)
         >>> grad_f = grad(f)
-        >>> print(grad_f[0])
-        [[0.0, 1.0, 2.0, 3.0, 4.0],
-         [0.0, -2.0, -4.0, -6.0, -8.0]]
-        >>> print(grad_f[1])
-        [[1.0, 1.0, 1.0, 1.0, -4.0],
-         [2.0, 2.0, 2.0, 2.0, -8.0]]
+        >>> grad_f[0]
+        uniform_discr([ 0.,  0.], [ 2.,  5.], (2, 5)).element(
+            [[ 0.,  1.,  2.,  3.,  4.],
+             [ 0., -2., -4., -6., -8.]]
+        )
+        >>> grad_f[1]
+        uniform_discr([ 0.,  0.], [ 2.,  5.], (2, 5)).element(
+            [[ 1.,  1.,  1.,  1., -4.],
+             [ 2.,  2.,  2.,  2., -8.]]
+        )
 
         Verify adjoint:
 
         >>> g = grad.range.element((data, data ** 2))
         >>> adj_g = grad.adjoint(g)
-        >>> print(adj_g)
-        [[0.0, -2.0, -5.0, -8.0, -11.0],
-         [0.0, -5.0, -14.0, -23.0, -32.0]]
+        >>> adj_g
+        uniform_discr([ 0.,  0.], [ 2.,  5.], (2, 5)).element(
+            [[  0.,  -2.,  -5.,  -8., -11.],
+             [  0.,  -5., -14., -23., -32.]]
+        )
         >>> g.inner(grad_f) / f.inner(adj_g)
         1.0
         """
@@ -440,9 +447,9 @@ class Divergence(PointwiseTensorFieldOperator):
         >>> f = div.domain.element([data, data])
         >>> div_f = div(f)
         >>> print(div_f)
-        [[2.0, 2.0, 2.0, 2.0, -3.0],
-         [2.0, 2.0, 2.0, 2.0, -4.0],
-         [-1.0, -2.0, -3.0, -4.0, -12.0]]
+        [[  2.,   2.,   2.,   2.,  -3.],
+         [  2.,   2.,   2.,   2.,  -4.],
+         [ -1.,  -2.,  -3.,  -4., -12.]]
 
         Verify adjoint:
 
@@ -594,10 +601,12 @@ class Laplacian(PointwiseTensorFieldOperator):
         >>> space = odl.uniform_discr([0, 0], [3, 3], [3, 3])
         >>> f = space.element(data)
         >>> lap = Laplacian(space)
-        >>> print(lap(f))
-        [[0.0, 1.0, 0.0],
-         [1.0, -4.0, 1.0],
-         [0.0, 1.0, 0.0]]
+        >>> lap(f)
+        uniform_discr([ 0.,  0.], [ 3.,  3.], (3, 3)).element(
+            [[ 0.,  1.,  0.],
+             [ 1., -4.,  1.],
+             [ 0.,  1.,  0.]]
+        )
         """
         if not isinstance(space, DiscreteLp):
             raise TypeError('`space` {!r} is not a DiscreteLp instance'

--- a/odl/discr/discr_mappings.py
+++ b/odl/discr/discr_mappings.py
@@ -25,7 +25,7 @@ from odl.space.base_ntuples import NtuplesBase, FnBase
 from odl.space import FunctionSet, FunctionSpace
 from odl.util import (
     is_valid_input_meshgrid, out_shape_from_array, out_shape_from_meshgrid,
-    is_string)
+    is_string, signature_string, indent)
 
 
 __all__ = ('FunctionSetMapping',
@@ -214,18 +214,18 @@ class PointCollocation(FunctionSetMapping):
         ... # Properly vectorized function
         >>> func_elem = funcset.element(lambda x: x[0] - x[1])
         >>> coll_op(func_elem)
-        rn(6).element([-2.0, -3.0, -4.0, -1.0, -2.0, -3.0])
+        rn(6).element([-2., -3., -4., -1., -2., -3.])
         >>> coll_op(lambda x: x[0] - x[1])  # Works directly
-        rn(6).element([-2.0, -3.0, -4.0, -1.0, -2.0, -3.0])
+        rn(6).element([-2., -3., -4., -1., -2., -3.])
         >>> out = odl.rn(6).element()
         >>> coll_op(func_elem, out=out)  # In-place
-        rn(6).element([-2.0, -3.0, -4.0, -1.0, -2.0, -3.0])
+        rn(6).element([-2., -3., -4., -1., -2., -3.])
 
         Fortran ordering:
 
         >>> coll_op = PointCollocation(funcset, partition, rn, order='F')
         >>> coll_op(func_elem)
-        rn(6).element([-2.0, -1.0, -3.0, -2.0, -4.0, -3.0])
+        rn(6).element([-2., -1., -3., -2., -4., -3.])
         """
         linear = isinstance(ip_fset, FunctionSpace)
         super(PointCollocation, self).__init__(
@@ -279,11 +279,12 @@ vectorization_guide.html>`_ for a detailed introduction.
 
     def __repr__(self):
         """Return ``repr(self)``."""
-        inner_str = '\n  {!r},\n  {!r},\n  {!r}'.format(
-            self.domain, self.grid, self.range)
-        if self.order != 'C':
-            inner_str += ",\n  order='{}'".format(self.order)
-        return '{}({})'.format(self.__class__.__name__, inner_str)
+        posargs = [self.range, self.grid, self.domain]
+        optargs = [('order', self.order, 'C')]
+        inner_str = signature_string(posargs, optargs,
+                                     sep=[',\n', ', ', ',\n'],
+                                     mod=['!r'])
+        return '{}(\n{}\n)'.format(self.__class__.__name__, indent(inner_str))
 
 
 class NearestInterpolation(FunctionSetMapping):
@@ -443,16 +444,13 @@ class NearestInterpolation(FunctionSetMapping):
 
     def __repr__(self):
         """Return ``repr(self)``."""
-        inner_str = '\n  {!r},\n  {!r},\n  {!r}'.format(
-            self.range, self.grid, self.domain)
-        sep = ',\n '
-        if self.order != 'C':
-            inner_str += sep + "order='{}'".format(self.order)
-            sep = ', '
-        if self.variant != 'left':
-            inner_str += sep + "variant='{}'".format(self.variant)
-
-        return '{}({})'.format(self.__class__.__name__, inner_str)
+        posargs = [self.range, self.grid, self.domain]
+        optargs = [('variant', self.variant, 'left'),
+                   ('order', self.order, 'C')]
+        inner_str = signature_string(posargs, optargs,
+                                     sep=[',\n', ', ', ',\n'],
+                                     mod=['!r', ''])
+        return '{}(\n{}\n)'.format(self.__class__.__name__, indent(inner_str))
 
 
 class LinearInterpolation(FunctionSetMapping):
@@ -526,13 +524,12 @@ class LinearInterpolation(FunctionSetMapping):
 
     def __repr__(self):
         """Return ``repr(self)``."""
-        inner_str = '\n  {!r},\n  {!r},\n  {!r}'.format(self.range,
-                                                        self.grid,
-                                                        self.domain)
-        if self.order != 'C':
-            inner_str += ",\n  order='{}'".format(self.order)
-
-        return '{}({})'.format(self.__class__.__name__, inner_str)
+        posargs = [self.range, self.grid, self.domain]
+        optargs = [('order', self.order, 'C')]
+        inner_str = signature_string(posargs, optargs,
+                                     sep=[',\n', ', ', ',\n'],
+                                     mod=['!r', ''])
+        return '{}(\n{}\n)'.format(self.__class__.__name__, indent(inner_str))
 
 
 class PerAxisInterpolation(FunctionSetMapping):
@@ -680,23 +677,18 @@ class PerAxisInterpolation(FunctionSetMapping):
         else:
             schemes = self.schemes
 
-        inner_str = '\n {!r},\n {!r},\n {!r},\n {!r}'.format(
-            self.range, self.grid, self.domain, schemes)
-        sep = '\n, '
-        if self.order != 'C':
-            inner_str += sep + "order='{}'".format(self.order)
-            sep = ', '
-
         if all(var == self.nn_variants[0] for var in self.nn_variants):
             variants = self.nn_variants[0]
         else:
             variants = self.nn_variants
-            sep = ',\n '
 
-        if variants is not None:
-            inner_str += sep + 'nn_variants={}'.format(variants)
-
-        return '{}({})'.format(self.__class__.__name__, inner_str)
+        posargs = [self.range, self.grid, self.domain, schemes]
+        optargs = [('order', self.order, 'C'),
+                   ('nn_variants', variants, 'left')]
+        inner_str = signature_string(posargs, optargs,
+                                     sep=[',\n', ', ', ',\n'],
+                                     mod=['!r', ''])
+        return '{}(\n{}\n)'.format(self.__class__.__name__, indent(inner_str))
 
 
 class _Interpolator(object):

--- a/odl/discr/discr_ops.py
+++ b/odl/discr/discr_ops.py
@@ -64,7 +64,7 @@ class Resampling(Operator):
         Apply the corresponding resampling operator to an element:
 
         >>> print(resampling([0, 1, 0]))
-        [0.0, 0.0, 1.0, 1.0, 0.0, 0.0]
+        [ 0.,  0.,  1.,  1.,  0.,  0.]
 
         The result depends on the interpolation chosen for the underlying
         spaces:
@@ -72,7 +72,7 @@ class Resampling(Operator):
         >>> coarse_discr = odl.uniform_discr(0, 1, 3, interp='linear')
         >>> linear_resampling = odl.Resampling(coarse_discr, fine_discr)
         >>> print(linear_resampling([0, 1, 0]))
-        [0.0, 0.25, 0.75, 0.75, 0.25, 0.0]
+        [ 0.  ,  0.25,  0.75,  0.75,  0.25,  0.  ]
         """
         if domain.uspace != range.uspace:
             raise ValueError('`domain.uspace` ({}) does not match '
@@ -132,13 +132,13 @@ class Resampling(Operator):
 
         >>> x = [0.0, 1.0, 0.0]
         >>> print(resampling_inv(resampling(x)))
-        [0.0, 1.0, 0.0]
+        [ 0.,  1.,  0.]
 
         However, it can fail in the other direction:
 
         >>> y = [0.0, 0.0, 0.0, 1.0, 0.0, 0.0]
         >>> print(resampling(resampling_inv(y)))
-        [0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+        [ 0.,  0.,  0.,  0.,  0.,  0.]
         """
         return self.inverse
 
@@ -212,7 +212,7 @@ class ResizingOperatorBase(Operator):
         >>> space = odl.uniform_discr([0, 0], [1, 1], (2, 4))
         >>> resize_op = odl.ResizingOperator(space, ran_shp=(4, 4))
         >>> resize_op.range
-        uniform_discr([-0.5, 0.0], [1.5, 1.0], (4, 4))
+        uniform_discr([-0.5,  0. ], [ 1.5,  1. ], (4, 4))
 
         Testing different padding methods in the first axis (zero padding
         is the default):
@@ -221,28 +221,28 @@ class ResizingOperatorBase(Operator):
         ...      [5, 6, 7, 8]]
         >>> resize_op = odl.ResizingOperator(space, ran_shp=(4, 4))
         >>> print(resize_op(x))
-        [[0.0, 0.0, 0.0, 0.0],
-         [1.0, 2.0, 3.0, 4.0],
-         [5.0, 6.0, 7.0, 8.0],
-         [0.0, 0.0, 0.0, 0.0]]
+        [[ 0.,  0.,  0.,  0.],
+         [ 1.,  2.,  3.,  4.],
+         [ 5.,  6.,  7.,  8.],
+         [ 0.,  0.,  0.,  0.]]
         >>>
         >>> resize_op = odl.ResizingOperator(space, ran_shp=(4, 4),
         ...                                  offset=(0, 0),
         ...                                  pad_mode='periodic')
         >>> print(resize_op(x))
-        [[1.0, 2.0, 3.0, 4.0],
-         [5.0, 6.0, 7.0, 8.0],
-         [1.0, 2.0, 3.0, 4.0],
-         [5.0, 6.0, 7.0, 8.0]]
+        [[ 1.,  2.,  3.,  4.],
+         [ 5.,  6.,  7.,  8.],
+         [ 1.,  2.,  3.,  4.],
+         [ 5.,  6.,  7.,  8.]]
         >>>
         >>> resize_op = odl.ResizingOperator(space, ran_shp=(4, 4),
         ...                                  offset=(0, 0),
         ...                                  pad_mode='order0')
         >>> print(resize_op(x))
-        [[1.0, 2.0, 3.0, 4.0],
-         [5.0, 6.0, 7.0, 8.0],
-         [5.0, 6.0, 7.0, 8.0],
-         [5.0, 6.0, 7.0, 8.0]]
+        [[ 1.,  2.,  3.,  4.],
+         [ 5.,  6.,  7.,  8.],
+         [ 5.,  6.,  7.,  8.],
+         [ 5.,  6.,  7.,  8.]]
 
         Alternatively, the range of the operator can be provided directly.
         This requires that the partitions match, i.e. that the cell sizes
@@ -253,10 +253,10 @@ class ResizingOperatorBase(Operator):
         >>> resize_op = odl.ResizingOperator(space, large_spc,
         ...                                  pad_mode='periodic')
         >>> print(resize_op(x))
-        [[5.0, 6.0, 7.0, 8.0],
-         [1.0, 2.0, 3.0, 4.0],
-         [5.0, 6.0, 7.0, 8.0],
-         [1.0, 2.0, 3.0, 4.0]]
+        [[ 5.,  6.,  7.,  8.],
+         [ 1.,  2.,  3.,  4.],
+         [ 5.,  6.,  7.,  8.],
+         [ 1.,  2.,  3.,  4.]]
         """
         from builtins import range as builtin_range
 

--- a/odl/discr/discretization.py
+++ b/odl/discr/discretization.py
@@ -347,7 +347,7 @@ class DiscretizedSetElement(NtuplesBaseVector):
 
         Assign x according to a continuous function:
 
-        >>> x.sampling(lambda x: x)
+        >>> x.sampling(lambda t: t)
         >>> x  # Print values at grid points (which are centered)
         uniform_discr(0.0, 1.0, 5).element([ 0.1,  0.3,  0.5,  0.7,  0.9])
 

--- a/odl/discr/discretization.py
+++ b/odl/discr/discretization.py
@@ -397,11 +397,11 @@ class DiscretizedSetElement(NtuplesBaseVector):
     def __repr__(self):
         """Return ``repr(self)``."""
         maxsize_full_print = 2 * np.get_printoptions()['edgeitems']
+        self_str = array_str(self, nprint=maxsize_full_print)
         if self.ndim == 1 and self.size <= maxsize_full_print:
-            return '{!r}.element({})'.format(self.space, array_str(self))
+            return '{!r}.element({})'.format(self.space, self_str)
         else:
-            return '{!r}.element(\n{}\n)'.format(self.space,
-                                                 indent(array_str(self)))
+            return '{!r}.element(\n{}\n)'.format(self.space, indent(self_str))
 
 
 class DiscretizedSpace(DiscretizedSet, FnBase):

--- a/odl/discr/discretization.py
+++ b/odl/discr/discretization.py
@@ -17,8 +17,8 @@ from odl.space.base_ntuples import (NtuplesBase, NtuplesBaseVector,
 from odl.space import FunctionSet, fn_impl, ntuples_impl
 from odl.set import RealNumbers, ComplexNumbers, LinearSpace
 from odl.util import (
-    arraynd_repr, arraynd_str,
-    is_real_floating_dtype, is_complex_floating_dtype, is_scalar_dtype)
+    array_str, indent,
+    is_real_floating_dtype, is_complex_floating_dtype, is_numeric_dtype)
 
 
 __all__ = ('DiscretizedSet', 'DiscretizedSetElement',
@@ -330,7 +330,7 @@ class DiscretizedSetElement(NtuplesBaseVector):
         self.ntuple.__setitem__(indices, input_data)
 
     def sampling(self, ufunc, **kwargs):
-        """Restrict a continuous function and assign to this element.
+        """Sample a continuous function and assign to this element.
 
         Parameters
         ----------
@@ -341,14 +341,14 @@ class DiscretizedSetElement(NtuplesBaseVector):
 
         Examples
         --------
-        >>> X = odl.uniform_discr(0, 1, 5)
-        >>> x = X.element()
+        >>> space = odl.uniform_discr(0, 1, 5)
+        >>> x = space.element()
 
         Assign x according to a continuous function:
 
         >>> x.sampling(lambda x: x)
-        >>> print(x)  # Print values at grid points (which are centered)
-        [0.1, 0.3, 0.5, 0.7, 0.9]
+        >>> x  # Print values at grid points (which are centered)
+        uniform_discr(0.0, 1.0, 5).element([ 0.1,  0.3,  0.5,  0.7,  0.9])
 
         See Also
         --------
@@ -391,12 +391,15 @@ class DiscretizedSetElement(NtuplesBaseVector):
 
     def __str__(self):
         """Return ``str(self)``."""
-        return arraynd_str(self.asarray())
+        return array_str(self)
 
     def __repr__(self):
         """Return ``repr(self)``."""
-        return '{!r}.element({})'.format(self.space,
-                                         arraynd_repr(self.asarray()))
+        if self.ndim == 1 and self.size <= 6:
+            return '{!r}.element({})'.format(self.space, array_str(self))
+        else:
+            return '{!r}.element(\n{}\n)'.format(self.space,
+                                                 indent(array_str(self)))
 
 
 class DiscretizedSpace(DiscretizedSet, FnBase):
@@ -577,7 +580,7 @@ def dspace_type(space, impl, dtype=None):
             raise TypeError('complex floating data type {!r} requires space '
                             'field to be of type ComplexNumbers, got {!r}'
                             ''.format(dtype, field_type))
-    elif is_scalar_dtype(dtype):
+    elif is_numeric_dtype(dtype):
         if field_type == ComplexNumbers:
             raise TypeError('non-floating data type {!r} requires space field '
                             'to be of type RealNumbers, got {!r}'

--- a/odl/discr/discretization.py
+++ b/odl/discr/discretization.py
@@ -10,6 +10,7 @@
 
 # Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
+import numpy as np
 
 from odl.operator import Operator
 from odl.space.base_ntuples import (NtuplesBase, NtuplesBaseVector,
@@ -395,7 +396,8 @@ class DiscretizedSetElement(NtuplesBaseVector):
 
     def __repr__(self):
         """Return ``repr(self)``."""
-        if self.ndim == 1 and self.size <= 6:
+        maxsize_full_print = 2 * np.get_printoptions()['edgeitems']
+        if self.ndim == 1 and self.size <= maxsize_full_print:
             return '{!r}.element({})'.format(self.space, array_str(self))
         else:
             return '{!r}.element(\n{}\n)'.format(self.space,

--- a/odl/discr/grid.py
+++ b/odl/discr/grid.py
@@ -21,7 +21,7 @@ import numpy as np
 from odl.set import Set, IntervalProd
 from odl.util import (
     normalized_index_expression, normalized_scalar_param_list, safe_int_conv,
-    array1d_repr, signature_string, indent_rows)
+    array_str, signature_string, indent)
 
 
 __all__ = ('RectGrid', 'uniform_grid', 'uniform_grid_fromintv')
@@ -92,8 +92,8 @@ class RectGrid(Set):
         >>> g = RectGrid([1, 2, 5], [-2, 1.5, 2])
         >>> g
         RectGrid(
-            [1.0, 2.0, 5.0],
-            [-2.0, 1.5, 2.0]
+            [ 1.,  2.,  5.],
+            [-2. ,  1.5,  2. ]
         )
         >>> g.ndim  # number of axes
         2
@@ -113,17 +113,17 @@ class RectGrid(Set):
 
         >>> g[:, 0, 0, 0]
         RectGrid(
-            [-1.0, 0.0, 3.0],
-            [2.0],
-            [5.0],
-            [2.0]
+            [-1.,  0.,  3.],
+            [ 2.],
+            [ 5.],
+            [ 2.]
         )
         >>> g[0, ..., 1:]
         RectGrid(
-            [-1.0],
-            [2.0, 4.0, 5.0],
-            [5.0],
-            [4.0, 7.0]
+            [-1.],
+            [ 2.,  4.,  5.],
+            [ 5.],
+            [ 4.,  7.]
         )
 
         Notes
@@ -462,7 +462,7 @@ class RectGrid(Set):
         --------
         >>> g = RectGrid([-1, 0, 3], [2, 4], [5], [2, 4, 7])
         >>> g.convex_hull()
-        IntervalProd([-1.0, 2.0, 5.0, 2.0], [3.0, 4.0, 5.0, 7.0])
+        IntervalProd([-1.,  2.,  5.,  2.], [ 3.,  4.,  5.,  7.])
         """
         return IntervalProd(self.min(), self.max())
 
@@ -669,19 +669,19 @@ class RectGrid(Set):
         >>> g2 = RectGrid([1], [-6, 15])
         >>> g1.insert(1, g2)
         RectGrid(
-            [0.0, 1.0],
-            [1.0],
-            [-6.0, 15.0],
-            [-1.0, 0.0, 2.0]
+            [ 0.,  1.],
+            [ 1.],
+            [ -6.,  15.],
+            [-1.,  0.,  2.]
         )
         >>> g1.insert(1, g2, g2)
         RectGrid(
-            [0.0, 1.0],
-            [1.0],
-            [-6.0, 15.0],
-            [1.0],
-            [-6.0, 15.0],
-            [-1.0, 0.0, 2.0]
+            [ 0.,  1.],
+            [ 1.],
+            [ -6.,  15.],
+            [ 1.],
+            [ -6.,  15.],
+            [-1.,  0.,  2.]
         )
 
         See Also
@@ -726,19 +726,19 @@ class RectGrid(Set):
         >>> g2 = RectGrid([1], [-6, 15])
         >>> g1.append(g2)
         RectGrid(
-            [0.0, 1.0],
-            [-1.0, 0.0, 2.0],
-            [1.0],
-            [-6.0, 15.0]
+            [ 0.,  1.],
+            [-1.,  0.,  2.],
+            [ 1.],
+            [ -6.,  15.]
         )
         >>> g1.append(g2, g2)
         RectGrid(
-            [0.0, 1.0],
-            [-1.0, 0.0, 2.0],
-            [1.0],
-            [-6.0, 15.0],
-            [1.0],
-            [-6.0, 15.0]
+            [ 0.,  1.],
+            [-1.,  0.,  2.],
+            [ 1.],
+            [ -6.,  15.],
+            [ 1.],
+            [ -6.,  15.]
         )
 
         See Also
@@ -765,8 +765,8 @@ class RectGrid(Set):
         >>> g = RectGrid([0, 1], [-1], [-1, 0, 2])
         >>> g.squeeze()
         RectGrid(
-            [0.0, 1.0],
-            [-1.0, 0.0, 2.0]
+            [ 0.,  1.],
+            [-1.,  0.,  2.]
         )
         """
         if axis is None:
@@ -840,7 +840,7 @@ class RectGrid(Set):
         --------
         >>> g = RectGrid([0, 1], [-1, 0, 2])
         >>> g.corner_grid()
-        uniform_grid([0.0, -1.0], [1.0, 2.0], (2, 2))
+        uniform_grid([ 0., -1.], [ 1.,  2.], (2, 2))
         """
         minmax_vecs = []
         for axis in range(self.ndim):
@@ -936,34 +936,34 @@ class RectGrid(Set):
 
         >>> g[:, 0, 0, 0]
         RectGrid(
-            [-1.0, 0.0, 3.0],
-            [2.0],
-            [5.0],
-            [2.0]
+            [-1.,  0.,  3.],
+            [ 2.],
+            [ 5.],
+            [ 2.]
         )
         >>> g[0, ..., 1:]
         RectGrid(
-            [-1.0],
-            [2.0, 4.0, 5.0],
-            [5.0],
-            [4.0, 7.0]
+            [-1.],
+            [ 2.,  4.,  5.],
+            [ 5.],
+            [ 4.,  7.]
         )
         >>> g[::2, ..., ::2]
         RectGrid(
-            [-1.0, 3.0],
-            [2.0, 4.0, 5.0],
-            [5.0],
-            [2.0, 7.0]
+            [-1.,  3.],
+            [ 2.,  4.,  5.],
+            [ 5.],
+            [ 2.,  7.]
         )
 
         Too few indices are filled up with an ellipsis from the right:
 
         >>> g[0]
         RectGrid(
-            [-1.0],
-            [2.0, 4.0, 5.0],
-            [5.0],
-            [2.0, 4.0, 7.0]
+            [-1.],
+            [ 2.,  4.,  5.],
+            [ 5.],
+            [ 2.,  4.,  7.]
         )
         >>> g[0] == g[0, :, :, :] == g[0, ...]
         True
@@ -1025,15 +1025,17 @@ class RectGrid(Set):
         """Return ``repr(self)``."""
         if self.is_uniform:
             constructor = 'uniform_grid'
-            posargs = [list(self.min_pt), list(self.max_pt), self.shape]
-            inner_str = signature_string(posargs, [])
+            posargs = [self.min_pt, self.max_pt, self.shape]
+            posmod = [array_str, array_str, '']
+            inner_str = signature_string(posargs, [], mod=[posmod, ''])
             return '{}({})'.format(constructor, inner_str)
         else:
             constructor = self.__class__.__name__
-            posargs = [array1d_repr(v) for v in self.coord_vectors]
+            posargs = self.coord_vectors
+            posmod = array_str
             inner_str = signature_string(posargs, [], sep=[',\n', ', ', ', '],
-                                         mod=['!s', ''])
-            return '{}(\n{}\n)'.format(constructor, indent_rows(inner_str))
+                                         mod=[posmod, ''])
+            return '{}(\n{}\n)'.format(constructor, indent(inner_str))
 
     __str__ = __repr__
 

--- a/odl/discr/grid.py
+++ b/odl/discr/grid.py
@@ -21,7 +21,7 @@ import numpy as np
 from odl.set import Set, IntervalProd
 from odl.util import (
     normalized_index_expression, normalized_scalar_param_list, safe_int_conv,
-    array_str, signature_string, indent)
+    array_str, signature_string, indent, npy_printoptions)
 
 
 __all__ = ('RectGrid', 'uniform_grid', 'uniform_grid_fromintv')
@@ -1027,7 +1027,8 @@ class RectGrid(Set):
             constructor = 'uniform_grid'
             posargs = [self.min_pt, self.max_pt, self.shape]
             posmod = [array_str, array_str, '']
-            inner_str = signature_string(posargs, [], mod=[posmod, ''])
+            with npy_printoptions(precision=4):
+                inner_str = signature_string(posargs, [], mod=[posmod, ''])
             return '{}({})'.format(constructor, inner_str)
         else:
             constructor = self.__class__.__name__

--- a/odl/discr/partition.py
+++ b/odl/discr/partition.py
@@ -25,7 +25,7 @@ from odl.set import IntervalProd
 from odl.util import (
     normalized_index_expression, normalized_nodes_on_bdry,
     normalized_scalar_param_list, safe_int_conv,
-    signature_string, indent, array_str)
+    signature_string, indent, array_str, npy_printoptions)
 
 
 __all__ = ('RectPartition', 'uniform_partition_fromintv',
@@ -869,7 +869,8 @@ class RectPartition(object):
 
             optargs = [('nodes_on_bdry', self.nodes_on_bdry, False)]
 
-            sig_str = signature_string(posargs, optargs, mod=[posmod, ''])
+            with npy_printoptions(precision=4):
+                sig_str = signature_string(posargs, optargs, mod=[posmod, ''])
             return '{}({})'.format(constructor, sig_str)
         else:
             constructor = 'nonuniform_partition'
@@ -893,14 +894,16 @@ class RectPartition(object):
                 optmod.append('')
             else:
                 # Append min/max_pt to list of optional args if not
-                # default (need check here because array comparison is
+                # default (need check manually because array comparison is
                 # ambiguous)
                 if not np.allclose(self.min_pt, def_min_pt):
                     if self.ndim == 1:
                         optargs.append(('min_pt', self.min_pt[0], None))
                         optmod.append(':.4')
                     else:
-                        optargs.append(('min_pt', array_str(self.min_pt), ''))
+                        with npy_printoptions(precision=4):
+                            optargs.append(
+                                ('min_pt', array_str(self.min_pt), ''))
                         optmod.append('!s')
 
                 if not np.allclose(self.max_pt, def_max_pt):
@@ -908,7 +911,9 @@ class RectPartition(object):
                         optargs.append(('max_pt', self.max_pt[0], None))
                         optmod.append(':.4')
                     else:
-                        optargs.append(('max_pt', array_str(self.max_pt), ''))
+                        with npy_printoptions(precision=4):
+                            optargs.append(
+                                ('max_pt', array_str(self.max_pt), ''))
                         optmod.append('!s')
 
             sig_str = signature_string(posargs, optargs, mod=[posmod, optmod],

--- a/odl/discr/partition.py
+++ b/odl/discr/partition.py
@@ -25,7 +25,7 @@ from odl.set import IntervalProd
 from odl.util import (
     normalized_index_expression, normalized_nodes_on_bdry,
     normalized_scalar_param_list, safe_int_conv,
-    signature_string, indent_rows)
+    signature_string, indent, array_str)
 
 
 __all__ = ('RectPartition', 'uniform_partition_fromintv',
@@ -499,7 +499,7 @@ class RectPartition(object):
         >>> partition = odl.uniform_partition(0, 10, 10)
         >>> partition[::2]
         nonuniform_partition(
-            [0.5, 2.5, 4.5, 6.5, 8.5],
+            [ 0.5,  2.5,  4.5,  6.5,  8.5],
             min_pt=0.0, max_pt=10.0
         )
 
@@ -510,11 +510,11 @@ class RectPartition(object):
         >>> part = odl.RectPartition(intvp, grid)
         >>> part
         nonuniform_partition(
-            [-1.0, 0.0, 3.0],
-            [2.0, 4.0],
-            [5.0],
-            [2.0, 4.0, 7.0],
-            min_pt=[-1.0, 1.0, 4.0, 2.0], max_pt=[3.0, 6.0, 5.0, 7.0]
+            [-1.,  0.,  3.],
+            [ 2.,  4.],
+            [ 5.],
+            [ 2.,  4.,  7.],
+            min_pt=[-1.,  1.,  4.,  2.], max_pt=[ 3.,  6.,  5.,  7.]
         )
 
         Take an advanced slice (every second along the first axis,
@@ -522,22 +522,22 @@ class RectPartition(object):
 
         >>> part[::2, ..., -1]
         nonuniform_partition(
-            [-1.0, 3.0],
-            [2.0, 4.0],
-            [5.0],
-            [7.0],
-            min_pt=[-1.0, 1.0, 4.0, 5.5], max_pt=[3.0, 6.0, 5.0, 7.0]
+            [-1.,  3.],
+            [ 2.,  4.],
+            [ 5.],
+            [ 7.],
+            min_pt=[-1. ,  1. ,  4. ,  5.5], max_pt=[ 3.,  6.,  5.,  7.]
         )
 
         Too few indices are filled up with an ellipsis from the right:
 
         >>> part[1]
         nonuniform_partition(
-            [0.0],
-            [2.0, 4.0],
-            [5.0],
-            [2.0, 4.0, 7.0],
-            min_pt=[-0.5, 1.0, 4.0, 2.0], max_pt=[1.5, 6.0, 5.0, 7.0]
+            [ 0.],
+            [ 2.,  4.],
+            [ 5.],
+            [ 2.,  4.,  7.],
+            min_pt=[-0.5,  1. ,  4. ,  2. ], max_pt=[ 1.5,  6. ,  5. ,  7. ]
         )
 
         Colons etc work as expected:
@@ -613,7 +613,7 @@ class RectPartition(object):
         >>> part1 = odl.uniform_partition([0, -1], [1, 2], (3, 3))
         >>> part2 = odl.uniform_partition(0, 1, 5)
         >>> part1.insert(1, part2)
-        uniform_partition([0.0, 0.0, -1.0], [1.0, 1.0, 2.0], (3, 5, 3))
+        uniform_partition([ 0.,  0., -1.], [ 1.,  1.,  2.], (3, 5, 3))
 
         See Also
         --------
@@ -645,9 +645,9 @@ class RectPartition(object):
         >>> part1 = odl.uniform_partition(-1, 2, 3)
         >>> part2 = odl.uniform_partition(0, 1, 5)
         >>> part1.append(part2)
-        uniform_partition([-1.0, 0.0], [2.0, 1.0], (3, 5))
+        uniform_partition([-1.,  0.], [ 2.,  1.], (3, 5))
         >>> part1.append(part2, part2)
-        uniform_partition([-1.0, 0.0, 0.0], [2.0, 1.0, 1.0], (3, 5, 5))
+        uniform_partition([-1.,  0.,  0.], [ 2.,  1.,  1.], (3, 5, 5))
 
         See Also
         --------
@@ -677,7 +677,7 @@ class RectPartition(object):
         The axis argument can be used to only squeeze some axes (if applicable)
 
         >>> p.squeeze(axis=0)
-        uniform_partition([0.0, -1.0], [1.0, 2.0], (3, 1))
+        uniform_partition([ 0., -1.], [ 1.,  2.], (3, 1))
 
         Notes
         -----
@@ -755,7 +755,7 @@ class RectPartition(object):
         >>> p.index([0.5, 2])
         (2, 0)
         >>> p[p.index([0.5, 2])]
-        uniform_partition([0.5, -1.0], [0.75, 2.0], (1, 1))
+        uniform_partition([ 0.5, -1. ], [ 0.75,  2.  ], (1, 1))
         """
         value = np.atleast_1d(self.set.element(value))
         result = []
@@ -804,9 +804,9 @@ class RectPartition(object):
         >>> p.byaxis[:] == p
         True
         >>> p.byaxis[1:]
-        uniform_partition([1.0, 2.0], [3.0, 5.0], (5, 6))
+        uniform_partition([ 1.,  2.], [ 3.,  5.], (5, 6))
         >>> p.byaxis[[0, 2]]
-        uniform_partition([0.0, 2.0], [1.0, 5.0], (3, 6))
+        uniform_partition([ 0.,  2.], [ 1.,  5.], (3, 6))
         """
         partition = self
 
@@ -862,16 +862,19 @@ class RectPartition(object):
             constructor = 'uniform_partition'
             if self.ndim == 1:
                 posargs = [self.min_pt[0], self.max_pt[0], self.shape[0]]
+                posmod = [':.4', ':.4', '']
             else:
-                posargs = [list(self.min_pt), list(self.max_pt), self.shape]
+                posargs = [self.min_pt, self.max_pt, self.shape]
+                posmod = [array_str, array_str, '']
 
             optargs = [('nodes_on_bdry', self.nodes_on_bdry, False)]
 
-            sig_str = signature_string(posargs, optargs)
+            sig_str = signature_string(posargs, optargs, mod=[posmod, ''])
             return '{}({})'.format(constructor, sig_str)
         else:
             constructor = 'nonuniform_partition'
-            posargs = [list(v) for v in self.coord_vectors]
+            posargs = self.coord_vectors
+            posmod = array_str
 
             optargs = []
             # Defaults with and without nodes_on_bdry option
@@ -882,24 +885,35 @@ class RectPartition(object):
 
             # Since min/max_pt and nodes_on_bdry are mutex, we need a
             # couple of cases here
+            optmod = []
             if (np.allclose(self.min_pt, nodes_def_min_pt) and
                     np.allclose(self.max_pt, nodes_def_max_pt)):
                 # Append nodes_on_bdry to list of optional args
                 optargs.append(('nodes_on_bdry', self.nodes_on_bdry, False))
+                optmod.append('')
             else:
                 # Append min/max_pt to list of optional args if not
                 # default (need check here because array comparison is
                 # ambiguous)
                 if not np.allclose(self.min_pt, def_min_pt):
-                    p = self.min_pt[0] if self.ndim == 1 else list(self.min_pt)
-                    optargs.append((('min_pt', p, None)))
-                if not np.allclose(self.max_pt, def_max_pt):
-                    p = self.max_pt[0] if self.ndim == 1 else list(self.max_pt)
-                    optargs.append((('max_pt', p, None)))
+                    if self.ndim == 1:
+                        optargs.append(('min_pt', self.min_pt[0], None))
+                        optmod.append(':.4')
+                    else:
+                        optargs.append(('min_pt', array_str(self.min_pt), ''))
+                        optmod.append('!s')
 
-            sig_str = signature_string(posargs, optargs,
+                if not np.allclose(self.max_pt, def_max_pt):
+                    if self.ndim == 1:
+                        optargs.append(('max_pt', self.max_pt[0], None))
+                        optmod.append(':.4')
+                    else:
+                        optargs.append(('max_pt', array_str(self.max_pt), ''))
+                        optmod.append('!s')
+
+            sig_str = signature_string(posargs, optargs, mod=[posmod, optmod],
                                        sep=[',\n', ', ', ',\n'])
-            return '{}(\n{}\n)'.format(constructor, indent_rows(sig_str))
+            return '{}(\n{}\n)'.format(constructor, indent(sig_str))
 
     def __str__(self):
         """Return ``str(self)``."""
@@ -1298,7 +1312,7 @@ def nonuniform_partition(*coord_vecs, **kwargs):
     >>> odl.nonuniform_partition([0, 1, 2, 3])
     uniform_partition(-0.5, 3.5, 4)
     >>> odl.nonuniform_partition([0, 1, 2, 3], [1, 2])
-    uniform_partition([-0.5, 0.5], [3.5, 2.5], (4, 2))
+    uniform_partition([-0.5,  0.5], [ 3.5,  2.5], (4, 2))
 
     If the points are not uniformly spaced, a nonuniform partition is
     created. Note that the containing interval is calculated by assuming
@@ -1306,7 +1320,7 @@ def nonuniform_partition(*coord_vecs, **kwargs):
 
     >>> odl.nonuniform_partition([0, 1, 3])
     nonuniform_partition(
-        [0.0, 1.0, 3.0]
+        [ 0.,  1.,  3.]
     )
 
     Higher dimensional partitions are created by specifying the gridpoints
@@ -1314,8 +1328,8 @@ def nonuniform_partition(*coord_vecs, **kwargs):
 
     >>> odl.nonuniform_partition([0, 1, 3], [1, 2])
     nonuniform_partition(
-        [0.0, 1.0, 3.0],
-        [1.0, 2.0]
+        [ 0.,  1.,  3.],
+        [ 1.,  2.]
     )
 
     Partitions with a single element are by default degenerate
@@ -1328,7 +1342,7 @@ def nonuniform_partition(*coord_vecs, **kwargs):
 
     >>> odl.nonuniform_partition([0, 1, 3], nodes_on_bdry=True)
     nonuniform_partition(
-        [0.0, 1.0, 3.0],
+        [ 0.,  1.,  3.],
         nodes_on_bdry=True
     )
 
@@ -1337,7 +1351,7 @@ def nonuniform_partition(*coord_vecs, **kwargs):
 
     >>> odl.nonuniform_partition([0, 1, 3], min_pt=-2, max_pt=3)
     nonuniform_partition(
-        [0.0, 1.0, 3.0],
+        [ 0.,  1.,  3.],
         min_pt=-2.0, max_pt=3.0
     )
     """

--- a/odl/operator/default_ops.py
+++ b/odl/operator/default_ops.py
@@ -50,11 +50,11 @@ class ScalingOperator(Operator):
         >>> out = r3.element()
         >>> op = ScalingOperator(r3, 2.0)
         >>> op(vec, out)  # In-place, Returns out
-        rn(3).element([2.0, 4.0, 6.0])
+        rn(3).element([ 2.,  4.,  6.])
         >>> out
-        rn(3).element([2.0, 4.0, 6.0])
+        rn(3).element([ 2.,  4.,  6.])
         >>> op(vec)  # Out-of-place
-        rn(3).element([2.0, 4.0, 6.0])
+        rn(3).element([ 2.,  4.,  6.])
         """
         if not isinstance(domain, (LinearSpace, Field)):
             raise TypeError('`space` {!r} not a `LinearSpace` or `Field` '
@@ -193,9 +193,9 @@ class LinCombOperator(Operator):
         >>> z = r3.element()
         >>> op = LinCombOperator(r3, 1.0, 1.0)
         >>> op(xy, out=z)  # Returns z
-        rn(3).element([2.0, 4.0, 6.0])
+        rn(3).element([ 2.,  4.,  6.])
         >>> z
-        rn(3).element([2.0, 4.0, 6.0])
+        rn(3).element([ 2.,  4.,  6.])
         """
         domain = ProductSpace(space, space)
         super(LinCombOperator, self).__init__(domain, space, linear=True)
@@ -254,19 +254,19 @@ class MultiplyOperator(Operator):
 
         >>> op = MultiplyOperator(x)
         >>> op(x)
-        rn(3).element([1.0, 4.0, 9.0])
+        rn(3).element([ 1.,  4.,  9.])
         >>> out = r3.element()
         >>> op(x, out)
-        rn(3).element([1.0, 4.0, 9.0])
+        rn(3).element([ 1.,  4.,  9.])
 
         Multiply by scalar:
 
         >>> op2 = MultiplyOperator(x, domain=r3.field)
         >>> op2(3)
-        rn(3).element([3.0, 6.0, 9.0])
+        rn(3).element([ 3.,  6.,  9.])
         >>> out = r3.element()
         >>> op2(3, out)
-        rn(3).element([3.0, 6.0, 9.0])
+        rn(3).element([ 3.,  6.,  9.])
         """
         if domain is None:
             domain = multiplicand.space
@@ -318,7 +318,7 @@ class MultiplyOperator(Operator):
         >>> op = MultiplyOperator(x)
         >>> out = r3.element()
         >>> op.adjoint(x)
-        rn(3).element([1.0, 4.0, 9.0])
+        rn(3).element([ 1.,  4.,  9.])
 
         Multiply scalars with a fixed vector:
 
@@ -330,7 +330,7 @@ class MultiplyOperator(Operator):
 
         >>> op2 = MultiplyOperator(3.0, domain=r3, range=r3)
         >>> op2.adjoint(x)
-        rn(3).element([3.0, 6.0, 9.0])
+        rn(3).element([ 3.,  6.,  9.])
         """
         if self.__domain_is_field:
             return InnerProductOperator(self.multiplicand)
@@ -375,7 +375,7 @@ class PowerOperator(Operator):
 
         >>> op = PowerOperator(odl.rn(3), exponent=2)
         >>> op([1, 2, 3])
-        rn(3).element([1.0, 4.0, 9.0])
+        rn(3).element([ 1.,  4.,  9.])
 
         or scalars
 
@@ -425,7 +425,7 @@ class PowerOperator(Operator):
         >>> op = PowerOperator(odl.rn(3), exponent=2)
         >>> dop = op.derivative(op.domain.element([1, 2, 3]))
         >>> dop([1, 1, 1])
-        rn(3).element([2.0, 4.0, 6.0])
+        rn(3).element([ 2.,  4.,  6.])
 
         Use with scalars:
 
@@ -505,7 +505,7 @@ class InnerProductOperator(Operator):
         >>> x = r3.element([1, 2, 3])
         >>> op = InnerProductOperator(x)
         >>> op.adjoint(2.0)
-        rn(3).element([2.0, 4.0, 6.0])
+        rn(3).element([ 2.,  4.,  6.])
         """
         return MultiplyOperator(self.vector, self.vector.space.field)
 
@@ -523,9 +523,9 @@ class InnerProductOperator(Operator):
         >>> r3 = odl.rn(3)
         >>> x = r3.element([1, 2, 3])
         >>> x.T
-        InnerProductOperator(rn(3).element([1.0, 2.0, 3.0]))
+        InnerProductOperator(rn(3).element([ 1.,  2.,  3.]))
         >>> x.T.T
-        rn(3).element([1.0, 2.0, 3.0])
+        rn(3).element([ 1.,  2.,  3.])
         """
         return self.vector
 
@@ -755,7 +755,7 @@ class ConstantOperator(Operator):
         >>> x = r3.element([1, 2, 3])
         >>> op = ConstantOperator(x)
         >>> op(x, out=r3.element())
-        rn(3).element([1.0, 2.0, 3.0])
+        rn(3).element([ 1.,  2.,  3.])
         """
 
         if ((domain is None or range is None) and
@@ -806,7 +806,7 @@ class ConstantOperator(Operator):
         >>> op = ConstantOperator(x)
         >>> deriv = op.derivative([1, 1, 1])
         >>> deriv([2, 2, 2])
-        rn(3).element([0.0, 0.0, 0.0])
+        rn(3).element([ 0.,  0.,  0.])
         """
         return ZeroOperator(domain=self.domain, range=self.range)
 
@@ -840,13 +840,13 @@ class ZeroOperator(Operator):
         --------
         >>> op = odl.ZeroOperator(odl.rn(3))
         >>> op([1, 2, 3])
-        rn(3).element([0.0, 0.0, 0.0])
+        rn(3).element([ 0.,  0.,  0.])
 
         Also works with domain != range:
 
         >>> op = odl.ZeroOperator(odl.rn(3), odl.cn(4))
         >>> op([1, 2, 3])
-        cn(4).element([0j, 0j, 0j, 0j])
+        cn(4).element([ 0.+0.j,  0.+0.j,  0.+0.j,  0.+0.j])
         """
         if range is None:
             range = domain
@@ -906,14 +906,14 @@ class RealPart(Operator):
         >>> c3 = odl.cn(3)
         >>> op = RealPart(c3)
         >>> op([1 + 2j, 2, 3 - 1j])
-        rn(3).element([1.0, 2.0, 3.0])
+        rn(3).element([ 1.,  2.,  3.])
 
         The operator is the identity on real spaces:
 
         >>> r3 = odl.rn(3)
         >>> op = RealPart(r3)
         >>> op([1, 2, 3])
-        rn(3).element([1.0, 2.0, 3.0])
+        rn(3).element([ 1.,  2.,  3.])
 
         The operator also works on other `FnBase` spaces such as
         `DiscreteLp` spaces:
@@ -921,7 +921,7 @@ class RealPart(Operator):
         >>> r3 = odl.uniform_discr(0, 1, 3, dtype=complex)
         >>> op = RealPart(r3)
         >>> op([1, 2, 3])
-        uniform_discr(0.0, 1.0, 3).element([1.0, 2.0, 3.0])
+        uniform_discr(0.0, 1.0, 3).element([ 1.,  2.,  3.])
         """
         real_space = space.real_space
         linear = (space == real_space)
@@ -942,7 +942,7 @@ class RealPart(Operator):
         >>> r3 = odl.rn(3)
         >>> op = RealPart(r3)
         >>> op.inverse(op([1, 2, 3]))
-        rn(3).element([1.0, 2.0, 3.0])
+        rn(3).element([ 1.,  2.,  3.])
 
         This is not a true inverse, only a pseudoinverse, the complex part
         will by necessity be lost.
@@ -950,7 +950,7 @@ class RealPart(Operator):
         >>> c3 = odl.cn(3)
         >>> op = RealPart(c3)
         >>> op.inverse(op([1 + 2j, 2, 3 - 1j]))
-        cn(3).element([(1+0j), (2+0j), (3+0j)])
+        cn(3).element([ 1.+0.j,  2.+0.j,  3.+0.j])
         """
         if self.is_linear:
             return self
@@ -1022,14 +1022,14 @@ class ImagPart(Operator):
         >>> c3 = odl.cn(3)
         >>> op = ImagPart(c3)
         >>> op([1 + 2j, 2, 3 - 1j])
-        rn(3).element([2.0, 0.0, -1.0])
+        rn(3).element([ 2.,  0., -1.])
 
         The operator is the zero operator on real spaces:
 
         >>> r3 = odl.rn(3)
         >>> op = ImagPart(r3)
         >>> op([1, 2, 3])
-        rn(3).element([0.0, 0.0, 0.0])
+        rn(3).element([ 0.,  0.,  0.])
         """
         real_space = space.real_space
         linear = (space == real_space)
@@ -1050,7 +1050,7 @@ class ImagPart(Operator):
         >>> r3 = odl.rn(3)
         >>> op = ImagPart(r3)
         >>> op.inverse(op([1, 2, 3]))
-        rn(3).element([0.0, 0.0, 0.0])
+        rn(3).element([ 0.,  0.,  0.])
 
         This is not a true inverse, only a pseudoinverse, the real part
         will by necessity be lost.
@@ -1058,7 +1058,7 @@ class ImagPart(Operator):
         >>> c3 = odl.cn(3)
         >>> op = ImagPart(c3)
         >>> op.inverse(op([1 + 2j, 2, 3 - 1j]))
-        cn(3).element([2j, 0j, (-0-1j)])
+        cn(3).element([ 0.+2.j,  0.+0.j, -0.-1.j])
         """
         if self.is_linear:
             return ZeroOperator(self.domain)
@@ -1133,13 +1133,13 @@ class ComplexEmbedding(Operator):
         >>> r3 = odl.rn(3)
         >>> op = ComplexEmbedding(r3)
         >>> op([1, 2, 3])
-        cn(3).element([(1+0j), (2+0j), (3+0j)])
+        cn(3).element([ 1.+0.j,  2.+0.j,  3.+0.j])
 
         Embed real vector as imaginary part into complex space:
 
         >>> op = ComplexEmbedding(r3, scalar=1j)
         >>> op([1, 2, 3])
-        cn(3).element([1j, 2j, 3j])
+        cn(3).element([ 0.+1.j,  0.+2.j,  0.+3.j])
 
         On complex spaces the operator is the same as simple multiplication by
         scalar:
@@ -1147,7 +1147,7 @@ class ComplexEmbedding(Operator):
         >>> c3 = odl.cn(3)
         >>> op = ComplexEmbedding(c3, scalar=1 + 2j)
         >>> op([1 + 1j, 2 + 2j, 3 + 3j])
-        cn(3).element([(-1+3j), (-2+6j), (-3+9j)])
+        cn(3).element([-1.+3.j, -2.+6.j, -3.+9.j])
         """
         complex_space = space.complex_space
         self.scalar = complex_space.field.element(scalar)
@@ -1176,7 +1176,7 @@ class ComplexEmbedding(Operator):
         >>> r3 = odl.rn(3)
         >>> op = ComplexEmbedding(r3, scalar=1)
         >>> op.inverse(op([1, 2, 4]))
-        rn(3).element([1.0, 2.0, 4.0])
+        rn(3).element([ 1.,  2.,  4.])
         """
         if self.domain.is_rn:
             # Real domain
@@ -1271,14 +1271,14 @@ class ComplexModulus(Operator):
         >>> c2 = odl.cn(2)
         >>> op = odl.ComplexModulus(c2)
         >>> op([3 + 4j, 2])
-        rn(2).element([5.0, 2.0])
+        rn(2).element([ 5.,  2.])
 
         The operator is the absolute value on real spaces:
 
         >>> r2 = odl.rn(2)
         >>> op = odl.ComplexModulus(r2)
         >>> op([1, -2])
-        rn(2).element([1.0, 2.0])
+        rn(2).element([ 1.,  2.])
 
         The operator also works on other `FnBase` spaces such as
         `DiscreteLp` spaces:
@@ -1286,7 +1286,7 @@ class ComplexModulus(Operator):
         >>> r2 = odl.uniform_discr(0, 1, 2, dtype=complex)
         >>> op = odl.ComplexModulus(r2)
         >>> op([3 + 4j, 2])
-        uniform_discr(0.0, 1.0, 2).element([5.0, 2.0])
+        uniform_discr(0.0, 1.0, 2).element([ 5.,  2.])
         """
         real_space = space.real_space
         linear = (space == real_space)
@@ -1307,7 +1307,7 @@ class ComplexModulus(Operator):
         >>> r2 = odl.rn(2)
         >>> op = ComplexModulus(r2)
         >>> op.inverse(op([1, -2]))
-        rn(2).element([1.0, 2.0])
+        rn(2).element([ 1.,  2.])
 
         If the domain is complex, a pseudo-inverse is taken, assigning equal
         positive weights to the real and complex parts:
@@ -1315,7 +1315,7 @@ class ComplexModulus(Operator):
         >>> c2 = odl.cn(2)
         >>> op = ComplexModulus(c2)
         >>> op.inverse(op([np.sqrt(2), 2 + 2j]))
-        cn(2).element([(1+1j), (2+2j)])
+        cn(2).element([ 1.+1.j,  2.+2.j])
         """
         if self.is_linear:
             return IdentityOperator(self.domain)

--- a/odl/operator/fn_ops.py
+++ b/odl/operator/fn_ops.py
@@ -62,10 +62,10 @@ class SamplingOperator(Operator):
         >>> sampling_points = [[0, 1], [1, 1]]
         >>> A = odl.SamplingOperator(X, sampling_points, 'point_eval')
         >>> A(x)
-        rn(2).element([1.0, 3.0])
+        rn(2).element([ 1.,  3.])
         >>> A = odl.SamplingOperator(X, sampling_points, 'integrate')
         >>> A(x)
-        rn(2).element([0.25, 0.75])
+        rn(2).element([ 0.25,  0.75])
         """
         if not isinstance(domain, (FnBase, DiscreteLp)):
             raise TypeError('`domain` {!r} not a `FnBase` or `DiscreteLp` '
@@ -194,12 +194,16 @@ class WeightedSumSamplingOperator(Operator):
         >>> A = odl.WeightedSumSamplingOperator(X, sampling_points, 'dirac')
         >>> x = A.domain.one()
         >>> A(x)
-        uniform_discr([0.0, 0.0], [1.0, 1.0], (2, 2)).element([[0.0, 4.0],
-        [0.0, 4.0]])
+        uniform_discr([ 0.,  0.], [ 1.,  1.], (2, 2)).element(
+            [[ 0.,  4.],
+             [ 0.,  4.]]
+        )
         >>> A = odl.WeightedSumSamplingOperator(X, sampling_points, 'char_fun')
         >>> A(x)
-        uniform_discr([0.0, 0.0], [1.0, 1.0], (2, 2)).element([[0.0, 1.0],
-        [0.0, 1.0]])
+        uniform_discr([ 0.,  0.], [ 1.,  1.], (2, 2)).element(
+            [[ 0.,  1.],
+             [ 0.,  1.]]
+        )
         """
 
         self.__sampling_points = np.asarray(sampling_points, dtype=int)
@@ -322,7 +326,7 @@ class FlatteningOperator(Operator):
         >>> x = X.element(range(X.size))
         >>> A = odl.FlatteningOperator(X)
         >>> A(x)
-        rn(6).element([0.0, 1.0, 2.0, 3.0, 4.0, 5.0])
+        rn(6).element([ 0.,  1.,  2.,  3.,  4.,  5.])
         """
         if not isinstance(domain, (LinearSpace, Field)):
             raise TypeError('`domain` {!r} not a `LinearSpace` or `Field` '
@@ -410,7 +414,9 @@ class FlatteningOperatorAdjoint(Operator):
         >>> A = odl.FlatteningOperatorAdjoint(X)
         >>> x = A.domain.element(range(A.domain.size))
         >>> A(x)
-        uniform_discr([-1.0, -1.0], [1.0, 1.0], (1, 2)).element([[0.0, 1.0]])
+        uniform_discr([-1., -1.], [ 1.,  1.], (1, 2)).element(
+            [[ 0.,  1.]]
+        )
         """
         if not isinstance(range, (LinearSpace, Field)):
             raise TypeError('`range` {!r} not a `LinearSpace` or `Field` '

--- a/odl/operator/operator.py
+++ b/odl/operator/operator.py
@@ -651,15 +651,15 @@ class Operator(object):
         Out-of-place evaluation:
 
         >>> op(x)
-        rn(3).element([2.0, 4.0, 6.0])
+        rn(3).element([ 2.,  4.,  6.])
 
         In-place evaluation:
 
         >>> y = rn.element()
         >>> op(x, out=y)
-        rn(3).element([2.0, 4.0, 6.0])
+        rn(3).element([ 2.,  4.,  6.])
         >>> y
-        rn(3).element([2.0, 4.0, 6.0])
+        rn(3).element([ 2.,  4.,  6.])
 
         See Also
         --------
@@ -848,10 +848,10 @@ class Operator(object):
         >>> op = odl.IdentityOperator(rn)
         >>> x = rn.element([1, 2, 3])
         >>> op(x)
-        rn(3).element([1.0, 2.0, 3.0])
+        rn(3).element([ 1.,  2.,  3.])
         >>> Scaled = op * 3
         >>> Scaled(x)
-        rn(3).element([3.0, 6.0, 9.0])
+        rn(3).element([ 3.,  6.,  9.])
         """
         if isinstance(other, Operator):
             return OperatorComp(self, other)
@@ -930,10 +930,10 @@ class Operator(object):
         >>> op = odl.IdentityOperator(rn)
         >>> x = rn.element([1, 2, 3])
         >>> op(x)
-        rn(3).element([1.0, 2.0, 3.0])
+        rn(3).element([ 1.,  2.,  3.])
         >>> Scaled = 3 * op
         >>> Scaled(x)
-        rn(3).element([3.0, 6.0, 9.0])
+        rn(3).element([ 3.,  6.,  9.])
         """
         if isinstance(other, Operator):
             return OperatorComp(other, self)
@@ -981,13 +981,13 @@ class Operator(object):
         >>> op = odl.ScalingOperator(rn, 3)
         >>> x = rn.element([1, 2, 3])
         >>> op(x)
-        rn(3).element([3.0, 6.0, 9.0])
+        rn(3).element([ 3.,  6.,  9.])
         >>> squared = op**2
         >>> squared(x)
-        rn(3).element([9.0, 18.0, 27.0])
+        rn(3).element([  9.,  18.,  27.])
         >>> squared = op**3
         >>> squared(x)
-        rn(3).element([27.0, 54.0, 81.0])
+        rn(3).element([ 27.,  54.,  81.])
         """
         if isinstance(n, Integral) and n > 0:
             op = self
@@ -1023,10 +1023,10 @@ class Operator(object):
         >>> op = odl.IdentityOperator(rn)
         >>> x = rn.element([3, 6, 9])
         >>> op(x)
-        rn(3).element([3.0, 6.0, 9.0])
+        rn(3).element([ 3.,  6.,  9.])
         >>> Scaled = op / 3.0
         >>> Scaled(x)
-        rn(3).element([1.0, 2.0, 3.0])
+        rn(3).element([ 1.,  2.,  3.])
         """
         if isinstance(other, Number):
             return self * (1.0 / other)
@@ -1107,11 +1107,11 @@ class OperatorSum(Operator):
         >>> x = r3.element([1, 2, 3])
         >>> out = r3.element()
         >>> OperatorSum(op, op)(x, out)  # In-place, returns out
-        rn(3).element([2.0, 4.0, 6.0])
+        rn(3).element([ 2.,  4.,  6.])
         >>> out
-        rn(3).element([2.0, 4.0, 6.0])
+        rn(3).element([ 2.,  4.,  6.])
         >>> OperatorSum(op, op)(x)
-        rn(3).element([2.0, 4.0, 6.0])
+        rn(3).element([ 2.,  4.,  6.])
         """
         if left.range != right.range:
             raise OpTypeError('operator ranges {!r} and {!r} do not match'
@@ -1239,7 +1239,7 @@ class OperatorVectorSum(Operator):
         >>> sum_op = odl.OperatorVectorSum(ident_op, y)
         >>> x = r3.element([4, 5, 6])
         >>> sum_op(x)
-        rn(3).element([5.0, 7.0, 9.0])
+        rn(3).element([ 5.,  7.,  9.])
         """
         if not isinstance(operator, Operator):
             raise TypeError('`op` {!r} not a Operator instance'
@@ -1293,7 +1293,7 @@ class OperatorVectorSum(Operator):
         >>> sum = odl.OperatorVectorSum(op, r3.element([1, 2, 3]))
         >>> x = r3.element([4, 5, 6])
         >>> sum.derivative(x)(x)
-        rn(3).element([4.0, 5.0, 6.0])
+        rn(3).element([ 4.,  5.,  6.])
         """
         return self.operator.derivative(point)
 
@@ -1545,7 +1545,7 @@ class OperatorLeftScalarMult(Operator):
         >>> operator = odl.IdentityOperator(space)
         >>> left_mul_op = OperatorLeftScalarMult(operator, 3)
         >>> left_mul_op([1, 2, 3])
-        rn(3).element([3.0, 6.0, 9.0])
+        rn(3).element([ 3.,  6.,  9.])
         """
         if not isinstance(operator.range, (LinearSpace, Field)):
             raise OpTypeError('range {!r} not a `LinearSpace` or `Field` '
@@ -1603,7 +1603,7 @@ class OperatorLeftScalarMult(Operator):
         >>> operator = odl.IdentityOperator(space)
         >>> left_mul_op = OperatorLeftScalarMult(operator, 3)
         >>> left_mul_op.inverse([3, 3, 3])
-        rn(3).element([1.0, 1.0, 1.0])
+        rn(3).element([ 1.,  1.,  1.])
         """
         if self.scalar == 0.0:
             raise ZeroDivisionError('{} not invertible'.format(self))
@@ -1634,7 +1634,7 @@ class OperatorLeftScalarMult(Operator):
         >>> left_mul_op = OperatorLeftScalarMult(operator, 3)
         >>> derivative = left_mul_op.derivative([0, 0, 0])
         >>> derivative([1, 1, 1])
-        rn(3).element([3.0, 3.0, 3.0])
+        rn(3).element([ 3.,  3.,  3.])
         """
         if self.is_linear:
             return self
@@ -1662,7 +1662,7 @@ class OperatorLeftScalarMult(Operator):
         >>> operator = odl.IdentityOperator(space)
         >>> left_mul_op = OperatorLeftScalarMult(operator, 3)
         >>> left_mul_op.adjoint([1, 2, 3])
-        rn(3).element([3.0, 6.0, 9.0])
+        rn(3).element([ 3.,  6.,  9.])
         """
 
         if not self.is_linear:
@@ -1711,7 +1711,7 @@ class OperatorRightScalarMult(Operator):
         >>> operator = odl.IdentityOperator(space)
         >>> left_mul_op = OperatorRightScalarMult(operator, 3)
         >>> left_mul_op([1, 2, 3])
-        rn(3).element([3.0, 6.0, 9.0])
+        rn(3).element([ 3.,  6.,  9.])
         """
         if not isinstance(operator.domain, (LinearSpace, Field)):
             raise OpTypeError('domain {!r} not a `LinearSpace` or `Field` '
@@ -1790,7 +1790,7 @@ class OperatorRightScalarMult(Operator):
         >>> operator = odl.IdentityOperator(space)
         >>> left_mul_op = OperatorRightScalarMult(operator, 3)
         >>> left_mul_op.inverse([3, 3, 3])
-        rn(3).element([1.0, 1.0, 1.0])
+        rn(3).element([ 1.,  1.,  1.])
         """
         if self.scalar == 0.0:
             raise ZeroDivisionError('{} not invertible'.format(self))
@@ -1818,7 +1818,7 @@ class OperatorRightScalarMult(Operator):
         >>> left_mul_op = OperatorRightScalarMult(operator, 3)
         >>> derivative = left_mul_op.derivative([0, 0, 0])
         >>> derivative([1, 1, 1])
-        rn(3).element([3.0, 3.0, 3.0])
+        rn(3).element([ 3.,  3.,  3.])
         """
         return self.scalar * self.operator.derivative(self.scalar * x)
 
@@ -1843,7 +1843,7 @@ class OperatorRightScalarMult(Operator):
         >>> operator = odl.IdentityOperator(space)
         >>> left_mul_op = OperatorRightScalarMult(operator, 3)
         >>> left_mul_op.adjoint([1, 2, 3])
-        rn(3).element([3.0, 6.0, 9.0])
+        rn(3).element([ 3.,  6.,  9.])
         """
 
         if not self.is_linear:
@@ -1894,7 +1894,7 @@ class FunctionalLeftVectorMult(Operator):
         >>> functional = odl.InnerProductOperator(y)
         >>> left_mul_op = FunctionalLeftVectorMult(functional, y)
         >>> left_mul_op([1, 2, 3])
-        rn(3).element([14.0, 28.0, 42.0])
+        rn(3).element([ 14.,  28.,  42.])
         """
         if not isinstance(vector, LinearSpaceElement):
             raise TypeError('`vector` {!r} not is not a LinearSpaceElement'

--- a/odl/operator/pspace_ops.py
+++ b/odl/operator/pspace_ops.py
@@ -118,7 +118,7 @@ class ProductSpaceOperator(Operator):
         >>> prod_op = ProductSpaceOperator([I, I])
         >>> prod_op(x)
         ProductSpace(rn(3), 1).element([
-            [5.0, 7.0, 9.0]
+            [ 5.,  7.,  9.]
         ])
 
         Diagonal operator -- 0 or ``None`` means ignore, or the implicit
@@ -127,8 +127,8 @@ class ProductSpaceOperator(Operator):
         >>> prod_op = ProductSpaceOperator([[I, 0], [0, I]])
         >>> prod_op(x)
         ProductSpace(rn(3), 2).element([
-            [1.0, 2.0, 3.0],
-            [4.0, 5.0, 6.0]
+            [ 1.,  2.,  3.],
+            [ 4.,  5.,  6.]
         ])
 
         Complicated combinations:
@@ -136,8 +136,8 @@ class ProductSpaceOperator(Operator):
         >>> prod_op = ProductSpaceOperator([[I, I], [I, 0]])
         >>> prod_op(x)
         ProductSpace(rn(3), 2).element([
-            [5.0, 7.0, 9.0],
-            [1.0, 2.0, 3.0]
+            [ 5.,  7.,  9.],
+            [ 1.,  2.,  3.]
         ])
         """
         # Lazy import to improve `import odl` time
@@ -266,13 +266,13 @@ class ProductSpaceOperator(Operator):
         ...                                domain=X, range=X)
         >>> prod_op(x)
         ProductSpace(rn(3), 2).element([
-            [4.0, 5.0, 6.0],
-            [0.0, 0.0, 0.0]
+            [ 4.,  5.,  6.],
+            [ 0.,  0.,  0.]
         ])
         >>> prod_op.derivative(x)(x)
         ProductSpace(rn(3), 2).element([
-            [4.0, 5.0, 6.0],
-            [0.0, 0.0, 0.0]
+            [ 4.,  5.,  6.],
+            [ 0.,  0.,  0.]
         ])
 
         Example with affine operator
@@ -285,16 +285,16 @@ class ProductSpaceOperator(Operator):
 
         >>> op(x)
         ProductSpace(rn(3), 2).element([
-            [3.0, 4.0, 5.0],
-            [0.0, 0.0, 0.0]
+            [ 3.,  4.,  5.],
+            [ 0.,  0.,  0.]
         ])
 
         Derivative of affine operator does not have this offset
 
         >>> op.derivative(x)(x)
         ProductSpace(rn(3), 2).element([
-            [4.0, 5.0, 6.0],
-            [0.0, 0.0, 0.0]
+            [ 4.,  5.,  6.],
+            [ 0.,  0.,  0.]
         ])
         """
         # Lazy import to improve `import odl` time
@@ -339,13 +339,13 @@ class ProductSpaceOperator(Operator):
         ...                                domain=X, range=X)
         >>> prod_op(x)
         ProductSpace(rn(3), 2).element([
-            [4.0, 5.0, 6.0],
-            [0.0, 0.0, 0.0]
+            [ 4.,  5.,  6.],
+            [ 0.,  0.,  0.]
         ])
         >>> prod_op.adjoint(x)
         ProductSpace(rn(3), 2).element([
-            [0.0, 0.0, 0.0],
-            [1.0, 2.0, 3.0]
+            [ 0.,  0.,  0.],
+            [ 1.,  2.,  3.]
         ])
         """
         # Lazy import to improve `import odl` time
@@ -489,15 +489,15 @@ class ComponentProjection(Operator):
         ...      [2.0, 3.0],
         ...      [4.0, 5.0, 6.0]]
         >>> proj(x)
-        rn(1).element([1.0])
+        rn(1).element([ 1.])
 
         Projection on sub-space:
 
         >>> proj = odl.ComponentProjection(X, [0, 2])
         >>> proj(x)
         ProductSpace(rn(1), rn(3)).element([
-            [1.0],
-            [4.0, 5.0, 6.0]
+            [ 1.],
+            [ 4.,  5.,  6.]
         ])
         """
         self.__index = index
@@ -579,9 +579,9 @@ class ComponentProjectionAdjoint(Operator):
         >>> proj_adj = odl.ComponentProjectionAdjoint(X, 0)
         >>> proj_adj(x[0])
         ProductSpace(rn(1), rn(2), rn(3)).element([
-            [1.0],
-            [0.0, 0.0],
-            [0.0, 0.0, 0.0]
+            [ 1.],
+            [ 0.,  0.],
+            [ 0.,  0.,  0.]
         ])
 
         Projection on a sub-space corresponding to indices 0 and 2:
@@ -589,9 +589,9 @@ class ComponentProjectionAdjoint(Operator):
         >>> proj_adj = odl.ComponentProjectionAdjoint(X, [0, 2])
         >>> proj_adj(x[[0, 2]])
         ProductSpace(rn(1), rn(2), rn(3)).element([
-            [1.0],
-            [0.0, 0.0],
-            [4.0, 5.0, 6.0]
+            [ 1.],
+            [ 0.,  0.],
+            [ 4.,  5.,  6.]
         ])
         """
         self.__index = index
@@ -678,8 +678,8 @@ class BroadcastOperator(Operator):
         >>> x = [1, 2, 3]
         >>> op(x)
         ProductSpace(rn(3), 2).element([
-            [1.0, 2.0, 3.0],
-            [2.0, 4.0, 6.0]
+            [ 1.,  2.,  3.],
+            [ 2.,  4.,  6.]
         ])
 
         Can also initialize by calling an operator repeatedly:
@@ -754,16 +754,16 @@ class BroadcastOperator(Operator):
         >>> x = [1, 2, 3]
         >>> op(x)
         ProductSpace(rn(3), 2).element([
-            [0.0, 1.0, 2.0],
-            [0.0, 2.0, 4.0]
+            [ 0.,  1.,  2.],
+            [ 0.,  2.,  4.]
         ])
 
         The derivative of this affine operator does not have an offset:
 
         >>> op.derivative(x)(x)
         ProductSpace(rn(3), 2).element([
-            [1.0, 2.0, 3.0],
-            [2.0, 4.0, 6.0]
+            [ 1.,  2.,  3.],
+            [ 2.,  4.,  6.]
         ])
         """
         return BroadcastOperator(*[op.derivative(x) for op in
@@ -782,7 +782,7 @@ class BroadcastOperator(Operator):
         >>> I = odl.IdentityOperator(odl.rn(3))
         >>> op = BroadcastOperator(I, 2 * I)
         >>> op.adjoint([[1, 2, 3], [2, 3, 4]])
-        rn(3).element([5.0, 8.0, 11.0])
+        rn(3).element([  5.,   8.,  11.])
         """
         return ReductionOperator(*[op.adjoint for op in self.operators])
 
@@ -843,9 +843,9 @@ class ReductionOperator(Operator):
         Evaluating in a point gives the sum of the evaluation results of
         the individual operators:
 
-        >>> op([[1.0, 2.0, 3.0],
-        ...     [4.0, 6.0, 8.0]])
-        rn(3).element([9.0, 14.0, 19.0])
+        >>> op([[1, 2, 3],
+        ...     [4, 6, 8]])
+        rn(3).element([  9.,  14.,  19.])
 
         An ``out`` argument can be given for in-place evaluation:
 
@@ -853,7 +853,7 @@ class ReductionOperator(Operator):
         >>> result = op([[1.0, 2.0, 3.0],
         ...              [4.0, 6.0, 8.0]], out=out)
         >>> out
-        rn(3).element([9.0, 14.0, 19.0])
+        rn(3).element([  9.,  14.,  19.])
         >>> result is out
         True
 
@@ -931,9 +931,9 @@ class ReductionOperator(Operator):
 
         >>> op = ReductionOperator(I, 2 * I)
         >>> op([x, y])
-        rn(3).element([9.0, 14.0, 19.0])
+        rn(3).element([  9.,  14.,  19.])
         >>> op.derivative([x, y])([x, y])
-        rn(3).element([9.0, 14.0, 19.0])
+        rn(3).element([  9.,  14.,  19.])
 
         Example with affine operator
 
@@ -943,12 +943,12 @@ class ReductionOperator(Operator):
         Calling operator gives offset by [3, 3, 3]
 
         >>> op([x, y])
-        rn(3).element([6.0, 11.0, 16.0])
+        rn(3).element([  6.,  11.,  16.])
 
         Derivative of affine operator does not have this offset
 
         >>> op.derivative([x, y])([x, y])
-        rn(3).element([9.0, 14.0, 19.0])
+        rn(3).element([  9.,  14.,  19.])
         """
         return ReductionOperator(*[op.derivative(xi)
                                    for op, xi in zip(self.operators, x)])
@@ -967,8 +967,8 @@ class ReductionOperator(Operator):
         >>> op = ReductionOperator(I, 2 * I)
         >>> op.adjoint([1, 2, 3])
         ProductSpace(rn(3), 2).element([
-            [1.0, 2.0, 3.0],
-            [2.0, 4.0, 6.0]
+            [ 1.,  2.,  3.],
+            [ 2.,  4.,  6.]
         ])
         """
         return BroadcastOperator(*[op.adjoint for op in self.operators])
@@ -1042,8 +1042,8 @@ class DiagonalOperator(ProductSpaceOperator):
         >>> op([[1, 2, 3],
         ...     [4, 5, 6]])
         ProductSpace(rn(3), 2).element([
-            [1.0, 2.0, 3.0],
-            [8.0, 10.0, 12.0]
+            [ 1.,  2.,  3.],
+            [  8.,  10.,  12.]
         ])
 
         Can also be created using a multiple of a single operator

--- a/odl/operator/tensor_ops.py
+++ b/odl/operator/tensor_ops.py
@@ -17,7 +17,7 @@ from odl.operator import Operator
 from odl.set import RealNumbers, ComplexNumbers
 from odl.space import ProductSpace, fn
 from odl.space.base_ntuples import FnBase
-from odl.util import writable_array, signature_string, indent_rows
+from odl.util import writable_array, signature_string, indent
 
 
 __all__ = ('PointwiseNorm', 'PointwiseInner', 'PointwiseSum', 'MatrixOperator')
@@ -136,7 +136,7 @@ class PointwiseNorm(PointwiseTensorFieldOperator):
 
         >>> spc = odl.uniform_discr([-1, -1], [1, 1], (1, 2))
         >>> vfspace = odl.ProductSpace(spc, 2)
-        >>> pw_norm = PointwiseNorm(vfspace)
+        >>> pw_norm = odl.PointwiseNorm(vfspace)
         >>> pw_norm.range == spc
         True
 
@@ -145,7 +145,7 @@ class PointwiseNorm(PointwiseTensorFieldOperator):
         >>> x = vfspace.element([[[1, -4]],
         ...                      [[0, 3]]])
         >>> print(pw_norm(x))
-        [[1.0, 5.0]]
+        [[ 1.,  5.]]
 
         We can change the exponent either in the vector field space
         or in the operator directly:
@@ -153,11 +153,11 @@ class PointwiseNorm(PointwiseTensorFieldOperator):
         >>> vfspace = odl.ProductSpace(spc, 2, exponent=1)
         >>> pw_norm = PointwiseNorm(vfspace)
         >>> print(pw_norm(x))
-        [[1.0, 7.0]]
+        [[ 1.,  7.]]
         >>> vfspace = odl.ProductSpace(spc, 2)
         >>> pw_norm = PointwiseNorm(vfspace, exponent=1)
         >>> print(pw_norm(x))
-        [[1.0, 7.0]]
+        [[ 1.,  7.]]
         """
         if not isinstance(vfspace, ProductSpace):
             raise TypeError('`vfspace` {!r} is not a ProductSpace '
@@ -491,7 +491,7 @@ class PointwiseInner(PointwiseInnerBase):
         >>> x = vfspace.element([[[1, -4]],
         ...                      [[0, 3]]])
         >>> print(pw_inner(x))
-        [[0.0, -7.0]]
+        [[ 0., -7.]]
         """
         super(PointwiseInner, self).__init__(
             adjoint=False, vfspace=vfspace, vecfield=vecfield,
@@ -678,7 +678,7 @@ class PointwiseSum(PointwiseInner):
         >>> x = vfspace.element([[[1, -4]],
         ...                      [[0, 3]]])
         >>> print(pw_sum(x))
-        [[1.0, -1.0]]
+        [[ 1., -1.]]
         """
         if not isinstance(vfspace, ProductSpace):
             raise TypeError('`vfspace` {!r} is not a ProductSpace '
@@ -736,7 +736,7 @@ class MatrixOperator(Operator):
         >>> op.range
         rn(3)
         >>> op([1, 2, 3, 4])
-        rn(3).element([10.0, 10.0, 10.0])
+        rn(3).element([ 10.,  10.,  10.])
 
         They can also be provided explicitly, for example with
         `uniform_discr` spaces:
@@ -745,7 +745,7 @@ class MatrixOperator(Operator):
         >>> ran = odl.uniform_discr(0, 1, 3)
         >>> op = MatrixOperator(matrix, domain=dom, range=ran)
         >>> op(dom.one())
-        uniform_discr(0.0, 1.0, 3).element([4.0, 4.0, 4.0])
+        uniform_discr(0.0, 1.0, 3).element([ 4., 4., 4.])
 
         For storage efficiency, SciPy sparse matrices can be used:
 
@@ -762,7 +762,7 @@ class MatrixOperator(Operator):
                [ 0.,  0.,  0.,  5.]])
         >>> op = MatrixOperator(matrix)
         >>> op(op.domain.one())
-        rn(4).element([13.0, 7.0, 0.0, 5.0])
+        rn(4).element([ 13.,   7.,   0.,   5.])
         """
         # Lazy import to improve `import odl` time
         import scipy.sparse
@@ -898,8 +898,7 @@ class MatrixOperator(Operator):
 
         inner_str = signature_string(posargs, optargs, sep=[', ', ', ', ',\n'],
                                      mod=[['!s'], ['!r', '!r']])
-        return '{}(\n{}\n)'.format(self.__class__.__name__,
-                                   indent_rows(inner_str))
+        return '{}(\n{}\n)'.format(self.__class__.__name__, indent(inner_str))
 
     def __str__(self):
         """Return ``str(self)``."""

--- a/odl/phantom/geometric.py
+++ b/odl/phantom/geometric.py
@@ -42,19 +42,21 @@ def cuboid(space, min_pt=None, max_pt=None):
     middle of the space domain and extends halfway towards all sides:
 
     >>> space = odl.uniform_discr([0, 0], [1, 1], [4, 6])
-    >>> print(odl.phantom.cuboid(space))
-    [[0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
-     [0.0, 1.0, 1.0, 1.0, 1.0, 0.0],
-     [0.0, 1.0, 1.0, 1.0, 1.0, 0.0],
-     [0.0, 0.0, 0.0, 0.0, 0.0, 0.0]]
+    >>> cuboid = odl.phantom.cuboid(space)
+    >>> print(odl.util.array_str(cuboid, nprint=10))
+    [[ 0.,  0.,  0.,  0.,  0.,  0.],
+     [ 0.,  1.,  1.,  1.,  1.,  0.],
+     [ 0.,  1.,  1.,  1.,  1.,  0.],
+     [ 0.,  0.,  0.,  0.,  0.,  0.]]
 
     By specifying the corners, the cuboid can be arbitrarily shaped:
 
-    >>> print(odl.phantom.cuboid(space, [0.25, 0], [0.75, 0.5]))
-    [[0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
-     [1.0, 1.0, 1.0, 0.0, 0.0, 0.0],
-     [1.0, 1.0, 1.0, 0.0, 0.0, 0.0],
-     [0.0, 0.0, 0.0, 0.0, 0.0, 0.0]]
+    >>> other_cuboid = odl.phantom.cuboid(space, [0.25, 0], [0.75, 0.5])
+    >>> print(odl.util.array_str(other_cuboid, nprint=10))
+    [[ 0.,  0.,  0.,  0.,  0.,  0.],
+     [ 1.,  1.,  1.,  0.,  0.,  0.],
+     [ 1.,  1.,  1.,  0.,  0.,  0.],
+     [ 0.,  0.,  0.,  0.,  0.,  0.]]
     """
     dom_min_pt = np.asarray(space.domain.min())
     dom_max_pt = np.asarray(space.domain.max())
@@ -197,49 +199,50 @@ def indicate_proj_axis(space, scale_structures=0.5):
     --------
     Phantom in 2D space:
 
-    >>> np.set_printoptions(edgeitems=4)  # make numpy print whole arrays
     >>> space = odl.uniform_discr([0, 0], [1, 1], shape=(8, 8))
     >>> phantom = indicate_proj_axis(space).asarray()
-    >>> print(phantom)
-    [[ 0.  0.  0.  0.  0.  0.  0.  0.]
-     [ 0.  0.  0.  1.  1.  0.  0.  0.]
-     [ 0.  0.  0.  1.  1.  0.  0.  0.]
-     [ 0.  0.  0.  0.  0.  0.  0.  0.]
-     [ 0.  0.  0.  0.  0.  0.  0.  0.]
-     [ 0.  0.  0.  0.  1.  0.  0.  0.]
-     [ 0.  0.  0.  1.  0.  0.  0.  0.]
-     [ 0.  0.  0.  0.  0.  0.  0.  0.]]
+    >>> print(odl.util.array_str(phantom, nprint=10))
+    [[ 0.,  0.,  0.,  0.,  0.,  0.,  0.,  0.],
+     [ 0.,  0.,  0.,  1.,  1.,  0.,  0.,  0.],
+     [ 0.,  0.,  0.,  1.,  1.,  0.,  0.,  0.],
+     [ 0.,  0.,  0.,  0.,  0.,  0.,  0.,  0.],
+     [ 0.,  0.,  0.,  0.,  0.,  0.,  0.,  0.],
+     [ 0.,  0.,  0.,  0.,  1.,  0.,  0.,  0.],
+     [ 0.,  0.,  0.,  1.,  0.,  0.,  0.,  0.],
+     [ 0.,  0.,  0.,  0.,  0.,  0.,  0.,  0.]]
 
-    >>> space = odl.uniform_discr([0, 0, 0], [1, 1, 1], shape=(8, 8, 8))
-    >>> phantom = indicate_proj_axis(space).asarray()
-    >>> np.set_printoptions(edgeitems=4)  # make numpy print whole arrays
-    >>> print(np.sum(phantom, 0))
-    [[ 0.  0.  0.  0.  0.  0.  0.  0.]
-     [ 0.  0.  0.  0.  0.  0.  0.  0.]
-     [ 0.  0.  0.  0.  0.  0.  0.  0.]
-     [ 0.  0.  0.  3.  3.  0.  0.  0.]
-     [ 0.  0.  0.  3.  3.  0.  0.  0.]
-     [ 0.  0.  0.  0.  0.  0.  0.  0.]
-     [ 0.  0.  0.  0.  0.  0.  0.  0.]
-     [ 0.  0.  0.  0.  0.  0.  0.  0.]]
-    >>> print(np.sum(phantom, 1))
-    [[ 0.  0.  0.  0.  0.  0.  0.  0.]
-     [ 0.  0.  0.  2.  2.  0.  0.  0.]
-     [ 0.  0.  0.  2.  2.  0.  0.  0.]
-     [ 0.  0.  0.  0.  0.  0.  0.  0.]
-     [ 0.  0.  0.  0.  0.  0.  0.  0.]
-     [ 0.  0.  0.  1.  1.  0.  0.  0.]
-     [ 0.  0.  0.  1.  1.  0.  0.  0.]
-     [ 0.  0.  0.  0.  0.  0.  0.  0.]]
-    >>> print(np.sum(phantom, 2))
-    [[ 0.  0.  0.  0.  0.  0.  0.  0.]
-     [ 0.  0.  0.  2.  2.  0.  0.  0.]
-     [ 0.  0.  0.  2.  2.  0.  0.  0.]
-     [ 0.  0.  0.  0.  0.  0.  0.  0.]
-     [ 0.  0.  0.  0.  0.  0.  0.  0.]
-     [ 0.  0.  0.  0.  2.  0.  0.  0.]
-     [ 0.  0.  0.  2.  0.  0.  0.  0.]
-     [ 0.  0.  0.  0.  0.  0.  0.  0.]]
+    >>> space = odl.uniform_discr([0] * 3, [1] * 3, [8, 8, 8])
+    >>> phantom = odl.phantom.indicate_proj_axis(space).asarray()
+    >>> axis_sum_0 = np.sum(phantom, axis=0)
+    >>> print(odl.util.array_str(axis_sum_0, nprint=10))
+    [[ 0.,  0.,  0.,  0.,  0.,  0.,  0.,  0.],
+     [ 0.,  0.,  0.,  0.,  0.,  0.,  0.,  0.],
+     [ 0.,  0.,  0.,  0.,  0.,  0.,  0.,  0.],
+     [ 0.,  0.,  0.,  3.,  3.,  0.,  0.,  0.],
+     [ 0.,  0.,  0.,  3.,  3.,  0.,  0.,  0.],
+     [ 0.,  0.,  0.,  0.,  0.,  0.,  0.,  0.],
+     [ 0.,  0.,  0.,  0.,  0.,  0.,  0.,  0.],
+     [ 0.,  0.,  0.,  0.,  0.,  0.,  0.,  0.]]
+    >>> axis_sum_1 = np.sum(phantom, axis=1)
+    >>> print(odl.util.array_str(axis_sum_1, nprint=10))
+    [[ 0.,  0.,  0.,  0.,  0.,  0.,  0.,  0.],
+     [ 0.,  0.,  0.,  2.,  2.,  0.,  0.,  0.],
+     [ 0.,  0.,  0.,  2.,  2.,  0.,  0.,  0.],
+     [ 0.,  0.,  0.,  0.,  0.,  0.,  0.,  0.],
+     [ 0.,  0.,  0.,  0.,  0.,  0.,  0.,  0.],
+     [ 0.,  0.,  0.,  1.,  1.,  0.,  0.,  0.],
+     [ 0.,  0.,  0.,  1.,  1.,  0.,  0.,  0.],
+     [ 0.,  0.,  0.,  0.,  0.,  0.,  0.,  0.]]
+    >>> axis_sum_2 = np.sum(phantom, axis=2)
+    >>> print(odl.util.array_str(axis_sum_2, nprint=10))
+    [[ 0.,  0.,  0.,  0.,  0.,  0.,  0.,  0.],
+     [ 0.,  0.,  0.,  2.,  2.,  0.,  0.,  0.],
+     [ 0.,  0.,  0.,  2.,  2.,  0.,  0.,  0.],
+     [ 0.,  0.,  0.,  0.,  0.,  0.,  0.,  0.],
+     [ 0.,  0.,  0.,  0.,  0.,  0.,  0.,  0.],
+     [ 0.,  0.,  0.,  0.,  2.,  0.,  0.,  0.],
+     [ 0.,  0.,  0.,  2.,  0.,  0.,  0.,  0.],
+     [ 0.,  0.,  0.,  0.,  0.,  0.,  0.,  0.]]
     """
     if not 0 < scale_structures <= 1:
         raise ValueError('`scale_structures` ({}) is not in (0, 1]'
@@ -590,11 +593,11 @@ def ellipsoid_phantom(space, ellipsoids):
     >>> ellipses = [[1.0, 1.0, 1.0, 0.0, 0.0, 0.0],
     ...             [1.0, 0.6, 0.6, 0.0, 0.0, 0.0]]
     >>> print(ellipsoid_phantom(space, ellipses))
-    [[0.0, 0.0, 1.0, 0.0, 0.0],
-     [0.0, 1.0, 2.0, 1.0, 0.0],
-     [1.0, 2.0, 2.0, 2.0, 1.0],
-     [0.0, 1.0, 2.0, 1.0, 0.0],
-     [0.0, 0.0, 1.0, 0.0, 0.0]]
+    [[ 0.,  0.,  1.,  0.,  0.],
+     [ 0.,  1.,  2.,  1.,  0.],
+     [ 1.,  2.,  2.,  2.,  1.],
+     [ 0.,  1.,  2.,  1.,  0.],
+     [ 0.,  0.,  1.,  0.,  0.]]
 
     See Also
     --------
@@ -808,6 +811,5 @@ if __name__ == '__main__':
     defrise(space).show('defrise 3D', coords=[0, None, None])
 
     # Run also the doctests
-    # pylint: disable=wrong-import-position
     from odl.util.testutils import run_doctests
     run_doctests()

--- a/odl/phantom/geometric.py
+++ b/odl/phantom/geometric.py
@@ -42,21 +42,24 @@ def cuboid(space, min_pt=None, max_pt=None):
     middle of the space domain and extends halfway towards all sides:
 
     >>> space = odl.uniform_discr([0, 0], [1, 1], [4, 6])
-    >>> cuboid = odl.phantom.cuboid(space)
-    >>> print(odl.util.array_str(cuboid, nprint=10))
-    [[ 0.,  0.,  0.,  0.,  0.,  0.],
-     [ 0.,  1.,  1.,  1.,  1.,  0.],
-     [ 0.,  1.,  1.,  1.,  1.,  0.],
-     [ 0.,  0.,  0.,  0.,  0.,  0.]]
+    >>> odl.phantom.cuboid(space)
+    uniform_discr([ 0.,  0.], [ 1.,  1.], (4, 6)).element(
+        [[ 0.,  0.,  0.,  0.,  0.,  0.],
+         [ 0.,  1.,  1.,  1.,  1.,  0.],
+         [ 0.,  1.,  1.,  1.,  1.,  0.],
+         [ 0.,  0.,  0.,  0.,  0.,  0.]]
+    )
 
-    By specifying the corners, the cuboid can be arbitrarily shaped:
+    By specifying the corners, the cuboid can be arbitrarily placed and
+    scaled:
 
-    >>> other_cuboid = odl.phantom.cuboid(space, [0.25, 0], [0.75, 0.5])
-    >>> print(odl.util.array_str(other_cuboid, nprint=10))
-    [[ 0.,  0.,  0.,  0.,  0.,  0.],
-     [ 1.,  1.,  1.,  0.,  0.,  0.],
-     [ 1.,  1.,  1.,  0.,  0.,  0.],
-     [ 0.,  0.,  0.,  0.,  0.,  0.]]
+    >>> odl.phantom.cuboid(space, [0.25, 0], [0.75, 0.5])
+    uniform_discr([ 0.,  0.], [ 1.,  1.], (4, 6)).element(
+        [[ 0.,  0.,  0.,  0.,  0.,  0.],
+         [ 1.,  1.,  1.,  0.,  0.,  0.],
+         [ 1.,  1.,  1.,  0.,  0.,  0.],
+         [ 0.,  0.,  0.,  0.,  0.,  0.]]
+    )
     """
     dom_min_pt = np.asarray(space.domain.min())
     dom_max_pt = np.asarray(space.domain.max())

--- a/odl/set/domain.py
+++ b/odl/set/domain.py
@@ -16,7 +16,7 @@ import numpy as np
 
 from odl.set.sets import Set
 from odl.util import (
-    array1d_repr, is_valid_input_array, is_valid_input_meshgrid, safe_int_conv)
+    array_str, is_valid_input_array, is_valid_input_meshgrid, safe_int_conv)
 
 
 __all__ = ('IntervalProd',)
@@ -44,10 +44,10 @@ class IntervalProd(Set):
 
         Examples
         --------
-        >>> min_pt, max_pt = [-1, 2.5, 70, 80], [-0.5, 10, 75, 90]
+        >>> min_pt, max_pt = [-1, 2.5, 70], [-0.5, 10, 75]
         >>> rbox = odl.IntervalProd(min_pt, max_pt)
         >>> rbox
-        IntervalProd([-1.0, 2.5, 70.0, 80.0], [-0.5, 10.0, 75.0, 90.0])
+        IntervalProd([ -1. ,   2.5,  70. ], [ -0.5,  10. ,  75. ])
         """
         super(IntervalProd, self).__init__()
         self.__min_pt = np.atleast_1d(min_pt).astype('float64')
@@ -519,9 +519,9 @@ class IntervalProd(Set):
         >>> min_pt, max_pt = [-1, 0, 2], [-0.5, 1, 3]
         >>> rbox = IntervalProd(min_pt, max_pt)
         >>> rbox.collapse(1, 0)
-        IntervalProd([-1.0, 0.0, 2.0], [-0.5, 0.0, 3.0])
+        IntervalProd([-1.,  0.,  2.], [-0.5,  0. ,  3. ])
         >>> rbox.collapse([1, 2], [0, 2.5])
-        IntervalProd([-1.0, 0.0, 2.5], [-0.5, 0.0, 2.5])
+        IntervalProd([-1. ,  0. ,  2.5], [-0.5,  0. ,  2.5])
         """
         indices = np.atleast_1d(indices).astype('int64', casting='safe')
         values = np.atleast_1d(values)
@@ -568,7 +568,7 @@ class IntervalProd(Set):
         >>> min_pt, max_pt = [-1, 0, 2], [-0.5, 1, 3]
         >>> rbox = IntervalProd(min_pt, max_pt)
         >>> rbox.collapse(1, 0).squeeze()
-        IntervalProd([-1.0, 2.0], [-0.5, 3.0])
+        IntervalProd([-1.,  2.], [-0.5,  3. ])
         >>> rbox.collapse([1, 2], [0, 2.5]).squeeze()
         IntervalProd(-1.0, -0.5)
         >>> rbox.collapse([0, 1, 2], [-1, 0, 2.5]).squeeze()
@@ -605,11 +605,11 @@ class IntervalProd(Set):
         >>> intv = IntervalProd([-1, 2], [-0.5, 3])
         >>> intv2 = IntervalProd(0, 1)
         >>> intv.insert(0, intv2)
-        IntervalProd([0.0, -1.0, 2.0], [1.0, -0.5, 3.0])
+        IntervalProd([ 0., -1.,  2.], [ 1. , -0.5,  3. ])
         >>> intv.insert(-1, intv2)
-        IntervalProd([-1.0, 0.0, 2.0], [-0.5, 1.0, 3.0])
+        IntervalProd([-1.,  0.,  2.], [-0.5,  1. ,  3. ])
         >>> intv.insert(1, intv2, intv2)
-        IntervalProd([-1.0, 0.0, 0.0, 2.0], [-0.5, 1.0, 1.0, 3.0])
+        IntervalProd([-1.,  0.,  0.,  2.], [-0.5,  1. ,  1. ,  3. ])
         """
         index, index_in = safe_int_conv(index), index
 
@@ -658,9 +658,9 @@ class IntervalProd(Set):
         >>> intv = IntervalProd([-1, 2], [-0.5, 3])
         >>> intv2 = IntervalProd(0, 1)
         >>> intv.append(intv2)
-        IntervalProd([-1.0, 2.0, 0.0], [-0.5, 3.0, 1.0])
+        IntervalProd([-1.,  2.,  0.], [-0.5,  3. ,  1. ])
         >>> intv.append(intv2, intv2)
-        IntervalProd([-1.0, 2.0, 0.0, 0.0], [-0.5, 3.0, 1.0, 1.0])
+        IntervalProd([-1.,  2.,  0.,  0.], [-0.5,  3. ,  1. ,  1. ])
 
         See Also
         --------
@@ -692,7 +692,8 @@ class IntervalProd(Set):
         array([[-1. ,  2. ,  0. ],
                [-1. ,  2. ,  0.5],
                [-1. ,  3. ,  0. ],
-               ...,
+               [-1. ,  3. ,  0.5],
+               [-0.5,  2. ,  0. ],
                [-0.5,  2. ,  0.5],
                [-0.5,  3. ,  0. ],
                [-0.5,  3. ,  0.5]])
@@ -700,7 +701,8 @@ class IntervalProd(Set):
         array([[-1. ,  2. ,  0. ],
                [-0.5,  2. ,  0. ],
                [-1. ,  3. ,  0. ],
-               ...,
+               [-0.5,  3. ,  0. ],
+               [-1. ,  2. ,  0.5],
                [-0.5,  2. ,  0.5],
                [-1. ,  3. ,  0.5],
                [-0.5,  3. ,  0.5]])
@@ -746,14 +748,14 @@ class IntervalProd(Set):
         With slices, multiple axes can be selected:
 
         >>> rbox[:]
-        IntervalProd([-1.0, 2.0, 0.0], [-0.5, 3.0, 0.5])
+        IntervalProd([-1.,  2.,  0.], [-0.5,  3. ,  0.5])
         >>> rbox[::2]
-        IntervalProd([-1.0, 0.0], [-0.5, 0.5])
+        IntervalProd([-1.,  0.], [-0.5,  0.5])
 
         A list of integers can be used for free combinations of axes:
 
         >>> rbox[[0, 1, 0]]
-        IntervalProd([-1.0, 2.0, -1.0], [-0.5, 3.0, -0.5])
+        IntervalProd([-1.,  2., -1.], [-0.5,  3. , -0.5])
         """
         return IntervalProd(self.min_pt[indices], self.max_pt[indices])
 
@@ -832,13 +834,12 @@ class IntervalProd(Set):
     def __repr__(self):
         """Return ``repr(self)``."""
         if self.ndim == 1:
-            return '{}({!r}, {!r})'.format(self.__class__.__name__,
-                                           self.min_pt[0],
-                                           self.max_pt[0])
+            return '{}({:.4}, {:.4})'.format(self.__class__.__name__,
+                                             self.min_pt[0], self.max_pt[0])
         else:
             return '{}({}, {})'.format(self.__class__.__name__,
-                                       array1d_repr(self.min_pt),
-                                       array1d_repr(self.max_pt))
+                                       array_str(self.min_pt),
+                                       array_str(self.max_pt))
 
     def __str__(self):
         """Return ``str(self)``."""

--- a/odl/set/sets.py
+++ b/odl/set/sets.py
@@ -15,7 +15,7 @@ from past.builtins import basestring
 
 from numbers import Integral, Real, Complex
 import numpy as np
-from odl.util import is_int_dtype, is_real_dtype, is_scalar_dtype, unique
+from odl.util import is_int_dtype, is_real_dtype, is_numeric_dtype, unique
 
 
 __all__ = ('Set', 'EmptySet', 'UniversalSet', 'Field', 'Integers',
@@ -347,7 +347,7 @@ class ComplexNumbers(Field):
         dtype = getattr(other, 'dtype', None)
         if dtype is None:
             dtype = np.result_type(*other)
-        return is_scalar_dtype(dtype)
+        return is_numeric_dtype(dtype)
 
     def __eq__(self, other):
         """Return ``self == other``."""

--- a/odl/solvers/functional/derivatives.py
+++ b/odl/solvers/functional/derivatives.py
@@ -55,7 +55,7 @@ class NumericalDerivative(Operator):
         >>> func = odl.solvers.L2NormSquared(space)
         >>> hess = NumericalDerivative(func.gradient, [1, 1, 1])
         >>> hess([0, 0, 1])
-        rn(3).element([0.0, 0.0, 2.0])
+        rn(3).element([ 0.,  0.,  2.])
 
         Find the Hessian matrix:
 
@@ -174,7 +174,7 @@ class NumericalGradient(Operator):
         >>> func = odl.solvers.L2NormSquared(space)
         >>> grad = NumericalGradient(func)
         >>> grad([1, 1, 1])
-        rn(3).element([2.0, 2.0, 2.0])
+        rn(3).element([ 2.,  2.,  2.])
 
         The gradient gives the correct value with sufficiently small step size:
 
@@ -185,13 +185,13 @@ class NumericalGradient(Operator):
 
         >>> grad = NumericalGradient(func, step=0.5)
         >>> grad([1, 1, 1])
-        rn(3).element([2.5, 2.5, 2.5])
+        rn(3).element([ 2.5,  2.5,  2.5])
 
         But it can be improved by using the more accurate ``method='central'``:
 
         >>> grad = NumericalGradient(func, method='central', step=0.5)
         >>> grad([1, 1, 1])
-        rn(3).element([2.0, 2.0, 2.0])
+        rn(3).element([ 2.,  2.,  2.])
 
         Notes
         -----
@@ -297,7 +297,7 @@ class NumericalGradient(Operator):
         >>> grad = NumericalGradient(func)
         >>> hess = grad.derivative([1, 1, 1])
         >>> hess([1, 0, 0])
-        rn(3).element([2.0, 0.0, 0.0])
+        rn(3).element([ 2.,  0.,  0.])
 
         Find the Hessian matrix:
 

--- a/odl/solvers/functional/functional.py
+++ b/odl/solvers/functional/functional.py
@@ -18,7 +18,7 @@ from odl.operator.default_ops import (IdentityOperator, ConstantOperator)
 from odl.solvers.nonsmooth import (proximal_arg_scaling, proximal_translation,
                                    proximal_quadratic_perturbation,
                                    proximal_const_func, proximal_convex_conj)
-from odl.util import (signature_string, indent_rows)
+from odl.util import signature_string, indent
 
 
 __all__ = ('Functional', 'FunctionalLeftScalarMult',
@@ -43,7 +43,7 @@ class Functional(Operator):
     The implementation of the functional class assumes that the domain
     :math:`X` is a Hilbert space and that the field of scalars :math:`F` is a
     is the real numbers. It is possible to create functions that do not fulfil
-    these assumptions, however some mathematical results might not be valide in
+    these assumptions, however some mathematical results might not be valid in
     this case. For more information, see `the ODL functional guide
     <http://odlgroup.github.io/odl/guide/in_depth/functional_guide.html>`_.
     """
@@ -890,8 +890,7 @@ class InfimalConvolution(Functional):
         """Return ``repr(self)``."""
         posargs = [self.left, self.right]
         inner_str = signature_string(posargs, [], sep=',\n')
-        return '{}(\n{}\n)'.format(self.__class__.__name__,
-                                   indent_rows(inner_str))
+        return '{}(\n{}\n)'.format(self.__class__.__name__, indent(inner_str))
 
     def __str__(self):
         """Return ``str(self)``."""
@@ -1282,7 +1281,7 @@ def simple_functional(space, fcall=None, grad=None, prox=None, grad_lip=np.nan,
     >>> func([1, 2, 3])
     14.0
     >>> func.gradient([1, 2, 3])
-    rn(3).element([2.0, 4.0, 6.0])
+    rn(3).element([ 2.,  4.,  6.])
     """
     if grad is not None and not isinstance(grad, Operator):
         grad_in = grad

--- a/odl/solvers/util/callback.py
+++ b/odl/solvers/util/callback.py
@@ -92,7 +92,7 @@ class Callback(object):
         >>> operator = odl.ScalingOperator(r3, 2.0)
         >>> composed_callback = callback * operator
         >>> composed_callback([1, 2, 3])
-        rn(3).element([2.0, 4.0, 6.0])
+        rn(3).element([ 2.,  4.,  6.])
         """
         return _CallbackCompose(self, other)
 

--- a/odl/space/base_ntuples.py
+++ b/odl/space/base_ntuples.py
@@ -18,8 +18,8 @@ from odl.set import (Set, RealNumbers, ComplexNumbers, LinearSpace,
                      LinearSpaceElement)
 from odl.util.ufuncs import NtuplesBaseUfuncs
 from odl.util import (
-    array1d_repr, array1d_str, dtype_repr,
-    is_scalar_dtype, is_real_dtype, is_floating_dtype,
+    array_str, dtype_repr, indent,
+    is_numeric_dtype, is_real_dtype, is_floating_dtype,
     complex_dtype, real_dtype)
 
 
@@ -392,12 +392,15 @@ class NtuplesBaseVector(object):
 
     def __str__(self):
         """Return ``str(self)``."""
-        return array1d_str(self)
+        return array_str(self)
 
     def __repr__(self):
         """Return ``repr(self)``."""
-        return '{!r}.element({})'.format(self.space,
-                                         array1d_repr(self))
+        if self.size <= 6:
+            return '{!r}.element({})'.format(self.space, array_str(self))
+        else:
+            return '{!r}.element(\n{}\n)'.format(self.space,
+                                                 indent(array_str(self)))
 
     @property
     def ufuncs(self):
@@ -481,7 +484,7 @@ class FnBase(NtuplesBase, LinearSpace):
         """
         NtuplesBase.__init__(self, size, dtype)
 
-        if not is_scalar_dtype(self.dtype):
+        if not is_numeric_dtype(self.dtype):
             raise TypeError('{!r} is not a scalar data type'.format(dtype))
 
         if is_real_dtype(self.dtype):

--- a/odl/space/base_ntuples.py
+++ b/odl/space/base_ntuples.py
@@ -397,11 +397,11 @@ class NtuplesBaseVector(object):
     def __repr__(self):
         """Return ``repr(self)``."""
         maxsize_full_print = 2 * np.get_printoptions()['edgeitems']
+        self_str = array_str(self, nprint=maxsize_full_print)
         if self.size <= maxsize_full_print:
-            return '{!r}.element({})'.format(self.space, array_str(self))
+            return '{!r}.element({})'.format(self.space, self_str)
         else:
-            return '{!r}.element(\n{}\n)'.format(self.space,
-                                                 indent(array_str(self)))
+            return '{!r}.element(\n{}\n)'.format(self.space, indent(self_str))
 
     @property
     def ufuncs(self):

--- a/odl/space/base_ntuples.py
+++ b/odl/space/base_ntuples.py
@@ -396,7 +396,8 @@ class NtuplesBaseVector(object):
 
     def __repr__(self):
         """Return ``repr(self)``."""
-        if self.size <= 6:
+        maxsize_full_print = 2 * np.get_printoptions()['edgeitems']
+        if self.size <= maxsize_full_print:
             return '{!r}.element({})'.format(self.space, array_str(self))
         else:
             return '{!r}.element(\n{}\n)'.format(self.space,

--- a/odl/space/npy_ntuples.py
+++ b/odl/space/npy_ntuples.py
@@ -77,7 +77,7 @@ class NumpyNtuples(NtuplesBase):
         >>> strings3 = NumpyNtuples(3, dtype='U1')  # 1-char strings
         >>> x = strings3.element(['w', 'b', 'w'])
         >>> print(x)
-        [w, b, w]
+        ['w', 'b', 'w']
         >>> x.space
         ntuples(3, '<U1')
 
@@ -122,10 +122,10 @@ class NumpyNtuples(NtuplesBase):
 
         Examples
         --------
-        >>> c3 = NumpyNtuples(3, dtype=complex)
-        >>> x = c3.zero()
+        >>> r3 = odl.rn(3)
+        >>> x = r3.zero()
         >>> x
-        ntuples(3, 'complex').element([0j, 0j, 0j])
+        rn(3).element([ 0.,  0.,  0.])
         """
         return self.element(np.zeros(self.size, dtype=self.dtype))
 
@@ -134,10 +134,10 @@ class NumpyNtuples(NtuplesBase):
 
         Examples
         --------
-        >>> c3 = NumpyNtuples(3, dtype=complex)
-        >>> x = c3.one()
+        >>> r3 = odl.rn(3)
+        >>> x = r3.one()
         >>> x
-        ntuples(3, 'complex').element([(1+0j), (1+0j), (1+0j)])
+        rn(3).element([ 1.,  1.,  1.])
         """
         return self.element(np.ones(self.size, dtype=self.dtype))
 
@@ -332,12 +332,12 @@ class NumpyNtuplesVector(NtuplesBaseVector):
 
         Examples
         --------
-        >>> str_3 = NumpyNtuples(3, dtype='U6')  # 6-char unicode
+        >>> str_3 = odl.ntuples(3, dtype='U6')  # 6-char unicode
         >>> x = str_3.element(['a', 'Hello!', '0'])
         >>> print(x[0])
         a
         >>> print(x[1:3])
-        [Hello!, 0]
+        ['Hello!', '0']
         >>> x[1:3].space
         ntuples(2, '<U6')
         """
@@ -393,7 +393,7 @@ class NumpyNtuplesVector(NtuplesBaseVector):
 
         >>> x[1:3] = -2.
         >>> x
-        ntuples(3, 'int').element([0, -2, -2])
+        ntuples(3, 'int').element([ 0, -2, -2])
 
         Array views are preserved:
 
@@ -427,17 +427,17 @@ class NumpyNtuplesVector(NtuplesBaseVector):
         >>> r2 = NumpyFn(2)
         >>> x = r2.element([1, -2])
         >>> x.ufuncs.absolute()
-        rn(2).element([1.0, 2.0])
+        rn(2).element([ 1.,  2.])
 
         These functions can also be used with broadcasting
 
         >>> x.ufuncs.add(3)
-        rn(2).element([4.0, 1.0])
+        rn(2).element([ 4.,  1.])
 
         and non-space elements
 
         >>> x.ufuncs.subtract([3, 3])
-        rn(2).element([-2.0, -5.0])
+        rn(2).element([-2., -5.])
 
         There is also support for various reductions (sum, prod, min, max)
 
@@ -450,7 +450,7 @@ class NumpyNtuplesVector(NtuplesBaseVector):
         >>> out = r2.element()
         >>> result = x.ufuncs.add(y, out=out)
         >>> result
-        rn(2).element([4.0, 2.0])
+        rn(2).element([ 4.,  2.])
         >>> result is out
         True
 
@@ -802,9 +802,9 @@ class NumpyFn(FnBase, NumpyNtuples):
         >>> y = c3.element([4+0j, 5, 6+0.5j])
         >>> out = c3.element()
         >>> c3.lincomb(2j, x, 3-1j, y, out)  # out is returned
-        cn(3).element([(10-2j), (17-1j), (18.5+1.5j)])
+        cn(3).element([ 10.0-2.j ,  17.0-1.j ,  18.5+1.5j])
         >>> out
-        cn(3).element([(10-2j), (17-1j), (18.5+1.5j)])
+        cn(3).element([ 10.0-2.j ,  17.0-1.j ,  18.5+1.5j])
         """
         _lincomb_impl(a, x1, b, x2, out, self.dtype)
 
@@ -943,9 +943,9 @@ class NumpyFn(FnBase, NumpyNtuples):
         >>> y = c3.element([1, 2+1j, 3-1j])
         >>> out = c3.element()
         >>> c3.multiply(x, y, out)  # out is returned
-        cn(3).element([(5+1j), (6+3j), (4-8j)])
+        cn(3).element([ 5.+1.j,  6.+3.j,  4.-8.j])
         >>> out
-        cn(3).element([(5+1j), (6+3j), (4-8j)])
+        cn(3).element([ 5.+1.j,  6.+3.j,  4.-8.j])
         """
         np.multiply(x1.data, x2.data, out=out.data)
 
@@ -970,9 +970,9 @@ class NumpyFn(FnBase, NumpyNtuples):
         >>> y = r3.element([1, 2, 2])
         >>> out = r3.element()
         >>> r3.divide(x, y, out)  # out is returned
-        rn(3).element([3.0, 2.5, 3.0])
+        rn(3).element([ 3. ,  2.5,  3. ])
         >>> out
-        rn(3).element([3.0, 2.5, 3.0])
+        rn(3).element([ 3. ,  2.5,  3. ])
         """
         np.divide(x1.data, x2.data, out=out.data)
 
@@ -1123,17 +1123,16 @@ class NumpyFnVector(FnBaseVector, NumpyNtuplesVector):
 
         Examples
         --------
-        >>> c3 = NumpyFn(3, dtype=complex)
-        >>> x = c3.element([5+1j, 3, 2-2j])
+        >>> x = odl.cn(3).element([5+1j, 3, 2-2j])
         >>> x.real
-        rn(3).element([5.0, 3.0, 2.0])
+        rn(3).element([ 5.,  3.,  2.])
 
-        The `rn` vector is really a view, so changes affect
+        The `real` vector is really a view, so changes affect
         the original array:
 
         >>> x.real *= 2
         >>> x
-        cn(3).element([(10+1j), (6+0j), (4-2j)])
+        cn(3).element([ 10.+1.j,   6.+0.j,   4.-2.j])
         """
         return self.space.real_space.element(self.data.real)
 
@@ -1150,21 +1149,20 @@ class NumpyFnVector(FnBaseVector, NumpyNtuplesVector):
 
         Examples
         --------
-        >>> c3 = NumpyFn(3, dtype=complex)
-        >>> x = c3.element([5+1j, 3, 2-2j])
-        >>> a = NumpyFn(3).element([0, 0, 0])
+        >>> x = odl.cn(3).element([5+1j, 3, 2-2j])
+        >>> a = odl.rn(3).element([0, 0, 0])
         >>> x.real = a
         >>> x
-        cn(3).element([1j, 0j, -2j])
+        cn(3).element([ 0.+1.j,  0.+0.j,  0.-2.j])
 
         Other array-like types and broadcasting:
 
         >>> x.real = 1.0
         >>> x
-        cn(3).element([(1+1j), (1+0j), (1-2j)])
+        cn(3).element([ 1.+1.j,  1.+0.j,  1.-2.j])
         >>> x.real = [0, 2, -1]
         >>> x
-        cn(3).element([1j, (2+0j), (-1-2j)])
+        cn(3).element([ 0.+1.j,  2.+0.j, -1.-2.j])
         """
         self.real.data[:] = newreal
 
@@ -1179,17 +1177,16 @@ class NumpyFnVector(FnBaseVector, NumpyNtuplesVector):
 
         Examples
         --------
-        >>> c3 = NumpyFn(3, dtype=complex)
-        >>> x = c3.element([5+1j, 3, 2-2j])
+        >>> x = odl.cn(3).element([5+1j, 3, 2-2j])
         >>> x.imag
-        rn(3).element([1.0, 0.0, -2.0])
+        rn(3).element([ 1.,  0., -2.])
 
-        The `rn` vector is really a view, so changes affect
+        The `imag` vector is really a view, so changes affect
         the original array:
 
         >>> x.imag *= 2
         >>> x
-        cn(3).element([(5+2j), (3+0j), (2-4j)])
+        cn(3).element([ 5.+2.j,  3.+0.j,  2.-4.j])
         """
         return self.space.real_space.element(self.data.imag)
 
@@ -1206,17 +1203,20 @@ class NumpyFnVector(FnBaseVector, NumpyNtuplesVector):
 
         Examples
         --------
-        >>> x = cn(3).element([5+1j, 3, 2-2j])
-        >>> a = NumpyFn(3).element([0, 0, 0])
-        >>> x.imag = a; print(x)
-        [(5+0j), (3+0j), (2+0j)]
+        >>> x = odl.cn(3).element([5+1j, 3, 2-2j])
+        >>> a = odl.rn(3).element([0, 0, 0])
+        >>> x.imag = a
+        >>> x
+        cn(3).element([ 5.+0.j,  3.+0.j,  2.+0.j])
 
         Other array-like types and broadcasting:
 
-        >>> x.imag = 1.0; print(x)
-        [(5+1j), (3+1j), (2+1j)]
-        >>> x.imag = [0, 2, -1]; print(x)
-        [(5+0j), (3+2j), (2-1j)]
+        >>> x.imag = 1.0
+        >>> x
+        cn(3).element([ 5.+1.j,  3.+1.j,  2.+1.j])
+        >>> x.imag = [0, 2, -1]
+        >>> x
+        cn(3).element([ 5.+0.j,  3.+2.j,  2.-1.j])
         """
         self.imag.data[:] = newimag
 
@@ -1237,22 +1237,27 @@ class NumpyFnVector(FnBaseVector, NumpyNtuplesVector):
 
         Examples
         --------
-        >>> x = NumpyFn(3, dtype=complex).element([5+1j, 3, 2-2j])
-        >>> y = x.conj(); print(y)
-        [(5-1j), (3-0j), (2+2j)]
+        Default usage:
 
-        The out parameter allows you to avoid a copy
+        >>> x = odl.cn(3).element([5+1j, 3, 2-2j])
+        >>> y = x.conj()
+        >>> y
+        cn(3).element([ 5.-1.j,  3.-0.j,  2.+2.j])
 
-        >>> z = NumpyFn(3, dtype=complex).element()
-        >>> z_out = x.conj(out=z); print(z)
-        [(5-1j), (3-0j), (2+2j)]
+        The out parameter allows you to avoid a copy:
+
+        >>> z = odl.cn(3).element()
+        >>> z_out = x.conj(out=z)
+        >>> z
+        cn(3).element([ 5.-1.j,  3.-0.j,  2.+2.j])
         >>> z_out is z
         True
 
-        It can also be used for in-place conj
+        It can also be used for in-place conjugation:
 
-        >>> x_out = x.conj(out=x); print(x)
-        [(5-1j), (3-0j), (2+2j)]
+        >>> x_out = x.conj(out=x)
+        >>> x
+        cn(3).element([ 5.-1.j,  3.-0.j,  2.+2.j])
         >>> x_out is x
         True
         """

--- a/odl/space/npy_ntuples.py
+++ b/odl/space/npy_ntuples.py
@@ -1238,8 +1238,7 @@ class NumpyFnVector(FnBaseVector, NumpyNtuplesVector):
         Default usage:
 
         >>> x = odl.cn(3).element([5+1j, 3, 2-2j])
-        >>> y = x.conj()
-        >>> y
+        >>> x.conj()
         cn(3).element([ 5.-1.j,  3.-0.j,  2.+2.j])
 
         The out parameter allows you to avoid a copy:

--- a/odl/space/npy_ntuples.py
+++ b/odl/space/npy_ntuples.py
@@ -74,12 +74,12 @@ class NumpyNtuples(NtuplesBase):
 
         Examples
         --------
-        >>> strings3 = NumpyNtuples(3, dtype='U1')  # 1-char strings
-        >>> x = strings3.element(['w', 'b', 'w'])
-        >>> print(x)
-        ['w', 'b', 'w']
+        >>> bool3 = NumpyNtuples(3, dtype=bool)
+        >>> x = bool3.element([True, True, False])
+        >>> x
+        ntuples(3, 'bool').element([ True,  True, False])
         >>> x.space
-        ntuples(3, '<U1')
+        ntuples(3, 'bool')
 
         Construction from data pointer:
 
@@ -332,14 +332,12 @@ class NumpyNtuplesVector(NtuplesBaseVector):
 
         Examples
         --------
-        >>> str_3 = odl.ntuples(3, dtype='U6')  # 6-char unicode
-        >>> x = str_3.element(['a', 'Hello!', '0'])
-        >>> print(x[0])
-        a
-        >>> print(x[1:3])
-        ['Hello!', '0']
-        >>> x[1:3].space
-        ntuples(2, '<U6')
+        >>> bool3 = odl.ntuples(4, dtype=bool)
+        >>> x = bool3.element([True, False, True, True])
+        >>> x[0]
+        True
+        >>> x[1:3]
+        ntuples(2, 'bool').element([False,  True])
         """
         if isinstance(indices, Integral):
             return self.data[indices]  # single index

--- a/odl/space/pspace.py
+++ b/odl/space/pspace.py
@@ -579,6 +579,7 @@ class ProductSpace(LinearSpace):
     def __repr__(self):
         """Return ``repr(self)``."""
         weight_str = self.weighting.repr_part
+        edgeitems = np.get_printoptions()['edgeitems']
         if self.size == 0:
             posargs = []
             posmod = ''
@@ -589,7 +590,7 @@ class ProductSpace(LinearSpace):
             posmod = '!r'
             optargs = []
             oneline = True
-        elif self.size <= 6:
+        elif self.size <= 2 * edgeitems:
             posargs = self.spaces
             posmod = '!r'
             optargs = []
@@ -597,8 +598,10 @@ class ProductSpace(LinearSpace):
             oneline = (len(argstr + weight_str) <= 40 and
                        '\n' not in argstr + weight_str)
         else:
-            posargs = self.spaces[:3] + ('...',) + self.spaces[-3:]
-            posmod = ['!r'] * 3 + ['!s'] + ['!r'] * 3
+            posargs = (self.spaces[:edgeitems] +
+                       ('...',) +
+                       self.spaces[-edgeitems:])
+            posmod = ['!r'] * edgeitems + ['!s'] + ['!r'] * edgeitems
             optargs = []
             oneline = False
 

--- a/odl/space/pspace.py
+++ b/odl/space/pspace.py
@@ -20,7 +20,7 @@ from odl.set import LinearSpace, LinearSpaceElement
 from odl.space.weighting import (
     Weighting, ArrayWeighting, ConstWeighting, NoWeighting,
     CustomInner, CustomNorm, CustomDist)
-from odl.util import is_real_dtype, signature_string, indent_rows
+from odl.util import is_real_dtype, signature_string, indent
 from odl.util.ufuncs import ProductSpaceUfuncs
 
 
@@ -397,9 +397,8 @@ class ProductSpace(LinearSpace):
         >>> x3 = r3.element([1, 2, 3])
         >>> x = prod.element([x2, x3])
         >>> print(x)
-        {[1.0, 2.0], [1.0, 2.0, 3.0]}
+        {[ 1.,  2.], [ 1.,  2.,  3.]}
         """
-
         # If data is given as keyword arg, prefer it over arg list
         if inp is None:
             inp = [space.element() for space in self.spaces]
@@ -582,30 +581,40 @@ class ProductSpace(LinearSpace):
         weight_str = self.weighting.repr_part
         if self.size == 0:
             posargs = []
+            posmod = ''
             optargs = [('field', self.field, None)]
             oneline = True
         elif self.is_power_space:
             posargs = [self.spaces[0], self.size]
+            posmod = '!r'
             optargs = []
             oneline = True
-        else:
+        elif self.size <= 6:
             posargs = self.spaces
+            posmod = '!r'
             optargs = []
             argstr = ', '.join(repr(s) for s in self.spaces)
             oneline = (len(argstr + weight_str) <= 40 and
                        '\n' not in argstr + weight_str)
+        else:
+            posargs = self.spaces[:3] + ('...',) + self.spaces[-3:]
+            posmod = ['!r'] * 3 + ['!s'] + ['!r'] * 3
+            optargs = []
+            oneline = False
 
         if oneline:
-            inner_str = signature_string(posargs, optargs, sep=', ', mod='!r')
+            inner_str = signature_string(posargs, optargs, sep=', ',
+                                         mod=[posmod, '!r'])
             if weight_str:
                 inner_str = ', '.join([inner_str, weight_str])
             return '{}({})'.format(self.__class__.__name__, inner_str)
         else:
-            inner_str = signature_string(posargs, optargs, sep=',\n', mod='!r')
+            inner_str = signature_string(posargs, optargs, sep=',\n',
+                                         mod=[posmod, '!r'])
             if weight_str:
                 inner_str = ',\n'.join([inner_str, weight_str])
             return '{}(\n{}\n)'.format(self.__class__.__name__,
-                                       indent_rows(inner_str))
+                                       indent(inner_str))
 
     @property
     def element_type(self):
@@ -750,8 +759,8 @@ class ProductSpaceElement(LinearSpaceElement):
         >>> x = r22.element([[1, -2], [-3, 4]])
         >>> x.ufuncs.absolute()
         ProductSpace(rn(2), 2).element([
-            [1.0, 2.0],
-            [3.0, 4.0]
+            [ 1.,  2.],
+            [ 3.,  4.]
         ])
 
         These functions can also be used with non-vector arguments and
@@ -759,13 +768,13 @@ class ProductSpaceElement(LinearSpaceElement):
 
         >>> x.ufuncs.add([1, 2])
         ProductSpace(rn(2), 2).element([
-            [2.0, 0.0],
-            [-2.0, 6.0]
+            [ 2.,  0.],
+            [-2.,  6.]
         ])
         >>> x.ufuncs.subtract(1)
         ProductSpace(rn(2), 2).element([
-            [0.0, -3.0],
-            [-4.0, 3.0]
+            [ 0., -3.],
+            [-4.,  3.]
         ])
 
         There is also support for various reductions (sum, prod, min, max):
@@ -779,8 +788,8 @@ class ProductSpaceElement(LinearSpaceElement):
         >>> result = x.ufuncs.absolute(out=y)
         >>> result
         ProductSpace(rn(2), 2).element([
-            [1.0, 2.0],
-            [3.0, 4.0]
+            [ 1.,  2.],
+            [ 3.,  4.]
         ])
         >>> result is y
         True
@@ -816,11 +825,11 @@ class ProductSpaceElement(LinearSpaceElement):
 
         >>> x
         ProductSpace(rn(2), rn(3)).element([
-            [1.0, 2.0],
-            [3.0, 4.0, 5.0]
+            [ 1.,  2.],
+            [ 3.,  4.,  5.]
         ])
 
-        Nestled spaces work as well
+        Nestled spaces work as well:
 
         >>> X = ProductSpace(r2x3, r2x3)
         >>> x = X.element([[[1, 2], [3, 4, 5]],[[1, 2], [3, 4, 5]]])
@@ -829,12 +838,12 @@ class ProductSpaceElement(LinearSpaceElement):
         >>> x
         ProductSpace(ProductSpace(rn(2), rn(3)), 2).element([
             [
-                [1.0, 2.0],
-                [3.0, 4.0, 5.0]
+                [ 1.,  2.],
+                [ 3.,  4.,  5.]
             ],
             [
-                [1.0, 2.0],
-                [3.0, 4.0, 5.0]
+                [ 1.,  2.],
+                [ 3.,  4.,  5.]
             ]
         ])
         """
@@ -1229,7 +1238,7 @@ class ProductSpaceConstWeighting(ConstWeighting):
             dtype=x1[0].space.dtype, count=len(x1))
 
         inner = self.const * np.sum(inners)
-        return x1.space.field.element(inner)
+        return x1.space.field.element(inner.real)
 
     def norm(self, x):
         """Calculate the constant-weighted norm of an element.

--- a/odl/space/pspace.py
+++ b/odl/space/pspace.py
@@ -1238,7 +1238,7 @@ class ProductSpaceConstWeighting(ConstWeighting):
             dtype=x1[0].space.dtype, count=len(x1))
 
         inner = self.const * np.sum(inners)
-        return x1.space.field.element(inner.real)
+        return x1.space.field.element(inner)
 
     def norm(self, x):
         """Calculate the constant-weighted norm of an element.

--- a/odl/space/space_utils.py
+++ b/odl/space/space_utils.py
@@ -17,8 +17,7 @@ import numpy as np
 
 from odl.set import RealNumbers, ComplexNumbers
 from odl.space.entry_points import ntuples_impl, fn_impl
-from odl.util import (
-    is_real_floating_dtype, is_complex_floating_dtype, is_scalar_dtype)
+from odl.util import is_numeric_dtype
 
 
 def vector(array, dtype=None, impl='numpy'):
@@ -52,19 +51,19 @@ def vector(array, dtype=None, impl='numpy'):
     >>> vector([1, 2, 3])  # No automatic cast to float
     fn(3, 'int').element([1, 2, 3])
     >>> vector([1, 2, 3], dtype=float)
-    rn(3).element([1.0, 2.0, 3.0])
+    rn(3).element([ 1.,  2.,  3.])
     >>> vector([1 + 1j, 2, 3 - 2j])
-    cn(3).element([(1+1j), (2+0j), (3-2j)])
+    cn(3).element([ 1.+1.j,  2.+0.j,  3.-2.j])
 
     Non-scalar types are also supported:
 
     >>> vector([True, False])
-    ntuples(2, 'bool').element([True, False])
+    ntuples(2, 'bool').element([ True, False])
 
     Scalars become a one-element vector:
 
     >>> vector(0.0)
-    rn(1).element([0.0])
+    rn(1).element([ 0.])
     """
     # Sanitize input
     arr = np.array(array, copy=False, ndmin=1)
@@ -81,7 +80,7 @@ def vector(array, dtype=None, impl='numpy'):
         space_dtype = arr.dtype
 
     # Select implementation
-    if space_dtype is None or is_scalar_dtype(space_dtype):
+    if space_dtype is None or is_numeric_dtype(space_dtype):
         space_type = fn
     else:
         space_type = ntuples

--- a/odl/space/weighting.py
+++ b/odl/space/weighting.py
@@ -14,7 +14,7 @@ from __future__ import print_function, division, absolute_import
 import numpy as np
 
 from odl.space.base_ntuples import FnBaseVector
-from odl.util import array1d_repr, arraynd_repr, signature_string, indent_rows
+from odl.util import array_str, signature_string, indent
 
 
 __all__ = ('MatrixWeighting', 'ArrayWeighting', 'ConstWeighting',
@@ -472,7 +472,7 @@ class MatrixWeighting(Weighting):
         if self.matrix_issparse:
             part = 'weighting={}'.format(self.matrix)
         else:
-            part = 'weighting={}'.format(arraynd_repr(self.matrix, nprint=10))
+            part = 'weighting={}'.format(array_str(self.matrix, nprint=10))
         if self.exponent != 2.0:
             part += ', exponent={}'.format(self.exponent)
         if self.dist_using_inner:
@@ -631,7 +631,7 @@ class ArrayWeighting(Weighting):
     @property
     def repr_part(self):
         """String usable in a space's ``__repr__`` method."""
-        optargs = [('weighting', array1d_repr(self.array, nprint=10), ''),
+        optargs = [('weighting', array_str(self.array, nprint=10), ''),
                    ('exponent', self.exponent, 2.0),
                    ('dist_using_inner', self.dist_using_inner, False)]
         return signature_string([], optargs, sep=[',\n', ', ', ',\n'],
@@ -639,14 +639,13 @@ class ArrayWeighting(Weighting):
 
     def __repr__(self):
         """Return ``repr(self)``."""
-        posargs = [self.array]
+        posargs = [array_str(self.array)]
         optargs = [('exponent', self.exponent, 2.0),
                    ('dist_using_inner', self.dist_using_inner, False)]
         inner_str = signature_string(posargs, optargs,
                                      sep=[', ', ', ', ',\n'],
-                                     mod=['!r', ''])
-        return '{}(\n{}\n)'.format(self.__class__.__name__,
-                                   indent_rows(inner_str))
+                                     mod=['!s', ''])
+        return '{}(\n{}\n)'.format(self.__class__.__name__, indent(inner_str))
 
     def __str__(self):
         """Return ``str(self)``."""

--- a/odl/test/discr/discr_ops_test.py
+++ b/odl/test/discr/discr_ops_test.py
@@ -14,7 +14,7 @@ import numpy as np
 
 import odl
 from odl.discr.discr_ops import _SUPPORTED_RESIZE_PAD_MODES
-from odl.util import is_scalar_dtype, is_real_floating_dtype
+from odl.util import is_numeric_dtype, is_real_floating_dtype
 from odl.util.testutils import almost_equal, noise_element, dtype_places
 
 
@@ -105,7 +105,7 @@ def test_resizing_op_raise():
 
 def test_resizing_op_properties(fn_impl, padding):
     dtypes = [dt for dt in odl.fn_impl(fn_impl).available_dtypes()
-              if is_scalar_dtype(dt)]
+              if is_numeric_dtype(dt)]
 
     pad_mode, pad_const = padding
 
@@ -144,7 +144,7 @@ def test_resizing_op_properties(fn_impl, padding):
 
 def test_resizing_op_call(fn_impl):
     dtypes = [dt for dt in odl.fn_impl(fn_impl).available_dtypes()
-              if is_scalar_dtype(dt)]
+              if is_numeric_dtype(dt)]
 
     for dtype in dtypes:
         # Minimal test since this operator only wraps resize_array
@@ -195,7 +195,7 @@ def test_resizing_op_deriv(padding):
 def test_resizing_op_inverse(padding, fn_impl):
     pad_mode, pad_const = padding
     dtypes = [dt for dt in odl.fn_impl(fn_impl).available_dtypes()
-              if is_scalar_dtype(dt)]
+              if is_numeric_dtype(dt)]
 
     for dtype in dtypes:
         space = odl.uniform_discr([0, -1], [1, 1], (4, 5), dtype=dtype,

--- a/odl/test/system/import_test.py
+++ b/odl/test/system/import_test.py
@@ -23,9 +23,9 @@ def test_all_imports():
     odl.operator.default_ops.IdentityOperator(C3)
 
     # Test that utility needs to be explicitly imported
-    odl.util.utility.array1d_repr
+    odl.util.utility.array_str
     with pytest.raises(AttributeError):
-        odl.array1d_repr
+        odl.array_str
 
 
 if __name__ == '__main__':

--- a/odl/test/util/utility_test.py
+++ b/odl/test/util/utility_test.py
@@ -11,7 +11,7 @@ import odl
 import numpy as np
 
 from odl.util.utility import (
-    is_scalar_dtype, is_real_dtype, is_real_floating_dtype,
+    is_numeric_dtype, is_real_dtype, is_real_floating_dtype,
     is_complex_floating_dtype)
 
 
@@ -29,9 +29,9 @@ nonscalar_dtypes = [np.dtype('S1'), np.dtype('<U2'), np.dtype(object),
 # ---- Data type helpers ---- #
 
 
-def test_is_scalar_dtype():
+def test_is_numeric_dtype():
     for dtype in scalar_dtypes:
-        assert is_scalar_dtype(dtype)
+        assert is_numeric_dtype(dtype)
 
 
 def test_is_real_dtype():

--- a/odl/tomo/geometry/conebeam.py
+++ b/odl/tomo/geometry/conebeam.py
@@ -19,7 +19,7 @@ from odl.tomo.geometry.geometry import (
     DivergentBeamGeometry, AxisOrientedGeometry)
 from odl.tomo.util.utility import (
     euler_matrix, transform_system, is_inside_bounds)
-from odl.util import signature_string, indent_rows
+from odl.util import signature_string, indent, array_str
 
 
 __all__ = ('FanFlatGeometry', 'ConeFlatGeometry',
@@ -504,18 +504,17 @@ class FanFlatGeometry(DivergentBeamGeometry):
         if not np.allclose(self.src_to_det_init,
                            self._default_config['src_to_det_init']):
             optargs.append(
-                ['src_to_det_init', self.src_to_det_init.tolist(), None])
+                ['src_to_det_init', array_str(self.src_to_det_init), ''])
 
         if self._det_axis_init_arg is not None:
             optargs.append(
-                ['det_axis_init', self._det_axis_init_arg.tolist(), None])
+                ['det_axis_init', array_str(self._det_axis_init_arg), ''])
 
         if not np.array_equal(self.translation, (0, 0)):
-            optargs.append(['translation', self.translation.tolist(), None])
+            optargs.append(['translation', array_str(self.translation), ''])
 
         sig_str = signature_string(posargs, optargs, sep=',\n')
-        return '{}(\n{}\n)'.format(self.__class__.__name__,
-                                   indent_rows(sig_str))
+        return '{}(\n{}\n)'.format(self.__class__.__name__, indent(sig_str))
 
     def __getitem__(self, indices):
         """Return self[indices].
@@ -537,7 +536,7 @@ class FanFlatGeometry(DivergentBeamGeometry):
         >>> geom[::2, :]
         FanFlatGeometry(
             nonuniform_partition(
-                [0.5, 2.5],
+                [ 0.5,  2.5],
                 min_pt=0.0, max_pt=4.0
             ),
             uniform_partition(-1.0, 1.0, 20),
@@ -1146,27 +1145,26 @@ class ConeFlatGeometry(DivergentBeamGeometry, AxisOrientedGeometry):
                    ]
 
         if not np.allclose(self.axis, self._default_config['axis']):
-            optargs.append(['axis', self.axis.tolist(), None])
+            optargs.append(['axis', array_str(self.axis), ''])
 
         optargs.append(['offset_along_axis', self.offset_along_axis, 0])
 
         if self._src_to_det_init_arg is not None:
             optargs.append(['src_to_det_init',
-                            self._src_to_det_init_arg.tolist(),
+                            array_str(self._src_to_det_init_arg),
                             None])
 
         if self._det_axes_init_arg is not None:
             optargs.append(
                 ['det_axes_init',
-                 tuple(a.tolist() for a in self._det_axes_init_arg),
+                 tuple(array_str(a) for a in self._det_axes_init_arg),
                  None])
 
         if not np.array_equal(self.translation, (0, 0, 0)):
-            optargs.append(['translation', self.translation.tolist(), None])
+            optargs.append(['translation', array_str(self.translation), ''])
 
         sig_str = signature_string(posargs, optargs, sep=',\n')
-        return '{}(\n{}\n)'.format(self.__class__.__name__,
-                                   indent_rows(sig_str))
+        return '{}(\n{}\n)'.format(self.__class__.__name__, indent(sig_str))
 
     def __getitem__(self, indices):
         """Return self[indices].
@@ -1188,10 +1186,10 @@ class ConeFlatGeometry(DivergentBeamGeometry, AxisOrientedGeometry):
         >>> geom[::2]
         ConeFlatGeometry(
             nonuniform_partition(
-                [0.5, 2.5],
+                [ 0.5,  2.5],
                 min_pt=0.0, max_pt=4.0
             ),
-            uniform_partition([-1.0, -1.0], [1.0, 1.0], (20, 20)),
+            uniform_partition([-1., -1.], [ 1.,  1.], (20, 20)),
             src_radius=50.0,
             det_radius=100.0,
             pitch=2.0

--- a/odl/tomo/geometry/detector.py
+++ b/odl/tomo/geometry/detector.py
@@ -16,7 +16,7 @@ import numpy as np
 
 from odl.discr import RectPartition
 from odl.tomo.util import perpendicular_vector, is_inside_bounds
-from odl.util import indent_rows, signature_string
+from odl.util import indent, signature_string, array_str
 
 
 __all__ = ('Detector',
@@ -411,10 +411,9 @@ class Flat1dDetector(Detector):
     def __repr__(self):
         """Return ``repr(self)``."""
         posargs = [self.partition]
-        optargs = [('axis', self.axis.tolist(), None)]
+        optargs = [('axis', array_str(self.axis), '')]
         inner_str = signature_string(posargs, optargs, sep=',\n')
-        return '{}(\n{}\n)'.format(self.__class__.__name__,
-                                   indent_rows(inner_str))
+        return '{}(\n{}\n)'.format(self.__class__.__name__, indent(inner_str))
 
     def __str__(self):
         """Return ``str(self)``."""
@@ -625,10 +624,9 @@ class Flat2dDetector(Detector):
     def __repr__(self):
         """Return ``repr(self)``."""
         posargs = [self.partition]
-        optargs = [('axes', tuple(ax.tolist() for ax in self.axes), None)]
+        optargs = [('axes', tuple(array_str(ax) for ax in self.axes), None)]
         inner_str = signature_string(posargs, optargs, sep=',\n')
-        return '{}(\n{}\n)'.format(self.__class__.__name__,
-                                   indent_rows(inner_str))
+        return '{}(\n{}\n)'.format(self.__class__.__name__, indent(inner_str))
 
     def __str__(self):
         """Return ``str(self)``."""
@@ -897,10 +895,9 @@ class CircleSectionDetector(Detector):
     def __repr__(self):
         """Return ``repr(self)``."""
         posargs = [self.partition]
-        optargs = [('center', self.center.tolist(), None)]
+        optargs = [('center', array_str(self.center), None)]
         inner_str = signature_string(posargs, optargs, sep=',\n')
-        return '{}(\n{}\n)'.format(self.__class__.__name__,
-                                   indent_rows(inner_str))
+        return '{}(\n{}\n)'.format(self.__class__.__name__, indent(inner_str))
 
     def __str__(self):
         """Return ``str(self)``."""

--- a/odl/tomo/geometry/parallel.py
+++ b/odl/tomo/geometry/parallel.py
@@ -17,7 +17,7 @@ from odl.discr import uniform_partition
 from odl.tomo.geometry.detector import Flat1dDetector, Flat2dDetector
 from odl.tomo.geometry.geometry import Geometry, AxisOrientedGeometry
 from odl.tomo.util import euler_matrix, transform_system, is_inside_bounds
-from odl.util import signature_string, indent_rows
+from odl.util import signature_string, indent, array_str
 
 
 __all__ = ('ParallelBeamGeometry',
@@ -642,19 +642,18 @@ class Parallel2dGeometry(ParallelBeamGeometry):
         if not np.allclose(self.det_pos_init - self.translation,
                            self._default_config['det_pos_init']):
             optargs.append(
-                ['det_pos_init', self.det_pos_init.tolist(), None])
+                ['det_pos_init', array_str(self.det_pos_init), ''])
 
         if self._det_axis_init_arg is not None:
             optargs.append(
-                ['det_axis_init', self._det_axis_init_arg.tolist(), None])
+                ['det_axis_init', array_str(self._det_axis_init_arg), ''])
 
         if not np.array_equal(self.translation, (0, 0)):
             optargs.append(
-                ['translation', self.translation.tolist(), None])
+                ['translation', array_str(self.translation), ''])
 
         sig_str = signature_string(posargs, optargs, sep=',\n')
-        return '{}(\n{}\n)'.format(self.__class__.__name__,
-                                   indent_rows(sig_str))
+        return '{}(\n{}\n)'.format(self.__class__.__name__, indent(sig_str))
 
     def __getitem__(self, indices):
         """Return self[slc]
@@ -676,7 +675,7 @@ class Parallel2dGeometry(ParallelBeamGeometry):
         >>> geom[::2]
         Parallel2dGeometry(
             nonuniform_partition(
-                [0.5, 2.5],
+                [ 0.5,  2.5],
                 min_pt=0.0, max_pt=4.0
             ),
             uniform_partition(-1.0, 1.0, 20)
@@ -1051,20 +1050,19 @@ class Parallel3dEulerGeometry(ParallelBeamGeometry):
         if not np.allclose(self.det_pos_init - self.translation,
                            self._default_config['det_pos_init']):
             optargs.append(
-                ['det_pos_init', self.det_pos_init.tolist(), None])
+                ['det_pos_init', array_str(self.det_pos_init), ''])
 
         if self._det_axes_init_arg is not None:
             optargs.append(
-                ['det_axes_init',
-                 tuple(a.tolist() for a in self._det_axes_init_arg),
-                 None])
+                [('det_axes_init',
+                  tuple(array_str(a) for a in self._det_axes_init_arg),
+                  None)])
 
         if not np.array_equal(self.translation, (0, 0, 0)):
-            optargs.append(['translation', self.translation.tolist(), None])
+            optargs.append(['translation', array_str(self.translation), ''])
 
         sig_str = signature_string(posargs, optargs, sep=',\n')
-        return '{}(\n{}\n)'.format(self.__class__.__name__,
-                                   indent_rows(sig_str))
+        return '{}(\n{}\n)'.format(self.__class__.__name__, indent(sig_str))
 
 
 class Parallel3dAxisGeometry(ParallelBeamGeometry, AxisOrientedGeometry):
@@ -1402,25 +1400,24 @@ class Parallel3dAxisGeometry(ParallelBeamGeometry, AxisOrientedGeometry):
         optargs = []
 
         if not np.allclose(self.axis, self._default_config['axis']):
-            optargs.append(['axis', self.axis.tolist(), None])
+            optargs.append(['axis', array_str(self.axis), ''])
 
         if self._det_pos_init_arg is not None:
             optargs.append(['det_pos_init',
-                            self._det_pos_init_arg.tolist(),
+                            array_str(self._det_pos_init_arg),
                             None])
 
         if self._det_axes_init_arg is not None:
             optargs.append(
                 ['det_axes_init',
-                 tuple(a.tolist() for a in self._det_axes_init_arg),
+                 tuple(array_str(a) for a in self._det_axes_init_arg),
                  None])
 
         if not np.array_equal(self.translation, (0, 0, 0)):
-            optargs.append(['translation', self.translation.tolist(), None])
+            optargs.append(['translation', array_str(self.translation), ''])
 
         sig_str = signature_string(posargs, optargs, sep=',\n')
-        return '{}(\n{}\n)'.format(self.__class__.__name__,
-                                   indent_rows(sig_str))
+        return '{}(\n{}\n)'.format(self.__class__.__name__, indent(sig_str))
 
     def __getitem__(self, indices):
         """Return self[indices].
@@ -1442,10 +1439,10 @@ class Parallel3dAxisGeometry(ParallelBeamGeometry, AxisOrientedGeometry):
         >>> geom[::2]
         Parallel3dAxisGeometry(
             nonuniform_partition(
-                [0.5, 2.5],
+                [ 0.5,  2.5],
                 min_pt=0.0, max_pt=4.0
             ),
-            uniform_partition([-1.0, -1.0], [1.0, 1.0], (20, 20))
+            uniform_partition([-1., -1.], [ 1.,  1.], (20, 20))
         )
         """
         part = self.partition[indices]

--- a/odl/tomo/geometry/spect.py
+++ b/odl/tomo/geometry/spect.py
@@ -15,7 +15,7 @@ import numpy as np
 
 from odl.tomo.geometry.parallel import Parallel3dAxisGeometry
 from odl.tomo.util.utility import transform_system
-from odl.util import signature_string, indent_rows
+from odl.util import signature_string, indent, array_str
 
 __all__ = ('ParallelHoleCollimatorGeometry', )
 
@@ -176,22 +176,21 @@ class ParallelHoleCollimatorGeometry(Parallel3dAxisGeometry):
         optargs = [('det_radius', self.det_radius, -1)]
 
         if not np.allclose(self.axis, self._default_config['axis']):
-            optargs.append(['axis', self.axis.tolist(), None])
+            optargs.append(['axis', array_str(self.axis), ''])
 
         if self._orig_to_det_init_arg is not None:
             optargs.append(['orig_to_det_init',
-                            self._orig_to_det_init_arg.tolist(),
-                            None])
+                            array_str(self._orig_to_det_init_arg),
+                            ''])
 
         if self._det_axes_init_arg is not None:
             optargs.append(
                 ['det_axes_init',
-                 tuple(a.tolist() for a in self._det_axes_init_arg),
+                 tuple(array_str(a) for a in self._det_axes_init_arg),
                  None])
 
         if not np.array_equal(self.translation, (0, 0, 0)):
-            optargs.append(['translation', self.translation.tolist(), None])
+            optargs.append(['translation', array_str(self.translation), ''])
 
         sig_str = signature_string(posargs, optargs, sep=',\n')
-        return '{}(\n{}\n)'.format(self.__class__.__name__,
-                                   indent_rows(sig_str))
+        return '{}(\n{}\n)'.format(self.__class__.__name__, indent(sig_str))

--- a/odl/trafos/util/ft_utils.py
+++ b/odl/trafos/util/ft_utils.py
@@ -20,7 +20,7 @@ from odl.discr import (
 from odl.set import RealNumbers
 from odl.util import (
     fast_1d_tensor_mult, conj_exponent,
-    is_real_dtype, is_scalar_dtype, is_real_floating_dtype,
+    is_real_dtype, is_numeric_dtype, is_real_floating_dtype,
     is_complex_floating_dtype, complex_dtype, dtype_repr,
     is_string,
     normalized_scalar_param_list, normalized_axes_tuple)
@@ -298,7 +298,7 @@ def dft_preprocess_data(arr, shift=True, axes=None, sign='-', out=None):
     is the complex counterpart of ``arr.dtype``.
     """
     arr = np.asarray(arr)
-    if not is_scalar_dtype(arr.dtype):
+    if not is_numeric_dtype(arr.dtype):
         raise ValueError('array has non-scalar data type {}'
                          ''.format(dtype_repr(arr.dtype)))
     elif is_real_dtype(arr.dtype) and not is_real_floating_dtype(arr.dtype):

--- a/odl/trafos/wavelet.py
+++ b/odl/trafos/wavelet.py
@@ -293,7 +293,7 @@ class WaveletTransform(WaveletTransformBase):
         ...                         [0, 0, 1, 1],
         ...                         [1, 0, 1, 0]])
         >>> print(decomp)
-        [1.0, 1.0, 0.5, ..., 0.0, -0.5, -0.5]
+        [ 1. ,  1. ,  0.5, ...,  0. , -0.5, -0.5]
         >>> decomp.shape
         (16,)
         """

--- a/odl/util/utility.py
+++ b/odl/util/utility.py
@@ -35,7 +35,42 @@ TYPE_MAP_C2R.update({k: k for k in TYPE_MAP_R2C.keys()})
 
 
 def indent(string, indent_str='    '):
-    """Return a copy of ``string`` indented by ``indent_str``."""
+    """Return a copy of ``string`` indented by ``indent_str``.
+
+    Parameters
+    ----------
+    string : str
+        Text that should be indented.
+    indent_str : str, optional
+        String to be inserted before each new line. The default is to
+        indent by 4 spaces.
+
+    Returns
+    -------
+    indented : str
+        The indented text.
+
+    Examples
+    --------
+    >>> text = '''This is line 1.
+    ... Next line.
+    ... And another one.'''
+    >>> print(text)
+    This is line 1.
+    Next line.
+    And another one.
+    >>> print(indent(text))
+        This is line 1.
+        Next line.
+        And another one.
+
+    Indenting by random stuff:
+
+    >>> print(indent(text, indent_str='|----|'))
+    |----|This is line 1.
+    |----|Next line.
+    |----|And another one.
+    """
     return '\n'.join(indent_str + row for row in string.split('\n'))
 
 

--- a/odl/util/utility.py
+++ b/odl/util/utility.py
@@ -6,7 +6,7 @@
 # v. 2.0. If a copy of the MPL was not distributed with this file, You can
 # obtain one at https://mozilla.org/MPL/2.0/.
 
-"""Utilities for internal use."""
+"""Utilities mainly for internal use."""
 
 # Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
@@ -16,9 +16,9 @@ from collections import OrderedDict
 import numpy as np
 
 
-__all__ = ('array1d_repr', 'array1d_str', 'arraynd_repr', 'arraynd_str',
-           'dtype_repr', 'dtype_str', 'signature_string', 'indent_rows',
-           'is_scalar_dtype', 'is_int_dtype', 'is_floating_dtype',
+__all__ = ('array_str', 'dtype_str', 'dtype_repr', 'npy_printoptions',
+           'signature_string', 'indent',
+           'is_numeric_dtype', 'is_int_dtype', 'is_floating_dtype',
            'is_real_dtype', 'is_real_floating_dtype',
            'is_complex_floating_dtype',
            'is_string',
@@ -34,131 +34,118 @@ TYPE_MAP_C2R = {cdt: np.empty(0, dtype=cdt).real.dtype
 TYPE_MAP_C2R.update({k: k for k in TYPE_MAP_R2C.keys()})
 
 
-def indent_rows(string, indent=4):
-    """Return ``string`` indented by ``indent`` spaces."""
-    return '\n'.join((' ' * indent) + row for row in string.split('\n'))
+def indent(string, indent_str='    '):
+    """Return a copy of ``string`` indented by ``indent_str``."""
+    return '\n'.join(indent_str + row for row in string.split('\n'))
 
 
-def array1d_repr(array, nprint=6):
-    """Stringification of a 1D array, keeping byte / unicode.
+class npy_printoptions(object):
 
-    Parameters
-    ----------
-    array : `array-like`
-        The array to print
-    nprint : int, optional
-        Maximum number of elements to print
-    """
-    assert int(nprint) > 0
+    """Context manager to temporarily set Numpy print options.
 
-    if len(array) <= nprint:
-        return repr(list(array))
-    else:
-        return (repr(list(array[:nprint // 2])).rstrip(']') + ', ..., ' +
-                repr(list(array[-(nprint // 2):])).lstrip('['))
-
-
-def array1d_str(array, nprint=6):
-    """Stringification of a 1D array, regardless of byte or unicode.
-
-    Parameters
-    ----------
-    array : `array-like`
-        The array to print
-    nprint : int, optional
-        Maximum number of elements to print
-    """
-    assert int(nprint) > 0
-
-    if len(array) <= nprint:
-        inner_str = ', '.join(str(a) for a in array)
-        return '[{}]'.format(inner_str)
-    else:
-        left_str = ', '.join(str(a) for a in array[:nprint // 2])
-        right_str = ', '.join(str(a) for a in array[-(nprint // 2):])
-        return '[{}, ..., {}]'.format(left_str, right_str)
-
-
-def arraynd_repr(array, nprint=None):
-    """Stringification of an nD array, keeping byte / unicode.
-
-    Parameters
-    ----------
-    array : `array-like`
-        The array to print
-    nprint : int, optional
-        Maximum number of elements to print.
-        Default: 6 if array.ndim <= 2, else 2
+    See Also
+    --------
+    numpy.get_printoptions
+    numpy.set_printoptions
 
     Examples
     --------
-    >>> print(arraynd_repr([[1, 2, 3], [4, 5, 6]]))
-    [[1, 2, 3],
-     [4, 5, 6]]
-    >>> print(arraynd_repr([[1, 2, 3], [4, 5, 6], [7, 8, 9]]))
-    [[1, 2, 3],
-     [4, 5, 6],
-     [7, 8, 9]]
+    >>> print(np.array([np.nan, 1.00001]))
+    [     nan  1.00001]
+    >>> with npy_printoptions(precision=3):
+    ...     print(np.array([np.nan, 1.00001]))
+    [ nan   1.]
+    >>> with npy_printoptions(nanstr='whoah!'):
+    ...     print(np.array([np.nan, 1.00001]))
+    [  whoah!  1.00001]
     """
-    array = np.asarray(array)
-    if nprint is None:
-        nprint = 6 if array.ndim <= 2 else 2
-    else:
-        assert nprint > 0
 
-    if array.ndim > 1:
-        if len(array) <= nprint:
-            inner_str = ',\n '.join(arraynd_repr(a) for a in array)
-            return '[{}]'.format(inner_str)
-        else:
-            left_str = ',\n '.join(arraynd_repr(a) for a in
-                                   array[:nprint // 2])
-            right_str = ',\n '.join(arraynd_repr(a) for a in
-                                    array[-(nprint // 2):])
-            return '[{},\n ...,\n {}]'.format(left_str, right_str)
-    else:
-        return array1d_repr(array)
+    def __init__(self, **extra_opts):
+        self.extra_opts = extra_opts
+        self.orig_opts = np.get_printoptions()
+
+    def __enter__(self):
+        new_opts = self.orig_opts.copy()
+        new_opts.update(self.extra_opts)
+        np.set_printoptions(**new_opts)
+
+    def __exit__(self, type, value, traceback):
+        np.set_printoptions(**self.orig_opts)
 
 
-def arraynd_str(array, nprint=None):
-    """Stringification of an nD array, regardless of byte or unicode.
+def array_str(a, nprint=6):
+    """Stringification of an array.
 
     Parameters
     ----------
-    array : `array-like`
-        The array to print
+    a : `array-like`
+        The array to print.
     nprint : int, optional
-        Maximum number of elements to print.
-        Default: 6 if array.ndim <= 2, else 2
+        Maximum number of elements to print per axis in ``a``. For larger
+        arrays, a summary is printed, with ``nprint // 2`` elements on
+        each side and ``...`` in the middle (per axis).
 
     Examples
     --------
-    >>> print(arraynd_str([[1, 2, 3], [4, 5, 6]]))
-    [[1, 2, 3],
-     [4, 5, 6]]
-    >>> print(arraynd_str([[1, 2, 3], [4, 5, 6], [7, 8, 9]]))
-    [[1, 2, 3],
-     [4, 5, 6],
-     [7, 8, 9]]
-    """
-    array = np.asarray(array)
-    if nprint is None:
-        nprint = 6 if array.ndim <= 2 else 2
-    else:
-        assert nprint > 0
+    Printing 1D arrays:
 
-    if array.ndim > 1:
-        if len(array) <= nprint:
-            inner_str = ',\n '.join(arraynd_str(a) for a in array)
-            return '[{}]'.format(inner_str)
-        else:
-            left_str = ',\n'.join(arraynd_str(a) for a in
-                                  array[:nprint // 2])
-            right_str = ',\n'.join(arraynd_str(a) for a in
-                                   array[- (nprint // 2):])
-            return '[{},\n    ...,\n{}]'.format(left_str, right_str)
-    else:
-        return array1d_str(array)
+    >>> print(array_str(np.arange(4)))
+    [0, 1, 2, 3]
+    >>> print(array_str(np.arange(10)))
+    [0, 1, 2, ..., 7, 8, 9]
+    >>> print(array_str(np.arange(10), nprint=10))
+    [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+
+    For 2D and higher, the ``nprint`` limitation applies per axis:
+
+    >>> print(array_str(np.arange(24).reshape(4, 6)))
+    [[ 0,  1,  2,  3,  4,  5],
+     [ 6,  7,  8,  9, 10, 11],
+     [12, 13, 14, 15, 16, 17],
+     [18, 19, 20, 21, 22, 23]]
+    >>> print(array_str(np.arange(32).reshape(4, 8)))
+    [[ 0,  1,  2, ...,  5,  6,  7],
+     [ 8,  9, 10, ..., 13, 14, 15],
+     [16, 17, 18, ..., 21, 22, 23],
+     [24, 25, 26, ..., 29, 30, 31]]
+    >>> print(array_str(np.arange(32).reshape(8, 4)))
+    [[ 0,  1,  2,  3],
+     [ 4,  5,  6,  7],
+     [ 8,  9, 10, 11],
+     ...,
+     [20, 21, 22, 23],
+     [24, 25, 26, 27],
+     [28, 29, 30, 31]]
+    >>> print(array_str(np.arange(64).reshape(8, 8)))
+    [[ 0,  1,  2, ...,  5,  6,  7],
+     [ 8,  9, 10, ..., 13, 14, 15],
+     [16, 17, 18, ..., 21, 22, 23],
+     ...,
+     [40, 41, 42, ..., 45, 46, 47],
+     [48, 49, 50, ..., 53, 54, 55],
+     [56, 57, 58, ..., 61, 62, 63]]
+
+    Printing of empty arrays and 0D arrays:
+
+    >>> print(array_str(np.array([])))  # 1D, size=0
+    []
+    >>> print(array_str(np.array(1.0)))  # 0D, size=1
+    1.0
+
+    Small deviations from round numbers will be suppressed:
+
+    >>> # 2.0000000000000004 in double precision
+    >>> print(array_str((np.array([2.0]) ** 0.5) ** 2))
+    [ 2.]
+    """
+    a = np.asarray(a)
+    max_shape = tuple(a.shape[i] if a.shape[i] < nprint else nprint
+                      for i in range(a.ndim))
+    with npy_printoptions(threshold=int(np.prod(max_shape)),
+                          edgeitems=nprint // 2,
+                          suppress=True):
+        a_str = np.array2string(a, separator=', ')
+    return a_str
 
 
 def dtype_repr(dtype):
@@ -242,8 +229,8 @@ def cache_arguments(function):
 
 
 @cache_arguments
-def is_scalar_dtype(dtype):
-    """Return ``True`` if ``dtype`` is a scalar type."""
+def is_numeric_dtype(dtype):
+    """Return ``True`` if ``dtype`` is a numeric type."""
     return np.issubsctype(dtype, np.number)
 
 
@@ -262,7 +249,7 @@ def is_floating_dtype(dtype):
 @cache_arguments
 def is_real_dtype(dtype):
     """Return ``True`` if ``dtype`` is a real (including integer) type."""
-    return is_scalar_dtype(dtype) and not is_complex_floating_dtype(dtype)
+    return is_numeric_dtype(dtype) and not is_complex_floating_dtype(dtype)
 
 
 @cache_arguments
@@ -508,7 +495,7 @@ class writable_array(object):
         >>> with writable_array(x) as arr:
         ...    arr += [1, 1, 1]
         >>> x
-        uniform_discr(0.0, 1.0, 3).element([2.0, 3.0, 4.0])
+        uniform_discr(0.0, 1.0, 3).element([ 2.,  3.,  4.])
 
         Can also be called with arguments to `numpy.asarray`
 
@@ -577,6 +564,9 @@ def signature_string(posargs, optargs, sep=', ', mod=''):
         Only those parameters that are different from the given default
         are included as ``name=value`` keyword pairs.
 
+        **Note:** The comparison is done by using ``if value == default:``,
+        which is not valid for, e.g., NumPy arrays.
+
     sep : string or sequence of strings, optional
         Separator(s) for the argument strings. A provided single string is
         used for all joining operations.
@@ -584,16 +574,26 @@ def signature_string(posargs, optargs, sep=', ', mod=''):
         The ``pos_sep`` and ``opt_sep`` strings are used for joining the
         respective sequences of argument strings, and ``part_sep`` joins
         these two joined strings.
-    mod : string or sequence, optional
-        Format modifier(s) for the argument strings. A provided single
-        string is used for all format strings.
-        A given sequence can must have 2 entries ``pos_mod, opt_mod``
-        that are either strings or sequences of strings.
-        If they are strings, they are used as modifiers for the respective
-        argument string sequences.
-        If they are sequences of strings, their lengths must match those
-        of ``posargs`` and ``optargs``, respectively, and they modify
-        the format strings in a one-to-one fashion.
+    mod : string or callable or sequence, optional
+        Format modifier(s) for the argument strings.
+        In its most general form, ``mod`` is a sequence of 2 sequences
+        ``pos_mod, opt_mod`` with ``len(pos_mod) == len(posargs)`` and
+        ``len(opt_mod) == len(optargs)``. Each entry ``m`` in those sequences
+        can be eiter a string, resulting in the following stringification
+        of ``arg``::
+
+            arg_fmt = {{{}}}.format(m)
+            arg_str = arg_fmt.format(arg)
+
+        For a callable ``to_str``, the stringification is simply
+        ``arg_str = to_str(arg)``.
+
+        The entries ``pos_mod, opt_mod`` of ``mod`` can also be strings
+        or callables instead of sequences, in which case the modifier
+        applies to all corresponding arguments.
+
+        Finally, if ``mod`` is a string or callable, it is applied to
+        all arguments.
 
     Returns
     -------
@@ -653,6 +653,13 @@ def signature_string(posargs, optargs, sep=', ', mod=''):
     >>> mod = [['', ''], [':.3', ':.2']]  # one modifier per argument
     >>> signature_string(posargs, optargs, mod=mod)
     "'hello', 2.345, extent=1.44, spacing=0.015"
+
+    Using callables for stringification:
+
+    >>> posargs = ['arg1', np.ones(3)]
+    >>> optargs = []
+    >>> signature_string(posargs, optargs, mod=[['', array_str], []])
+    "'arg1', [ 1., 1., 1.]"
     """
     # Define the separators for the two possible cases
     if is_string(sep):
@@ -661,20 +668,23 @@ def signature_string(posargs, optargs, sep=', ', mod=''):
         pos_sep, opt_sep, part_sep = sep
 
     # Convert modifiers to 2-sequence of sequence of strings
-    if is_string(mod):
+    if is_string(mod) or callable(mod):
         pos_mod = opt_mod = mod
     else:
         pos_mod, opt_mod = mod
 
     mods = []
     for m, args in zip((pos_mod, opt_mod), (posargs, optargs)):
-        if is_string(m):
+        if is_string(m) or callable(m):
             mods.append([m] * len(args))
         else:
-            if len(m) != len(args):
+            if len(m) == 1:
+                mods.append(m * len(args))
+            elif len(m) == len(args):
+                mods.append(m)
+            else:
                 raise ValueError('sequence length mismatch: '
                                  'len({}) != len({})'.format(m, args))
-            mods.append(m)
 
     pos_mod, opt_mod = mods
 
@@ -684,17 +694,19 @@ def signature_string(posargs, optargs, sep=', ', mod=''):
     # Stringify values, treating strings specially
     posargs_conv = []
     for arg, modifier in zip(posargs, pos_mod):
-        if is_string(arg):
+        if callable(modifier):
+            posargs_conv.append(modifier(arg))
+        elif is_string(arg):
             # Preserve single quotes for strings by default
             if modifier:
                 fmt = '{{{}}}'.format(modifier)
             else:
                 fmt = "'{}'"
+            posargs_conv.append(fmt.format(arg))
         else:
-            # All non-string types are passed a format conversion
+            # All non-string types are passed through a format conversion
             fmt = '{{{}}}'.format(modifier)
-
-        posargs_conv.append(fmt.format(arg))
+            posargs_conv.append(fmt.format(arg))
 
     if posargs_conv:
         parts.append(pos_sep.join(argstr for argstr in posargs_conv))
@@ -707,17 +719,20 @@ def signature_string(posargs, optargs, sep=', ', mod=''):
             continue
 
         # See above on str and repr
-        if is_string(value):
+        if callable(modifier):
+            optargs_conv.append('{}={}'.format(name, modifier(value)))
+        elif is_string(value):
             if modifier:
                 fmt = '{{{}}}'.format(modifier)
             else:
                 fmt = "'{}'"
+            value_str = fmt.format(value)
+            optargs_conv.append('{}={}'.format(name, value_str))
         else:
             fmt = '{{{}}}'.format(modifier)
+            value_str = fmt.format(value)
+            optargs_conv.append('{}={}'.format(name, value_str))
 
-        value_str = fmt.format(value)
-
-        optargs_conv.append('{}={}'.format(name, value_str))
     if optargs_conv:
         parts.append(opt_sep.join(optargs_conv))
 


### PR DESCRIPTION
Printing of spaces and stuff should be much better now. Includes:
- Using Numpy to print arrays (looks better, easier to implement)
  ```python
  >>> space = odl.uniform_discr([0, 0], [1, 1], (10, 10))
  >>> print(space.one())
  [[ 1.,  1.,  1., ...,  1.,  1.,  1.],
   [ 1.,  1.,  1., ...,  1.,  1.,  1.],
   [ 1.,  1.,  1., ...,  1.,  1.,  1.],
   ..., 
   [ 1.,  1.,  1., ...,  1.,  1.,  1.],
   [ 1.,  1.,  1., ...,  1.,  1.,  1.],
   [ 1.,  1.,  1., ...,  1.,  1.,  1.]]
  ```
- For 1D objects, print on one line up to size 6, otherwise print the content on an extra line. This is debatable, perhaps printing on 1 line is always okay in 1D since the array output is truncated anyway.
  ```python
  >>> space = odl.uniform_discr(0, 1, 6)
  >>> space.one()
  uniform_discr(0.0, 1.0, 6).element([ 1.,  1.,  1.,  1.,  1.,  1.])
  >>> space = odl.uniform_discr(0, 1, 8)
  >>> space.one()
  uniform_discr(0.0, 1.0, 8).element(
      [ 1.,  1.,  1., ...,  1.,  1.,  1.]
  )
  ```
- Floats are rounded to 4 digits of precision in the output, making in particular `uniform_discr` output nicer:
  ```python
  >>> odl.uniform_discr(1 /3, 2 / 3, 6)
  uniform_discr(0.3333, 0.6667, 6)
  ```
- And finally, product space printing is truncated from size 7 (and not attempted to put on one line):
  ```python
  >>> r2 = odl.rn(2)
  >>> r3 = odl.rn(3)
  >>> odl.ProductSpace(r2, r2, r2, r3, r3, r3)
  ProductSpace(rn(2), rn(2), rn(2), rn(3), rn(3), rn(3))
  >>> odl.ProductSpace(r2, r2, r2, r2, r2, r3, r3, r3, r3, r3)
  ProductSpace(
      rn(2),
      rn(2),
      rn(2),
      ...,
      rn(3),
      rn(3),
      rn(3)
  )
  ```