### PR TITLE
MAINT: refactor Python 2/3 compat imports

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -6,6 +6,7 @@
 # v. 2.0. If a copy of the MPL was not distributed with this file, You can
 # obtain one at https://mozilla.org/MPL/2.0/.
 
+from __future__ import print_function
 from distutils.version import StrictVersion
 import sphinx
 import glob
@@ -22,8 +23,8 @@ try:
     # Verify that we can import odl
     import odl
 except Exception as e:
-    print('Failed importing odl, exiting')
-    print(e)
+    print('Failed importing odl, exiting', file=sys.stderr)
+    print(e, file=sys.stderr)
     sys.exit(1)
 
 
@@ -85,6 +86,7 @@ def skip(app, what, name, obj, skip, options):
 
 def setup(app):
     app.connect("autodoc-skip-member", skip)
+
 
 # Autosummary
 autosummary_generate = glob.glob("./*.rst")

--- a/doc/source/generate_doc.py
+++ b/doc/source/generate_doc.py
@@ -6,9 +6,10 @@
 # v. 2.0. If a copy of the MPL was not distributed with this file, You can
 # obtain one at https://mozilla.org/MPL/2.0/.
 
-import odl
+from __future__ import print_function
 import inspect
 import importlib
+import odl
 
 
 __all__ = ('make_interface',)

--- a/doc/source/guide/code/functional_indepth_example.py
+++ b/doc/source/guide/code/functional_indepth_example.py
@@ -1,5 +1,6 @@
 """Example of how to implement and use functionals."""
 
+from __future__ import division, print_function
 import odl
 
 
@@ -26,7 +27,7 @@ class MyFunctional(odl.solvers.Functional):
     # the functional and always needs to be implemented.
     def _call(self, x):
         """Evaluate the functional."""
-        return x.norm()**2 + x.inner(self.y)
+        return x.norm() ** 2 + x.inner(self.y)
 
     # Next we define the gradient. Note that this is a property.
     @property

--- a/examples/diagnostics/diagonstics_space.py
+++ b/examples/diagnostics/diagonstics_space.py
@@ -1,6 +1,5 @@
 """Run the standardized diagonstics suite on some of the spaces."""
 
-from __future__ import print_function
 import odl
 
 print('\n\n TESTING FOR Lp SPACE \n\n')

--- a/examples/diagnostics/diagonstics_space.py
+++ b/examples/diagnostics/diagonstics_space.py
@@ -1,5 +1,6 @@
 """Run the standardized diagonstics suite on some of the spaces."""
 
+from __future__ import print_function
 import odl
 
 print('\n\n TESTING FOR Lp SPACE \n\n')

--- a/examples/operator/simple_operator.py
+++ b/examples/operator/simple_operator.py
@@ -1,5 +1,6 @@
 """An example of a very simple operator on rn."""
 
+from __future__ import print_function
 import odl
 
 

--- a/examples/operator/simple_operator.py
+++ b/examples/operator/simple_operator.py
@@ -1,6 +1,5 @@
 """An example of a very simple operator on rn."""
 
-from __future__ import print_function
 import odl
 
 

--- a/examples/solvers/douglas_rachford_pd_heron.py
+++ b/examples/solvers/douglas_rachford_pd_heron.py
@@ -13,7 +13,6 @@ the problem can be written as:
     min_{x in R^2}  sum_i inf_{z \in Omega_i} ||x - z||.
 """
 
-from __future__ import print_function
 import matplotlib.pyplot as plt
 import numpy as np
 import odl

--- a/examples/solvers/douglas_rachford_pd_heron.py
+++ b/examples/solvers/douglas_rachford_pd_heron.py
@@ -13,6 +13,7 @@ the problem can be written as:
     min_{x in R^2}  sum_i inf_{z \in Omega_i} ||x - z||.
 """
 
+from __future__ import print_function
 import matplotlib.pyplot as plt
 import numpy as np
 import odl

--- a/examples/solvers/find_optimal_parameters.py
+++ b/examples/solvers/find_optimal_parameters.py
@@ -8,7 +8,6 @@ To find the "best" parameter we use Powell's method to optimize a figure of
 merit, here the L2-distance to the true result.
 """
 
-from __future__ import print_function
 import numpy as np
 import scipy
 import odl

--- a/examples/solvers/find_optimal_parameters.py
+++ b/examples/solvers/find_optimal_parameters.py
@@ -1,4 +1,4 @@
-"""Example of how to use optimization in order to pick reconstruction parameters.
+"""Example of using optimization to pick reconstruction parameters.
 
 In this example, we solve the tomographic inversion problem with different
 regularizers (FBP, Huber-TV and TV) and pick the "best" regularization
@@ -8,9 +8,10 @@ To find the "best" parameter we use Powell's method to optimize a figure of
 merit, here the L2-distance to the true result.
 """
 
+from __future__ import print_function
 import numpy as np
-import odl
 import scipy
+import odl
 
 
 def optimal_parameters(reconstruction, fom, phantoms, data,
@@ -223,7 +224,8 @@ else:
 def fom(reco, true_image):
     """Sobolev type FoM enforcing both gradient and absolute similarity."""
     gradient = odl.Gradient(reco.space)
-    return gradient(reco - true_image).norm() + reco.space.dist(reco, true_image)
+    return (gradient(reco - true_image).norm() +
+            reco.space.dist(reco, true_image))
 
 
 # Find optimal lambda

--- a/examples/solvers/functional_basic_example.py
+++ b/examples/solvers/functional_basic_example.py
@@ -5,6 +5,7 @@ information on functionals, see `the ODL functional guide
 <http://odlgroup.github.io/odl/guide/in_depth/functional_guide.html>`_
 """
 
+from __future__ import print_function
 import numpy as np
 import odl
 

--- a/examples/solvers/functional_basic_example.py
+++ b/examples/solvers/functional_basic_example.py
@@ -5,7 +5,6 @@ information on functionals, see `the ODL functional guide
 <http://odlgroup.github.io/odl/guide/in_depth/functional_guide.html>`_
 """
 
-from __future__ import print_function
 import numpy as np
 import odl
 

--- a/examples/solvers/functional_basic_example_solver.py
+++ b/examples/solvers/functional_basic_example_solver.py
@@ -15,7 +15,6 @@ where ( )_+ denotes the positive part of the element, i.e.,
 (z_i)_+ = max(z_i, 0).
 """
 
-from __future__ import print_function
 import numpy as np
 import odl
 

--- a/examples/solvers/functional_basic_example_solver.py
+++ b/examples/solvers/functional_basic_example_solver.py
@@ -15,6 +15,7 @@ where ( )_+ denotes the positive part of the element, i.e.,
 (z_i)_+ = max(z_i, 0).
 """
 
+from __future__ import print_function
 import numpy as np
 import odl
 

--- a/examples/space/simple_r.py
+++ b/examples/space/simple_r.py
@@ -1,6 +1,6 @@
 ﻿"""An example of a very simple space, the real numbers."""
 
-
+from __future__ import print_function
 import odl
 
 

--- a/examples/space/simple_r.py
+++ b/examples/space/simple_r.py
@@ -1,6 +1,5 @@
 ﻿"""An example of a very simple space, the real numbers."""
 
-from __future__ import print_function
 import odl
 
 

--- a/examples/space/simple_rn.py
+++ b/examples/space/simple_rn.py
@@ -3,6 +3,7 @@
 Including some benchmarks with an optimized version.
 """
 
+from __future__ import print_function
 import numpy as np
 import odl
 from odl.space.base_ntuples import FnBase, FnBaseVector

--- a/examples/space/simple_rn.py
+++ b/examples/space/simple_rn.py
@@ -3,7 +3,6 @@
 Including some benchmarks with an optimized version.
 """
 
-from __future__ import print_function
 import numpy as np
 import odl
 from odl.space.base_ntuples import FnBase, FnBaseVector

--- a/examples/space/vectorization.py
+++ b/examples/space/vectorization.py
@@ -1,6 +1,5 @@
 """Example showing how to use vectorization of `FunctionSpaceElement`'s."""
 
-from __future__ import print_function
 import numpy as np
 import odl
 import timeit

--- a/examples/space/vectorization.py
+++ b/examples/space/vectorization.py
@@ -1,5 +1,6 @@
 """Example showing how to use vectorization of `FunctionSpaceElement`'s."""
 
+from __future__ import print_function
 import numpy as np
 import odl
 import timeit

--- a/examples/ufunc_ops/ufunc_basics.py
+++ b/examples/ufunc_ops/ufunc_basics.py
@@ -1,6 +1,5 @@
 """Basic examples of using the ufunc functionals in ODL."""
 
-from __future__ import print_function
 import odl
 
 
@@ -22,10 +21,10 @@ print('cos(0)={}, cos.gradient(0.2)={}, -sin(0.2)={}'.format(
 square = odl.ufunc_ops.square()
 
 print('[x^2](3) = {}, [d/dx x^2](3) = {}, '
-      '[d^2/dx^2 x^2](3) = {}, [d^3/dx^3 x^2](3) = {}'.format(
-    square(3), square.gradient(3),
-    square.gradient.gradient(3), square.gradient.gradient.gradient(3)))
-
+      '[d^2/dx^2 x^2](3) = {}, [d^3/dx^3 x^2](3) = {}'
+      ''.format(square(3), square.gradient(3),
+                square.gradient.gradient(3),
+                square.gradient.gradient.gradient(3)))
 
 # Can also define ufuncs on vector-spaces, then they act pointwise.
 

--- a/examples/ufunc_ops/ufunc_composition.py
+++ b/examples/ufunc_ops/ufunc_composition.py
@@ -8,6 +8,7 @@ L2NormSquared functional, and also by composing the square ufunc with the
 L2Norm functional.
 """
 
+from __future__ import print_function
 import odl
 
 # Create square functional. It's domain is by default the real numbers.

--- a/examples/ufunc_ops/ufunc_composition.py
+++ b/examples/ufunc_ops/ufunc_composition.py
@@ -8,7 +8,6 @@ L2NormSquared functional, and also by composing the square ufunc with the
 L2Norm functional.
 """
 
-from __future__ import print_function
 import odl
 
 # Create square functional. It's domain is by default the real numbers.

--- a/examples/ufunc_ops/ufunc_solvers.py
+++ b/examples/ufunc_ops/ufunc_solvers.py
@@ -5,6 +5,7 @@ Here, we minimize the logarithm of the rosenbrock function:
     min_x log(rosenbrock(x) + 0.1)
 """
 
+from __future__ import print_function
 import odl
 
 # Create space and functionals

--- a/examples/ufunc_ops/ufunc_solvers.py
+++ b/examples/ufunc_ops/ufunc_solvers.py
@@ -5,7 +5,6 @@ Here, we minimize the logarithm of the rosenbrock function:
     min_x log(rosenbrock(x) + 0.1)
 """
 
-from __future__ import print_function
 import odl
 
 # Create space and functionals

--- a/odl/contrib/datasets/ct/fips.py
+++ b/odl/contrib/datasets/ct/fips.py
@@ -8,6 +8,7 @@
 
 """Tomographic datasets from the Finish Inverse Problems Society (FIPS)."""
 
+from __future__ import division
 import numpy as np
 from odl.contrib.datasets.util import get_data
 from odl.discr import uniform_partition
@@ -142,7 +143,5 @@ def lotus_root_geometry():
 
 
 if __name__ == '__main__':
-    # Run doctests
-    # pylint: disable=wrong-import-position
     from odl.util.testutils import run_doctests
     run_doctests()

--- a/odl/contrib/datasets/images/cambridge.py
+++ b/odl/contrib/datasets/images/cambridge.py
@@ -153,7 +153,5 @@ def blurring_kernel(shape=None):
 
 
 if __name__ == '__main__':
-    # Run doctests
-    # pylint: disable=wrong-import-position
     from odl.util.testutils import run_doctests
     run_doctests()

--- a/odl/contrib/datasets/mri/examples/tugraz_reconstruct.py
+++ b/odl/contrib/datasets/mri/examples/tugraz_reconstruct.py
@@ -1,6 +1,7 @@
 """Example of using the TU Graz datasets."""
 
 import odl.contrib.datasets.mri.tugraz as tugraz
+from odl.util.testutils import run_doctests
 
 # 4-channel head example
 data = tugraz.mri_head_data_4_channel()
@@ -24,6 +25,4 @@ reconstruction = pseudo_inv(data)
 reconstruction.show(clim=[0, 1])
 
 # Run doctests
-# pylint: disable=wrong-import-position
-from odl.util.testutils import run_doctests
 run_doctests()

--- a/odl/contrib/datasets/mri/tugraz.py
+++ b/odl/contrib/datasets/mri/tugraz.py
@@ -208,7 +208,5 @@ platform_aktuell.html
 
 
 if __name__ == '__main__':
-    # Run doctests
-    # pylint: disable=wrong-import-position
     from odl.util.testutils import run_doctests
     run_doctests()

--- a/odl/contrib/datasets/mri/tugraz.py
+++ b/odl/contrib/datasets/mri/tugraz.py
@@ -205,8 +205,3 @@ platform_aktuell.html
     trafo = odl.trafos.FourierTransform(space)
 
     return odl.ReductionOperator(odl.ComplexModulus(space) * trafo.inverse, 8)
-
-
-if __name__ == '__main__':
-    from odl.util.testutils import run_doctests
-    run_doctests()

--- a/odl/contrib/datasets/util.py
+++ b/odl/contrib/datasets/util.py
@@ -8,16 +8,10 @@
 
 """Utilities for datasets."""
 
+from __future__ import print_function
 import os
 from os.path import join, expanduser, exists
-
-try:
-    # Python 2
-    from urllib2 import urlopen
-except ImportError:
-    # Python 3+
-    from urllib.request import urlopen
-
+from future.moves.urllib.request import urlopen
 from shutil import copyfileobj, rmtree
 from scipy import io
 import contextlib
@@ -82,7 +76,7 @@ def get_data(filename, subset, url):
 
     return data_dict
 
+
 if __name__ == '__main__':
-    # pylint: disable=wrong-import-position
     from odl.util.testutils import run_doctests
     run_doctests()

--- a/odl/contrib/fom/examples/haarpsi.py
+++ b/odl/contrib/fom/examples/haarpsi.py
@@ -1,6 +1,5 @@
 """Demonstration of the components of the HaarPSI figure of merit."""
 
-from __future__ import print_function
 import matplotlib.pyplot as plt
 import numpy as np
 import scipy.misc

--- a/odl/contrib/fom/examples/haarpsi.py
+++ b/odl/contrib/fom/examples/haarpsi.py
@@ -1,5 +1,6 @@
 """Demonstration of the components of the HaarPSI figure of merit."""
 
+from __future__ import print_function
 import matplotlib.pyplot as plt
 import numpy as np
 import scipy.misc

--- a/odl/contrib/fom/supervised.py
+++ b/odl/contrib/fom/supervised.py
@@ -8,8 +8,10 @@
 
 """Figures of merit (FOMs) for comparison against a known ground truth."""
 
-import odl
+from __future__ import division
 import numpy as np
+
+import odl
 
 __all__ = ('mean_squared_error', 'mean_absolute_error',
            'mean_value_difference', 'standard_deviation_difference',

--- a/odl/contrib/fom/test/test_supervised.py
+++ b/odl/contrib/fom/test/test_supervised.py
@@ -1,3 +1,14 @@
+# Copyright 2014-2017 The ODL contributors
+#
+# This file is part of ODL.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file, You can
+# obtain one at https://mozilla.org/MPL/2.0/.
+
+"""Tests for supervised FoMs."""
+
+from __future__ import division
 import numpy as np
 import pytest
 import scipy.signal
@@ -63,7 +74,7 @@ def test_psnr(space):
 
     mse = np.mean((true - data) ** 2)
     maxi = np.max(np.abs(true))
-    expected = 10 * np.log10(maxi**2 / mse)
+    expected = 10 * np.log10(maxi ** 2 / mse)
 
     assert result == pytest.approx(expected)
 

--- a/odl/contrib/fom/unsupervised.py
+++ b/odl/contrib/fom/unsupervised.py
@@ -8,6 +8,7 @@
 
 """Figures of Merit (FOMs) for measuring image quality without a reference."""
 
+from __future__ import division
 import numpy as np
 
 __all__ = ('estimate_noise_std',)
@@ -76,6 +77,5 @@ def estimate_noise_std(img, average=True):
 
 
 if __name__ == '__main__':
-    # pylint: disable=wrong-import-position
     from odl.util.testutils import run_doctests
     run_doctests()

--- a/odl/contrib/fom/util.py
+++ b/odl/contrib/fom/util.py
@@ -9,7 +9,6 @@
 """Utility functions for FOMs."""
 
 import numpy as np
-from builtins import str
 
 from odl.trafos.backends import PYFFTW_AVAILABLE
 

--- a/odl/contrib/fom/util.py
+++ b/odl/contrib/fom/util.py
@@ -9,6 +9,8 @@
 """Utility functions for FOMs."""
 
 import numpy as np
+from builtins import str
+
 from odl.trafos.backends import PYFFTW_AVAILABLE
 
 __all__ = ()

--- a/odl/contrib/mrc/examples/raw_binary_with_header_io.py
+++ b/odl/contrib/mrc/examples/raw_binary_with_header_io.py
@@ -12,8 +12,6 @@ Then, the same file is read again using a file specification and the
 sequence of dictionaries with a certain structure.
 """
 
-from __future__ import print_function
-
 from collections import OrderedDict
 import matplotlib.pyplot as plt
 import numpy as np

--- a/odl/contrib/mrc/mrc.py
+++ b/odl/contrib/mrc/mrc.py
@@ -9,7 +9,7 @@
 """Specification and reader for the MRC2014 file format."""
 
 from __future__ import print_function, division, absolute_import
-from builtins import int, object, range, str
+from builtins import int, object
 from collections import OrderedDict
 from itertools import permutations
 import numpy as np

--- a/odl/contrib/mrc/mrc.py
+++ b/odl/contrib/mrc/mrc.py
@@ -8,10 +8,8 @@
 
 """Specification and reader for the MRC2014 file format."""
 
-# Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
-from builtins import int
-
+from builtins import int, object, range, str
 from collections import OrderedDict
 from itertools import permutations
 import numpy as np

--- a/odl/contrib/mrc/uncompr_bin.py
+++ b/odl/contrib/mrc/uncompr_bin.py
@@ -9,7 +9,7 @@
 """Utilities and class for reading uncompressed binary files with header."""
 
 from __future__ import print_function, division, absolute_import
-from builtins import int, object, open, str
+from builtins import int, object
 from collections import OrderedDict
 import csv
 import numpy as np

--- a/odl/contrib/mrc/uncompr_bin.py
+++ b/odl/contrib/mrc/uncompr_bin.py
@@ -8,10 +8,8 @@
 
 """Utilities and class for reading uncompressed binary files with header."""
 
-# Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
-from builtins import int, object, open
-
+from builtins import int, object, open, str
 from collections import OrderedDict
 import csv
 import numpy as np

--- a/odl/contrib/pytorch/examples/operator.py
+++ b/odl/contrib/pytorch/examples/operator.py
@@ -1,5 +1,6 @@
 """Demonstration of basic ODL->pytorch integration functionality."""
 
+from __future__ import print_function
 import numpy as np
 import torch
 import odl

--- a/odl/contrib/pytorch/operator.py
+++ b/odl/contrib/pytorch/operator.py
@@ -13,6 +13,7 @@ see `the pytorch installation guide
 <https://github.com/pytorch/pytorch#installation>`_ for instructions.
 """
 
+from __future__ import division
 import numpy as np
 import torch
 

--- a/odl/contrib/solvers/functional/nonlocalmeans_functionals.py
+++ b/odl/contrib/solvers/functional/nonlocalmeans_functionals.py
@@ -8,9 +8,7 @@
 
 """Non Local Means functionals."""
 
-# Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
-
 import numpy as np
 
 from odl.operator import Operator
@@ -120,6 +118,5 @@ class NLMRegularizer(Functional):
 
 
 if __name__ == '__main__':
-    # pylint: disable=wrong-import-position
     from odl.util.testutils import run_doctests
     run_doctests()

--- a/odl/contrib/tensorflow/examples/tensorflow_layer_matrix.py
+++ b/odl/contrib/tensorflow/examples/tensorflow_layer_matrix.py
@@ -8,8 +8,10 @@ We also demonstrate that we can compute the "gradients" properly using the
 adjoint of the derivative.
 """
 
+from __future__ import print_function
 import tensorflow as tf
 import numpy as np
+
 import odl
 import odl.contrib.tensorflow
 

--- a/odl/contrib/tensorflow/examples/tensorflow_layer_productspace.py
+++ b/odl/contrib/tensorflow/examples/tensorflow_layer_productspace.py
@@ -4,6 +4,7 @@ This example is similar to ``tensorflow_layer_matrix``, but demonstrates how
 to handle product-spaces.
 """
 
+from __future__ import print_function
 import tensorflow as tf
 import odl
 import odl.contrib.tensorflow

--- a/odl/contrib/tensorflow/examples/tensorflow_layer_ray_transform.py
+++ b/odl/contrib/tensorflow/examples/tensorflow_layer_ray_transform.py
@@ -4,6 +4,7 @@ This example is similar to ``tensorflow_layer_matrix``, but demonstrates how
 more advanced operators, such as a ray transform, can be handled.
 """
 
+from __future__ import print_function
 import tensorflow as tf
 import numpy as np
 import odl

--- a/odl/contrib/tensorflow/examples/tensorflow_operator_matrix.py
+++ b/odl/contrib/tensorflow/examples/tensorflow_operator_matrix.py
@@ -4,6 +4,7 @@ In this example we take a tensorflow layer (given by matrix multiplication)
 and convert it into an ODL operator.
 """
 
+from __future__ import print_function
 import tensorflow as tf
 import numpy as np
 import odl

--- a/odl/contrib/tensorflow/layer.py
+++ b/odl/contrib/tensorflow/layer.py
@@ -8,10 +8,8 @@
 
 """Utilities for converting ODL operators to tensorflow layers."""
 
-# Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
 from builtins import range, str
-
 import numpy as np
 import uuid
 import tensorflow as tf
@@ -381,6 +379,5 @@ def as_tensorflow_layer(odl_op, name='ODLOperator',
 
 
 if __name__ == '__main__':
-    # pylint: disable=wrong-import-position
     from odl.util.testutils import run_doctests
     run_doctests()

--- a/odl/contrib/tensorflow/layer.py
+++ b/odl/contrib/tensorflow/layer.py
@@ -9,7 +9,6 @@
 """Utilities for converting ODL operators to tensorflow layers."""
 
 from __future__ import print_function, division, absolute_import
-from builtins import range, str
 import numpy as np
 import uuid
 import tensorflow as tf

--- a/odl/contrib/tensorflow/operator.py
+++ b/odl/contrib/tensorflow/operator.py
@@ -8,11 +8,10 @@
 
 """Utilities for converting ODL spaces to tensorflow layers."""
 
-# Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
-
 import tensorflow as tf
 import numpy as np
+
 import odl
 
 
@@ -93,6 +92,5 @@ class TensorflowOperator(odl.Operator):
 
 
 if __name__ == '__main__':
-    # pylint: disable=wrong-import-position
     from odl.util.testutils import run_doctests
     run_doctests()

--- a/odl/contrib/tensorflow/space.py
+++ b/odl/contrib/tensorflow/space.py
@@ -8,11 +8,11 @@
 
 """Utilities for converting ODL spaces to tensorflow layers."""
 
-# Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
-
 import tensorflow as tf
-from odl.set import LinearSpace, LinearSpaceElement, RealNumbers
+
+from odl.set import LinearSpace, RealNumbers
+from odl.set.space import LinearSpaceElement
 from odl.operator import Operator
 
 
@@ -133,6 +133,5 @@ class TensorflowSpaceOperator(Operator):
 
 
 if __name__ == '__main__':
-    # pylint: disable=wrong-import-position
     from odl.util.testutils import run_doctests
     run_doctests()

--- a/odl/contrib/theano/examples/theano_layer_matrix.py
+++ b/odl/contrib/theano/examples/theano_layer_matrix.py
@@ -8,6 +8,7 @@ We also demonstrate that we can compute the gradient of the scalar-valued
 squared L2-norm function properly using either Theano or ODL.
 """
 
+from __future__ import print_function
 import theano
 import theano.tensor as T
 import numpy as np

--- a/odl/contrib/theano/layer.py
+++ b/odl/contrib/theano/layer.py
@@ -8,7 +8,6 @@
 
 """Utilities for converting ODL operators to Theano operators."""
 
-# Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
 from future.utils import native
 

--- a/odl/contrib/tomo/elekta.py
+++ b/odl/contrib/tomo/elekta.py
@@ -370,7 +370,5 @@ def elekta_xvi_fbp(ray_transform,
 
 
 if __name__ == '__main__':
-    # Run doctests
-    # pylint: disable=wrong-import-position
     from odl.util.testutils import run_doctests
     run_doctests()

--- a/odl/deform/linearized.py
+++ b/odl/deform/linearized.py
@@ -8,9 +8,7 @@
 
 """Operators and functions for linearized deformation."""
 
-# Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
-
 import numpy as np
 
 from odl.discr import DiscreteLp, Gradient, Divergence
@@ -383,7 +381,7 @@ class LinDeformFixedDisp(Operator):
 
         return '{}({})'.format(self.__class__.__name__, arg_str)
 
+
 if __name__ == '__main__':
-    # pylint: disable=wrong-import-position
     from odl.util.testutils import run_doctests
     run_doctests()

--- a/odl/deform/linearized.py
+++ b/odl/deform/linearized.py
@@ -171,6 +171,7 @@ class LinDeformFixedTempl(Operator):
             domain = self.template.space.real_space.tangent_bundle
         else:
             if not isinstance(domain, ProductSpace):
+                # TODO: allow non-product spaces in the 1D case
                 raise TypeError('`domain` must be a `ProductSpace` '
                                 'instance, got {!r}'.format(domain))
             if not domain.is_power_space:

--- a/odl/deform/linearized.py
+++ b/odl/deform/linearized.py
@@ -14,6 +14,7 @@ import numpy as np
 from odl.discr import DiscreteLp, Gradient, Divergence
 from odl.operator import Operator, PointwiseInner
 from odl.space import ProductSpace
+from odl.util import signature_string, indent
 
 
 __all__ = ('LinDeformFixedTempl', 'LinDeformFixedDisp', 'linear_deform')
@@ -229,12 +230,10 @@ class LinDeformFixedTempl(Operator):
 
     def __repr__(self):
         """Return ``repr(self)``."""
-        arg_reprs = [repr(self.template)]
-        if self.domain != self.__displacement.space[0]:
-            arg_reprs.append('domain={!r}'.format(self.domain))
-        arg_str = ', '.join(arg_reprs)
-
-        return '{}({})'.format(self.__class__.__name__, arg_str)
+        posargs = [self.template]
+        optargs = [('domain', self.domain, self.template.space)]
+        inner_str = signature_string(posargs, optargs, mod='!r', sep=',\n')
+        return '{}(\n{}\n)'.format(self.__class__.__name__, indent(inner_str))
 
 
 class LinDeformFixedDisp(Operator):
@@ -374,12 +373,10 @@ class LinDeformFixedDisp(Operator):
 
     def __repr__(self):
         """Return ``repr(self)``."""
-        arg_reprs = [repr(self.displacement)]
-        if self.domain != self.__displacement.space[0]:
-            arg_reprs.append('templ_space={!r}'.format(self.domain))
-        arg_str = ', '.join(arg_reprs)
-
-        return '{}({})'.format(self.__class__.__name__, arg_str)
+        posargs = [self.displacement]
+        optargs = [('templ_space', self.domain, self.displacement.space[0])]
+        inner_str = signature_string(posargs, optargs, mod='!r', sep=',\n')
+        return '{}(\n{}\n)'.format(self.__class__.__name__, indent(inner_str))
 
 
 if __name__ == '__main__':

--- a/odl/diagnostics/examples.py
+++ b/odl/diagnostics/examples.py
@@ -8,9 +8,7 @@
 
 """Functions for generating standardized examples in spaces."""
 
-# Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
-
 from itertools import product
 
 __all__ = ('samples',)
@@ -43,6 +41,5 @@ def samples(*sets):
 
 
 if __name__ == '__main__':
-    # pylint: disable=wrong-import-position
     from odl.util.testutils import run_doctests
     run_doctests()

--- a/odl/diagnostics/operator.py
+++ b/odl/diagnostics/operator.py
@@ -8,10 +8,8 @@
 
 """Standardized tests for `Operator`'s."""
 
-# Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
 from builtins import object
-
 import numpy as np
 
 from odl.diagnostics.examples import samples
@@ -377,9 +375,8 @@ class OperatorTest(object):
     def __repr__(self):
         return '{}({!r})'.format(self.__class__.__name__, self.operator)
 
-if __name__ == '__main__':
-    # pylint: disable=wrong-import-position
 
+if __name__ == '__main__':
     import odl
     space = odl.uniform_discr([0, 0], [1, 1], [3, 3])
     # Linear operator

--- a/odl/diagnostics/space.py
+++ b/odl/diagnostics/space.py
@@ -8,10 +8,8 @@
 
 """Standardized tests for `LinearSpace`'s."""
 
-# Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
 from builtins import object
-
 from copy import copy, deepcopy
 
 from odl.set import Field
@@ -1003,7 +1001,6 @@ class SpaceTest(object):
 
 
 if __name__ == '__main__':
-    # pylint: disable=wrong-import-position
     from odl import rn, uniform_discr
     SpaceTest(rn(10), verbose=False).run_tests()
     SpaceTest(uniform_discr([0, 0], [1, 1], [5, 5])).run_tests()

--- a/odl/discr/diff_ops.py
+++ b/odl/discr/diff_ops.py
@@ -8,9 +8,8 @@
 
 """Operators defined for tensor fields."""
 
-# Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
-
+from builtins import range, str
 import numpy as np
 
 from odl.discr.lp_discr import DiscreteLp
@@ -873,9 +872,9 @@ def finite_diff(f, axis, dx=1.0, method='forward', out=None, **kwargs):
 
     Central differences and different edge orders:
 
-    >>> finite_diff(0.5 * f**2, axis=0, method='central', pad_mode='order1')
+    >>> finite_diff(0.5 * f ** 2, axis=0, method='central', pad_mode='order1')
     array([ 0.5,  1. ,  2. ,  3. ,  4. ,  5. ,  6. ,  7. ,  8. ,  8.5])
-    >>> finite_diff(0.5 * f**2, axis=0, method='central', pad_mode='order2')
+    >>> finite_diff(0.5 * f ** 2, axis=0, method='central', pad_mode='order2')
     array([-0.,  1.,  2.,  3.,  4.,  5.,  6.,  7.,  8.,  9.])
 
     In-place evaluation:
@@ -1136,6 +1135,5 @@ def finite_diff(f, axis, dx=1.0, method='forward', out=None, **kwargs):
 
 
 if __name__ == '__main__':
-    # pylint: disable=wrong-import-position
     from odl.util.testutils import run_doctests
     run_doctests()

--- a/odl/discr/diff_ops.py
+++ b/odl/discr/diff_ops.py
@@ -9,7 +9,6 @@
 """Operators defined for tensor fields."""
 
 from __future__ import print_function, division, absolute_import
-from builtins import range, str
 import numpy as np
 
 from odl.discr.lp_discr import DiscreteLp

--- a/odl/discr/discr_mappings.py
+++ b/odl/discr/discr_mappings.py
@@ -12,10 +12,8 @@ Includes grid evaluation (collocation) and various interpolation
 operators.
 """
 
-# Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
-from builtins import str, zip
-
+from builtins import object, range, str, zip
 from itertools import product
 import numpy as np
 
@@ -672,14 +670,13 @@ class PerAxisInterpolation(FunctionSpaceMapping):
         else:
             schemes = self.schemes
 
-        if all(var == self.nn_variants[0] for var in self.nn_variants):
-            variants = self.nn_variants[0]
-        else:
-            variants = self.nn_variants
-
         posargs = [self.range, self.grid, self.domain, schemes]
-        optargs = [('order', self.order, 'C'),
-                   ('nn_variants', variants, 'left')]
+
+        optargs = [('order', self.order, 'C')]
+        nn_relevant = [x for x in self.nn_variants if x is not None]
+        if nn_relevant:
+            optargs.append(('nn_variants', self.nn_variants, 'left'))
+
         inner_str = signature_string(posargs, optargs,
                                      sep=[',\n', ', ', ',\n'],
                                      mod=['!r', ''])
@@ -1035,6 +1032,5 @@ class _LinearInterpolator(_PerAxisInterpolator):
 
 
 if __name__ == '__main__':
-    # pylint: disable=wrong-import-position
     from odl.util.testutils import run_doctests
     run_doctests()

--- a/odl/discr/discr_mappings.py
+++ b/odl/discr/discr_mappings.py
@@ -13,7 +13,7 @@ operators.
 """
 
 from __future__ import print_function, division, absolute_import
-from builtins import object, range, str, zip
+from builtins import object
 from itertools import product
 import numpy as np
 

--- a/odl/discr/discr_ops.py
+++ b/odl/discr/discr_ops.py
@@ -8,9 +8,8 @@
 
 """Operators defined on `DiscreteLp`."""
 
-# Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
-
+from builtins import range, str, zip
 import numpy as np
 
 from odl.discr import DiscreteLp, uniform_partition
@@ -545,6 +544,5 @@ def _resize_discr(discr, newshp, offset, discr_kwargs):
                       order=order)
 
 if __name__ == '__main__':
-    # pylint: disable=wrong-import-position
     from odl.util.testutils import run_doctests
     run_doctests()

--- a/odl/discr/discr_ops.py
+++ b/odl/discr/discr_ops.py
@@ -9,7 +9,6 @@
 """Operators defined on `DiscreteLp`."""
 
 from __future__ import print_function, division, absolute_import
-from builtins import range, str, zip
 import numpy as np
 
 from odl.discr import DiscreteLp, uniform_partition
@@ -257,7 +256,9 @@ class ResizingOperatorBase(Operator):
          [ 5.,  6.,  7.,  8.],
          [ 1.,  2.,  3.,  4.]]
         """
-        from builtins import range as builtin_range
+        # Swap names to be able to use the range iterator without worries
+        import builtins
+        ran, range = range, builtins.range
 
         if not isinstance(domain, DiscreteLp):
             raise TypeError('`domain` must be a `DiscreteLp` instance, '
@@ -266,34 +267,34 @@ class ResizingOperatorBase(Operator):
         offset = kwargs.pop('offset', None)
         discr_kwargs = kwargs.pop('discr_kwargs', {})
 
-        if range is None:
+        if ran is None:
             if ran_shp is None:
-                raise ValueError('either `range` or `ran_shp` must be '
+                raise ValueError('either `ran` or `ran_shp` must be '
                                  'given')
 
             offset = normalized_scalar_param_list(
                 offset, domain.ndim, param_conv=safe_int_conv, keep_none=True)
 
-            range = _resize_discr(domain, ran_shp, offset, discr_kwargs)
-            self.__offset = tuple(_offset_from_spaces(domain, range))
+            ran = _resize_discr(domain, ran_shp, offset, discr_kwargs)
+            self.__offset = tuple(_offset_from_spaces(domain, ran))
 
         elif ran_shp is None:
             if offset is not None:
                 raise ValueError('`offset` can only be combined with '
                                  '`ran_shp`')
 
-            for i in builtin_range(domain.ndim):
-                if (range.is_uniform_byaxis[i] and
+            for i in range(domain.ndim):
+                if (ran.is_uniform_byaxis[i] and
                     domain.is_uniform_byaxis[i] and
-                        not np.isclose(range.cell_sides[i],
+                        not np.isclose(ran.cell_sides[i],
                                        domain.cell_sides[i])):
                     raise ValueError(
                         'in axis {}: cell sides of domain and range differ '
                         'significantly: (difference {})'
                         ''.format(i,
-                                  range.cell_sides[i] - domain.cell_sides[i]))
+                                  ran.cell_sides[i] - domain.cell_sides[i]))
 
-            self.__offset = _offset_from_spaces(domain, range)
+            self.__offset = _offset_from_spaces(domain, ran)
 
         else:
             raise ValueError('cannot combine `range` with `ran_shape`')
@@ -307,13 +308,13 @@ class ResizingOperatorBase(Operator):
         self.__pad_mode = pad_mode
         # Store constant in a way that ensures safe casting (one-element array)
         self.__pad_const = np.array(kwargs.pop('pad_const', 0),
-                                    dtype=range.dtype)
+                                    dtype=ran.dtype)
 
         # padding mode 'constant' with `pad_const != 0` is not linear
         linear = (self.pad_mode != 'constant' or self.pad_const == 0.0)
 
         super(ResizingOperatorBase, self).__init__(
-            domain, range, linear=linear)
+            domain, ran, linear=linear)
 
     @property
     def offset(self):

--- a/odl/discr/discretization.py
+++ b/odl/discr/discretization.py
@@ -8,7 +8,6 @@
 
 """Base classes for discretization."""
 
-# Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
 import numpy as np
 

--- a/odl/discr/discretization.py
+++ b/odl/discr/discretization.py
@@ -522,6 +522,5 @@ def dspace_type(space, impl, dtype=None):
 
 
 if __name__ == '__main__':
-    # pylint: disable=wrong-import-position
     from odl.util.testutils import run_doctests
     run_doctests()

--- a/odl/discr/grid.py
+++ b/odl/discr/grid.py
@@ -12,10 +12,8 @@ Sampling grids are collections of points in an n-dimensional coordinate
 space with a certain structure which is exploited to minimize storage.
 """
 
-# Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
 from builtins import range, str, zip
-
 import numpy as np
 
 from odl.set import Set, IntervalProd
@@ -1230,6 +1228,5 @@ def uniform_grid(min_pt, max_pt, shape, nodes_on_bdry=True):
 
 
 if __name__ == '__main__':
-    # pylint: disable=wrong-import-position
     from odl.util.testutils import run_doctests
     run_doctests()

--- a/odl/discr/grid.py
+++ b/odl/discr/grid.py
@@ -13,7 +13,6 @@ space with a certain structure which is exploited to minimize storage.
 """
 
 from __future__ import print_function, division, absolute_import
-from builtins import range, str, zip
 import numpy as np
 
 from odl.set import Set, IntervalProd

--- a/odl/discr/lp_discr.py
+++ b/odl/discr/lp_discr.py
@@ -9,7 +9,6 @@
 """:math:`L^p` type discretizations of function spaces."""
 
 from __future__ import print_function, division, absolute_import
-from builtins import object, range, str, zip
 from numbers import Integral
 import numpy as np
 

--- a/odl/discr/lp_discr.py
+++ b/odl/discr/lp_discr.py
@@ -1626,6 +1626,5 @@ def _scaling_func_list(bdry_fracs, exponent=1.0):
 
 
 if __name__ == '__main__':
-    # pylint: disable=wrong-import-position
     from odl.util.testutils import run_doctests
     run_doctests()

--- a/odl/discr/lp_discr.py
+++ b/odl/discr/lp_discr.py
@@ -8,12 +8,10 @@
 
 """:math:`L^p` type discretizations of function spaces."""
 
-# Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
-from builtins import str
-
-import numpy as np
+from builtins import object, range, str, zip
 from numbers import Integral
+import numpy as np
 
 from odl.discr.discretization import (
     DiscretizedSpace, DiscretizedSpaceElement, dspace_type)

--- a/odl/discr/partition.py
+++ b/odl/discr/partition.py
@@ -15,7 +15,7 @@ of partitions of intervals.
 """
 
 from __future__ import print_function, division, absolute_import
-from builtins import object, range, zip
+from builtins import object
 import numpy as np
 
 from odl.discr.grid import RectGrid, uniform_grid_fromintv

--- a/odl/discr/partition.py
+++ b/odl/discr/partition.py
@@ -14,10 +14,8 @@ considered here are based on hypercubes, i.e. the tensor products
 of partitions of intervals.
 """
 
-# Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
 from builtins import object, range, zip
-
 import numpy as np
 
 from odl.discr.grid import RectGrid, uniform_grid_fromintv
@@ -1407,6 +1405,5 @@ def nonuniform_partition(*coord_vecs, **kwargs):
 
 
 if __name__ == '__main__':
-    # pylint: disable=wrong-import-position
     from odl.util.testutils import run_doctests
     run_doctests()

--- a/odl/operator/default_ops.py
+++ b/odl/operator/default_ops.py
@@ -8,9 +8,7 @@
 
 """Default operators defined on any (reasonable) space."""
 
-# Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
-
 from copy import copy
 import numpy as np
 
@@ -1324,6 +1322,5 @@ class ComplexModulus(Operator):
 
 
 if __name__ == '__main__':
-    # pylint: disable=wrong-import-position
     from odl.util.testutils import run_doctests
     run_doctests()

--- a/odl/operator/fn_ops.py
+++ b/odl/operator/fn_ops.py
@@ -8,9 +8,7 @@
 
 """Default operators defined on fn (F^n where F is some field)."""
 
-# Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
-
 import numpy as np
 
 from odl.operator.operator import Operator
@@ -476,6 +474,5 @@ class FlatteningOperatorAdjoint(Operator):
         return repr(self)
 
 if __name__ == '__main__':
-    # pylint: disable=wrong-import-position
     from odl.util.testutils import run_doctests
     run_doctests()

--- a/odl/operator/operator.py
+++ b/odl/operator/operator.py
@@ -8,10 +8,8 @@
 
 """Abstract mathematical operators."""
 
-# Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
-from builtins import object
-
+from builtins import object, str, zip
 import inspect
 from numbers import Number, Integral
 import sys
@@ -982,7 +980,7 @@ class Operator(object):
         >>> x = rn.element([1, 2, 3])
         >>> op(x)
         rn(3).element([ 3.,  6.,  9.])
-        >>> squared = op**2
+        >>> squared = op ** 2
         >>> squared(x)
         rn(3).element([  9.,  18.,  27.])
         >>> squared = op**3
@@ -2244,6 +2242,5 @@ class OpNotImplementedError(NotImplementedError):
 
 
 if __name__ == '__main__':
-    # pylint: disable=wrong-import-position
     from odl.util.testutils import run_doctests
     run_doctests()

--- a/odl/operator/operator.py
+++ b/odl/operator/operator.py
@@ -9,7 +9,7 @@
 """Abstract mathematical operators."""
 
 from __future__ import print_function, division, absolute_import
-from builtins import object, str, zip
+from builtins import object
 import inspect
 from numbers import Number, Integral
 import sys

--- a/odl/operator/oputils.py
+++ b/odl/operator/oputils.py
@@ -8,10 +8,9 @@
 
 """Convenience functions for operators."""
 
-# Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
+from builtins import range
 from future.utils import native
-
 import numpy as np
 
 from odl.space.base_ntuples import FnBase

--- a/odl/operator/oputils.py
+++ b/odl/operator/oputils.py
@@ -9,7 +9,6 @@
 """Convenience functions for operators."""
 
 from __future__ import print_function, division, absolute_import
-from builtins import range
 from future.utils import native
 import numpy as np
 

--- a/odl/operator/oputils.py
+++ b/odl/operator/oputils.py
@@ -438,6 +438,5 @@ def as_proximal_lang_operator(op, norm_bound=None):
 
 
 if __name__ == '__main__':
-    # pylint: disable=wrong-import-position
     from odl.util.testutils import run_doctests
     run_doctests()

--- a/odl/operator/pspace_ops.py
+++ b/odl/operator/pspace_ops.py
@@ -8,11 +8,10 @@
 
 """Default operators defined on any `ProductSpace`."""
 
-# Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
-
-import numpy as np
+from builtins import range, zip
 from numbers import Integral
+import numpy as np
 
 from odl.operator.operator import Operator
 from odl.operator.default_ops import ZeroOperator
@@ -1200,6 +1199,5 @@ class DiagonalOperator(ProductSpaceOperator):
 
 
 if __name__ == '__main__':
-    # pylint: disable=wrong-import-position
     from odl.util.testutils import run_doctests
     run_doctests()

--- a/odl/operator/pspace_ops.py
+++ b/odl/operator/pspace_ops.py
@@ -9,7 +9,6 @@
 """Default operators defined on any `ProductSpace`."""
 
 from __future__ import print_function, division, absolute_import
-from builtins import range, zip
 from numbers import Integral
 import numpy as np
 

--- a/odl/operator/tensor_ops.py
+++ b/odl/operator/tensor_ops.py
@@ -8,9 +8,8 @@
 
 """Operators defined for tensor fields."""
 
-# Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
-
+from builtins import zip
 import numpy as np
 
 from odl.operator import Operator

--- a/odl/operator/tensor_ops.py
+++ b/odl/operator/tensor_ops.py
@@ -9,7 +9,6 @@
 """Operators defined for tensor fields."""
 
 from __future__ import print_function, division, absolute_import
-from builtins import zip
 import numpy as np
 
 from odl.operator import Operator

--- a/odl/operator/tensor_ops.py
+++ b/odl/operator/tensor_ops.py
@@ -969,6 +969,5 @@ def is_compatible_space(space, base_space):
 
 
 if __name__ == '__main__':
-    # pylint: disable=wrong-import-position
     from odl.util.testutils import run_doctests
     run_doctests()

--- a/odl/phantom/emission.py
+++ b/odl/phantom/emission.py
@@ -8,7 +8,6 @@
 
 """Phantoms used in emission tomography."""
 
-# Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
 
 from odl.phantom.geometric import ellipsoid_phantom
@@ -125,6 +124,8 @@ def derenzo_sources(space):
 if __name__ == '__main__':
     # Show the phantoms
     import odl
+    from odl.util.testutils import run_doctests
+
     n = 300
 
     # 2D
@@ -136,6 +137,4 @@ if __name__ == '__main__':
     derenzo_sources(discr).show('derenzo_sources 3d')
 
     # Run also the doctests
-    # pylint: disable=wrong-import-position
-    from odl.util.testutils import run_doctests
     run_doctests()

--- a/odl/phantom/geometric.py
+++ b/odl/phantom/geometric.py
@@ -9,7 +9,6 @@
 """Phantoms given by simple geometric objects such as cubes or spheres."""
 
 from __future__ import print_function, division, absolute_import
-from builtins import range, zip
 import numpy as np
 
 __all__ = ('cuboid', 'defrise', 'ellipsoid_phantom', 'indicate_proj_axis',

--- a/odl/phantom/geometric.py
+++ b/odl/phantom/geometric.py
@@ -8,9 +8,8 @@
 
 """Phantoms given by simple geometric objects such as cubes or spheres."""
 
-# Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
-
+from builtins import range, zip
 import numpy as np
 
 __all__ = ('cuboid', 'defrise', 'ellipsoid_phantom', 'indicate_proj_axis',

--- a/odl/phantom/misc_phantoms.py
+++ b/odl/phantom/misc_phantoms.py
@@ -8,9 +8,8 @@
 
 """Miscellaneous phantoms that do not fit in other categories."""
 
-# Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
-
+from builtins import str, zip
 import numpy as np
 import sys
 
@@ -256,6 +255,7 @@ def text(space, text, font=None, border=0.2, inverted=True):
 if __name__ == '__main__':
     # Show the phantoms
     import odl
+    from odl.util.testutils import run_doctests
 
     space = odl.uniform_discr([-1, -1], [1, 1], [300, 300])
     submarine(space, smooth=False).show('submarine smooth=False')
@@ -265,6 +265,4 @@ if __name__ == '__main__':
     text(space, text='phantom').show('phantom')
 
     # Run also the doctests
-    # pylint: disable=wrong-import-position
-    from odl.util.testutils import run_doctests
     run_doctests()

--- a/odl/phantom/misc_phantoms.py
+++ b/odl/phantom/misc_phantoms.py
@@ -9,7 +9,6 @@
 """Miscellaneous phantoms that do not fit in other categories."""
 
 from __future__ import print_function, division, absolute_import
-from builtins import str, zip
 import numpy as np
 import sys
 

--- a/odl/phantom/noise.py
+++ b/odl/phantom/noise.py
@@ -8,10 +8,9 @@
 
 """Functions to create noise samples of different distributions."""
 
-# Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
-
 import numpy as np
+
 from odl.util import as_flat_array, NumpyRandomSeed
 
 
@@ -250,6 +249,7 @@ def salt_pepper_noise(vector, fraction=0.05, salt_vs_pepper=0.5,
 if __name__ == '__main__':
     # Show the phantoms
     import odl
+    from odl.util.testutils import run_doctests
 
     r100 = odl.rn(100)
     white_noise(r100).show('white_noise')
@@ -269,6 +269,4 @@ if __name__ == '__main__':
     salt_pepper_noise(vector).show('salt_pepper_noise 2d')
 
     # Run also the doctests
-    # pylint: disable=wrong-import-position
-    from odl.util.testutils import run_doctests
     run_doctests()

--- a/odl/phantom/phantom_utils.py
+++ b/odl/phantom/phantom_utils.py
@@ -8,9 +8,7 @@
 
 """Utilities for creating phantoms."""
 
-# Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
-
 import numpy as np
 
 
@@ -28,6 +26,5 @@ def cylinders_from_ellipses(ellipses):
 
 
 if __name__ == '__main__':
-    # pylint: disable=wrong-import-position
     from odl.util.testutils import run_doctests
     run_doctests()

--- a/odl/phantom/transmission.py
+++ b/odl/phantom/transmission.py
@@ -9,7 +9,6 @@
 """Phantoms typically used in transmission tomography."""
 
 from __future__ import print_function, division, absolute_import
-from builtins import range, zip
 import numpy as np
 
 from odl.discr import DiscreteLp

--- a/odl/phantom/transmission.py
+++ b/odl/phantom/transmission.py
@@ -8,12 +8,12 @@
 
 """Phantoms typically used in transmission tomography."""
 
-# Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
+from builtins import range, zip
+import numpy as np
 
 from odl.discr import DiscreteLp
 from odl.phantom.geometric import ellipsoid_phantom
-import numpy as np
 
 
 __all__ = ('shepp_logan_ellipsoids', 'shepp_logan', 'forbild')
@@ -391,6 +391,7 @@ def forbild(space, resolution=False, ear=True, value_type='density',
 if __name__ == '__main__':
     # Show the phantoms
     import odl
+    from odl.util.testutils import run_doctests
 
     # 2D
     discr = odl.uniform_discr([-1, -1], [1, 1], [1000, 1000])
@@ -405,6 +406,4 @@ if __name__ == '__main__':
     shepp_logan(discr, modified=False).show('shepp_logan 3d modified=False')
 
     # Run also the doctests
-    # pylint: disable=wrong-import-position
-    from odl.util.testutils import run_doctests
     run_doctests()

--- a/odl/set/domain.py
+++ b/odl/set/domain.py
@@ -9,7 +9,6 @@
 """Domains for continuous functions. """
 
 from __future__ import print_function, division, absolute_import
-from builtins import zip
 import numpy as np
 
 from odl.set.sets import Set

--- a/odl/set/domain.py
+++ b/odl/set/domain.py
@@ -8,10 +8,8 @@
 
 """Domains for continuous functions. """
 
-# Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
 from builtins import zip
-
 import numpy as np
 
 from odl.set.sets import Set
@@ -848,6 +846,5 @@ class IntervalProd(Set):
 
 
 if __name__ == '__main__':
-    # pylint: disable=wrong-import-position
     from odl.util.testutils import run_doctests
     run_doctests()

--- a/odl/set/sets.py
+++ b/odl/set/sets.py
@@ -8,13 +8,12 @@
 
 """Basic abstract and concrete sets."""
 
-# Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
 from builtins import int, object, str, zip
-from past.builtins import basestring
-
 from numbers import Integral, Real, Complex
+from past.builtins import basestring
 import numpy as np
+
 from odl.util import is_int_dtype, is_real_dtype, is_numeric_dtype, unique
 
 
@@ -948,6 +947,5 @@ class FiniteSet(Set):
 
 
 if __name__ == '__main__':
-    # pylint: disable=wrong-import-position
     from odl.util.testutils import run_doctests
     run_doctests()

--- a/odl/set/sets.py
+++ b/odl/set/sets.py
@@ -9,7 +9,7 @@
 """Basic abstract and concrete sets."""
 
 from __future__ import print_function, division, absolute_import
-from builtins import int, object, str, zip
+from builtins import int, object
 from numbers import Integral, Real, Complex
 from past.builtins import basestring
 import numpy as np

--- a/odl/set/space.py
+++ b/odl/set/space.py
@@ -8,10 +8,8 @@
 
 """Abstract linear vector spaces."""
 
-# Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
-from builtins import object, range
-
+from builtins import object, range, str
 import numpy as np
 
 from odl.set.sets import Field, Set, UniversalSet
@@ -1057,6 +1055,5 @@ class LinearSpaceNotImplementedError(NotImplementedError):
 
 
 if __name__ == '__main__':
-    # pylint: disable=wrong-import-position
     from odl.util.testutils import run_doctests
     run_doctests()

--- a/odl/set/space.py
+++ b/odl/set/space.py
@@ -9,7 +9,7 @@
 """Abstract linear vector spaces."""
 
 from __future__ import print_function, division, absolute_import
-from builtins import object, range, str
+from builtins import object
 import numpy as np
 
 from odl.set.sets import Field, Set, UniversalSet

--- a/odl/solvers/functional/default_functionals.py
+++ b/odl/solvers/functional/default_functionals.py
@@ -8,11 +8,10 @@
 
 """Default functionals defined on any space similar to R^n or L^2."""
 
-# Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
-
-import numpy as np
+from builtins import range, zip
 from numbers import Integral
+import numpy as np
 
 from odl.solvers.functional.functional import (Functional,
                                                FunctionalQuadraticPerturb)
@@ -2505,6 +2504,5 @@ class Huber(Functional):
 
 
 if __name__ == '__main__':
-    # pylint: disable=wrong-import-position
     from odl.util.testutils import run_doctests
     run_doctests()

--- a/odl/solvers/functional/default_functionals.py
+++ b/odl/solvers/functional/default_functionals.py
@@ -9,7 +9,6 @@
 """Default functionals defined on any space similar to R^n or L^2."""
 
 from __future__ import print_function, division, absolute_import
-from builtins import range, zip
 from numbers import Integral
 import numpy as np
 

--- a/odl/solvers/functional/derivatives.py
+++ b/odl/solvers/functional/derivatives.py
@@ -8,9 +8,8 @@
 
 """Utilities for computing the gradient and Hessian of functionals."""
 
-# Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
-
+from builtins import range, str
 import numpy as np
 
 from odl.solvers.functional.functional import Functional

--- a/odl/solvers/functional/derivatives.py
+++ b/odl/solvers/functional/derivatives.py
@@ -307,7 +307,7 @@ class NumericalGradient(Operator):
         return NumericalDerivative(self, point,
                                    method=self.method, step=np.sqrt(self.step))
 
+
 if __name__ == '__main__':
-    # pylint: disable=wrong-import-position
     from odl.util.testutils import run_doctests
     run_doctests()

--- a/odl/solvers/functional/derivatives.py
+++ b/odl/solvers/functional/derivatives.py
@@ -9,7 +9,6 @@
 """Utilities for computing the gradient and Hessian of functionals."""
 
 from __future__ import print_function, division, absolute_import
-from builtins import range, str
 import numpy as np
 
 from odl.solvers.functional.functional import Functional

--- a/odl/solvers/functional/example_funcs.py
+++ b/odl/solvers/functional/example_funcs.py
@@ -9,7 +9,6 @@
 """Example functionals used in optimization."""
 
 from __future__ import print_function, division, absolute_import
-from builtins import range
 import numpy as np
 
 from odl.solvers.functional.functional import Functional

--- a/odl/solvers/functional/example_funcs.py
+++ b/odl/solvers/functional/example_funcs.py
@@ -8,9 +8,8 @@
 
 """Example functionals used in optimization."""
 
-# Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
-
+from builtins import range
 import numpy as np
 
 from odl.solvers.functional.functional import Functional
@@ -154,6 +153,5 @@ class RosenbrockFunctional(Functional):
 
 
 if __name__ == '__main__':
-    # pylint: disable=wrong-import-position
     from odl.util.testutils import run_doctests
     run_doctests()

--- a/odl/solvers/functional/functional.py
+++ b/odl/solvers/functional/functional.py
@@ -6,9 +6,7 @@
 # v. 2.0. If a copy of the MPL was not distributed with this file, You can
 # obtain one at https://mozilla.org/MPL/2.0/.
 
-# Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
-
 import numpy as np
 
 from odl.operator.operator import (
@@ -1359,6 +1357,5 @@ def simple_functional(space, fcall=None, grad=None, prox=None, grad_lip=np.nan,
 
 
 if __name__ == '__main__':
-    # pylint: disable=wrong-import-position
     from odl.util.testutils import run_doctests
     run_doctests()

--- a/odl/solvers/iterative/iterative.py
+++ b/odl/solvers/iterative/iterative.py
@@ -8,10 +8,10 @@
 
 """Simple iterative type optimization schemes."""
 
-# Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
-
+from builtins import next, range
 import numpy as np
+
 from odl.operator import IdentityOperator, OperatorComp, OperatorSum
 from odl.util import normalized_scalar_param_list
 
@@ -518,6 +518,5 @@ def kaczmarz(ops, x, rhs, niter, omega=1, projection=None, random=False,
 
 
 if __name__ == '__main__':
-    # pylint: disable=wrong-import-position
     from odl.util.testutils import run_doctests
     run_doctests()

--- a/odl/solvers/iterative/iterative.py
+++ b/odl/solvers/iterative/iterative.py
@@ -9,7 +9,7 @@
 """Simple iterative type optimization schemes."""
 
 from __future__ import print_function, division, absolute_import
-from builtins import next, range
+from builtins import next
 import numpy as np
 
 from odl.operator import IdentityOperator, OperatorComp, OperatorSum

--- a/odl/solvers/iterative/statistical.py
+++ b/odl/solvers/iterative/statistical.py
@@ -9,7 +9,6 @@
 """Maximum Likelihood Expectation Maximization algorithm."""
 
 from __future__ import print_function, division, absolute_import
-from builtins import range, str
 import numpy as np
 
 __all__ = ('mlem', 'osmlem', 'loglikelihood')

--- a/odl/solvers/iterative/statistical.py
+++ b/odl/solvers/iterative/statistical.py
@@ -8,9 +8,8 @@
 
 """Maximum Likelihood Expectation Maximization algorithm."""
 
-# Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
-
+from builtins import range, str
 import numpy as np
 
 __all__ = ('mlem', 'osmlem', 'loglikelihood')

--- a/odl/solvers/nonsmooth/admm.py
+++ b/odl/solvers/nonsmooth/admm.py
@@ -1,6 +1,8 @@
 """Alternating Direction method of Multipliers (ADMM) method variants."""
 
 from __future__ import division
+from builtins import range
+
 from odl.operator import Operator, OpDomainError
 
 

--- a/odl/solvers/nonsmooth/douglas_rachford.py
+++ b/odl/solvers/nonsmooth/douglas_rachford.py
@@ -9,7 +9,6 @@
 """Douglas-Rachford splitting algorithm for convex optimization."""
 
 from __future__ import print_function, division, absolute_import
-from builtins import range, zip
 
 from odl.operator import Operator
 

--- a/odl/solvers/nonsmooth/douglas_rachford.py
+++ b/odl/solvers/nonsmooth/douglas_rachford.py
@@ -8,8 +8,8 @@
 
 """Douglas-Rachford splitting algorithm for convex optimization."""
 
-# Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
+from builtins import range, zip
 
 from odl.operator import Operator
 

--- a/odl/solvers/nonsmooth/forward_backward.py
+++ b/odl/solvers/nonsmooth/forward_backward.py
@@ -9,7 +9,6 @@
 """Optimization methods based on a forward-backward splitting scheme."""
 
 from __future__ import print_function, division, absolute_import
-from builtins import range, zip
 
 from odl.operator import Operator
 

--- a/odl/solvers/nonsmooth/forward_backward.py
+++ b/odl/solvers/nonsmooth/forward_backward.py
@@ -8,9 +8,8 @@
 
 """Optimization methods based on a forward-backward splitting scheme."""
 
-
-# Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
+from builtins import range, zip
 
 from odl.operator import Operator
 

--- a/odl/solvers/nonsmooth/primal_dual_hybrid_gradient.py
+++ b/odl/solvers/nonsmooth/primal_dual_hybrid_gradient.py
@@ -12,9 +12,8 @@ The primal-dual hybrid gradient algorithm is a flexible method well suited for
 non-smooth convex optimization problems in imaging.
 """
 
-# Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
-
+from builtins import range
 import numpy as np
 
 from odl.operator import Operator
@@ -304,6 +303,5 @@ def pdhg(x, f, g, L, tau, sigma, niter, **kwargs):
 
 
 if __name__ == '__main__':
-    # pylint: disable=wrong-import-position
     from odl.util.testutils import run_doctests
     run_doctests()

--- a/odl/solvers/nonsmooth/primal_dual_hybrid_gradient.py
+++ b/odl/solvers/nonsmooth/primal_dual_hybrid_gradient.py
@@ -13,7 +13,6 @@ non-smooth convex optimization problems in imaging.
 """
 
 from __future__ import print_function, division, absolute_import
-from builtins import range
 import numpy as np
 
 from odl.operator import Operator

--- a/odl/solvers/nonsmooth/proximal_gradient_solvers.py
+++ b/odl/solvers/nonsmooth/proximal_gradient_solvers.py
@@ -8,8 +8,8 @@
 
 """(Fast) Iterative shrinkage-thresholding algorithm."""
 
-# Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
+from builtins import range
 
 import numpy as np
 
@@ -216,6 +216,5 @@ def accelerated_proximal_gradient(x, f, g, gamma, niter, callback=None,
 
 
 if __name__ == '__main__':
-    # pylint: disable=wrong-import-position
     from odl.util.testutils import run_doctests
     run_doctests()

--- a/odl/solvers/nonsmooth/proximal_gradient_solvers.py
+++ b/odl/solvers/nonsmooth/proximal_gradient_solvers.py
@@ -9,8 +9,6 @@
 """(Fast) Iterative shrinkage-thresholding algorithm."""
 
 from __future__ import print_function, division, absolute_import
-from builtins import range
-
 import numpy as np
 
 

--- a/odl/solvers/nonsmooth/proximal_operators.py
+++ b/odl/solvers/nonsmooth/proximal_operators.py
@@ -21,9 +21,8 @@ References
 Foundations and Trends in Optimization, 1 (2014), pp 127-239.
 """
 
-# Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
-
+from builtins import zip
 import numpy as np
 
 from odl.operator import (Operator, IdentityOperator, ScalingOperator,
@@ -1473,6 +1472,5 @@ def proximal_huber(space, gamma):
 
 
 if __name__ == '__main__':
-    # pylint: disable=wrong-import-position
     from odl.util.testutils import run_doctests
     run_doctests()

--- a/odl/solvers/nonsmooth/proximal_operators.py
+++ b/odl/solvers/nonsmooth/proximal_operators.py
@@ -22,7 +22,6 @@ Foundations and Trends in Optimization, 1 (2014), pp 127-239.
 """
 
 from __future__ import print_function, division, absolute_import
-from builtins import zip
 import numpy as np
 
 from odl.operator import (Operator, IdentityOperator, ScalingOperator,

--- a/odl/solvers/smooth/gradient.py
+++ b/odl/solvers/smooth/gradient.py
@@ -9,7 +9,6 @@
 """Gradient-based optimization schemes."""
 
 from __future__ import print_function, division, absolute_import
-from builtins import range
 import numpy as np
 
 from odl.solvers.util import ConstantLineSearch

--- a/odl/solvers/smooth/gradient.py
+++ b/odl/solvers/smooth/gradient.py
@@ -8,9 +8,8 @@
 
 """Gradient-based optimization schemes."""
 
-# Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
-
+from builtins import range
 import numpy as np
 
 from odl.solvers.util import ConstantLineSearch
@@ -183,6 +182,5 @@ def adam(f, x, learning_rate=1e-3, beta1=0.9, beta2=0.999, eps=1e-8,
 
 
 if __name__ == '__main__':
-    # pylint: disable=wrong-import-position
     from odl.util.testutils import run_doctests
     run_doctests()

--- a/odl/solvers/smooth/newton.py
+++ b/odl/solvers/smooth/newton.py
@@ -9,7 +9,6 @@
 """(Quasi-)Newton schemes to find zeros of functionals."""
 
 from __future__ import print_function, division, absolute_import
-from builtins import range
 import numpy as np
 
 from odl.solvers.util import ConstantLineSearch

--- a/odl/solvers/smooth/newton.py
+++ b/odl/solvers/smooth/newton.py
@@ -8,10 +8,10 @@
 
 """(Quasi-)Newton schemes to find zeros of functionals."""
 
-# Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
-
+from builtins import range
 import numpy as np
+
 from odl.solvers.util import ConstantLineSearch
 from odl.solvers.iterative.iterative import conjugate_gradient
 
@@ -488,6 +488,5 @@ def broydens_method(f, x, line_search=1.0, impl='first', maxiter=1000,
 
 
 if __name__ == '__main__':
-    # pylint: disable=wrong-import-position
     from odl.util.testutils import run_doctests
     run_doctests()

--- a/odl/solvers/smooth/nonlinear_cg.py
+++ b/odl/solvers/smooth/nonlinear_cg.py
@@ -9,7 +9,6 @@
 """Nonlinear version of the conjugate gradient method."""
 
 from __future__ import print_function, division, absolute_import
-from builtins import range
 
 from odl.solvers.util import ConstantLineSearch
 

--- a/odl/solvers/smooth/nonlinear_cg.py
+++ b/odl/solvers/smooth/nonlinear_cg.py
@@ -8,8 +8,8 @@
 
 """Nonlinear version of the conjugate gradient method."""
 
-# Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
+from builtins import range
 
 from odl.solvers.util import ConstantLineSearch
 

--- a/odl/solvers/util/callback.py
+++ b/odl/solvers/util/callback.py
@@ -9,7 +9,7 @@
 """Callback objects for per-iterate actions in iterative methods."""
 
 from __future__ import print_function, division, absolute_import
-from builtins import object, str
+from builtins import object
 import copy
 import numpy as np
 import os

--- a/odl/solvers/util/callback.py
+++ b/odl/solvers/util/callback.py
@@ -8,14 +8,13 @@
 
 """Callback objects for per-iterate actions in iterative methods."""
 
-# Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
-
-import warnings
-import time
-import os
+from builtins import object, str
 import copy
 import numpy as np
+import os
+import time
+import warnings
 
 from odl.util import signature_string
 
@@ -1036,6 +1035,5 @@ class CallbackProgressBar(Callback):
 
 
 if __name__ == '__main__':
-    # pylint: disable=wrong-import-position
     from odl.util.testutils import run_doctests
     run_doctests()

--- a/odl/solvers/util/steplen.py
+++ b/odl/solvers/util/steplen.py
@@ -8,9 +8,8 @@
 
 """Step length computation for optimization schemes."""
 
-# Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
-
+from builtins import object
 import numpy as np
 
 
@@ -290,6 +289,5 @@ class LineSearchFromIterNum(LineSearch):
 
 
 if __name__ == '__main__':
-    # pylint: disable=wrong-import-position
     from odl.util.testutils import run_doctests
     run_doctests()

--- a/odl/space/base_ntuples.py
+++ b/odl/space/base_ntuples.py
@@ -8,9 +8,7 @@
 
 """Base classes for implementations of n-tuples."""
 
-# Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
-
 import numpy as np
 import sys
 

--- a/odl/space/base_ntuples.py
+++ b/odl/space/base_ntuples.py
@@ -706,6 +706,5 @@ class FnBaseVector(LinearSpaceElement):
 
 
 if __name__ == '__main__':
-    # pylint: disable=wrong-import-position
     from odl.util.testutils import run_doctests
     run_doctests()

--- a/odl/space/entry_points.py
+++ b/odl/space/entry_points.py
@@ -20,7 +20,6 @@ See Also
 NumpyFn : Numpy based implementation of `FnBase`
 """
 
-# Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
 
 from odl.space.npy_ntuples import NumpyFn

--- a/odl/space/fspace.py
+++ b/odl/space/fspace.py
@@ -8,9 +8,8 @@
 
 """Spaces of functions with common domain and range."""
 
-# Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
-
+from builtins import range, str, zip, object
 from inspect import isfunction
 import numpy as np
 

--- a/odl/space/fspace.py
+++ b/odl/space/fspace.py
@@ -9,7 +9,7 @@
 """Spaces of functions with common domain and range."""
 
 from __future__ import print_function, division, absolute_import
-from builtins import range, str, zip, object
+from builtins import object
 from inspect import isfunction
 import numpy as np
 

--- a/odl/space/npy_ntuples.py
+++ b/odl/space/npy_ntuples.py
@@ -8,11 +8,9 @@
 
 """CPU implementations of ``n``-dimensional Cartesian spaces."""
 
-# Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
 from future.utils import native
 import builtins
-
 import ctypes
 from functools import partial
 from numbers import Integral

--- a/odl/space/npy_ntuples.py
+++ b/odl/space/npy_ntuples.py
@@ -1877,6 +1877,5 @@ def _lincomb_impl(a, x1, b, x2, out, dtype):
 
 
 if __name__ == '__main__':
-    # pylint: disable=wrong-import-position
     from odl.util.testutils import run_doctests
     run_doctests()

--- a/odl/space/pspace.py
+++ b/odl/space/pspace.py
@@ -8,12 +8,10 @@
 
 """Cartesian products of `LinearSpace` instances."""
 
-# Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
 from builtins import range, str, zip
-
-from numbers import Integral
 from itertools import product
+from numbers import Integral
 import numpy as np
 
 from odl.set import LinearSpace, LinearSpaceElement
@@ -1384,6 +1382,5 @@ def _indent(x):
 
 
 if __name__ == '__main__':
-    # pylint: disable=wrong-import-position
     from odl.util.testutils import run_doctests
     run_doctests()

--- a/odl/space/pspace.py
+++ b/odl/space/pspace.py
@@ -9,7 +9,6 @@
 """Cartesian products of `LinearSpace` instances."""
 
 from __future__ import print_function, division, absolute_import
-from builtins import range, str, zip
 from itertools import product
 from numbers import Integral
 import numpy as np

--- a/odl/space/space_utils.py
+++ b/odl/space/space_utils.py
@@ -8,15 +8,13 @@
 
 """Utility functions for space implementations."""
 
-# Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
-
-__all__ = ('vector', 'fn', 'cn', 'rn')
-
 import numpy as np
 
 from odl.set import RealNumbers, ComplexNumbers
 from odl.space.entry_points import fn_impl
+
+__all__ = ('vector', 'fn', 'cn', 'rn')
 
 
 def vector(array, dtype=None, impl='numpy'):

--- a/odl/space/space_utils.py
+++ b/odl/space/space_utils.py
@@ -204,6 +204,5 @@ def rn(size, dtype=None, impl='numpy', **kwargs):
 
 
 if __name__ == '__main__':
-    # pylint: disable=wrong-import-position
     from odl.util.testutils import run_doctests
     run_doctests()

--- a/odl/space/weighting.py
+++ b/odl/space/weighting.py
@@ -8,9 +8,8 @@
 
 """Weightings for finite-dimensional spaces."""
 
-# Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
-
+from builtins import object, str
 import numpy as np
 
 from odl.space.base_ntuples import FnBaseVector

--- a/odl/space/weighting.py
+++ b/odl/space/weighting.py
@@ -909,6 +909,5 @@ class CustomDist(Weighting):
 
 
 if __name__ == '__main__':
-    # pylint: disable=wrong-import-position
     from odl.util.testutils import run_doctests
     run_doctests()

--- a/odl/space/weighting.py
+++ b/odl/space/weighting.py
@@ -9,7 +9,7 @@
 """Weightings for finite-dimensional spaces."""
 
 from __future__ import print_function, division, absolute_import
-from builtins import object, str
+from builtins import object
 import numpy as np
 
 from odl.space.base_ntuples import FnBaseVector

--- a/odl/test/deform/linearized_deform_test.py
+++ b/odl/test/deform/linearized_deform_test.py
@@ -160,7 +160,7 @@ def test_fixed_templ_init():
     template = space.element(template_function)
 
     # Valid input
-    print(LinDeformFixedTempl(template))
+    repr(LinDeformFixedTempl(template))
 
     # Invalid input
     with pytest.raises(TypeError):
@@ -218,8 +218,8 @@ def test_fixed_disp_init():
         disp_field_factory(space.ndim))
 
     # Valid input
-    print(LinDeformFixedDisp(disp_field))
-    print(LinDeformFixedDisp(disp_field, templ_space=space))
+    repr(LinDeformFixedDisp(disp_field))
+    repr(LinDeformFixedDisp(disp_field, templ_space=space))
 
     # Non-valid input
     with pytest.raises(TypeError):  # displacement not ProductSpaceElement

--- a/odl/test/deform/linearized_deform_test.py
+++ b/odl/test/deform/linearized_deform_test.py
@@ -160,7 +160,10 @@ def test_fixed_templ_init():
     template = space.element(template_function)
 
     # Valid input
-    repr(LinDeformFixedTempl(template))
+    op = LinDeformFixedTempl(template)
+    assert repr(op) != ''
+    op = LinDeformFixedTempl(template, domain=space.astype('float32'))
+    assert repr(op) != ''
 
     # Invalid input
     with pytest.raises(TypeError):
@@ -218,8 +221,10 @@ def test_fixed_disp_init():
         disp_field_factory(space.ndim))
 
     # Valid input
-    repr(LinDeformFixedDisp(disp_field))
-    repr(LinDeformFixedDisp(disp_field, templ_space=space))
+    op = LinDeformFixedDisp(disp_field)
+    assert repr(op) != ''
+    op = LinDeformFixedDisp(disp_field, templ_space=space)
+    assert repr(op) != ''
 
     # Non-valid input
     with pytest.raises(TypeError):  # displacement not ProductSpaceElement

--- a/odl/test/deform/linearized_deform_test.py
+++ b/odl/test/deform/linearized_deform_test.py
@@ -162,7 +162,7 @@ def test_fixed_templ_init():
     # Valid input
     op = LinDeformFixedTempl(template)
     assert repr(op) != ''
-    op = LinDeformFixedTempl(template, domain=space.astype('float32'))
+    op = LinDeformFixedTempl(template, domain=space.astype('float32') ** 1)
     assert repr(op) != ''
 
     # Invalid input

--- a/odl/test/discr/discr_mappings_test.py
+++ b/odl/test/discr/discr_mappings_test.py
@@ -52,6 +52,8 @@ def test_nearest_interpolation_1d_complex(fn_impl):
     function(mg, out=out)
     assert all_equal(out, true_mg)
 
+    assert repr(interp_op) != ''
+
 
 def test_nearest_interpolation_1d_variants():
     intv = odl.IntervalProd(0, 1)
@@ -64,6 +66,7 @@ def test_nearest_interpolation_1d_variants():
 
     # 'left' variant
     interp_op = NearestInterpolation(space, part, dspace, variant='left')
+    assert repr(interp_op) != ''
     function = interp_op([0, 1, 2, 3, 4])
 
     # Testing two midpoints and the extreme values
@@ -73,6 +76,7 @@ def test_nearest_interpolation_1d_variants():
 
     # 'right' variant
     interp_op = NearestInterpolation(space, part, dspace, variant='right')
+    assert repr(interp_op) != ''
     function = interp_op([0, 1, 2, 3, 4])
 
     # Testing two midpoints and the extreme values
@@ -113,6 +117,8 @@ def test_nearest_interpolation_2d_float():
     function(mg, out=out)
     assert all_equal(out, true_mg)
 
+    assert repr(interp_op) != ''
+
 
 def test_nearest_interpolation_2d_string():
     rect = odl.IntervalProd([0, 0], [1, 1])
@@ -146,6 +152,8 @@ def test_nearest_interpolation_2d_string():
     out = np.empty((2, 2), dtype='U1')
     function(mg, out=out)
     assert all_equal(out, true_mg)
+
+    assert repr(interp_op) != ''
 
 
 def test_linear_interpolation_1d():
@@ -238,6 +246,8 @@ def test_linear_interpolation_2d():
     function(mg, out=out)
     assert all_equal(out, true_mg)
 
+    assert repr(interp_op) != ''
+
 
 def test_per_axis_interpolation():
     rect = odl.IntervalProd([0, 0], [1, 1])
@@ -294,6 +304,8 @@ def test_per_axis_interpolation():
     out = np.empty((2, 2), dtype='float64')
     function(mg, out=out)
     assert all_equal(out, true_mg)
+
+    assert repr(interp_op) != ''
 
 
 def test_collocation_interpolation_identity():

--- a/odl/test/largescale/solvers/nonsmooth/default_functionals_slow_test.py
+++ b/odl/test/largescale/solvers/nonsmooth/default_functionals_slow_test.py
@@ -8,10 +8,11 @@
 
 """Tests for the factory functions to create proximal operators."""
 
-from __future__ import division
+from __future__ import division, print_function
 import numpy as np
 import pytest
 import scipy.special
+
 import odl
 from odl.util.testutils import (noise_element, all_almost_equal,
                                 simple_fixture)

--- a/odl/test/operator/operator_test.py
+++ b/odl/test/operator/operator_test.py
@@ -149,16 +149,16 @@ def test_nonlinear_scale():
     wrongscalars = [1j, [1, 2], (1, 2)]
     for wrongscalar in wrongscalars:
         with pytest.raises(TypeError):
-            print(OperatorLeftScalarMult(Aop, wrongscalar))
+            OperatorLeftScalarMult(Aop, wrongscalar)
 
         with pytest.raises(TypeError):
-            print(OperatorRightScalarMult(Aop, wrongscalar))
+            OperatorRightScalarMult(Aop, wrongscalar)
 
         with pytest.raises(TypeError):
-            print(Aop * wrongscalar)
+            Aop * wrongscalar
 
         with pytest.raises(TypeError):
-            print(wrongscalar * Aop)
+            wrongscalar * Aop
 
 
 def test_nonlinear_vector_mult():
@@ -698,7 +698,7 @@ def test_nonlinear_functional_out():
     out = op.range.element()
 
     with pytest.raises(TypeError):
-        print(op(x, out=out))
+        op(x, out=out)
 
 
 def test_nonlinear_functional_operators():

--- a/odl/test/tomo/geometry/geometry_test.py
+++ b/odl/test/tomo/geometry/geometry_test.py
@@ -9,7 +9,6 @@
 """Test ODL geometry objects for tomography."""
 
 from __future__ import division
-
 from itertools import permutations, product
 import pytest
 import numpy as np

--- a/odl/tomo/analytic/filtered_back_projection.py
+++ b/odl/tomo/analytic/filtered_back_projection.py
@@ -6,10 +6,9 @@
 # v. 2.0. If a copy of the MPL was not distributed with this file, You can
 # obtain one at https://mozilla.org/MPL/2.0/.
 
-# Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
-
 import numpy as np
+
 from odl.discr import ResizingOperator
 from odl.trafos import FourierTransform, PYFFTW_AVAILABLE
 from odl.space.weighting import NoWeighting
@@ -513,6 +512,7 @@ def fbp_op(ray_trafo, padding=True, filter_type='Ram-Lak',
 if __name__ == '__main__':
     import odl
     import matplotlib.pyplot as plt
+    from odl.util.testutils import run_doctests
 
     # Display the various filters
     x = np.linspace(0, 1, 100)
@@ -554,6 +554,5 @@ if __name__ == '__main__':
     parker_weighting = parker_weighting(ray_trafo)
     parker_weighting.show('Parker weighting')
 
-    # pylint: disable=wrong-import-position
-    from odl.util.testutils import run_doctests
+    # Also run the doctests
     run_doctests()

--- a/odl/tomo/backends/astra_cpu.py
+++ b/odl/tomo/backends/astra_cpu.py
@@ -8,14 +8,12 @@
 
 """Backend for ASTRA using CPU."""
 
-# Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
-
+import numpy as np
 try:
     import astra
 except ImportError:
     pass
-import numpy as np
 
 from odl.discr import DiscreteLp, DiscreteLpElement
 from odl.tomo.backends.astra_setup import (

--- a/odl/tomo/backends/astra_cuda.py
+++ b/odl/tomo/backends/astra_cuda.py
@@ -8,9 +8,8 @@
 
 """Backend for ASTRA using CUDA."""
 
-# Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
-
+from builtins import object
 import numpy as np
 try:
     import astra

--- a/odl/tomo/backends/astra_setup.py
+++ b/odl/tomo/backends/astra_setup.py
@@ -24,7 +24,6 @@ ODL geometry representation to ASTRA's data structures, including:
 """
 
 from __future__ import print_function, division, absolute_import
-from builtins import range, str
 import numpy as np
 try:
     import astra

--- a/odl/tomo/backends/astra_setup.py
+++ b/odl/tomo/backends/astra_setup.py
@@ -23,9 +23,9 @@ ODL geometry representation to ASTRA's data structures, including:
 `ASTRA on GitHub <https://github.com/astra-toolbox/>`_.
 """
 
-# Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
-
+from builtins import range, str
+import numpy as np
 try:
     import astra
     ASTRA_AVAILABLE = True
@@ -43,12 +43,9 @@ try:
     # Don't import pkg_resources only for this, it's slow
     if (_maj, _min) < (1, 7):
         raise RuntimeError('ASTRA version < 1.7 not supported, please update')
-
 except ImportError:
     ASTRA_AVAILABLE = False
     ASTRA_VERSION = ''
-
-import numpy as np
 
 from odl.discr import DiscreteLp, DiscreteLpElement
 from odl.tomo.geometry import (

--- a/odl/tomo/backends/skimage_radon.py
+++ b/odl/tomo/backends/skimage_radon.py
@@ -8,13 +8,15 @@
 
 """Radon transform (ray transform) in 2d using skimage.transform."""
 
-from odl.discr import uniform_discr_frompartition, uniform_partition
+from __future__ import division
 import numpy as np
 try:
     import skimage
     SKIMAGE_AVAILABLE = True
 except ImportError:
     SKIMAGE_AVAILABLE = False
+
+from odl.discr import uniform_discr_frompartition, uniform_partition
 
 __all__ = ('skimage_radon_forward', 'skimage_radon_back_projector',
            'SKIMAGE_AVAILABLE')

--- a/odl/tomo/backends/stir_bindings.py
+++ b/odl/tomo/backends/stir_bindings.py
@@ -303,6 +303,5 @@ def stir_projector_from_file(volume_file, projection_file):
 
 
 if __name__ == '__main__':
-    # pylint: disable=wrong-import-position
     from odl.util.testutils import run_doctests
     run_doctests()

--- a/odl/tomo/geometry/conebeam.py
+++ b/odl/tomo/geometry/conebeam.py
@@ -8,9 +8,7 @@
 
 """Cone beam geometries in 2 and 3 dimensions."""
 
-# Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
-
 import numpy as np
 
 from odl.discr import uniform_partition

--- a/odl/tomo/geometry/detector.py
+++ b/odl/tomo/geometry/detector.py
@@ -9,7 +9,7 @@
 """Detectors for tomographic imaging."""
 
 from __future__ import print_function, division, absolute_import
-from builtins import object, zip
+from builtins import object
 import numpy as np
 
 from odl.discr import RectPartition

--- a/odl/tomo/geometry/detector.py
+++ b/odl/tomo/geometry/detector.py
@@ -8,10 +8,8 @@
 
 """Detectors for tomographic imaging."""
 
-# Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
-from builtins import object
-
+from builtins import object, zip
 import numpy as np
 
 from odl.discr import RectPartition

--- a/odl/tomo/geometry/geometry.py
+++ b/odl/tomo/geometry/geometry.py
@@ -9,7 +9,7 @@
 """Geometry base and mixin classes."""
 
 from __future__ import print_function, division, absolute_import
-from builtins import object, range
+from builtins import object
 import numpy as np
 
 from odl.discr import RectPartition

--- a/odl/tomo/geometry/geometry.py
+++ b/odl/tomo/geometry/geometry.py
@@ -8,10 +8,8 @@
 
 """Geometry base and mixin classes."""
 
-# Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
-from builtins import object
-
+from builtins import object, range
 import numpy as np
 
 from odl.discr import RectPartition

--- a/odl/tomo/geometry/parallel.py
+++ b/odl/tomo/geometry/parallel.py
@@ -8,9 +8,8 @@
 
 """Parallel beam geometries in 2 or 3 dimensions."""
 
-# Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
-
+from builtins import range
 import numpy as np
 
 from odl.discr import uniform_partition

--- a/odl/tomo/geometry/parallel.py
+++ b/odl/tomo/geometry/parallel.py
@@ -9,7 +9,6 @@
 """Parallel beam geometries in 2 or 3 dimensions."""
 
 from __future__ import print_function, division, absolute_import
-from builtins import range
 import numpy as np
 
 from odl.discr import uniform_partition

--- a/odl/tomo/geometry/spect.py
+++ b/odl/tomo/geometry/spect.py
@@ -8,9 +8,7 @@
 
 """Single-photon emission computed tomography (SPECT) geometry."""
 
-# Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
-
 import numpy as np
 
 from odl.tomo.geometry.parallel import Parallel3dAxisGeometry

--- a/odl/tomo/operators/ray_trafo.py
+++ b/odl/tomo/operators/ray_trafo.py
@@ -9,7 +9,6 @@
 """Ray transforms."""
 
 from __future__ import print_function, division, absolute_import
-from builtins import str
 import numpy as np
 import warnings
 

--- a/odl/tomo/operators/ray_trafo.py
+++ b/odl/tomo/operators/ray_trafo.py
@@ -8,10 +8,8 @@
 
 """Ray transforms."""
 
-# Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
 from builtins import str
-
 import numpy as np
 import warnings
 
@@ -533,6 +531,5 @@ class RayBackProjection(RayTransformBase):
 
 
 if __name__ == '__main__':
-    # pylint: disable=wrong-import-position
     from odl.util.testutils import run_doctests
     run_doctests()

--- a/odl/tomo/util/testutils.py
+++ b/odl/tomo/util/testutils.py
@@ -6,7 +6,6 @@
 # v. 2.0. If a copy of the MPL was not distributed with this file, You can
 # obtain one at https://mozilla.org/MPL/2.0/.
 
-# Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
 
 __all__ = ('skip_if_no_astra', 'skip_if_no_astra_cuda', 'skip_if_no_skimage')

--- a/odl/tomo/util/utility.py
+++ b/odl/tomo/util/utility.py
@@ -6,9 +6,8 @@
 # v. 2.0. If a copy of the MPL was not distributed with this file, You can
 # obtain one at https://mozilla.org/MPL/2.0/.
 
-# Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
-
+from builtins import range
 import numpy as np
 
 __all__ = ('euler_matrix', 'axis_rotation', 'axis_rotation_matrix',

--- a/odl/tomo/util/utility.py
+++ b/odl/tomo/util/utility.py
@@ -7,7 +7,6 @@
 # obtain one at https://mozilla.org/MPL/2.0/.
 
 from __future__ import print_function, division, absolute_import
-from builtins import range
 import numpy as np
 
 __all__ = ('euler_matrix', 'axis_rotation', 'axis_rotation_matrix',

--- a/odl/trafos/backends/pyfftw_bindings.py
+++ b/odl/trafos/backends/pyfftw_bindings.py
@@ -13,15 +13,11 @@ wrapper around the well-known `FFTW <http://fftw.org/>`_ library for fast
 Fourier transforms.
 """
 
-# Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
 from builtins import range
-
 from multiprocessing import cpu_count
-import warnings
 import numpy as np
-from odl.util import (
-    is_real_dtype, dtype_repr, complex_dtype, normalized_axes_tuple)
+import warnings
 try:
     import pyfftw
     PYFFTW_AVAILABLE = True
@@ -33,6 +29,9 @@ else:
         warnings.warn('PyFFTW < 0.10.4 is known to cause problems with some '
                       'ODL functionality, see issue #1002.',
                       RuntimeWarning)
+
+from odl.util import (
+    is_real_dtype, dtype_repr, complex_dtype, normalized_axes_tuple)
 
 __all__ = ('pyfftw_call', 'PYFFTW_AVAILABLE')
 
@@ -300,6 +299,5 @@ def _pyfftw_check_args(arr_in, arr_out, axes, halfcomplex, direction):
 
 
 if __name__ == '__main__':
-    # pylint: disable=wrong-import-position
     from odl.util.testutils import run_doctests
     run_doctests(skip_if=not PYFFTW_AVAILABLE)

--- a/odl/trafos/backends/pyfftw_bindings.py
+++ b/odl/trafos/backends/pyfftw_bindings.py
@@ -14,7 +14,6 @@ Fourier transforms.
 """
 
 from __future__ import print_function, division, absolute_import
-from builtins import range
 from multiprocessing import cpu_count
 import numpy as np
 import warnings

--- a/odl/trafos/backends/pywt_bindings.py
+++ b/odl/trafos/backends/pywt_bindings.py
@@ -14,7 +14,6 @@ of built-in wavelet filters.
 """
 
 from __future__ import print_function, division, absolute_import
-from builtins import range, str, zip
 from itertools import product
 import numpy as np
 try:

--- a/odl/trafos/backends/pywt_bindings.py
+++ b/odl/trafos/backends/pywt_bindings.py
@@ -13,12 +13,10 @@ for wavelet transforms in arbitrary dimensions, featuring a large number
 of built-in wavelet filters.
 """
 
-# Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
-
+from builtins import range, str, zip
 from itertools import product
 import numpy as np
-
 try:
     import pywt
     PYWT_AVAILABLE = True
@@ -812,6 +810,5 @@ modes.html
 
 
 if __name__ == '__main__':
-    # pylint: disable=wrong-import-position
     from odl.util.testutils import run_doctests
     run_doctests(skip_if=not PYWT_AVAILABLE)

--- a/odl/trafos/fourier.py
+++ b/odl/trafos/fourier.py
@@ -8,9 +8,8 @@
 
 """Discretized Fourier transform on L^p spaces."""
 
-# Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
-
+from builtins import str
 import numpy as np
 
 from odl.discr import DiscreteLp, discr_sequence_space
@@ -1646,6 +1645,5 @@ class FourierTransformInverse(FourierTransformBase):
 
 
 if __name__ == '__main__':
-    # pylint: disable=wrong-import-position
     from odl.util.testutils import run_doctests
     run_doctests()

--- a/odl/trafos/fourier.py
+++ b/odl/trafos/fourier.py
@@ -9,7 +9,6 @@
 """Discretized Fourier transform on L^p spaces."""
 
 from __future__ import print_function, division, absolute_import
-from builtins import str
 import numpy as np
 
 from odl.discr import DiscreteLp, discr_sequence_space

--- a/odl/trafos/util/ft_utils.py
+++ b/odl/trafos/util/ft_utils.py
@@ -9,7 +9,6 @@
 """Utility functions for Fourier transforms on regularly sampled data."""
 
 from __future__ import print_function, division, absolute_import
-from builtins import str, range, zip
 import numpy as np
 
 from odl.discr import (

--- a/odl/trafos/util/ft_utils.py
+++ b/odl/trafos/util/ft_utils.py
@@ -8,10 +8,8 @@
 
 """Utility functions for Fourier transforms on regularly sampled data."""
 
-# Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
-from builtins import range
-
+from builtins import str, range, zip
 import numpy as np
 
 from odl.discr import (

--- a/odl/trafos/wavelet.py
+++ b/odl/trafos/wavelet.py
@@ -9,7 +9,6 @@
 """Discrete wavelet transformation on L2 spaces."""
 
 from __future__ import print_function, division, absolute_import
-from builtins import range, str
 import numpy as np
 
 from odl.discr import DiscreteLp

--- a/odl/trafos/wavelet.py
+++ b/odl/trafos/wavelet.py
@@ -8,10 +8,8 @@
 
 """Discrete wavelet transformation on L2 spaces."""
 
-# Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
-from builtins import str
-
+from builtins import range, str
 import numpy as np
 
 from odl.discr import DiscreteLp
@@ -498,6 +496,5 @@ class WaveletTransformInverse(WaveletTransformBase):
 
 
 if __name__ == '__main__':
-    # pylint: disable=wrong-import-position
     from odl.util.testutils import run_doctests
     run_doctests(skip_if=not PYWT_AVAILABLE)

--- a/odl/ufunc_ops/ufunc_ops.py
+++ b/odl/ufunc_ops/ufunc_ops.py
@@ -8,17 +8,16 @@
 
 """Ufunc operators for ODL vectors."""
 
-# Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
-
 import numpy as np
+
 from odl.set import LinearSpace, RealNumbers, Field
 from odl.space import ProductSpace, fn
 from odl.operator import Operator, MultiplyOperator
 from odl.solvers import (Functional, ScalingFunctional, FunctionalQuotient,
                          ConstantFunctional)
-from odl.util import is_int_dtype
 from odl.util.ufuncs import UFUNCS
+from odl.util.utility import is_int_dtype
 
 __all__ = ()
 

--- a/odl/ufunc_ops/ufunc_ops.py
+++ b/odl/ufunc_ops/ufunc_ops.py
@@ -367,6 +367,5 @@ for name, nargin, nargout, docstring in UFUNCS:
 
 
 if __name__ == '__main__':
-    # pylint: disable=wrong-import-position
     from odl.util.testutils import run_doctests
     run_doctests()

--- a/odl/util/graphics.py
+++ b/odl/util/graphics.py
@@ -9,7 +9,6 @@
 """Functions for graphical output."""
 
 from __future__ import print_function, division, absolute_import
-from builtins import range, str
 import numpy as np
 import warnings
 

--- a/odl/util/graphics.py
+++ b/odl/util/graphics.py
@@ -8,9 +8,8 @@
 
 """Functions for graphical output."""
 
-# Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
-
+from builtins import range, str
 import numpy as np
 import warnings
 

--- a/odl/util/normalize.py
+++ b/odl/util/normalize.py
@@ -8,9 +8,8 @@
 
 """Utilities for normalization of user input."""
 
-# Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
-
+from builtins import zip
 import numpy as np
 
 
@@ -395,6 +394,5 @@ def safe_int_conv(number):
 
 
 if __name__ == '__main__':
-    # pylint: disable=wrong-import-position
     from odl.util.testutils import run_doctests
     run_doctests()

--- a/odl/util/normalize.py
+++ b/odl/util/normalize.py
@@ -9,7 +9,6 @@
 """Utilities for normalization of user input."""
 
 from __future__ import print_function, division, absolute_import
-from builtins import zip
 import numpy as np
 
 

--- a/odl/util/numerics.py
+++ b/odl/util/numerics.py
@@ -8,9 +8,8 @@
 
 """Numerical helper functions for convenience or speed."""
 
-# Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
-
+from builtins import range, str, zip
 import numpy as np
 
 from odl.util.normalize import normalized_scalar_param_list, safe_int_conv
@@ -837,7 +836,7 @@ def zscore(arr):
         arr /= std
     return arr
 
+
 if __name__ == '__main__':
-    # pylint: disable=wrong-import-position
     from odl.util.testutils import run_doctests
     run_doctests()

--- a/odl/util/numerics.py
+++ b/odl/util/numerics.py
@@ -9,7 +9,6 @@
 """Numerical helper functions for convenience or speed."""
 
 from __future__ import print_function, division, absolute_import
-from builtins import range, str, zip
 import numpy as np
 
 from odl.util.normalize import normalized_scalar_param_list, safe_int_conv

--- a/odl/util/pytest_plugins.py
+++ b/odl/util/pytest_plugins.py
@@ -9,7 +9,7 @@
 """Test configuration file."""
 
 from __future__ import print_function, division, absolute_import
-
+from builtins import str
 import numpy as np
 import operator
 import os

--- a/odl/util/pytest_plugins.py
+++ b/odl/util/pytest_plugins.py
@@ -9,7 +9,6 @@
 """Test configuration file."""
 
 from __future__ import print_function, division, absolute_import
-from builtins import str
 import numpy as np
 import operator
 import os

--- a/odl/util/testutils.py
+++ b/odl/util/testutils.py
@@ -9,7 +9,7 @@
 """Utilities for internal use."""
 
 from __future__ import print_function, division, absolute_import
-from builtins import int, object, range, str
+from builtins import object
 from future.moves.itertools import zip_longest
 import numpy as np
 import sys

--- a/odl/util/testutils.py
+++ b/odl/util/testutils.py
@@ -8,16 +8,15 @@
 
 """Utilities for internal use."""
 
-# Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
-from builtins import int, object
+from builtins import int, object, range, str
 from future.moves.itertools import zip_longest
-
 import numpy as np
 import sys
 import os
 import warnings
 from time import time
+
 from odl.util.utility import run_from_ipython, is_string
 
 

--- a/odl/util/ufuncs.py
+++ b/odl/util/ufuncs.py
@@ -23,9 +23,8 @@ and then apply a ufunc to it. Afterwards, ``FnBaseVector.__array_wrap__``
 is used to re-wrap the data into the appropriate space.
 """
 
-# Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
-
+from builtins import object, zip
 import numpy as np
 import re
 

--- a/odl/util/ufuncs.py
+++ b/odl/util/ufuncs.py
@@ -24,7 +24,7 @@ is used to re-wrap the data into the appropriate space.
 """
 
 from __future__ import print_function, division, absolute_import
-from builtins import object, zip
+from builtins import object
 import numpy as np
 import re
 

--- a/odl/util/utility.py
+++ b/odl/util/utility.py
@@ -9,7 +9,7 @@
 """Utilities mainly for internal use."""
 
 from __future__ import print_function, division, absolute_import
-from builtins import object, range, str, zip
+from builtins import object
 from collections import OrderedDict
 from functools import wraps
 import numpy as np

--- a/odl/util/utility.py
+++ b/odl/util/utility.py
@@ -8,11 +8,10 @@
 
 """Utilities mainly for internal use."""
 
-# Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
-
-from functools import wraps
+from builtins import object, range, str, zip
 from collections import OrderedDict
+from functools import wraps
 import numpy as np
 
 
@@ -955,6 +954,5 @@ def unique(seq):
 
 
 if __name__ == '__main__':
-    # pylint: disable=wrong-import-position
     from odl.util.testutils import run_doctests
     run_doctests()

--- a/odl/util/vectorization.py
+++ b/odl/util/vectorization.py
@@ -8,9 +8,8 @@
 
 """Utilities for internal functionality connected to vectorization."""
 
-# Imports for common Python 2/3 codebase
 from __future__ import print_function, division, absolute_import
-
+from builtins import object
 from functools import wraps
 import numpy as np
 
@@ -291,6 +290,5 @@ class _NumpyVectorizeWrapper(object):
 
 
 if __name__ == '__main__':
-    # pylint: disable=wrong-import-position
     from odl.util.testutils import run_doctests
     run_doctests()


### PR DESCRIPTION
Mega-boring PR that does this:

- Add `__future__` imports that make sense, but not in examples
- Remove `# Imports for common Python 2/3 codebase`
- Remove `# pylint: disable=wrong-import-position`