### PR TITLE
MAINT: attempt to fix pep8speaks config

### DIFF
--- a/.pep8speaks.yml
+++ b/.pep8speaks.yml
@@ -1,10 +1,9 @@
 message:  # Customize the comment made by the bot
     opened:  # Messages when a new PR is submitted
-        # Just show something if there are violations
-        header: ""
+        header: "Checking new PR..."
         footer: ""
     updated:  # Messages when new commits are added to the PR
-        header: ""
+        header: "Checking updated PR..."
         footer: ""
     no_errors: "No PEP8 issues."
 
@@ -12,9 +11,10 @@ scanner:
     diff_only: False  # If True, errors caused by only the patch are shown
 
 pycodestyle:
-    max-line-length: 79  # Default is 79 in PEP8
+    show-source: True
     ignore:  # Errors and warnings to ignore
         - E402
 
-only_mention_files_with_errors: True  # If False, a separate status comment for each file is made.
-descending_issues_order: False # If True, PEP8 issues in message will be displayed in descending order of line numbers in the file
+no_blank_comment: False
+only_mention_files_with_errors: True
+descending_issues_order: True


### PR DESCRIPTION
Possible that the heading comment in the `opened` section broke the config file parsing. Let's try.