### PR TITLE
BLD: fix wrong argument order for travis-sphinx

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -69,7 +69,7 @@ script:
     # To avoid clogging the logs, we redirect stderr to /dev/null
     - if [[ "$BUILD_DOCS" == "true" && "$TRAVIS_BRANCH" == "master" && "$TRAVIS_PULL_REQUEST" == "false" ]]; then
         cd $TRAVIS_BUILD_DIR/doc/source && python generate_doc.py && cd -;
-        travis-sphinx -n -s $TRAVIS_BUILD_DIR/doc/source build 2>/dev/null;
+        travis-sphinx build -n -s $TRAVIS_BUILD_DIR/doc/source 2>/dev/null;
       fi
 
 after_success:


### PR DESCRIPTION
Recent doc builds were broken after `travis-sphinx` update to 2.0.0.