### PR TITLE
Issue 860  remove set classes

### DIFF
--- a/doc/source/dev/extend.rst
+++ b/doc/source/dev/extend.rst
@@ -12,15 +12,15 @@ There are several ways to extend ODL, some of which are listed below.
 
 Adding Fn spaces
 ----------------
-The abstract spaces `FnBase` and `NtuplesBase` are the workhorses of the ODL space machinery. They are used in both the discrete :math:`R^n` case, as well as data representation for discretized function spaces such as :math:`L^2([0, 1])` in the `DiscretizedSpace` class. These are in general created through the `rn` and `uniform_discr` functions who take an ``impl`` parameter, allowing users to select the backend to use.
+The abstract space `FnBase` is the workhorse of the ODL space machinery. They are used in both the discrete :math:`R^n` case, as well as data representation for discretized function spaces such as :math:`L^2([0, 1])` in the `DiscretizedSpace` class. These are in general created through the `rn` and `uniform_discr` functions who take an ``impl`` parameter, allowing users to select the backend to use.
 
-In the core ODL package, there is only a single backend available: `NumpyFn`/`NumpyNtuples`, given by ``impl='numpy'``, which is the default choice. Users can add CUDA support by installing the add-on library odlcuda_, which contains the additional spaces ``CudaFn``/``CudaNtuples``. By using the `rn`/`uniform_discr` functions, users can then seamlessly change the backend of their spaces.
+In the core ODL package, there is only a single backend available: `NumpyFn`, given by ``impl='numpy'``, which is the default choice. Users can add CUDA support by installing the add-on library odlcuda_, which contains the additional space ``CudaFn``. By using the `rn`/`uniform_discr` functions, users can then seamlessly change the backend of their spaces.
 
 As an advanced user, you may need to add additional spaces of this type that can be used inside ODL, perhaps to add MPI_ support. There are a few steps to do this:
 
 * Create a new library with a ``setuptools`` installer.
-* Add the spaces that you want to add to the library. The space needs to inherit from `NtuplesBase` or `FnBase`, respectively, and implement all of the abstract methods in those spaces. See the spaces for further information on the specific methods that need to be implemented.
-* Add the methods ``ntuples_impls()`` and ``fn_impls()`` to a file ``odl_plugin.py`` in your library. These should return a ``dict`` mapping names to implementations.
+* Add the spaces that you want to add to the library. The space needs to inherit from `FnBase` and implement all of the abstract methods in those spaces. See the spaces for further information on the specific methods that need to be implemented.
+* Add the methods ``fn_impl_names()`` and ``fn_impls()`` to a file ``odl_plugin.py`` in your library. These should return a ``dict`` mapping names to implementations.
 * Add the following to your library's ``setup.py`` setup call: ``entry_points={'odl.space': ['odl_cuda = odlcuda.odl_plugin']``, where you replace ``odlcuda`` with the name of your plugin.
 
 .. _odlcuda: https://github.com/odlgroup/odlcuda

--- a/odl/deform/linearized.py
+++ b/odl/deform/linearized.py
@@ -214,7 +214,7 @@ class LinDeformFixedTempl(Operator):
         """
         # To implement the complex case we need to be able to embed the real
         # vector field space into the range of the gradient. Issue #59.
-        if not self.range.is_rn:
+        if not self.range.is_real:
             raise NotImplementedError('derivative not implemented for complex '
                                       'spaces.')
 

--- a/odl/discr/discr_ops.py
+++ b/odl/discr/discr_ops.py
@@ -29,10 +29,10 @@ class Resampling(Operator):
 
     """An operator that resamples on a different grid in the same set.
 
-    The operator uses the underlying `DiscretizedSet.sampling` and
-    `DiscretizedSet.interpolation` operators to achieve this.
+    The operator uses the underlying `DiscretizedSpace.sampling` and
+    `DiscretizedSpace.interpolation` operators to achieve this.
 
-    The spaces need to have the same `DiscretizedSet.uspace` in order
+    The spaces need to have the same `DiscretizedSpace.uspace` in order
     for this to work. The data space implementations may be different,
     although performance may suffer drastically due to translation
     steps.
@@ -43,9 +43,9 @@ class Resampling(Operator):
 
         Parameters
         ----------
-        domain : `DiscretizedSet`
+        domain : `DiscretizedSpace`
             Set of elements that are to be resampled.
-        range : `DiscretizedSet`
+        range : `DiscretizedSpace`
             Set in which the resampled elements lie.
 
         Examples

--- a/odl/discr/lp_discr.py
+++ b/odl/discr/lp_discr.py
@@ -688,7 +688,7 @@ class DiscreteLpElement(DiscretizedSpaceElement):
             shape is allowed as ``values``.
         """
         if values in self.space:
-            # For DiscretizedSetElement of the same type, use ntuple directly
+            # For DiscretizedSpaceElement of the same type, use ntuple directly
             self.ntuple[indices] = values.ntuple
         else:
             # Other sequence types are piped through a Numpy array. Equivalent
@@ -995,7 +995,9 @@ def uniform_discr_frompartition(partition, exponent=2.0, interp='nearest',
         raise ValueError('`partition` is not uniform')
 
     dtype = kwargs.pop('dtype', None)
-    if dtype is not None:
+    if dtype is None:
+        dtype = fn_impl(impl).default_dtype(RealNumbers())
+    else:
         dtype = np.dtype(dtype)
 
     fspace = FunctionSpace(partition.set, out_dtype=dtype)

--- a/odl/operator/default_ops.py
+++ b/odl/operator/default_ops.py
@@ -1156,7 +1156,7 @@ class ComplexEmbedding(Operator):
 
     def _call(self, x, out):
         """Return ``self(x)``."""
-        if self.domain.is_rn:
+        if self.domain.is_real:
             # Real domain, multiply separately
             out.real = self.scalar.real * x
             out.imag = self.scalar.imag * x
@@ -1178,7 +1178,7 @@ class ComplexEmbedding(Operator):
         >>> op.inverse(op([1, 2, 4]))
         rn(3).element([ 1.,  2.,  4.])
         """
-        if self.domain.is_rn:
+        if self.domain.is_real:
             # Real domain
             # Optimizations for simple cases.
             if self.scalar.real == self.scalar:
@@ -1235,7 +1235,7 @@ class ComplexEmbedding(Operator):
         >>> AtAxy == AxAy
         True
         """
-        if self.domain.is_rn:
+        if self.domain.is_real:
             # Real domain
             # Optimizations for simple cases.
             if self.scalar.real == self.scalar:

--- a/odl/operator/operator.py
+++ b/odl/operator/operator.py
@@ -2074,7 +2074,7 @@ class OperatorLeftVectorMult(Operator):
         if not self.is_linear:
             raise OpNotImplementedError('nonlinear operators have no adjoint')
 
-        if self.vector.space.is_rn:
+        if self.vector.space.is_real:
             # The complex conjugate of a real vector is the vector itself.
             return self.operator.adjoint * self.vector
         else:
@@ -2194,7 +2194,7 @@ class OperatorRightVectorMult(Operator):
         if not self.is_linear:
             raise OpNotImplementedError('nonlinear operators have no adjoint')
 
-        if self.vector.space.is_rn:
+        if self.vector.space.is_real:
             # The complex conjugate of a real vector is the vector itself.
             return self.vector * self.operator.adjoint
         else:

--- a/odl/phantom/noise.py
+++ b/odl/phantom/noise.py
@@ -54,7 +54,7 @@ def white_noise(space, mean=0, stddev=1, seed=None):
             values = [white_noise(subspace, mean, stddev)
                       for subspace in space]
         else:
-            if space.is_cn:
+            if space.is_complex:
                 real = np.random.normal(
                     loc=mean.real, scale=stddev, size=space.shape)
                 imag = np.random.normal(
@@ -106,7 +106,7 @@ def uniform_noise(space, low=0, high=1, seed=None):
             values = [uniform_noise(subspace, low, high)
                       for subspace in space]
         else:
-            if space.is_cn:
+            if space.is_complex:
                 real = np.random.uniform(low=low.real, high=high.real,
                                          size=space.shape)
                 imag = np.random.uniform(low=low.imag, high=high.imag,

--- a/odl/set/space.py
+++ b/odl/set/space.py
@@ -36,12 +36,14 @@ class LinearSpace(Set):
 
         Parameters
         ----------
-        field : `Field`
+        field : `Field` or None
             Scalar field of numbers for this space.
         """
-        if not isinstance(field, Field):
-            raise TypeError('`field` {!r} is not a `Field` instance')
-        self.__field = field
+        if field is None or isinstance(field, Field):
+            self.__field = field
+        else:
+            raise TypeError('`field` must be a `Field` instance or `None`, '
+                            'got {!r}'.format(field))
 
     @property
     def field(self):
@@ -96,7 +98,6 @@ class LinearSpace(Set):
         This method is intended to be private. Public callers should
         resort to `dist` which is type-checked.
         """
-        # default implementation
         return self.norm(x1 - x2)
 
     def _norm(self, x):
@@ -105,7 +106,6 @@ class LinearSpace(Set):
         This method is intended to be private. Public callers should
         resort to `norm` which is type-checked.
         """
-        # default implementation
         return float(np.sqrt(self.inner(x, x).real))
 
     def _inner(self, x1, x2):
@@ -114,7 +114,6 @@ class LinearSpace(Set):
         This method is intended to be private. Public callers should
         resort to `inner` which is type-checked.
         """
-        # No default implementation possible
         raise LinearSpaceNotImplementedError(
             'inner product not implemented in space {!r}'.format(self))
 
@@ -124,7 +123,6 @@ class LinearSpace(Set):
         This method is intended to be private. Public callers should
         resort to `multiply` which is type-checked.
         """
-        # No default implementation possible
         raise LinearSpaceNotImplementedError(
             'multiplication not implemented in space {!r}'.format(self))
 
@@ -204,7 +202,7 @@ class LinearSpace(Set):
         elif out not in self:
             raise LinearSpaceTypeError('`out` {!r} is not an element of {!r}'
                                        ''.format(out, self))
-        if a not in self.field:
+        if self.field is not None and a not in self.field:
             raise LinearSpaceTypeError('`a` {!r} not an element of the field '
                                        '{!r} of {!r}'
                                        ''.format(a, self.field, self))
@@ -219,7 +217,7 @@ class LinearSpace(Set):
             return out
 
         else:  # Two elements
-            if b not in self.field:
+            if self.field is not None and b not in self.field:
                 raise LinearSpaceTypeError('`b` {!r} not an element of the '
                                            'field {!r} of {!r}'
                                            ''.format(b, self.field, self))
@@ -250,7 +248,6 @@ class LinearSpace(Set):
         if x2 not in self:
             raise LinearSpaceTypeError('`x2` {!r} is not an element of '
                                        '{!r}'.format(x2, self))
-
         return float(self._dist(x1, x2))
 
     def norm(self, x):
@@ -269,7 +266,6 @@ class LinearSpace(Set):
         if x not in self:
             raise LinearSpaceTypeError('`x` {!r} is not an element of '
                                        '{!r}'.format(x, self))
-
         return float(self._norm(x))
 
     def inner(self, x1, x2):
@@ -291,8 +287,11 @@ class LinearSpace(Set):
         if x2 not in self:
             raise LinearSpaceTypeError('`x2` {!r} is not an element of '
                                        '{!r}'.format(x2, self))
-
-        return self.field.element(self._inner(x1, x2))
+        inner = self._inner(x1, x2)
+        if self.field is None:
+            return inner
+        else:
+            return self.field.element(self._inner(x1, x2))
 
     def multiply(self, x1, x2, out=None):
         """Return the pointwise product of ``x1`` and ``x2``.

--- a/odl/solvers/util/callback.py
+++ b/odl/solvers/util/callback.py
@@ -569,7 +569,7 @@ class CallbackShow(Callback):
     See Also
     --------
     odl.discr.lp_discr.DiscreteLpElement.show
-    odl.space.base_ntuples.NtuplesBaseVector.show
+    odl.space.base_ntuples.FnBaseVector.show
     """
 
     def __init__(self, title=None, step=1, saveto=None, **kwargs):

--- a/odl/space/base_ntuples.py
+++ b/odl/space/base_ntuples.py
@@ -10,7 +10,6 @@
 
 # Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
-from builtins import int
 
 import numpy as np
 
@@ -44,6 +43,8 @@ class FnBase(LinearSpace):
             as built-in type, as one of NumPy's internal datatype
             objects or as string.
         """
+        # Make sure that huge sizes don't overflow in Py2
+        from builtins import int
         self.__size = int(size)
         if self.size < 0:
             raise ValueError('`size` must be non-negative, got {}'

--- a/odl/space/base_ntuples.py
+++ b/odl/space/base_ntuples.py
@@ -45,8 +45,9 @@ class FnBase(LinearSpace):
             objects or as string.
         """
         # Make sure that huge sizes don't overflow in Py2
+        import builtins
         if sys.version_info.major < 3:
-            self.__size = long(size)
+            self.__size = builtins.int(size)
         else:
             self.__size = int(size)
 
@@ -99,7 +100,15 @@ class FnBase(LinearSpace):
 
     @property
     def size(self):
-        """Number of entries per tuple."""
+        """Number of entries per tuple.
+
+        .. note::
+            In Python 2, the returned type is ``builtins.int`` from the
+            ``future`` library, to mimic the auto-width behavior of Python 3
+            ``int``. This avoids different printing between Python versions
+            while ensuring that sizes larger than ``2 ** 31 - 1`` do not
+            overflow.
+        """
         return self.__size
 
     @property

--- a/odl/space/entry_points.py
+++ b/odl/space/entry_points.py
@@ -8,9 +8,9 @@
 
 """Entry points for adding more spaces to ODL using external packages.
 
-External packages can add implementations of `NtuplesBase` and `FnBase` by
-hooking into the setuptools entry point ``'odl.space'`` and exposing the
-methods ``ntuples_impls`` and ``fn_impls``.
+External packages can add implementations of `FnBase` by hooking into the
+setuptools entry point ``'odl.space'`` and exposing the methods
+``fn_impl_names`` and ``fn_impl``.
 
 This is used with functions such as `rn`, `fn` and `uniform_discr` in order
 to allow arbitrary implementations.
@@ -18,25 +18,22 @@ to allow arbitrary implementations.
 See Also
 --------
 NumpyFn : Numpy based implementation of `FnBase`
-NumpyNtuples : Numpy based implementation of `NtuplesBase`
 """
 
 # Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
 
-from odl.space.npy_ntuples import NumpyNtuples, NumpyFn
+from odl.space.npy_ntuples import NumpyFn
 
-__all__ = ('ntuples_impl_names', 'fn_impl_names',
-           'ntuples_impl', 'fn_impl')
+__all__ = ('fn_impl_names', 'fn_impl')
 
 IS_INITIALIZED = False
-NTUPLES_IMPLS = {'numpy': NumpyNtuples}
 FN_IMPLS = {'numpy': NumpyFn}
 
 
 def _initialize_if_needed():
-    """Initialize ``NTUPLES_IMPLS`` and ``FN_IMPLS`` if not already done."""
-    global IS_INITIALIZED, NTUPLES_IMPLS, FN_IMPLS
+    """Initialize ``FN_IMPLS`` if not already done."""
+    global IS_INITIALIZED, FN_IMPLS
     if not IS_INITIALIZED:
         # pkg_resources has long import time
         from pkg_resources import iter_entry_points
@@ -46,51 +43,14 @@ def _initialize_if_needed():
             except ImportError:
                 pass
             else:
-                NTUPLES_IMPLS.update(module.ntuples_impls())
                 FN_IMPLS.update(module.fn_impls())
         IS_INITIALIZED = True
-
-
-def ntuples_impl_names():
-    """A tuple of strings with valid ntuples implementation names."""
-    _initialize_if_needed()
-    return tuple(NTUPLES_IMPLS.keys())
 
 
 def fn_impl_names():
     """A tuple of strings with valid fn implementation names."""
     _initialize_if_needed()
     return tuple(FN_IMPLS.keys())
-
-
-def ntuples_impl(impl):
-    """N-tuples class corresponding to key.
-
-    Parameters
-    ----------
-    impl : `str`
-        Name of the implementation, see `ntuples_impl_names` for full list.
-
-    Returns
-    -------
-    ntuples_impl : `type`
-        Class inheriting from `NtuplesBase`.
-
-    Raises
-    ------
-    ValueError
-        If ``impl`` is not a valid name of a ntuples imlementation.
-    """
-    if impl != 'numpy':
-        # Shortcut to improve "import odl" times since most users do not use
-        # non-numpy backend.
-        _initialize_if_needed()
-
-    try:
-        return NTUPLES_IMPLS[impl]
-    except KeyError:
-        raise ValueError("key '{}' does not correspond to a valid ntuples "
-                         "implmentation".format(impl))
 
 
 def fn_impl(impl):

--- a/odl/space/fspace.py
+++ b/odl/space/fspace.py
@@ -15,7 +15,7 @@ from inspect import isfunction
 import numpy as np
 
 from odl.operator.operator import Operator, _dispatch_call_args
-from odl.set import (RealNumbers, ComplexNumbers, Set, Field, LinearSpace,
+from odl.set import (RealNumbers, ComplexNumbers, Set, LinearSpace,
                      LinearSpaceElement)
 from odl.util import (
     is_real_dtype, is_complex_floating_dtype, dtype_repr,
@@ -25,8 +25,7 @@ from odl.util import (
 from odl.util.utility import preload_first_arg
 
 
-__all__ = ('FunctionSet', 'FunctionSetElement',
-           'FunctionSpace', 'FunctionSpaceElement')
+__all__ = ('FunctionSpace', 'FunctionSpaceElement')
 
 
 def _default_in_place(func, x, out, **kwargs):
@@ -70,515 +69,37 @@ def _broadcast_to(array, shape):
         return array + np.zeros(shape, dtype=array.dtype)
 
 
-class FunctionSet(Set):
+class FunctionSpace(LinearSpace):
 
-    """A general set of functions with common domain and range."""
+    """A vector space of functions."""
 
-    def __init__(self, domain, range, out_dtype=None):
+    def __init__(self, domain, out_dtype=float):
         """Initialize a new instance.
 
         Parameters
         ----------
         domain : `Set`
             The domain of the functions.
-        range : `Set`
-            The range of the functions.
         out_dtype : optional
-            Data type of the return value of a function in this space.
-            Can be given in any way `numpy.dtype` understands, e.g. as
-            string ('bool') or data type (bool).
-            If no data type is given, a "lazy" evaluation is applied,
-            i.e. an adequate data type is inferred during function
-            evaluation.
+            Scalar data type of the return value of a function in this
+            space. Can be provided in any way the `numpy.dtype`
+            constructor understands, e.g. as built-in type or as a string.
+            For ``None``, dtypes of results are inferred lazily at runtime.
         """
         if not isinstance(domain, Set):
             raise TypeError('`domain` {!r} not a `Set` instance'
                             ''.format(domain))
 
-        if not isinstance(range, Set):
-            raise TypeError('`range` {!r} not a `Set` instance'
-                            ''.format(range))
-
-        self.__domain = domain
-        self.__range = range
-        self.__out_dtype = None if out_dtype is None else np.dtype(out_dtype)
-
-    @property
-    def domain(self):
-        """Common domain of all functions in this set."""
-        return self.__domain
-
-    @property
-    def range(self):
-        """Common range of all functions in this set."""
-        return self.__range
-
-    @property
-    def out_dtype(self):
-        """Output data type of this function.
-
-        If ``None``, the output data type is not uniquely pre-defined.
-        """
-        return self.__out_dtype
-
-    def element(self, fcall, vectorized=True):
-        """Create a `FunctionSet` element.
-
-        Parameters
-        ----------
-        fcall : callable
-            The actual instruction for out-of-place evaluation.
-            It must return a `FunctionSet.range` element or a
-            `numpy.ndarray` of such (vectorized call).
-
-        vectorized : bool, optional
-            Whether ``fcall`` supports vectorized evaluation.
-
-        Returns
-        -------
-        element : `FunctionSetElement`
-            The new element, always supports vectorization
-
-        See Also
-        --------
-        odl.discr.grid.RectGrid.meshgrid : efficient grids for function
-            evaluation
-        """
-        if not callable(fcall):
-            raise TypeError('`fcall` {!r} is not callable'.format(fcall))
-        elif fcall in self:
-            return fcall
-        else:
-            if not vectorized:
-                fcall = vectorize(fcall)
-
-            return self.element_type(self, fcall)
-
-    def __eq__(self, other):
-        """Return ``self == other``.
-
-        Returns
-        -------
-        equals : bool
-            ``True`` if ``other`` is a `FunctionSet` with same
-            `FunctionSet.domain` and `FunctionSet.range`, ``False`` otherwise.
-        """
-        if other is self:
-            return True
-
-        return (isinstance(other, type(self)) and
-                isinstance(self, type(other)) and
-                self.domain == other.domain and
-                self.range == other.range and
-                self.out_dtype == other.out_dtype)
-
-    def __hash__(self):
-        """Return ``hash(self)``."""
-        return hash((type(self), self.domain, self.range, self.out_dtype))
-
-    def __contains__(self, other):
-        """Return ``other in self``.
-
-        Returns
-        -------
-        equals : bool
-            ``True`` if ``other`` is a `FunctionSetElement`
-            whose `FunctionSetElement.space` attribute
-            equals this space, ``False`` otherwise.
-        """
-        return (isinstance(other, self.element_type) and
-                self == other.space)
-
-    def __repr__(self):
-        """Return ``repr(self)``."""
-        return '{}({!r}, {!r})'.format(self.__class__.__name__,
-                                       self.domain, self.range)
-
-    def __str__(self):
-        """Return ``str(self)``."""
-        return '{}({}, {})'.format(self.__class__.__name__,
-                                   self.domain, self.range)
-
-    @property
-    def element_type(self):
-        """`FunctionSetElement`"""
-        return FunctionSetElement
-
-
-class FunctionSetElement(Operator):
-
-    """Representation of a `FunctionSet` element."""
-
-    def __init__(self, fset, fcall):
-        """Initialize a new instance.
-
-        Parameters
-        ----------
-        fset : `FunctionSet`
-            Set of functions this element lives in.
-        fcall : callable
-            The actual instruction for out-of-place evaluation.
-            It must return a `FunctionSet.range` element or a
-            `numpy.ndarray` of such (vectorized call).
-        """
-        super(FunctionSetElement, self).__init__(
-            fset.domain, fset.range, linear=False)
-        self.__space = fset
-
-        # Determine which type of implementation fcall is
-        if isinstance(fcall, FunctionSetElement):
-            call_has_out, call_out_optional, _ = _dispatch_call_args(
-                bound_call=fcall._call)
-
-        # Numpy Ufuncs and similar objects (e.g. Numba DUfuncs)
-        elif hasattr(fcall, 'nin') and hasattr(fcall, 'nout'):
-            if fcall.nin != 1:
-                raise ValueError('ufunc {} has {} input parameter(s), '
-                                 'expected 1'
-                                 ''.format(fcall.__name__, fcall.nin))
-            if fcall.nout > 1:
-                raise ValueError('ufunc {} has {} output parameter(s), '
-                                 'expected at most 1'
-                                 ''.format(fcall.__name__, fcall.nout))
-            call_has_out = call_out_optional = (fcall.nout == 1)
-        elif isfunction(fcall):
-            call_has_out, call_out_optional, _ = _dispatch_call_args(
-                unbound_call=fcall)
-        elif callable(fcall):
-            call_has_out, call_out_optional, _ = _dispatch_call_args(
-                bound_call=fcall.__call__)
-        else:
-            raise TypeError('type {!r} not callable')
-
-        self._call_has_out = call_has_out
-        self._call_out_optional = call_out_optional
-
-        if not call_has_out:
-            # Out-of-place-only
-            self._call_in_place = preload_first_arg(self, 'in-place')(
-                _default_in_place)
-            self._call_out_of_place = fcall
-        elif call_out_optional:
-            # Dual-use
-            self._call_in_place = self._call_out_of_place = fcall
-        else:
-            # In-place-only
-            self._call_in_place = fcall
-            self._call_out_of_place = preload_first_arg(self, 'out-of-place')(
-                _default_out_of_place)
-
-    @property
-    def space(self):
-        """Space or set this function belongs to."""
-        return self.__space
-
-    @property
-    def out_dtype(self):
-        """Output data type of this function.
-
-        If ``None``, the output data type is not uniquely pre-defined.
-        """
-        return self.space.out_dtype
-
-    def _call(self, x, out=None, **kwargs):
-        """Raw evaluation method."""
-        if out is None:
-            return self._call_out_of_place(x, **kwargs)
-        else:
-            self._call_in_place(x, out=out, **kwargs)
-
-    def __call__(self, x, out=None, **kwargs):
-        """Return ``self(x[, out, **kwargs])``.
-
-        Parameters
-        ----------
-        x : `domain` `element-like`, `meshgrid` or `numpy.ndarray`
-            Input argument for the function evaluation. Conditions
-            on ``x`` depend on its type:
-
-            element-like: must be a castable to a domain element
-
-            meshgrid: length must be ``space.ndim``, and the arrays must
-            be broadcastable against each other.
-
-            array:  shape must be ``(d, N)``, where ``d`` is the number
-            of dimensions of the function domain
-
-        out : `numpy.ndarray`, optional
-            Output argument holding the result of the function
-            evaluation, can only be used for vectorized
-            functions. Its shape must be equal to
-            ``np.broadcast(*x).shape``.
-
-        Other Parameters
-        ----------------
-        bounds_check : bool, optional
-            If ``True``, check if all input points lie in the function
-            domain in the case of vectorized evaluation. This requires
-            the domain to implement `Set.contains_all`.
-            Default: ``True``
-
-        Returns
-        -------
-        out : range element or array of elements
-            Result of the function evaluation. If ``out`` was provided,
-            the returned object is a reference to it.
-
-        Raises
-        ------
-        TypeError
-            If ``x`` is not a valid vectorized evaluation argument
-
-            If ``out`` is not a range element or a `numpy.ndarray`
-            of range elements
-
-        ValueError
-            If evaluation points fall outside the valid domain
-        """
-        bounds_check = kwargs.pop('bounds_check', True)
-        if bounds_check and not hasattr(self.domain, 'contains_all'):
-            raise AttributeError('bounds check not possible for '
-                                 'domain {}, missing `contains_all()` '
-                                 'method'.format(self.domain))
-
-        if bounds_check and not hasattr(self.range, 'contains_all'):
-            raise AttributeError('bounds check not possible for '
-                                 'range {}, missing `contains_all()` '
-                                 'method'.format(self.range))
-
-        ndim = getattr(self.domain, 'ndim', None)
-        # Check for input type and determine output shape
-        if is_valid_input_meshgrid(x, ndim):
-            out_shape = out_shape_from_meshgrid(x)
-            scalar_out = False
-            # Avoid operations on tuples like x * 2 by casting to array
-            if ndim == 1:
-                x = x[0][None, ...]
-        elif is_valid_input_array(x, ndim):
-            x = np.asarray(x)
-            out_shape = out_shape_from_array(x)
-            scalar_out = False
-            # For 1d, squeeze the array
-            if ndim == 1 and x.ndim == 2:
-                x = x.squeeze()
-        elif x in self.domain:
-            x = np.atleast_2d(x).T  # make a (d, 1) array
-            out_shape = (1,)
-            scalar_out = (out is None)
-        else:
-            # Unknown input
-            txt_1d = ' or (n,)' if ndim == 1 else ''
-            raise TypeError('Argument {!r} not a valid vectorized '
-                            'input. Expected an element of the domain '
-                            '{domain}, an array-like with shape '
-                            '({domain.ndim}, n){} or a length-{domain.ndim} '
-                            'meshgrid tuple.'
-                            ''.format(x, txt_1d, domain=self.domain))
-
-        # Check bounds if specified
-        if bounds_check:
-            if not self.domain.contains_all(x):
-                raise ValueError('input contains points outside '
-                                 'the domain {}'.format(self.domain))
-
-        # Call the function and check out shape, before or after
-        if out is None:
-            if ndim == 1:
-                try:
-                    out = self._call(x, **kwargs)
-                except (TypeError, IndexError):
-                    # TypeError is raised if a meshgrid was used but the
-                    # function expected an array (1d only). In this case we try
-                    # again with the first meshgrid vector.
-                    # IndexError is raised in expressions like x[x > 0] since
-                    # "x > 0" evaluates to 'True', i.e. 1, and that index is
-                    # out of range for a meshgrid tuple of length 1 :-). To get
-                    # the real errors with indexing, we check again for the
-                    # same scenario (scalar output when not valid) as in the
-                    # first case.
-                    out = self._call(x[0], **kwargs)
-
-                # squeeze to remove extra axes.
-                out = np.squeeze(out)
-            else:
-                out = self._call(x, **kwargs)
-
-            # Cast to proper dtype if needed, also convert to array if out
-            # is scalar.
-            out = np.asarray(out, self.out_dtype)
-
-            if out_shape != (1,) and out.shape != out_shape:
-                # Try to broadcast the returned element if possible
-                out = _broadcast_to(out, out_shape)
-        else:
-            if not isinstance(out, np.ndarray):
-                raise TypeError('output {!r} not a `numpy.ndarray` '
-                                'instance')
-            if out_shape != (1,) and out.shape != out_shape:
-                raise ValueError('output shape {} not equal to shape '
-                                 '{} expected from input'
-                                 ''.format(out.shape, out_shape))
-            if self.out_dtype is not None and out.dtype != self.out_dtype:
-                raise ValueError('`out.dtype` ({}) does not match out_dtype '
-                                 '({})'.format(out.dtype, self.out_dtype))
-
-            if ndim == 1:
-                # TypeError for meshgrid in 1d, but expected array (see above)
-                try:
-                    self._call(x, out=out, **kwargs)
-                except TypeError:
-                    self._call(x[0], out=out, **kwargs)
-            else:
-                self._call(x, out=out, **kwargs)
-
-        # Check output values
-        if bounds_check:
-            if not self.range.contains_all(out):
-                raise ValueError('output contains points outside '
-                                 'the range {}'
-                                 ''.format(self.range))
-
-        # Numpy does not implement __complex__ for arrays (in contrast to
-        # __float__), so we have to fish out the scalar ourselves.
-        return self.range.element(out.ravel()[0]) if scalar_out else out
-
-    def assign(self, other):
-        """Assign ``other`` to ``self``.
-
-        This is implemented without `FunctionSpace.lincomb` to ensure that
-        ``self == other`` evaluates to True after ``self.assign(other)``.
-        """
-        if other not in self.space:
-            raise TypeError('`other` {!r} is not an element of the space '
-                            '{} of this function'
-                            ''.format(other, self.space))
-        self._call_in_place = other._call_in_place
-        self._call_out_of_place = other._call_out_of_place
-        self._call_has_out = other._call_has_out
-        self._call_out_optional = other._call_out_optional
-
-    def copy(self):
-        """Create an identical (deep) copy of this element."""
-        result = self.space.element()
-        result.assign(self)
-        return result
-
-    def __eq__(self, other):
-        """Return ``self == other``.
-
-        Returns
-        -------
-        equals : bool
-            ``True`` if ``other`` is a `FunctionSetElement` with
-            ``other.space == self.space``, and the functions for evaluation
-            evaluation of ``self`` and ``other`` are the same, ``False``
-            otherwise.
-        """
-        if other is self:
-            return True
-
-        if not isinstance(other, FunctionSetElement):
-            return False
-
-        # We cannot blindly compare since functions may have been wrapped
-        if (self._call_has_out != other._call_has_out or
-                self._call_out_optional != other._call_out_optional):
-            return False
-
-        if self._call_has_out:
-            # Out-of-place can be wrapped in this case, so we compare only
-            # the in-place methods.
-            funcs_equal = self._call_in_place == other._call_in_place
-        else:
-            # Just the opposite of the first case
-            funcs_equal = self._call_out_of_place == other._call_out_of_place
-
-        return self.space == other.space and funcs_equal
-
-    def __str__(self):
-        """Return ``str(self)``."""
-        if self._call_has_out:
-            func = self._call_in_place
-        else:
-            func = self._call_out_of_place
-        return '{}: {} --> {}'.format(func, self.domain, self.range)
-
-    def __repr__(self):
-        """Return ``repr(self)``."""
-        if self._call_has_out:
-            func = self._call_in_place
-        else:
-            func = self._call_out_of_place
-
-        return '{!r}.element({!r})'.format(self.space, func)
-
-
-class FunctionSpace(FunctionSet, LinearSpace):
-
-    """A vector space of functions."""
-
-    def __init__(self, domain, field=None, out_dtype=None):
-        """Initialize a new instance.
-
-        Parameters
-        ----------
-        domain : `Set`
-            The domain of the functions
-        field : `Field`, optional
-            The range of the functions, usually the `RealNumbers` or
-            `ComplexNumbers`. If not given, the field is either inferred
-            from ``out_dtype``, or, if the latter is also ``None``, set
-            to ``RealNumbers()``.
-        out_dtype : optional
-            Data type of the return value of a function in this space.
-            Can be given in any way `numpy.dtype` understands, e.g. as
-            string (``'float64'``) or data type (``float``).
-            By default, ``'float64'`` is used for real and ``'complex128'``
-            for complex spaces.
-        """
-        if not isinstance(domain, Set):
-            raise TypeError('`domain` {!r} not a Set instance'.format(domain))
-
-        if field is not None and not isinstance(field, Field):
-            raise TypeError('`field` {!r} not a `Field` instance'
-                            ''.format(field))
-
-        # Data type: check if consistent with field, take default for None
-        dtype, dtype_in = np.dtype(out_dtype), out_dtype
-
-        # Default for both None
-        if field is None and out_dtype is None:
+        if is_real_dtype(out_dtype):
             field = RealNumbers()
-            out_dtype = np.dtype('float64')
+        elif is_complex_floating_dtype(out_dtype):
+            field = ComplexNumbers()
+        else:
+            field = None
 
-        # field None, dtype given -> infer field
-        elif field is None:
-            if is_real_dtype(dtype):
-                field = RealNumbers()
-            elif is_complex_floating_dtype(dtype):
-                field = ComplexNumbers()
-            else:
-                raise ValueError('{} is not a scalar data type'
-                                 ''.format(dtype_in))
-
-        # field given -> infer dtype if not given, else check consistency
-        elif field == RealNumbers():
-            if out_dtype is None:
-                out_dtype = np.dtype('float64')
-            elif not is_real_dtype(dtype):
-                raise ValueError('{} is not a real data type'
-                                 ''.format(dtype_in))
-        elif field == ComplexNumbers():
-            if out_dtype is None:
-                out_dtype = np.dtype('complex128')
-            elif not is_complex_floating_dtype(dtype):
-                raise ValueError('{} is not a complex data type'
-                                 ''.format(dtype_in))
-
-        # Else: keep out_dtype=None, which results in lazy dtype determination
-
-        LinearSpace.__init__(self, field)
-        FunctionSet.__init__(self, domain, field, out_dtype)
+        super(FunctionSpace, self).__init__(field)
+        self.__domain = domain
+        self.__out_dtype = None if out_dtype is None else np.dtype(out_dtype)
 
         # Init cache attributes for real / complex variants
         if self.field == RealNumbers():
@@ -597,6 +118,19 @@ class FunctionSpace(FunctionSet, LinearSpace):
             self.__real_space = None
             self.__complex_out_dtype = None
             self.__complex_space = None
+
+    @property
+    def domain(self):
+        """Common domain of all functions in this set."""
+        return self.__domain
+
+    @property
+    def out_dtype(self):
+        """Output data type of this function.
+
+        If ``None``, the output data type is not uniquely pre-defined.
+        """
+        return self.__out_dtype
 
     @property
     def real_out_dtype(self):
@@ -625,12 +159,11 @@ class FunctionSpace(FunctionSet, LinearSpace):
         ----------
         fcall : callable, optional
             The actual instruction for out-of-place evaluation.
-            It must return a `FunctionSet.range` element or a
+            It must return a `FunctionSpace.range` element or a
             `numpy.ndarray` of such (vectorized call).
-
-            If fcall is a `FunctionSetElement`, it is wrapped
+            If ``fcall`` is a `FunctionSpaceElement`, it is wrapped
             as a new `FunctionSpaceElement`.
-
+            For ``None``, the `zero` element is returned.
         vectorized : bool, optional
             Whether ``fcall`` supports vectorized evaluation.
 
@@ -641,24 +174,31 @@ class FunctionSpace(FunctionSet, LinearSpace):
 
         Notes
         -----
-        If you specify ``vectorized=False``, the function is decorated
-        with a vectorizer, which makes two elements created this way
-        from the same function being regarded as *not equal*.
+        For ``vectorized=False``, the function is decorated with a
+        vectorizer, which makes two elements created this way from the same
+        function being regarded as *not equal*.
+
+        See Also
+        --------
+        odl.discr.grid.RectGrid.meshgrid : efficient grids for function
+            evaluation
         """
         if fcall is None:
             return self.zero()
         elif fcall in self:
             return fcall
+        elif not callable(fcall):
+            raise TypeError('`fcall` {!r} is not callable'.format(fcall))
         else:
-            if not callable(fcall):
-                raise TypeError('`fcall` {!r} is not callable'.format(fcall))
             if not vectorized:
                 if self.field == RealNumbers():
-                    dtype = 'float64'
+                    otypes = ['float64']
+                elif self.field == ComplexNumbers():
+                    otypes = ['complex128']
                 else:
-                    dtype = 'complex128'
+                    otypes = []
 
-                fcall = vectorize(otypes=[dtype])(fcall)
+                fcall = vectorize(otypes=otypes)(fcall)
 
             return self.element_type(self, fcall)
 
@@ -682,7 +222,10 @@ class FunctionSpace(FunctionSet, LinearSpace):
             if out is None:
                 return np.zeros(out_shape, dtype=self.out_dtype)
             else:
-                out.fill(0)
+                # Need to go through an array to fill with the correct
+                # zero value for all dtypes
+                fill_value = np.zeros(1, dtype=self.out_dtype)[0]
+                out.fill(fill_value)
 
         return self.element_type(self, zero_vec)
 
@@ -703,9 +246,46 @@ class FunctionSpace(FunctionSet, LinearSpace):
             if out is None:
                 return np.ones(out_shape, dtype=self.out_dtype)
             else:
-                out.fill(1)
+                # Need to go through an array to fill with the correct
+                # one value for all dtypes
+                fill_value = np.ones(1, dtype=self.out_dtype)[0]
+                out.fill(fill_value)
 
         return self.element_type(self, one_vec)
+
+    def __eq__(self, other):
+        """Return ``self == other``.
+
+        Returns
+        -------
+        equals : bool
+            ``True`` if ``other`` is a `FunctionSpace` with same
+            `FunctionSpace.domain` and `FunctionSpace.range`, ``False``
+            otherwise.
+        """
+        if other is self:
+            return True
+
+        return (type(self) is type(other) and
+                self.domain == other.domain and
+                self.out_dtype == other.out_dtype)
+
+    def __hash__(self):
+        """Return ``hash(self)``."""
+        return hash((type(self), self.domain, self.out_dtype))
+
+    def __contains__(self, other):
+        """Return ``other in self``.
+
+        Returns
+        -------
+        equals : bool
+            ``True`` if ``other`` is a `FunctionSpaceElement`
+            whose `FunctionSpaceElement.space` attribute
+            equals this space, ``False`` otherwise.
+        """
+        return (isinstance(other, self.element_type) and
+                other.space == self)
 
     def _astype(self, out_dtype):
         """Internal helper for ``astype``."""
@@ -716,7 +296,7 @@ class FunctionSpace(FunctionSet, LinearSpace):
 
         Parameters
         ----------
-        out_dtype : optional
+        out_dtype :
             Output data type of the returned space. Can be given in any
             way `numpy.dtype` understands, e.g. as string ('complex64')
             or data type (complex). None is interpreted as 'float64'.
@@ -987,10 +567,7 @@ class FunctionSpace(FunctionSet, LinearSpace):
 
         # Zero and One
         yield ('Zero', self.zero())
-        try:
-            yield ('One', self.one())
-        except NotImplementedError:
-            pass
+        yield ('One', self.one())
 
         # Indicator function in first dimension
         def _step_fun(x):
@@ -1075,11 +652,6 @@ class FunctionSpace(FunctionSet, LinearSpace):
 
             yield ('Grad all', self.element(_all_gradient_fun))
 
-    @property
-    def element_type(self):
-        """`FunctionSpaceElement`"""
-        return FunctionSpaceElement
-
     def __repr__(self):
         """Return ``repr(self)``."""
         inner_str = '{!r}'.format(self.domain)
@@ -1126,8 +698,13 @@ class FunctionSpace(FunctionSet, LinearSpace):
 
         return '{}({})'.format(self.__class__.__name__, inner_str)
 
+    @property
+    def element_type(self):
+        """`FunctionSpaceElement`"""
+        return FunctionSpaceElement
 
-class FunctionSpaceElement(LinearSpaceElement, FunctionSetElement):
+
+class FunctionSpaceElement(LinearSpaceElement):
 
     """Representation of a `FunctionSpace` element."""
 
@@ -1140,25 +717,285 @@ class FunctionSpaceElement(LinearSpaceElement, FunctionSetElement):
             Set of functions this element lives in.
         fcall : callable
             The actual instruction for out-of-place evaluation.
-            It must return an `FunctionSet.range` element or a
-            ``numpy.ndarray`` of such (vectorized call).
+            It must return a `FunctionSpace.range` element or a
+            `numpy.ndarray` of such (vectorized call).
         """
-        if not isinstance(fspace, FunctionSpace):
-            raise TypeError('`fspace` {!r} not a `FunctionSpace` '
-                            'instance'.format(fspace))
+        super(FunctionSpaceElement, self).__init__(fspace)
 
-        LinearSpaceElement.__init__(self, fspace)
-        FunctionSetElement.__init__(self, fspace, fcall)
+        # Determine which type of implementation fcall is
+        if isinstance(fcall, FunctionSpaceElement):
+            call_has_out, call_out_optional, _ = _dispatch_call_args(
+                bound_call=fcall._call)
 
-    # Tradeoff: either we subclass LinearSpaceElement first and override the
-    # 3 methods in FunctionSetElement (as below) which LinearSpaceElement
-    # also has, or we switch inheritance order and need to override all magic
-    # methods from LinearSpaceElement which are not in-place. This is due to
-    # the fact that FunctionSetElement inherits from Operator which defines
-    # some of those magic methods, and those do not work in this case.
-    __eq__ = FunctionSetElement.__eq__
-    assign = FunctionSetElement.assign
-    copy = FunctionSetElement.copy
+        # Numpy Ufuncs and similar objects (e.g. Numba DUfuncs)
+        elif hasattr(fcall, 'nin') and hasattr(fcall, 'nout'):
+            if fcall.nin != 1:
+                raise ValueError('ufunc {} has {} input parameter(s), '
+                                 'expected 1'
+                                 ''.format(fcall.__name__, fcall.nin))
+            if fcall.nout > 1:
+                raise ValueError('ufunc {} has {} output parameter(s), '
+                                 'expected at most 1'
+                                 ''.format(fcall.__name__, fcall.nout))
+            call_has_out = call_out_optional = (fcall.nout == 1)
+        elif isfunction(fcall):
+            call_has_out, call_out_optional, _ = _dispatch_call_args(
+                unbound_call=fcall)
+        elif callable(fcall):
+            call_has_out, call_out_optional, _ = _dispatch_call_args(
+                bound_call=fcall.__call__)
+        else:
+            raise TypeError('type {!r} not callable')
+
+        self._call_has_out = call_has_out
+        self._call_out_optional = call_out_optional
+
+        if not call_has_out:
+            # Out-of-place-only
+            self._call_in_place = preload_first_arg(self, 'in-place')(
+                _default_in_place)
+            self._call_out_of_place = fcall
+        elif call_out_optional:
+            # Dual-use
+            self._call_in_place = self._call_out_of_place = fcall
+        else:
+            # In-place-only
+            self._call_in_place = fcall
+            self._call_out_of_place = preload_first_arg(self, 'out-of-place')(
+                _default_out_of_place)
+
+    @property
+    def domain(self):
+        """Set of objects on which this function can be evaluated."""
+        return self.space.domain
+
+    @property
+    def out_dtype(self):
+        """Output data type of this function.
+        If ``None``, the output data type is not uniquely pre-defined.
+        """
+        return self.space.out_dtype
+
+    def _call(self, x, out=None, **kwargs):
+        """Raw evaluation method."""
+        if out is None:
+            return self._call_out_of_place(x, **kwargs)
+        else:
+            self._call_in_place(x, out=out, **kwargs)
+
+    def __call__(self, x, out=None, **kwargs):
+        """Return ``self(x[, out, **kwargs])``.
+
+        Parameters
+        ----------
+        x : `domain` `element-like`, `meshgrid` or `numpy.ndarray`
+            Input argument for the function evaluation. Conditions
+            on ``x`` depend on its type:
+
+            element-like: must be a castable to a domain element
+
+            meshgrid: length must be ``space.ndim``, and the arrays must
+            be broadcastable against each other.
+
+            array:  shape must be ``(d, N)``, where ``d`` is the number
+            of dimensions of the function domain
+
+        out : `numpy.ndarray`, optional
+            Output argument holding the result of the function
+            evaluation, can only be used for vectorized
+            functions. Its shape must be equal to
+            ``np.broadcast(*x).shape``.
+
+        Other Parameters
+        ----------------
+        bounds_check : bool, optional
+            If ``True``, check if all input points lie in the function
+            domain in the case of vectorized evaluation. This requires
+            the domain to implement `Set.contains_all`.
+            Default: ``True`` if `space` has a ``field``, ``False``
+            otherwise.
+
+        Returns
+        -------
+        out : range element or array of elements
+            Result of the function evaluation. If ``out`` was provided,
+            the returned object is a reference to it.
+
+        Raises
+        ------
+        TypeError
+            If ``x`` is not a valid vectorized evaluation argument
+
+            If ``out`` is not a range element or a `numpy.ndarray`
+            of range elements
+
+        ValueError
+            If evaluation points fall outside the valid domain
+        """
+        bounds_check = kwargs.pop('bounds_check', self.space.field is not None)
+        if bounds_check and not hasattr(self.domain, 'contains_all'):
+            raise AttributeError('bounds check not possible for '
+                                 'domain {}, missing `contains_all()` '
+                                 'method'.format(self.domain))
+
+        if bounds_check and not hasattr(self.space.field, 'contains_all'):
+            raise AttributeError('bounds check not possible for '
+                                 'range {}, missing `contains_all()` '
+                                 'method'.format(self.space.field))
+
+        ndim = getattr(self.domain, 'ndim', None)
+        # Check for input type and determine output shape
+        if is_valid_input_meshgrid(x, ndim):
+            out_shape = out_shape_from_meshgrid(x)
+            scalar_out = False
+            # Avoid operations on tuples like x * 2 by casting to array
+            if ndim == 1:
+                x = x[0][None, ...]
+        elif is_valid_input_array(x, ndim):
+            x = np.asarray(x)
+            out_shape = out_shape_from_array(x)
+            scalar_out = False
+            # For 1d, squeeze the array
+            if ndim == 1 and x.ndim == 2:
+                x = x.squeeze()
+        elif x in self.domain:
+            x = np.atleast_2d(x).T  # make a (d, 1) array
+            out_shape = (1,)
+            scalar_out = (out is None)
+        else:
+            # Unknown input
+            txt_1d = ' or (n,)' if ndim == 1 else ''
+            raise TypeError('Argument {!r} not a valid vectorized '
+                            'input. Expected an element of the domain '
+                            '{domain}, an array-like with shape '
+                            '({domain.ndim}, n){} or a length-{domain.ndim} '
+                            'meshgrid tuple.'
+                            ''.format(x, txt_1d, domain=self.domain))
+
+        # Check bounds if specified
+        if bounds_check:
+            if not self.domain.contains_all(x):
+                raise ValueError('input contains points outside '
+                                 'the domain {}'.format(self.domain))
+
+        # Call the function and check out shape, before or after
+        if out is None:
+            if ndim == 1:
+                try:
+                    out = self._call(x, **kwargs)
+                except (TypeError, IndexError):
+                    # TypeError is raised if a meshgrid was used but the
+                    # function expected an array (1d only). In this case we try
+                    # again with the first meshgrid vector.
+                    # IndexError is raised in expressions like x[x > 0] since
+                    # "x > 0" evaluates to 'True', i.e. 1, and that index is
+                    # out of range for a meshgrid tuple of length 1 :-). To get
+                    # the real errors with indexing, we check again for the
+                    # same scenario (scalar output when not valid) as in the
+                    # first case.
+                    out = self._call(x[0], **kwargs)
+
+                # squeeze to remove extra axes.
+                out = np.squeeze(out)
+            else:
+                out = self._call(x, **kwargs)
+
+            # Cast to proper dtype if needed, also convert to array if out
+            # is scalar.
+            out = np.asarray(out, self.out_dtype)
+
+            if out_shape != (1,) and out.shape != out_shape:
+                # Try to broadcast the returned element if possible
+                out = _broadcast_to(out, out_shape)
+        else:
+            if not isinstance(out, np.ndarray):
+                raise TypeError('output {!r} not a `numpy.ndarray` '
+                                'instance')
+            if out_shape != (1,) and out.shape != out_shape:
+                raise ValueError('output shape {} not equal to shape '
+                                 '{} expected from input'
+                                 ''.format(out.shape, out_shape))
+            if self.out_dtype is not None and out.dtype != self.out_dtype:
+                raise ValueError('`out.dtype` ({}) does not match out_dtype '
+                                 '({})'.format(out.dtype, self.out_dtype))
+
+            if ndim == 1:
+                # TypeError for meshgrid in 1d, but expected array (see above)
+                try:
+                    self._call(x, out=out, **kwargs)
+                except TypeError:
+                    self._call(x[0], out=out, **kwargs)
+            else:
+                self._call(x, out=out, **kwargs)
+
+        # Check output values
+        if bounds_check and not self.space.field.contains_all(out):
+                raise ValueError('output contains points outside '
+                                 'the range {}'
+                                 ''.format(self.field))
+
+        # Numpy does not implement __complex__ for arrays (in contrast to
+        # __float__), so we have to fish out the scalar ourselves.
+        if scalar_out:
+            out = out.ravel()[0]
+
+        if scalar_out and self.space.field is not None:
+            return self.space.field.element(out)
+        else:
+            return out
+
+    def assign(self, other):
+        """Assign ``other`` to ``self``.
+
+        This is implemented without `FunctionSpace.lincomb` to ensure that
+        ``self == other`` evaluates to True after ``self.assign(other)``.
+        """
+        if other not in self.space:
+            raise TypeError('`other` {!r} is not an element of the space '
+                            '{} of this function'
+                            ''.format(other, self.space))
+        self._call_in_place = other._call_in_place
+        self._call_out_of_place = other._call_out_of_place
+        self._call_has_out = other._call_has_out
+        self._call_out_optional = other._call_out_optional
+
+    def copy(self):
+        """Create an identical (deep) copy of this element."""
+        result = self.space.element()
+        result.assign(self)
+        return result
+
+    def __eq__(self, other):
+        """Return ``self == other``.
+
+        Returns
+        -------
+        equals : bool
+            ``True`` if ``other`` is a `FunctionSpaceElement` with
+            ``other.space == self.space``, and the functions for evaluation
+            evaluation of ``self`` and ``other`` are the same, ``False``
+            otherwise.
+        """
+        if other is self:
+            return True
+
+        if not isinstance(other, FunctionSpaceElement):
+            return False
+
+        # We cannot blindly compare since functions may have been wrapped
+        if (self._call_has_out != other._call_has_out or
+                self._call_out_optional != other._call_out_optional):
+            return False
+
+        if self._call_has_out:
+            # Out-of-place can be wrapped in this case, so we compare only
+            # the in-place methods.
+            funcs_equal = self._call_in_place == other._call_in_place
+        else:
+            # Just the opposite of the first case
+            funcs_equal = self._call_out_of_place == other._call_out_of_place
+
+        return self.space == other.space and funcs_equal
 
     # Power functions are more general than the ones in LinearSpace
     def __pow__(self, p):
@@ -1185,12 +1022,24 @@ class FunctionSpaceElement(LinearSpaceElement, FunctionSetElement):
         """Pointwise complex conjugate of this function."""
         return self.space._conj(self)
 
+    def __str__(self):
+        """Return ``str(self)``."""
+        if self._call_has_out:
+            func = self._call_in_place
+        else:
+            func = self._call_out_of_place
+        return '{}: {} --> {}'.format(func, self.domain, self.range)
+
     def __repr__(self):
         """Return ``repr(self)``."""
-        return 'FunctionSpaceElement'
+        if self._call_has_out:
+            func = self._call_in_place
+        else:
+            func = self._call_out_of_place
+
+        return '{!r}.element({!r})'.format(self.space, func)
 
 
 if __name__ == '__main__':
-    # pylint: disable=wrong-import-position
     from odl.util.testutils import run_doctests
     run_doctests()

--- a/odl/space/npy_ntuples.py
+++ b/odl/space/npy_ntuples.py
@@ -47,8 +47,8 @@ class NumpyFn(FnBase):
 
     """Set of n-tuples of arbitrary type.
 
-    This space implements n-tuples of elements from a `Field` ``F``,
-    which is usually the real or complex numbers.
+    This space implements n-tuples of elements from a `Field`, which is
+    usually the real or complex numbers.
 
     Its elements are represented as instances of the `NumpyFnVector` class.
     """

--- a/odl/space/npy_ntuples.py
+++ b/odl/space/npy_ntuples.py
@@ -20,17 +20,16 @@ import scipy.linalg as linalg
 from scipy.sparse.base import isspmatrix
 
 from odl.set import RealNumbers, ComplexNumbers
-from odl.space.base_ntuples import (
-    NtuplesBase, NtuplesBaseVector, FnBase, FnBaseVector)
+from odl.space.base_ntuples import FnBase, FnBaseVector
 from odl.space.weighting import (
     Weighting, MatrixWeighting, ArrayWeighting,
     ConstWeighting, NoWeighting,
     CustomInner, CustomNorm, CustomDist)
 from odl.util import dtype_repr, is_real_dtype
-from odl.util.ufuncs import NumpyNtuplesUfuncs
+from odl.util.ufuncs import NumpyFnUfuncs
 
 
-__all__ = ('NumpyNtuples', 'NumpyNtuplesVector', 'NumpyFn', 'NumpyFnVector',
+__all__ = ('NumpyFn', 'NumpyFnVector',
            'npy_weighted_dist', 'npy_weighted_norm', 'npy_weighted_inner')
 
 
@@ -42,534 +41,17 @@ THRESHOLD_SMALL = 100
 THRESHOLD_MEDIUM = 50000
 
 
-class NumpyNtuples(NtuplesBase):
+class NumpyFn(FnBase):
 
-    """Set of n-tuples of arbitrary type."""
-
-    def element(self, inp=None, data_ptr=None):
-        """Create a new element.
-
-        Parameters
-        ----------
-        inp : `array-like`, optional
-            Input to initialize the new element.
-
-            If ``inp`` is ``None``, an empty element is created with no
-            guarantee of its state (memory allocation only).
-
-            If ``inp`` is a `numpy.ndarray` of shape ``(size,)``
-            and the same data type as this space, the array is wrapped,
-            not copied.
-            Other `array-like` objects are copied.
-
-        Returns
-        -------
-        element : `NumpyNtuplesVector`
-            The new element created (from ``inp``).
-
-        Notes
-        -----
-        This method preserves "array views" of correct size and type,
-        see the examples below.
-
-        Examples
-        --------
-        >>> bool3 = NumpyNtuples(3, dtype=bool)
-        >>> x = bool3.element([True, True, False])
-        >>> x
-        ntuples(3, 'bool').element([ True,  True, False])
-        >>> x.space
-        ntuples(3, 'bool')
-
-        Construction from data pointer:
-
-        >>> int3 = NumpyNtuples(3, dtype='int')
-        >>> x = int3.element([1, 2, 3])
-        >>> y = int3.element(data_ptr=x.data_ptr)
-        >>> print(y)
-        [1, 2, 3]
-        >>> y[0] = 5
-        >>> print(x)
-        [5, 2, 3]
-        """
-        if inp is None:
-            if data_ptr is None:
-                arr = np.empty(self.size, dtype=self.dtype)
-                return self.element_type(self, arr)
-            else:
-                ctype_array_def = ctypes.c_byte * (self.size *
-                                                   self.dtype.itemsize)
-                as_ctype_array = ctype_array_def.from_address(data_ptr)
-                as_numpy_array = np.ctypeslib.as_array(as_ctype_array)
-                arr = as_numpy_array.view(dtype=self.dtype)
-                return self.element_type(self, arr)
-        else:
-            if data_ptr is None:
-                if inp in self:
-                    return inp
-                else:
-                    arr = np.array(inp, copy=False, dtype=self.dtype, ndmin=1)
-                    if arr.shape != (self.size,):
-                        raise ValueError('expected input shape {}, got {}'
-                                         ''.format((self.size,), arr.shape))
-
-                    return self.element_type(self, arr)
-            else:
-                raise ValueError('cannot provide both `inp` and `data_ptr`')
-
-    def zero(self):
-        """Create a vector of zeros.
-
-        Examples
-        --------
-        >>> r3 = odl.rn(3)
-        >>> x = r3.zero()
-        >>> x
-        rn(3).element([ 0.,  0.,  0.])
-        """
-        return self.element(np.zeros(self.size, dtype=self.dtype))
-
-    def one(self):
-        """Create a vector of ones.
-
-        Examples
-        --------
-        >>> r3 = odl.rn(3)
-        >>> x = r3.one()
-        >>> x
-        rn(3).element([ 1.,  1.,  1.])
-        """
-        return self.element(np.ones(self.size, dtype=self.dtype))
-
-    def __repr__(self):
-        """Return ``repr(self)``."""
-        constructor_name = 'ntuples'
-
-        inner_str = '{}'.format(self.size)
-        inner_str += ', {}'.format(dtype_repr(self.dtype))
-
-        return '{}({})'.format(constructor_name, inner_str)
-
-    @property
-    def element_type(self):
-        """`NumpyNtuplesVector`"""
-        return NumpyNtuplesVector
-
-    impl = 'numpy'
-
-    @staticmethod
-    def available_dtypes():
-        """Available data types.
-
-        Notes
-        -----
-        This is all dtypes available to numpy. See ``numpy.sctypes``
-        for more information.
-
-        The available dtypes may depend on the specific system used.
-        """
-        all_types = []
-        for val in np.sctypes.values():
-            all_types.extend(val)
-        return all_types
-
-
-class NumpyNtuplesVector(NtuplesBaseVector):
-
-    """Representation of an `NumpyNtuples` element."""
-
-    def __init__(self, space, data):
-        """Initialize a new instance."""
-        super(NumpyNtuplesVector, self).__init__(space)
-        self.__data = data
-
-    @property
-    def data(self):
-        """Raw Numpy array representing the data."""
-        return self.__data
-
-    def asarray(self, start=None, stop=None, step=None, out=None):
-        """Extract the data of this array as a numpy array.
-
-        Parameters
-        ----------
-        start : int, optional
-            Start position. ``None`` means the first element.
-        stop : int, optional
-            One element past the last element to be extracted.
-            ``None`` means the last element.
-        step : int, optional
-            Step length. ``None`` is equivalent to 1.
-        out : `numpy.ndarray`, optional
-            Array to which the result should be written.
-            Has to be contiguous and of the correct data type.
-
-        Returns
-        -------
-        asarray : `numpy.ndarray`
-            Numpy array of the same type as the space.
-
-        Examples
-        --------
-        >>> import ctypes
-        >>> vec = NumpyNtuples(3, 'float').element([1, 2, 3])
-        >>> vec.asarray()
-        array([ 1.,  2.,  3.])
-        >>> vec.asarray(start=1, stop=3)
-        array([ 2.,  3.])
-
-        Using the out parameter
-
-        >>> out = np.empty((3,), dtype='float')
-        >>> result = vec.asarray(out=out)
-        >>> out
-        array([ 1.,  2.,  3.])
-        >>> result is out
-        True
-        """
-        if out is None:
-            return self.data[start:stop:step]
-        else:
-            out[:] = self.data[start:stop:step]
-            return out
-
-    @property
-    def data_ptr(self):
-        """A raw pointer to the data container.
-
-        Examples
-        --------
-        >>> import ctypes
-        >>> vec = NumpyNtuples(3, 'int32').element([1, 2, 3])
-        >>> arr_type = ctypes.c_int32 * 3
-        >>> buffer = arr_type.from_address(vec.data_ptr)
-        >>> arr = np.frombuffer(buffer, dtype='int32')
-        >>> print(arr)
-        [1 2 3]
-
-        In-place modification via pointer:
-
-        >>> arr[0] = 5
-        >>> print(vec)
-        [5, 2, 3]
-        """
-        return self.data.ctypes.data
-
-    def __eq__(self, other):
-        """Return ``self == other``.
-
-        Returns
-        -------
-        equals : bool
-            ``True`` if all entries of other are equal to this
-            vector's entries, ``False`` otherwise.
-
-        Notes
-        -----
-        Space membership is not checked, hence vectors from
-        different spaces can be equal.
-
-        Examples
-        --------
-        >>> vec1 = NumpyNtuples(3, int).element([1, 2, 3])
-        >>> vec2 = NumpyNtuples(3, int).element([-1, 2, 0])
-        >>> vec1 == vec2
-        False
-        >>> vec2 = NumpyNtuples(3, int).element([1, 2, 3])
-        >>> vec1 == vec2
-        True
-
-        Space membership matters:
-
-        >>> vec2 = NumpyNtuples(3, float).element([1, 2, 3])
-        >>> vec1 == vec2 or vec2 == vec1
-        False
-        """
-        if other is self:
-            return True
-        elif other not in self.space:
-            return False
-        else:
-            return np.array_equal(self.data, other.data)
-
-    def copy(self):
-        """Create an identical (deep) copy of this vector.
-
-        Parameters
-        ----------
-        None
-
-        Returns
-        -------
-        copy : `NumpyNtuplesVector`
-            The deep copy
-
-        Examples
-        --------
-        >>> vec1 = NumpyNtuples(3, 'int').element([1, 2, 3])
-        >>> vec2 = vec1.copy()
-        >>> vec2
-        ntuples(3, 'int').element([1, 2, 3])
-        >>> vec1 == vec2
-        True
-        >>> vec1 is vec2
-        False
-        """
-        return self.space.element(self.data.copy())
-
-    def __getitem__(self, indices):
-        """Access values of this vector.
-
-        Parameters
-        ----------
-        indices : int or `slice`
-            The position(s) that should be accessed
-
-        Returns
-        -------
-        values : scalar or `NumpyNtuplesVector`
-            The value(s) at the index (indices)
-
-        Examples
-        --------
-        >>> bool3 = odl.ntuples(4, dtype=bool)
-        >>> x = bool3.element([True, False, True, True])
-        >>> x[0]
-        True
-        >>> x[1:3]
-        ntuples(2, 'bool').element([False,  True])
-        """
-        if isinstance(indices, Integral):
-            return self.data[indices]  # single index
-        else:
-            arr = self.data[indices]
-            return type(self.space)(len(arr), dtype=self.dtype).element(arr)
-
-    def __setitem__(self, indices, values):
-        """Set values of this vector.
-
-        Parameters
-        ----------
-        indices : int or `slice`
-            The position(s) that should be set
-        values : scalar or `array-like`
-            The value(s) that are to be assigned.
-
-            If ``indices`` is an integer, ``value`` must be scalar.
-
-            If ``indices`` is a slice, ``value`` must be
-            broadcastable to the size of the slice (same size,
-            shape ``(1,)`` or single value).
-
-        Returns
-        -------
-        None
-
-        Examples
-        --------
-        >>> int_3 = NumpyNtuples(3, 'int')
-        >>> x = int_3.element([1, 2, 3])
-        >>> x[0] = 5
-        >>> x
-        ntuples(3, 'int').element([5, 2, 3])
-
-        Assignment from array-like structures or another
-        vector:
-
-        >>> y = NumpyNtuples(2, 'short').element([-1, 2])
-        >>> x[:2] = y
-        >>> x
-        ntuples(3, 'int').element([-1, 2, 3])
-        >>> x[1:3] = [7, 8]
-        >>> x
-        ntuples(3, 'int').element([-1, 7, 8])
-        >>> x[:] = np.array([0, 0, 0])
-        >>> x
-        ntuples(3, 'int').element([0, 0, 0])
-
-        Broadcasting is also supported:
-
-        >>> x[1:3] = -2.
-        >>> x
-        ntuples(3, 'int').element([ 0, -2, -2])
-
-        Array views are preserved:
-
-        >>> y = x[::2]  # view into x
-        >>> y[:] = -9
-        >>> print(y)
-        [-9, -9]
-        >>> print(x)
-        [-9, -2, -9]
-
-        Be aware of unsafe casts and over-/underflows, there
-        will be warnings at maximum.
-
-        >>> x = NumpyNtuples(2, 'int8').element([0, 0])
-        >>> maxval = 255  # maximum signed 8-bit unsigned int
-        >>> x[0] = maxval + 1
-        >>> x
-        ntuples(2, 'int8').element([0, 0])
-        """
-        if isinstance(values, NumpyNtuplesVector):
-            self.data[indices] = values.data
-        else:
-            self.data[indices] = values
-
-    @property
-    def ufuncs(self):
-        """`NumpyNtuplesUfuncs`, access to numpy style ufuncs.
-
-        Examples
-        --------
-        >>> r2 = NumpyFn(2)
-        >>> x = r2.element([1, -2])
-        >>> x.ufuncs.absolute()
-        rn(2).element([ 1.,  2.])
-
-        These functions can also be used with broadcasting
-
-        >>> x.ufuncs.add(3)
-        rn(2).element([ 4.,  1.])
-
-        and non-space elements
-
-        >>> x.ufuncs.subtract([3, 3])
-        rn(2).element([-2., -5.])
-
-        There is also support for various reductions (sum, prod, min, max)
-
-        >>> x.ufuncs.sum()
-        -1.0
-
-        They also support an out parameter
-
-        >>> y = r2.element([3, 4])
-        >>> out = r2.element()
-        >>> result = x.ufuncs.add(y, out=out)
-        >>> result
-        rn(2).element([ 4.,  2.])
-        >>> result is out
-        True
-
-        Notes
-        -----
-        These are optimized for use with ntuples and incur no overhead.
-        """
-        return NumpyNtuplesUfuncs(self)
-
-
-def _blas_is_applicable(*args):
-    """Whether BLAS routines can be applied or not.
-
-    BLAS routines are available for single and double precision
-    float or complex data only. If the arrays are non-contiguous,
-    BLAS methods are usually slower, and array-writing routines do
-    not work at all. Hence, only contiguous arrays are allowed.
-    Furthermore, BLAS uses 32-bit integers internally for indexing,
-    which makes it unusable for arrays lager than ``2 ** 31 - 1``.
-
-    Parameters
-    ----------
-    x1,...,xN : `NtuplesBaseVector`
-        The vectors to be tested for BLAS conformity
-    """
-    return (all(x.dtype == args[0].dtype and
-                x.dtype in _BLAS_DTYPES and
-                x.data.flags.contiguous and
-                x.size <= np.iinfo('int32').max
-                for x in args))
-
-
-def _lincomb_impl(a, x1, b, x2, out, dtype):
-    """Raw linear combination depending on data type."""
-    # Convert to native since BLAS needs it
-    size = native(x1.size)
-
-    # Shortcut for small problems
-    if size <= THRESHOLD_SMALL:  # small array optimization
-        out.data[:] = a * x1.data + b * x2.data
-        return
-
-    # If data is very big, use BLAS if possible
-    if size > THRESHOLD_MEDIUM and _blas_is_applicable(x1, x2, out):
-        axpy, scal, copy = linalg.blas.get_blas_funcs(
-            ['axpy', 'scal', 'copy'], arrays=(x1.data, x2.data, out.data))
-    else:
-        # Use fallbacks otherwise
-        def fallback_axpy(x1, x2, n, a):
-            """Fallback axpy implementation avoiding copy."""
-            if a != 0:
-                x2 /= a
-                x2 += x1
-                x2 *= a
-            return x2
-
-        def fallback_scal(a, x, n):
-            """Fallback scal implementation."""
-            x *= a
-            return x
-
-        def fallback_copy(x1, x2, n):
-            """Fallback copy implementation."""
-            x2[...] = x1[...]
-            return x2
-
-        axpy, scal, copy = (fallback_axpy, fallback_scal, fallback_copy)
-
-    if x1 is x2 and b != 0:
-        # x1 is aligned with x2 -> out = (a+b)*x1
-        _lincomb_impl(a + b, x1, 0, x1, out, dtype)
-    elif out is x1 and out is x2:
-        # All the vectors are aligned -> out = (a+b)*out
-        scal(a + b, out.data, size)
-    elif out is x1:
-        # out is aligned with x1 -> out = a*out + b*x2
-        if a != 1:
-            scal(a, out.data, size)
-        if b != 0:
-            axpy(x2.data, out.data, size, b)
-    elif out is x2:
-        # out is aligned with x2 -> out = a*x1 + b*out
-        if b != 1:
-            scal(b, out.data, size)
-        if a != 0:
-            axpy(x1.data, out.data, size, a)
-    else:
-        # We have exhausted all alignment options, so x1 != x2 != out
-        # We now optimize for various values of a and b
-        if b == 0:
-            if a == 0:  # Zero assignment -> out = 0
-                out.data[:] = 0
-            else:  # Scaled copy -> out = a*x1
-                copy(x1.data, out.data, size)
-                if a != 1:
-                    scal(a, out.data, size)
-        else:
-            if a == 0:  # Scaled copy -> out = b*x2
-                copy(x2.data, out.data, size)
-                if b != 1:
-                    scal(b, out.data, size)
-
-            elif a == 1:  # No scaling in x1 -> out = x1 + b*x2
-                copy(x1.data, out.data, size)
-                axpy(x2.data, out.data, size, b)
-            else:  # Generic case -> out = a*x1 + b*x2
-                copy(x2.data, out.data, size)
-                if b != 1:
-                    scal(b, out.data, size)
-                axpy(x1.data, out.data, size, a)
-
-
-class NumpyFn(FnBase, NumpyNtuples):
-
-    """Vector space F^n with vector multiplication.
+    """Set of n-tuples of arbitrary type.
 
     This space implements n-tuples of elements from a `Field` ``F``,
     which is usually the real or complex numbers.
 
     Its elements are represented as instances of the `NumpyFnVector` class.
     """
+
+    impl = 'numpy'
 
     def __init__(self, size, dtype='float64', **kwargs):
         """Initialize a new instance.
@@ -700,8 +182,9 @@ class NumpyFn(FnBase, NumpyNtuples):
         rn(3, weighting=[1, 2, 3])
         """
         # TODO: fix dead link `scipy.sparse.spmatrix`
-        NumpyNtuples.__init__(self, size, dtype)
-        FnBase.__init__(self, size, dtype)
+        if np.dtype(dtype).char not in self.available_dtypes():
+            raise ValueError('`dtype` {!r} not supported'.format(dtype))
+        super(NumpyFn, self).__init__(size, dtype)
 
         dist = kwargs.pop('dist', None)
         norm = kwargs.pop('norm', None)
@@ -773,6 +256,101 @@ class NumpyFn(FnBase, NumpyNtuples):
     def is_weighted(self):
         """``True`` if the weighting is not `NumpyFnNoWeighting`."""
         return not isinstance(self.weighting, NumpyFnNoWeighting)
+
+    def element(self, inp=None, data_ptr=None):
+        """Create a new element.
+
+        Parameters
+        ----------
+        inp : `array-like`, optional
+            Input to initialize the new element.
+
+            If ``inp`` is ``None``, an empty element is created with no
+            guarantee of its state (memory allocation only).
+
+            If ``inp`` is a `numpy.ndarray` of shape ``(size,)``
+            and the same data type as this space, the array is wrapped,
+            not copied.
+            Other `array-like` objects are copied.
+
+        Returns
+        -------
+        element : `NumpyFnVector`
+            The new element created (from ``inp``).
+
+        Notes
+        -----
+        This method preserves "array views" of correct size and type,
+        see the examples below.
+
+        Examples
+        --------
+        >>> bool3 = odl.fn(3, dtype=bool)
+        >>> x = bool3.element([True, True, False])
+        >>> x
+        fn(3, 'bool').element([ True,  True, False])
+        >>> x.space
+        fn(3, 'bool')
+
+        Construction from data pointer:
+
+        >>> int3 = odl.fn(3, dtype='int')
+        >>> x = int3.element([1, 2, 3])
+        >>> y = int3.element(data_ptr=x.data_ptr)
+        >>> print(y)
+        [1, 2, 3]
+        >>> y[0] = 5
+        >>> print(x)
+        [5, 2, 3]
+        """
+        if inp is None:
+            if data_ptr is None:
+                arr = np.empty(self.size, dtype=self.dtype)
+                return self.element_type(self, arr)
+            else:
+                ctype_array_def = ctypes.c_byte * (self.size *
+                                                   self.dtype.itemsize)
+                as_ctype_array = ctype_array_def.from_address(data_ptr)
+                as_numpy_array = np.ctypeslib.as_array(as_ctype_array)
+                arr = as_numpy_array.view(dtype=self.dtype)
+                return self.element_type(self, arr)
+        else:
+            if data_ptr is None:
+                if inp in self:
+                    return inp
+                else:
+                    arr = np.array(inp, copy=False, dtype=self.dtype, ndmin=1)
+                    if arr.shape != (self.size,):
+                        raise ValueError('expected input shape {}, got {}'
+                                         ''.format((self.size,), arr.shape))
+
+                    return self.element_type(self, arr)
+            else:
+                raise ValueError('cannot provide both `inp` and `data_ptr`')
+
+    def zero(self):
+        """Create a vector of zeros.
+
+        Examples
+        --------
+        >>> r3 = odl.rn(3)
+        >>> x = r3.zero()
+        >>> x
+        rn(3).element([ 0.,  0.,  0.])
+        """
+        return self.element(np.zeros(self.size, dtype=self.dtype))
+
+    def one(self):
+        """Create a vector of ones.
+
+        Examples
+        --------
+        >>> r3 = odl.rn(3)
+        >>> x = r3.one()
+        >>> x
+        rn(3).element([ 1.,  1.,  1.])
+        """
+        return self.element(np.ones(self.size, dtype=self.dtype))
 
     def _lincomb(self, a, x1, b, x2, out):
         """Linear combination of ``x1`` and ``x2``.
@@ -1024,39 +602,12 @@ class NumpyFn(FnBase, NumpyNtuples):
         if other is self:
             return True
 
-        return (NumpyNtuples.__eq__(self, other) and
+        return (super(NumpyFn, self).__eq__(other) and
                 self.weighting == other.weighting)
 
     def __hash__(self):
         """Return ``hash(self)``."""
-        return NumpyNtuples.__hash__(self) ^ hash(self.weighting)
-
-    def __repr__(self):
-        """Return ``repr(self)``."""
-        if self.is_rn:
-            constructor_name = 'rn'
-        elif self.is_cn:
-            constructor_name = 'cn'
-        else:
-            constructor_name = 'fn'
-
-        inner_str = '{}'.format(self.size)
-        if self.dtype != self.default_dtype(self.field):
-            inner_str += ', {}'.format(dtype_repr(self.dtype))
-
-        weight_str = self.weighting.repr_part
-        if weight_str:
-            inner_str += ', ' + weight_str
-        return '{}({})'.format(constructor_name, inner_str)
-
-    # Copy these to handle bug in ABCmeta
-    zero = NumpyNtuples.zero
-    one = NumpyNtuples.one
-
-    @property
-    def element_type(self):
-        """`NumpyFnVector`"""
-        return NumpyFnVector
+        return hash((super(NumpyFn, self).__hash__(), self.weighting))
 
     @staticmethod
     def available_dtypes():
@@ -1064,13 +615,17 @@ class NumpyFn(FnBase, NumpyNtuples):
 
         Notes
         -----
-        This is the set of all arithmetic dtypes available to numpy. See
-        `numpy.sctypes` for more information.
+        This is all dtypes available to numpy. See ``numpy.sctypes``
+        for more information.
 
         The available dtypes may depend on the specific system used.
         """
-        # TODO: fix dead link `numpy.sctypes`
-        return np.sctypes['int'] + np.sctypes['float'] + np.sctypes['complex']
+        all_dtypes = []
+        for lst in np.sctypes.values():
+            all_dtypes.extend(set(lst))
+        dtypes = [np.dtype(dtype) for dtype in all_dtypes]
+        dtypes.remove(np.dtype('void'))
+        return tuple(dtypes)
 
     @staticmethod
     def default_dtype(field=None):
@@ -1100,15 +655,314 @@ class NumpyFn(FnBase, NumpyNtuples):
             raise ValueError('no default data type defined for field {}.'
                              ''.format(field))
 
+    def __repr__(self):
+        """Return ``repr(self)``."""
+        if self.is_real:
+            constructor_name = 'rn'
+        elif self.is_complex:
+            constructor_name = 'cn'
+        else:
+            constructor_name = 'fn'
 
-class NumpyFnVector(FnBaseVector, NumpyNtuplesVector):
+        inner_str = '{}'.format(self.size)
+        if self.dtype != self.default_dtype(self.field):
+            inner_str += ', {}'.format(dtype_repr(self.dtype))
+
+        weight_str = self.weighting.repr_part
+        if weight_str:
+            inner_str += ', ' + weight_str
+        return '{}({})'.format(constructor_name, inner_str)
+
+    @property
+    def element_type(self):
+        """`NumpyFnVector`"""
+        return NumpyFnVector
+
+
+class NumpyFnVector(FnBaseVector):
 
     """Representation of an `NumpyFn` element."""
 
     def __init__(self, space, data):
         """Initialize a new instance."""
-        FnBaseVector.__init__(self, space)
-        NumpyNtuplesVector.__init__(self, space, data)
+        super(NumpyFnVector, self).__init__(space)
+        self.__data = data
+
+    @property
+    def data(self):
+        """Raw Numpy array representing the data."""
+        return self.__data
+
+    def asarray(self, start=None, stop=None, step=None, out=None):
+        """Extract the data of this array as a numpy array.
+
+        Parameters
+        ----------
+        start : int, optional
+            Start position. ``None`` means the first element.
+        stop : int, optional
+            One element past the last element to be extracted.
+            ``None`` means the last element.
+        step : int, optional
+            Step length. ``None`` is equivalent to 1.
+        out : `numpy.ndarray`, optional
+            Array to which the result should be written.
+            Has to be contiguous and of the correct data type.
+
+        Returns
+        -------
+        asarray : `numpy.ndarray`
+            Numpy array of the same type as the space.
+
+        Examples
+        --------
+        >>> import ctypes
+        >>> vec = odl.fn(3, 'float').element([1, 2, 3])
+        >>> vec.asarray()
+        array([ 1.,  2.,  3.])
+        >>> vec.asarray(start=1, stop=3)
+        array([ 2.,  3.])
+
+        Using the out parameter
+
+        >>> out = np.empty((3,), dtype='float')
+        >>> result = vec.asarray(out=out)
+        >>> out
+        array([ 1.,  2.,  3.])
+        >>> result is out
+        True
+        """
+        if out is None:
+            return self.data[start:stop:step]
+        else:
+            out[:] = self.data[start:stop:step]
+            return out
+
+    @property
+    def data_ptr(self):
+        """A raw pointer to the data container.
+
+        Examples
+        --------
+        >>> import ctypes
+        >>> vec = odl.fn(3, 'int32').element([1, 2, 3])
+        >>> arr_type = ctypes.c_int32 * 3
+        >>> buffer = arr_type.from_address(vec.data_ptr)
+        >>> arr = np.frombuffer(buffer, dtype='int32')
+        >>> print(arr)
+        [1 2 3]
+
+        In-place modification via pointer:
+
+        >>> arr[0] = 5
+        >>> print(vec)
+        [5, 2, 3]
+        """
+        return self.data.ctypes.data
+
+    def __eq__(self, other):
+        """Return ``self == other``.
+
+        Returns
+        -------
+        equals : bool
+            ``True`` if all entries of other are equal to this
+            vector's entries, ``False`` otherwise.
+
+        Notes
+        -----
+        Space membership is not checked, hence vectors from
+        different spaces can be equal.
+
+        Examples
+        --------
+        >>> vec1 = odl.fn(3, int).element([1, 2, 3])
+        >>> vec2 = odl.fn(3, int).element([-1, 2, 0])
+        >>> vec1 == vec2
+        False
+        >>> vec2 = odl.fn(3, int).element([1, 2, 3])
+        >>> vec1 == vec2
+        True
+
+        Space membership matters:
+
+        >>> vec2 = odl.fn(3, float).element([1, 2, 3])
+        >>> vec1 == vec2 or vec2 == vec1
+        False
+        """
+        if other is self:
+            return True
+        elif other not in self.space:
+            return False
+        else:
+            return np.array_equal(self.data, other.data)
+
+    def copy(self):
+        """Create an identical (deep) copy of this vector.
+
+        Parameters
+        ----------
+        None
+
+        Returns
+        -------
+        copy : `NumpyFnVector`
+            The deep copy
+
+        Examples
+        --------
+        >>> vec1 = odl.fn(3, 'int').element([1, 2, 3])
+        >>> vec2 = vec1.copy()
+        >>> vec2
+        fn(3, 'int').element([1, 2, 3])
+        >>> vec1 == vec2
+        True
+        >>> vec1 is vec2
+        False
+        """
+        return self.space.element(self.data.copy())
+
+    def __getitem__(self, indices):
+        """Access values of this vector.
+
+        Parameters
+        ----------
+        indices : int or `slice`
+            The position(s) that should be accessed
+
+        Returns
+        -------
+        values : scalar or `NumpyFnVector`
+            The value(s) at the index (indices)
+
+        Examples
+        --------
+        >>> bool3 = odl.fn(4, dtype=bool)
+        >>> x = bool3.element([True, False, True, True])
+        >>> x[0]
+        True
+        >>> x[1:3]
+        fn(2, 'bool').element([False,  True])
+        """
+        if isinstance(indices, Integral):
+            return self.data[indices]  # single index
+        else:
+            arr = self.data[indices]
+            return type(self.space)(len(arr), dtype=self.dtype).element(arr)
+
+    def __setitem__(self, indices, values):
+        """Set values of this vector.
+
+        Parameters
+        ----------
+        indices : int or `slice`
+            The position(s) that should be set
+        values : scalar or `array-like`
+            The value(s) that are to be assigned.
+
+            If ``indices`` is an integer, ``value`` must be scalar.
+
+            If ``indices`` is a slice, ``value`` must be
+            broadcastable to the size of the slice (same size,
+            shape ``(1,)`` or single value).
+
+        Returns
+        -------
+        None
+
+        Examples
+        --------
+        >>> int_3 = odl.fn(3, 'int')
+        >>> x = int_3.element([1, 2, 3])
+        >>> x[0] = 5
+        >>> x
+        fn(3, 'int').element([5, 2, 3])
+
+        Assignment from array-like structures or another
+        vector:
+
+        >>> y = odl.fn(2, 'short').element([-1, 2])
+        >>> x[:2] = y
+        >>> x
+        fn(3, 'int').element([-1, 2, 3])
+        >>> x[1:3] = [7, 8]
+        >>> x
+        fn(3, 'int').element([-1, 7, 8])
+        >>> x[:] = np.array([0, 0, 0])
+        >>> x
+        fn(3, 'int').element([0, 0, 0])
+
+        Broadcasting is also supported:
+
+        >>> x[1:3] = -2.
+        >>> x
+        fn(3, 'int').element([ 0, -2, -2])
+
+        Array views are preserved:
+
+        >>> y = x[::2]  # view into x
+        >>> y[:] = -9
+        >>> print(y)
+        [-9, -9]
+        >>> print(x)
+        [-9, -2, -9]
+
+        Be aware of unsafe casts and over-/underflows, there
+        will be warnings at maximum.
+
+        >>> x = odl.fn(2, 'int8').element([0, 0])
+        >>> maxval = 255  # maximum signed 8-bit unsigned int
+        >>> x[0] = maxval + 1
+        >>> x
+        fn(2, 'int8').element([0, 0])
+        """
+        if isinstance(values, NumpyFnVector):
+            self.data[indices] = values.data
+        else:
+            self.data[indices] = values
+
+    @property
+    def ufuncs(self):
+        """`NumpyFnUfuncs`, access to numpy style ufuncs.
+
+        Examples
+        --------
+        >>> r2 = NumpyFn(2)
+        >>> x = r2.element([1, -2])
+        >>> x.ufuncs.absolute()
+        rn(2).element([ 1.,  2.])
+
+        These functions can also be used with broadcasting
+
+        >>> x.ufuncs.add(3)
+        rn(2).element([ 4.,  1.])
+
+        and non-space elements
+
+        >>> x.ufuncs.subtract([3, 3])
+        rn(2).element([-2., -5.])
+
+        There is also support for various reductions (sum, prod, min, max)
+
+        >>> x.ufuncs.sum()
+        -1.0
+
+        They also support an out parameter
+
+        >>> y = r2.element([3, 4])
+        >>> out = r2.element()
+        >>> result = x.ufuncs.add(y, out=out)
+        >>> result
+        rn(2).element([ 4.,  2.])
+        >>> result is out
+        True
+
+        Notes
+        -----
+        These are optimized for use with ``NumpyFnVector`` objects and
+        incur no overhead.
+        """
+        return NumpyFnUfuncs(self)
 
     @property
     def real(self):
@@ -2010,6 +1864,111 @@ class NumpyFnCustomDist(CustomDist):
             - ``dist(x, y) <= dist(x, z) + dist(z, y)``
         """
         super(NumpyFnCustomDist, self).__init__(dist, impl='numpy')
+
+
+# --- Auxiliary functions --- #
+
+
+def _blas_is_applicable(*args):
+    """Whether BLAS routines can be applied or not.
+
+    BLAS routines are available for single and double precision
+    float or complex data only. If the arrays are non-contiguous,
+    BLAS methods are usually slower, and array-writing routines do
+    not work at all. Hence, only contiguous arrays are allowed.
+    Furthermore, BLAS uses 32-bit integers internally for indexing,
+    which makes it unusable for arrays lager than ``2 ** 31 - 1``.
+
+    Parameters
+    ----------
+    x1,...,xN : `NtuplesBaseVector`
+        The vectors to be tested for BLAS conformity
+    """
+    return (all(x.dtype == args[0].dtype and
+                x.dtype in _BLAS_DTYPES and
+                x.data.flags.contiguous and
+                x.size <= np.iinfo('int32').max
+                for x in args))
+
+
+def _lincomb_impl(a, x1, b, x2, out, dtype):
+    """Raw linear combination depending on data type."""
+    # Convert to native since BLAS needs it
+    size = native(x1.size)
+
+    # Shortcut for small problems
+    if size <= THRESHOLD_SMALL:  # small array optimization
+        out.data[:] = a * x1.data + b * x2.data
+        return
+
+    # If data is very big, use BLAS if possible
+    if size > THRESHOLD_MEDIUM and _blas_is_applicable(x1, x2, out):
+        axpy, scal, copy = linalg.blas.get_blas_funcs(
+            ['axpy', 'scal', 'copy'], arrays=(x1.data, x2.data, out.data))
+    else:
+        # Use fallbacks otherwise
+        def fallback_axpy(x1, x2, n, a):
+            """Fallback axpy implementation avoiding copy."""
+            if a != 0:
+                x2 /= a
+                x2 += x1
+                x2 *= a
+            return x2
+
+        def fallback_scal(a, x, n):
+            """Fallback scal implementation."""
+            x *= a
+            return x
+
+        def fallback_copy(x1, x2, n):
+            """Fallback copy implementation."""
+            x2[...] = x1[...]
+            return x2
+
+        axpy, scal, copy = (fallback_axpy, fallback_scal, fallback_copy)
+
+    if x1 is x2 and b != 0:
+        # x1 is aligned with x2 -> out = (a+b)*x1
+        _lincomb_impl(a + b, x1, 0, x1, out, dtype)
+    elif out is x1 and out is x2:
+        # All the vectors are aligned -> out = (a+b)*out
+        scal(a + b, out.data, size)
+    elif out is x1:
+        # out is aligned with x1 -> out = a*out + b*x2
+        if a != 1:
+            scal(a, out.data, size)
+        if b != 0:
+            axpy(x2.data, out.data, size, b)
+    elif out is x2:
+        # out is aligned with x2 -> out = a*x1 + b*out
+        if b != 1:
+            scal(b, out.data, size)
+        if a != 0:
+            axpy(x1.data, out.data, size, a)
+    else:
+        # We have exhausted all alignment options, so x1 != x2 != out
+        # We now optimize for various values of a and b
+        if b == 0:
+            if a == 0:  # Zero assignment -> out = 0
+                out.data[:] = 0
+            else:  # Scaled copy -> out = a*x1
+                copy(x1.data, out.data, size)
+                if a != 1:
+                    scal(a, out.data, size)
+        else:
+            if a == 0:  # Scaled copy -> out = b*x2
+                copy(x2.data, out.data, size)
+                if b != 1:
+                    scal(b, out.data, size)
+
+            elif a == 1:  # No scaling in x1 -> out = x1 + b*x2
+                copy(x1.data, out.data, size)
+                axpy(x2.data, out.data, size, b)
+            else:  # Generic case -> out = a*x1 + b*x2
+                copy(x2.data, out.data, size)
+                if b != 1:
+                    scal(b, out.data, size)
+                axpy(x1.data, out.data, size, a)
 
 
 if __name__ == '__main__':

--- a/odl/space/npy_ntuples.py
+++ b/odl/space/npy_ntuples.py
@@ -11,6 +11,7 @@
 # Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
 from future.utils import native
+import builtins
 
 import ctypes
 from functools import partial
@@ -18,6 +19,7 @@ from numbers import Integral
 import numpy as np
 import scipy.linalg as linalg
 from scipy.sparse.base import isspmatrix
+import sys
 
 from odl.set import RealNumbers, ComplexNumbers
 from odl.space.base_ntuples import FnBase, FnBaseVector
@@ -182,6 +184,10 @@ class NumpyFn(FnBase):
         rn(3, weighting=[1, 2, 3])
         """
         # TODO: fix dead link `scipy.sparse.spmatrix`
+        if sys.version_info.major < 3 and dtype is builtins.int:
+            raise TypeError('cannot use `builtins.int` as `dtype` since '
+                            'Numpy does not recognize it as int')
+
         if np.dtype(dtype).char not in self.available_dtypes():
             raise ValueError('`dtype` {!r} not supported'.format(dtype))
         super(NumpyFn, self).__init__(size, dtype)

--- a/odl/space/pspace.py
+++ b/odl/space/pspace.py
@@ -754,7 +754,7 @@ class ProductSpaceElement(LinearSpaceElement):
         """`ProductSpaceUfuncs`, access to Numpy style ufuncs.
 
         These are always available if the underlying spaces are
-        `NtuplesBase`.
+        `FnBase`.
 
         Examples
         --------
@@ -799,8 +799,8 @@ class ProductSpaceElement(LinearSpaceElement):
 
         See Also
         --------
-        odl.util.ufuncs.NtuplesBaseUfuncs
-            Base class for ufuncs in `NtuplesBase` spaces, subspaces may
+        odl.util.ufuncs.FnBaseUfuncs
+            Base class for ufuncs in `FnBase` spaces, subspaces may
             override this for greater efficiency.
         odl.util.ufuncs.ProductSpaceUfuncs
             For a list of available ufuncs.
@@ -920,7 +920,7 @@ class ProductSpaceElement(LinearSpaceElement):
         --------
         odl.discr.lp_discr.DiscreteLpElement.show :
             Display of a discretized function
-        odl.space.base_ntuples.NtuplesBaseVector.show :
+        odl.space.base_ntuples.FnBaseVector.show :
             Display of sequence type data
         odl.util.graphics.show_discrete_data :
             Underlying implementation

--- a/odl/space/space_utils.py
+++ b/odl/space/space_utils.py
@@ -11,13 +11,12 @@
 # Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
 
-__all__ = ('vector', 'ntuples', 'fn', 'cn', 'rn')
+__all__ = ('vector', 'fn', 'cn', 'rn')
 
 import numpy as np
 
 from odl.set import RealNumbers, ComplexNumbers
-from odl.space.entry_points import ntuples_impl, fn_impl
-from odl.util import is_numeric_dtype
+from odl.space.entry_points import fn_impl
 
 
 def vector(array, dtype=None, impl='numpy'):
@@ -32,12 +31,12 @@ def vector(array, dtype=None, impl='numpy'):
         Set the data type of the vector manually with this option.
         By default, the space type is inferred from the input data.
     impl : string, optional
-        The backend to use. See `odl.space.entry_points.ntuples_impl_names` and
-        `odl.space.entry_points.fn_impl_names` for available options.
+        The backend to use. See `odl.space.entry_points.fn_impl_names`
+        for available options.
 
     Returns
     -------
-    vec : `NtuplesBaseVector`
+    vec : `FnBaseVector`
         Vector created from the input array. Its concrete type depends
         on the provided arguments.
 
@@ -58,7 +57,7 @@ def vector(array, dtype=None, impl='numpy'):
     Non-scalar types are also supported:
 
     >>> vector([True, False])
-    ntuples(2, 'bool').element([ True, False])
+    fn(2, 'bool').element([ True, False])
 
     Scalars become a one-element vector:
 
@@ -79,44 +78,7 @@ def vector(array, dtype=None, impl='numpy'):
     else:
         space_dtype = arr.dtype
 
-    # Select implementation
-    if space_dtype is None or is_numeric_dtype(space_dtype):
-        space_type = fn
-    else:
-        space_type = ntuples
-
-    return space_type(len(arr), dtype=space_dtype, impl=impl).element(arr)
-
-
-def ntuples(size, dtype, impl='numpy', **kwargs):
-    """Set of tuples of a fixed size.
-
-    Parameters
-    ----------
-    size : positive int
-        The number of dimensions of the space
-    dtype : `object`
-        The data type of the storage array. Can be provided in any
-        way the `numpy.dtype` function understands, most notably
-        as built-in type, as one of NumPy's internal datatype
-        objects or as string.
-
-        Only complex floating-point data types are allowed.
-    impl : string, optional
-        The backend to use. See `odl.space.entry_points.ntuples_impl_names` for
-        available options.
-    kwargs :
-        Extra keyword arguments to pass to the implmentation.
-
-    Returns
-    -------
-    ntuple : `NtuplesBase`
-
-    See Also
-    --------
-    fn : n-tuples over a field with arbitrary scalar data type.
-    """
-    return ntuples_impl(impl)(size, dtype, **kwargs)
+    return fn(len(arr), dtype=space_dtype, impl=impl).element(arr)
 
 
 def fn(size, dtype=None, impl='numpy', **kwargs):
@@ -146,7 +108,7 @@ def fn(size, dtype=None, impl='numpy', **kwargs):
 
     See Also
     --------
-    ntuples : n-tuples over a field with arbitrary data type.
+    rn, cn : Constructors for real and complex spaces
     """
     fn_cls = fn_impl(impl)
 
@@ -194,9 +156,9 @@ def cn(size, dtype=None, impl='numpy', **kwargs):
 
     cn = cn_cls(size, dtype, **kwargs)
 
-    if not cn.is_cn:
-        raise TypeError('data type {!r} not a complex floating-point type.'
-                        ''.format(dtype))
+    if not cn.is_complex:
+        raise ValueError('data type {!r} not a complex floating-point type.'
+                         ''.format(dtype))
     return cn
 
 
@@ -237,9 +199,9 @@ def rn(size, dtype=None, impl='numpy', **kwargs):
 
     rn = rn_impl(size, dtype, **kwargs)
 
-    if not rn.is_rn:
-        raise TypeError('data type {!r} not a real floating-point type.'
-                        ''.format(dtype))
+    if not rn.is_real:
+        raise ValueError('data type {!r} not a real floating-point type.'
+                         ''.format(dtype))
     return rn
 
 

--- a/odl/test/deform/linearized_deform_test.py
+++ b/odl/test/deform/linearized_deform_test.py
@@ -186,7 +186,7 @@ def test_fixed_templ_call(space):
 
 
 def test_fixed_templ_deriv(space):
-    if not space.is_rn:
+    if not space.is_real:
         pytest.skip('derivative not implemented for complex dtypes')
 
     # Set up template and displacement field

--- a/odl/test/discr/discr_mappings_test.py
+++ b/odl/test/discr/discr_mappings_test.py
@@ -9,7 +9,6 @@
 """Unit tests for `discr_mappings`."""
 
 from __future__ import division
-import pytest
 import numpy as np
 
 import odl
@@ -27,7 +26,7 @@ def test_nearest_interpolation_1d_complex(fn_impl):
     # Coordinate vectors are:
     # [0.1, 0.3, 0.5, 0.7, 0.9]
 
-    space = odl.FunctionSpace(intv, field=odl.ComplexNumbers())
+    space = odl.FunctionSpace(intv, out_dtype=complex)
     dspace = odl.cn(part.size)
     interp_op = NearestInterpolation(space, part, dspace)
     function = interp_op([0 + 1j, 1 + 2j, 2 + 3j, 3 + 4j, 4 + 5j])
@@ -121,8 +120,8 @@ def test_nearest_interpolation_2d_string():
     # Coordinate vectors are:
     # [0.125, 0.375, 0.625, 0.875], [0.25, 0.75]
 
-    space = odl.FunctionSet(rect, odl.Strings(1))
-    dspace = odl.ntuples(part.size, dtype='U1')
+    space = odl.FunctionSpace(rect, out_dtype='U1')
+    dspace = odl.fn(part.size, dtype='U1')
     interp_op = NearestInterpolation(space, part, dspace)
     values = np.array([c for c in 'mystring'])
     function = interp_op(values)

--- a/odl/test/discr/lp_discr_test.py
+++ b/odl/test/discr/lp_discr_test.py
@@ -30,7 +30,7 @@ def test_init(exponent):
 
     # Normal discretization of unit interval with complex
     complex_space = odl.FunctionSpace(odl.IntervalProd(0, 1),
-                                      field=odl.ComplexNumbers())
+                                      out_dtype=complex)
 
     cn = odl.cn(10, exponent=exponent)
     odl.DiscreteLp(complex_space, part, cn, exponent=exponent)
@@ -80,7 +80,7 @@ def test_factory(exponent, fn_impl):
 
     assert isinstance(discr.dspace, FnBase)
     assert discr.dspace.impl == fn_impl
-    assert discr.is_rn
+    assert discr.is_real
     assert discr.dspace.exponent == exponent
 
     # Complex
@@ -90,7 +90,7 @@ def test_factory(exponent, fn_impl):
 
         assert isinstance(discr.dspace, FnBase)
         assert discr.dspace.impl == fn_impl
-        assert discr.is_cn
+        assert discr.is_complex
         assert discr.dspace.exponent == exponent
     except TypeError:
         # Not all spaces support complex, that is fine.
@@ -108,7 +108,7 @@ def test_factory_dtypes(fn_impl):
             discr = odl.uniform_discr(0, 1, 10, impl=fn_impl, dtype=dtype)
             assert isinstance(discr.dspace, FnBase)
             assert discr.dspace.impl == fn_impl
-            assert discr.is_rn
+            assert discr.is_real
         except TypeError:
             continue
 
@@ -126,7 +126,7 @@ def test_factory_dtypes(fn_impl):
             discr = odl.uniform_discr(0, 1, 10, impl=fn_impl, dtype=dtype)
             assert isinstance(discr.dspace, FnBase)
             assert discr.dspace.impl == fn_impl
-            assert discr.is_cn
+            assert discr.is_complex
             assert discr.dspace.element().space.dtype == dtype
         except TypeError:
             continue

--- a/odl/test/space/fspace_test.py
+++ b/odl/test/space/fspace_test.py
@@ -11,7 +11,7 @@ import pytest
 import numpy as np
 
 import odl
-from odl import FunctionSet, FunctionSpace
+from odl import FunctionSpace
 from odl.discr.grid import sparse_meshgrid
 from odl.util.testutils import (all_almost_equal, all_equal, almost_equal,
                                 simple_fixture)
@@ -20,41 +20,38 @@ from odl.util.testutils import (all_almost_equal, all_equal, almost_equal,
 def test_fspace_init():
     intv = odl.IntervalProd(0, 1)
     FunctionSpace(intv)
-    FunctionSpace(intv, field=odl.RealNumbers())
-    FunctionSpace(intv, field=odl.ComplexNumbers())
+    FunctionSpace(intv, out_dtype=float)
+    FunctionSpace(intv, out_dtype=complex)
 
     rect = odl.IntervalProd([0, 0], [1, 2])
     FunctionSpace(rect)
-    FunctionSpace(rect, field=odl.RealNumbers())
-    FunctionSpace(rect, field=odl.ComplexNumbers())
+    FunctionSpace(rect, out_dtype=float)
+    FunctionSpace(rect, out_dtype=complex)
 
     cube = odl.IntervalProd([0, 0, 0], [1, 2, 3])
     FunctionSpace(cube)
-    FunctionSpace(cube, field=odl.RealNumbers())
-    FunctionSpace(cube, field=odl.ComplexNumbers())
+    FunctionSpace(cube, out_dtype=float)
+    FunctionSpace(cube, out_dtype=complex)
 
     ndbox = odl.IntervalProd([0] * 10, np.arange(1, 11))
     FunctionSpace(ndbox)
-    FunctionSpace(ndbox, field=odl.RealNumbers())
-    FunctionSpace(ndbox, field=odl.ComplexNumbers())
+    FunctionSpace(ndbox, out_dtype=float)
+    FunctionSpace(ndbox, out_dtype=complex)
 
-
-def test_fset_init():
     str3 = odl.Strings(3)
-    ints = odl.Integers()
-    FunctionSet(str3, ints)
+    FunctionSpace(str3, out_dtype=int)
 
 
 def test_fspace_simple_attributes():
     intv = odl.IntervalProd(0, 1)
     fspace = FunctionSpace(intv)
-    fspace_r = FunctionSpace(intv, field=odl.RealNumbers())
-    fspace_c = FunctionSpace(intv, field=odl.ComplexNumbers())
+    fspace_r = FunctionSpace(intv, out_dtype=float)
+    fspace_c = FunctionSpace(intv, out_dtype=complex)
 
     assert fspace.domain == intv
-    assert fspace.range == odl.RealNumbers()
-    assert fspace_r.range == odl.RealNumbers()
-    assert fspace_c.range == odl.ComplexNumbers()
+    assert fspace.field == odl.RealNumbers()
+    assert fspace_r.field == odl.RealNumbers()
+    assert fspace_c.field == odl.ComplexNumbers()
 
 
 def _test_eq(x, y):
@@ -76,8 +73,8 @@ def test_equals():
     intv = odl.IntervalProd(0, 1)
     intv2 = odl.IntervalProd(-1, 1)
     fspace = FunctionSpace(intv)
-    fspace_r = FunctionSpace(intv, field=odl.RealNumbers())
-    fspace_c = FunctionSpace(intv, field=odl.ComplexNumbers())
+    fspace_r = FunctionSpace(intv, out_dtype=float)
+    fspace_c = FunctionSpace(intv, out_dtype=complex)
     fspace_intv2 = FunctionSpace(intv2)
 
     _test_eq(fspace, fspace)
@@ -130,7 +127,7 @@ def test_fspace_vector_init():
     fspace.element(func_2d_vec_dual, vectorized=True)
 
     # 2d, complex
-    fspace = FunctionSpace(rect, field=odl.ComplexNumbers())
+    fspace = FunctionSpace(rect, out_dtype=complex)
     fspace.element(cfunc_2d_novec, vectorized=False)
     fspace.element(cfunc_2d_vec_oop)
     fspace.element(cfunc_2d_vec_oop, vectorized=True)
@@ -138,10 +135,9 @@ def test_fspace_vector_init():
     fspace.element(cfunc_2d_vec_dual, vectorized=True)
 
 
-def test_fset_vector_eval():
+def test_fspace_vector_eval():
     str3 = odl.Strings(3)
-    ints = odl.Integers()
-    fset = FunctionSet(str3, ints)
+    fset = FunctionSpace(str3, out_dtype=int)
     strings = np.array(['aa', 'b', 'cab', 'aba'])
     out_vec = np.empty((4,), dtype=int)
 
@@ -184,7 +180,7 @@ def test_fspace_out_dtype():
 def test_fspace_astype():
 
     rspace = FunctionSpace(odl.IntervalProd(0, 1))
-    cspace = FunctionSpace(odl.IntervalProd(0, 1), field=odl.ComplexNumbers())
+    cspace = FunctionSpace(odl.IntervalProd(0, 1), out_dtype=complex)
     rspace_s = FunctionSpace(odl.IntervalProd(0, 1), out_dtype='float32')
     cspace_s = FunctionSpace(odl.IntervalProd(0, 1), out_dtype='complex64')
 
@@ -262,7 +258,7 @@ def test_fspace_vector_eval_real():
 def test_fspace_vector_eval_complex():
     rect, points, mg = _standard_setup_2d()
 
-    fspace = FunctionSpace(rect, field=odl.ComplexNumbers())
+    fspace = FunctionSpace(rect, out_dtype=complex)
     f_novec = fspace.element(cfunc_2d_novec, vectorized=False)
     f_vec_oop = fspace.element(cfunc_2d_vec_oop, vectorized=True)
     f_vec_ip = fspace.element(cfunc_2d_vec_ip, vectorized=True)
@@ -402,7 +398,7 @@ def test_fspace_vector_copy():
 
 def test_fspace_vector_real_imag():
     rect, _, mg = _standard_setup_2d()
-    cspace = FunctionSpace(rect, field=odl.ComplexNumbers())
+    cspace = FunctionSpace(rect, out_dtype=complex)
     f = cspace.element(cfunc_2d_vec_oop)
 
     # real / imag on complex functions
@@ -441,7 +437,7 @@ def test_fspace_zero():
     assert all_equal(zero_vec(mg), np.zeros((2, 3), dtype=float))
 
     # complex
-    fspace = FunctionSpace(rect, field=odl.ComplexNumbers())
+    fspace = FunctionSpace(rect, out_dtype=complex)
     zero_vec = fspace.zero()
 
     assert zero_vec([0.5, 1.5]) == 0.0 + 1j * 0.0
@@ -461,7 +457,7 @@ def test_fspace_one():
     assert all_equal(one_vec(mg), np.ones((2, 3), dtype=float))
 
     # complex
-    fspace = FunctionSpace(rect, field=odl.ComplexNumbers())
+    fspace = FunctionSpace(rect, out_dtype=complex)
     one_vec = fspace.one()
 
     assert one_vec([0.5, 1.5]) == 1.0 + 1j * 0.0

--- a/odl/test/space/ntuples_test.py
+++ b/odl/test/space/ntuples_test.py
@@ -107,7 +107,7 @@ def test_init():
     from builtins import int as future_int
     import sys
     if sys.version_info.major != 3:
-        with pytest.raises(ValueError):
+        with pytest.raises(TypeError):
             NumpyFn(3, future_int)
 
     # Init with weights or custom space functions

--- a/odl/test/space/ntuples_test.py
+++ b/odl/test/space/ntuples_test.py
@@ -13,7 +13,7 @@ import operator
 import scipy
 
 import odl
-from odl import NumpyNtuples, NumpyFn, NumpyFnVector
+from odl import NumpyFn, NumpyFnVector
 from odl.operator.operator import Operator
 from odl.set.space import LinearSpaceTypeError
 from odl.space.npy_ntuples import (
@@ -69,43 +69,37 @@ fn = simple_fixture('fn', [odl.rn(10, np.float64), odl.rn(10, np.float32),
 exponent = simple_fixture('exponent', [2.0, 1.0, float('inf'), 0.5, 1.5])
 
 
-# ---- Tests of Ntuples, Rn and Cn ---- #
+# ---- Tests of Fn, Rn and Cn ---- #
 
 
 def test_init():
-    # Test run
-    NumpyNtuples(3, int)
-    NumpyNtuples(3, float)
-    NumpyNtuples(3, complex)
-    NumpyNtuples(3, 'S1')
-
     # Fn
     NumpyFn(3, int)
     NumpyFn(3, float)
     NumpyFn(3, complex)
+    NumpyFn(3, 'S1')
 
-    # Fn only works on scalars
-    with pytest.raises(TypeError):
-        NumpyFn(3, 'S1')
+    with pytest.raises(ValueError):
+        NumpyFn(3, np.void)
 
     # Rn
     odl.rn(3, float)
 
     # Rn only works on reals
-    with pytest.raises(TypeError):
+    with pytest.raises(ValueError):
         odl.rn(3, complex)
-    with pytest.raises(TypeError):
+    with pytest.raises(ValueError):
         odl.rn(3, 'S1')
-    with pytest.raises(TypeError):
+    with pytest.raises(ValueError):
         odl.rn(3, int)
 
     # Cn
     odl.cn(3, complex)
 
     # Cn only works on reals
-    with pytest.raises(TypeError):
+    with pytest.raises(ValueError):
         odl.cn(3, float)
-    with pytest.raises(TypeError):
+    with pytest.raises(ValueError):
         odl.cn(3, 'S1')
 
     # Backported int from future fails (not recognized by numpy.dtype())
@@ -113,7 +107,7 @@ def test_init():
     from builtins import int as future_int
     import sys
     if sys.version_info.major != 3:
-        with pytest.raises(TypeError):
+        with pytest.raises(ValueError):
             NumpyFn(3, future_int)
 
     # Init with weights or custom space functions

--- a/odl/test/space/space_utils_test.py
+++ b/odl/test/space/space_utils_test.py
@@ -53,19 +53,19 @@ def test_vector_numpy():
     inp = [1, 2, 3]
 
     x = vector(inp)
-    assert isinstance(x, odl.NumpyNtuplesVector)
+    assert isinstance(x, odl.NumpyFnVector)
     assert x.dtype == np.dtype('int')
     assert all_equal(x, inp)
 
     # Ntuples
     inp = ['a', 'b', 'c']
     x = vector(inp)
-    assert isinstance(x, odl.NumpyNtuplesVector)
+    assert isinstance(x, odl.NumpyFnVector)
     assert np.issubdtype(x.dtype, basestring)
     assert all_equal(x, inp)
 
     x = vector([1, 2, 'inf'])  # Becomes string type
-    assert isinstance(x, odl.NumpyNtuplesVector)
+    assert isinstance(x, odl.NumpyFnVector)
     assert np.issubdtype(x.dtype, basestring)
     assert all_equal(x, ['1', '2', 'inf'])
 

--- a/odl/test/trafos/fourier_test.py
+++ b/odl/test/trafos/fourier_test.py
@@ -510,7 +510,7 @@ def test_fourier_trafo_scaling():
         return np.exp(-1j * x / 2) * sinc(x / 2) / np.sqrt(2 * np.pi)
 
     fspace = odl.FunctionSpace(odl.IntervalProd(-2, 2),
-                               field=odl.ComplexNumbers())
+                               out_dtype=complex)
     discr = odl.uniform_discr_fromspace(fspace, 40, impl='numpy')
     dft = FourierTransform(discr)
 

--- a/odl/tomo/operators/ray_trafo.py
+++ b/odl/tomo/operators/ray_trafo.py
@@ -299,10 +299,10 @@ class RayTransformBase(Operator):
 
     def _call(self, x, out=None):
         """Return ``self(x[, out])``."""
-        if self.domain.is_rn:
+        if self.domain.is_real:
             return self._call_real(x, out)
 
-        elif self.domain.is_cn:
+        elif self.domain.is_complex:
             result_parts = [
                 self._call_real(x.real, getattr(out, 'real', None)),
                 self._call_real(x.imag, getattr(out, 'imag', None))]

--- a/odl/util/pytest_plugins.py
+++ b/odl/util/pytest_plugins.py
@@ -103,16 +103,6 @@ def fn_impl(request):
     return request.param
 
 
-ntuples_impl_params = odl.ntuples_impl_names()
-ntuples_impl_ids = [" impl='{}' ".format(p) for p in ntuples_impl_params]
-
-
-@fixture(scope="module", ids=ntuples_impl_ids, params=ntuples_impl_params)
-def ntuples_impl(request):
-    """String with an available `NtuplesBase` implementation name."""
-    return request.param
-
-
 floating_dtype_params = np.sctypes['float'] + np.sctypes['complex']
 floating_dtype_ids = [' dtype={} '.format(dtype_repr(dt))
                       for dt in floating_dtype_params]

--- a/odl/util/ufuncs.py
+++ b/odl/util/ufuncs.py
@@ -9,7 +9,7 @@
 """Ufuncs for ODL vectors.
 
 These functions are internal and should only be used as methods on
-`NtuplesBaseVector` type spaces.
+`FnBaseVector` type spaces.
 
 See `numpy.ufuncs
 <http://docs.scipy.org/doc/numpy/reference/ufuncs.html>`_
@@ -18,8 +18,8 @@ for more information.
 Notes
 -----
 The default implementation of these methods make heavy use of the
-``NtuplesBaseVector.__array__`` to extract a `numpy.ndarray` from the vector,
-and then apply a ufunc to it. Afterwards, ``NtuplesBaseVector.__array_wrap__``
+``FnBaseVector.__array__`` to extract a `numpy.ndarray` from the vector,
+and then apply a ufunc to it. Afterwards, ``FnBaseVector.__array_wrap__``
 is used to re-wrap the data into the appropriate space.
 """
 
@@ -30,7 +30,7 @@ import numpy as np
 import re
 
 
-__all__ = ('NtuplesBaseUfuncs', 'NumpyNtuplesUfuncs',
+__all__ = ('FnBaseUfuncs', 'NumpyFnUfuncs',
            'DiscreteLpUfuncs', 'ProductSpaceUfuncs')
 
 
@@ -85,7 +85,7 @@ numpy.{}
 # Wrap all numpy ufuncs
 
 def wrap_ufunc_base(name, n_in, n_out, doc):
-    """Add ufunc methods to `NtuplesBaseUfuncs`."""
+    """Add ufunc methods to `FnBaseUfuncs`."""
     wrapped = getattr(np, name)
     if n_in == 1:
         if n_out == 0:
@@ -136,7 +136,7 @@ def wrap_ufunc_base(name, n_in, n_out, doc):
 
 # Wrap reductions
 def wrap_reduction_base(name, doc):
-    """Add ufunc methods to `NtuplesBaseUfuncs`."""
+    """Add ufunc methods to `FnBaseUfuncs`."""
     wrapped = getattr(np, name)
 
     def wrapper(self):
@@ -147,11 +147,11 @@ def wrap_reduction_base(name, doc):
     return wrapper
 
 
-class NtuplesBaseUfuncs(object):
+class FnBaseUfuncs(object):
 
-    """Ufuncs for `NtuplesBaseVector` objects.
+    """Ufuncs for `FnBaseVector` objects.
 
-    Internal object, should not be created except in `NtuplesBaseVector`.
+    Internal object, should not be created except in `FnBaseVector`.
     """
 
     def __init__(self, vector):
@@ -162,19 +162,19 @@ class NtuplesBaseUfuncs(object):
 # Add ufunc methods to ufunc class
 for name, n_in, n_out, doc in UFUNCS:
     method = wrap_ufunc_base(name, n_in, n_out, doc)
-    setattr(NtuplesBaseUfuncs, name, method)
+    setattr(FnBaseUfuncs, name, method)
 
 # Add reduction methods to ufunc class
 for name, doc in REDUCTIONS:
     method = wrap_reduction_base(name, doc)
-    setattr(NtuplesBaseUfuncs, name, method)
+    setattr(FnBaseUfuncs, name, method)
 
 
 # Optimized implementation of ufuncs since we can use the out parameter
-# as well as the data parameter to avoid one call to asarray() when using an
-# NumpyNtuplesVector
-def wrap_ufunc_ntuples(name, n_in, n_out, doc):
-    """Add ufunc methods to `NumpyNtuplesUfuncs`."""
+# as well as the data parameter to avoid one call to asarray() when using a
+# NumpyFnVector
+def wrap_ufunc_fn(name, n_in, n_out, doc):
+    """Add ufunc methods to `NumpyFnUfuncs`."""
 
     # Get method from numpy
     wrapped = getattr(np, name)
@@ -222,23 +222,23 @@ def wrap_ufunc_ntuples(name, n_in, n_out, doc):
     return wrapper
 
 
-class NumpyNtuplesUfuncs(NtuplesBaseUfuncs):
+class NumpyFnUfuncs(FnBaseUfuncs):
 
-    """Ufuncs for `NumpyNtuplesVector` objects.
+    """Ufuncs for `NumpyFnVector` objects.
 
-    Internal object, should not be created except in `NumpyNtuplesVector`.
+    Internal object, should not be created except in `NumpyFnVector`.
     """
 
 
 # Add ufunc methods to ufunc class
 for name, n_in, n_out, doc in UFUNCS:
-    method = wrap_ufunc_ntuples(name, n_in, n_out, doc)
-    setattr(NumpyNtuplesUfuncs, name, method)
+    method = wrap_ufunc_fn(name, n_in, n_out, doc)
+    setattr(NumpyFnUfuncs, name, method)
 
 
 # Optimized implementation of ufuncs since we can use the out parameter
 # as well as the data parameter to avoid one call to asarray() when using a
-# NumpyNtuplesVector
+# NumpyFnVector
 def wrap_ufunc_discretelp(name, n_in, n_out, doc):
     """Add ufunc methods to `DiscreteLpUfuncs`."""
 
@@ -311,7 +311,7 @@ def wrap_reduction_discretelp(name, doc):
     return wrapper
 
 
-class DiscreteLpUfuncs(NtuplesBaseUfuncs):
+class DiscreteLpUfuncs(FnBaseUfuncs):
 
     """Ufuncs for `DiscreteLpElement` objects.
 

--- a/odl/util/vectorization.py
+++ b/odl/util/vectorization.py
@@ -32,7 +32,7 @@ def is_valid_input_array(x, ndim=None):
 
 def is_valid_input_meshgrid(x, ndim):
     """Test if ``x`` is a `meshgrid` sequence for points in R^d."""
-    # This case is triggered in FunctionSetElement.__call__ if the
+    # This case is triggered in FunctionSpaceElement.__call__ if the
     # domain does not have an 'ndim' attribute. We return False and
     # continue.
     if ndim is None:


### PR DESCRIPTION
Big maintenance change broken out of the tensors PR. I based it on #1203 to not have to go back and change lots of things. Only the last commit is relevant.

Important changes:
- Merge of
  - `FunctionSet` and `FunctionSpace` & elements
  - `DiscretizedSet` and `DiscretizedSpace` & elements
  - `NumpyNtuples` and `NumpyFn` & elements
  - `NtuplesBase` and `FnBase` & elements
- `FunctionSpaceElement` no longer subclasses `Operator` (simpler, had no benefits anyway)
- `FunctionSpace` with non-numeric dtype will have `field=None`. Because of that, `LinearSpace` needs to handle that case. It does so by not checking anything in that case.