### PR TITLE
FIX: Correct in-place evaluation of MultiplyOperator, fixes #1219.

### DIFF
--- a/odl/operator/default_ops.py
+++ b/odl/operator/default_ops.py
@@ -293,7 +293,7 @@ class MultiplyOperator(Operator):
             if self.__domain_is_field:
                 out.lincomb(x, self.multiplicand)
             else:
-                x.multiply(self.multiplicand, out=out)
+                out.assign(self.multiplicand * x)
         else:
             raise ValueError('can only use `out` with `LinearSpace` range')
 


### PR DESCRIPTION
Obviously, the in-place evaluation did not work for scalar values of `multiplicand`. Thanks to @aringh for the help.

Possibly it would be good to add some unit tests in addition to the doctests.