### PR TITLE
ENH: add min/max_pt to ellipsoid_phantom

### DIFF
--- a/odl/phantom/emission.py
+++ b/odl/phantom/emission.py
@@ -104,19 +104,46 @@ def _derenzo_sources_2d():
             [1.0, 0.023968, 0.023968, 0.88528, -0.11791, 0.0]]
 
 
-def derenzo_sources(space):
+def derenzo_sources(space, min_pt=None, max_pt=None):
     """Create the PET/SPECT Derenzo sources phantom.
 
     The Derenzo phantom contains a series of circles of decreasing size.
 
     In 3d the phantom is simply the 2d phantom extended in the z direction as
     cylinders.
+
+    Parameters
+    ----------
+    space : `DiscreteLp`
+        Space in which the phantom should be created, must be 2- or
+        3-dimensional. If ``space.shape`` is 1 in an axis, a corresponding
+        slice of the phantom is created (instead of squashing the whole
+        phantom into the slice).
+    min_pt, max_pt : array-like, optional
+        If provided, use these vectors to determine the bounding box of the
+        phantom instead of ``space.min_pt`` and ``space.max_pt``.
+        It is currently required that ``min_pt >= space.min_pt`` and
+        ``max_pt <= space.max_pt``, i.e., shifting or scaling outside the
+        original space is not allowed.
+
+        Providing one of them results in a shift, e.g., for ``min_pt``::
+
+            new_min_pt = min_pt
+            new_max_pt = space.max_pt + (min_pt - space.min_pt)
+
+        Providing both results in a scaled version of the phantom.
+
+    Returns
+    -------
+    phantom : ``space`` element
+        The Derenzo source phantom in the given space.
     """
     if space.ndim == 2:
-        return ellipsoid_phantom(space, _derenzo_sources_2d())
+        return ellipsoid_phantom(space, _derenzo_sources_2d(), min_pt, max_pt)
     if space.ndim == 3:
         return ellipsoid_phantom(
-            space, cylinders_from_ellipses(_derenzo_sources_2d()))
+            space, cylinders_from_ellipses(_derenzo_sources_2d()),
+            min_pt, max_pt)
     else:
         raise ValueError('dimension not 2, no phantom available')
 

--- a/odl/phantom/transmission.py
+++ b/odl/phantom/transmission.py
@@ -111,7 +111,7 @@ def shepp_logan_ellipsoids(ndim, modified=False):
     return ellipsoids
 
 
-def shepp_logan(space, modified=False):
+def shepp_logan(space, modified=False, min_pt=None, max_pt=None):
     """Standard `Shepp-Logan phantom`_ in 2 or 3 dimensions.
 
     Parameters
@@ -124,6 +124,19 @@ def shepp_logan(space, modified=False):
         True if the modified Shepp-Logan phantom should be given.
         The modified phantom has greatly amplified contrast to aid
         visualization.
+    min_pt, max_pt : array-like, optional
+        If provided, use these vectors to determine the bounding box of the
+        phantom instead of ``space.min_pt`` and ``space.max_pt``.
+        It is currently required that ``min_pt >= space.min_pt`` and
+        ``max_pt <= space.max_pt``, i.e., shifting or scaling outside the
+        original space is not allowed.
+
+        Providing one of them results in a shift, e.g., for ``min_pt``::
+
+            new_min_pt = min_pt
+            new_max_pt = space.max_pt + (min_pt - space.min_pt)
+
+        Providing both results in a scaled version of the phantom.
 
     See Also
     --------
@@ -138,8 +151,7 @@ def shepp_logan(space, modified=False):
     .. _Shepp-Logan phantom: en.wikipedia.org/wiki/Shepp–Logan_phantom
     """
     ellipsoids = shepp_logan_ellipsoids(space.ndim, modified)
-
-    return ellipsoid_phantom(space, ellipsoids)
+    return ellipsoid_phantom(space, ellipsoids, min_pt, max_pt)
 
 
 def _analytical_forbild_phantom(resolution, ear):


### PR DESCRIPTION
All ellipsoid phantoms can now be created with provided `min_pt` and `max_pt`, for shifted or scaled versions.