### PR TITLE
BUG: fix sign flip in 2D geometries

### DIFF
--- a/examples/tomo/checks/check_axes_cone2d_bp.py
+++ b/examples/tomo/checks/check_axes_cone2d_bp.py
@@ -37,6 +37,6 @@ geometry = odl.tomo.cone_beam_geometry(reco_space, src_radius, det_radius,
 # Test back-projection
 ray_trafo = odl.tomo.RayTransform(reco_space, geometry, impl=impl)
 proj_data = ray_trafo(phantom)
-back_proj = ray_trafo.adjoint(proj_data)
-back_proj.show('Back-projection')
+backproj = ray_trafo.adjoint(proj_data)
+backproj.show('Back-projection')
 phantom.show('Phantom')

--- a/examples/tomo/checks/check_axes_cone3d_fp.py
+++ b/examples/tomo/checks/check_axes_cone3d_fp.py
@@ -78,12 +78,7 @@ proj_data = ray_trafo(phantom)
 # axis = [0, 0, 1], 0 degrees
 proj_data.show(indices=[0, None, None],
                title='Projection at 0 degrees, axis [0, 0, 1], u = x, v = z')
-fig, ax = plt.subplots()
-ax.imshow(sum_along_y.T, cmap='bone', origin='lower')
-ax.set_xlabel('x')
-ax.set_ylabel('z')
-plt.title('Sum along y axis')
-plt.show()
+sum_along_y.show('Sum along y axis')
 # Check axes in geometry
 axes_sum_y = geometry.det_axes(np.deg2rad(0))
 assert np.allclose(axes_sum_y[0], [1, 0, 0])
@@ -97,12 +92,7 @@ assert np.allclose(axes_sum_y[1], [0, 0, 1])
 # axis = [0, 0, 1], 90 degrees
 proj_data.show(indices=[1, None, None],
                title='Projection at 90 degrees, axis [0, 0, 1], u = y, v = z')
-fig, ax = plt.subplots()
-ax.imshow(sum_along_x.T, cmap='bone', origin='lower')
-ax.set_xlabel('y')
-ax.set_ylabel('z')
-plt.title('Sum along x axis')
-plt.show()
+sum_along_x.show('Sum along x axis')
 # Check axes in geometry
 axes_sum_x = geometry.det_axes(np.deg2rad(90))
 assert np.allclose(axes_sum_x[0], [0, 1, 0])
@@ -132,12 +122,7 @@ proj_data = ray_trafo(phantom)
 # axis = [0, 1, 0], 0 degrees
 proj_data.show(indices=[0, None, None],
                title='Projection at 0 degrees, axis [0, 1, 0], u = x, v = y')
-fig, ax = plt.subplots()
-ax.imshow(sum_along_z.T, cmap='bone', origin='lower')
-ax.set_xlabel('x')
-ax.set_ylabel('y')
-plt.title('Sum along z axis')
-plt.show()
+sum_along_z.show('Sum along z axis')
 # Check geometry axes
 axes_sum_z = geometry.det_axes(np.deg2rad(0))
 assert np.allclose(axes_sum_z[0], [1, 0, 0])

--- a/examples/tomo/checks/check_axes_parallel2d_bp.py
+++ b/examples/tomo/checks/check_axes_parallel2d_bp.py
@@ -34,6 +34,6 @@ geometry = odl.tomo.parallel_beam_geometry(reco_space, num_angles=360)
 # Test back-projection
 ray_trafo = odl.tomo.RayTransform(reco_space, geometry, impl=impl)
 proj_data = ray_trafo(phantom)
-back_proj = ray_trafo.adjoint(proj_data)
-back_proj.show('Back-projection')
+backproj = ray_trafo.adjoint(proj_data)
+backproj.show('Back-projection')
 phantom.show('Phantom')

--- a/examples/tomo/checks/check_axes_parallel3d_fp.py
+++ b/examples/tomo/checks/check_axes_parallel3d_fp.py
@@ -70,12 +70,7 @@ proj_data = ray_trafo(phantom)
 # axis = [0, 0, 1], 0 degrees
 proj_data.show(indices=[0, None, None],
                title='Projection at 0 degrees, axis [0, 0, 1], u = x, v = z')
-fig, ax = plt.subplots()
-ax.imshow(sum_along_y.T, cmap='bone', origin='lower')
-ax.set_xlabel('x')
-ax.set_ylabel('z')
-plt.title('Sum along y axis')
-plt.show()
+sum_along_y.show('Sum along y axis')
 # Check axes in geometry
 axes_sum_y = geometry.det_axes(np.deg2rad(0))
 assert np.allclose(axes_sum_y[0], [1, 0, 0])
@@ -89,12 +84,7 @@ assert np.allclose(axes_sum_y[1], [0, 0, 1])
 # axis = [0, 0, 1], 90 degrees
 proj_data.show(indices=[1, None, None],
                title='Projection at 90 degrees, axis [0, 0, 1], u = y, v = z')
-fig, ax = plt.subplots()
-ax.imshow(sum_along_x.T, cmap='bone', origin='lower')
-ax.set_xlabel('y')
-ax.set_ylabel('z')
-plt.title('Sum along x axis')
-plt.show()
+sum_along_x.show('Sum along x axis')
 # Check axes in geometry
 axes_sum_x = geometry.det_axes(np.deg2rad(90))
 assert np.allclose(axes_sum_x[0], [0, 1, 0])
@@ -123,12 +113,7 @@ proj_data = ray_trafo(phantom)
 # axis = [0, 1, 0], 0 degrees
 proj_data.show(indices=[0, None, None],
                title='Projection at 0 degrees, axis [0, 1, 0], u = x, v = y')
-fig, ax = plt.subplots()
-ax.imshow(sum_along_z.T, cmap='bone', origin='lower')
-ax.set_xlabel('x')
-ax.set_ylabel('y')
-plt.title('Sum along z axis')
-plt.show()
+sum_along_z.show('Sum along z axis')
 # Check geometry axes
 axes_sum_z = geometry.det_axes(np.deg2rad(0))
 assert np.allclose(axes_sum_z[0], [1, 0, 0])

--- a/odl/util/utility.py
+++ b/odl/util/utility.py
@@ -913,7 +913,7 @@ def pkg_supports(feature, pkg_version, pkg_feat_dict):
 
     # If one of the requirements in the list is met, return True
     for req in ver_reqs:
-        if req.specifier.contains(pkg_version):
+        if req.specifier.contains(pkg_version, prereleases=True):
             return True
 
     # No match


### PR DESCRIPTION
Serious stuff. The detector axis had a sign flip in the first component, due to me misinterpreting the ASTRA axis convention. ~~The fix needs vec geometries, so until then parallel 2D is broken in that sense.~~

~~This is WIP, some tests fail.~~

Turned out that we only need to map `xmin, xmax -> -xmax, -xmin` in the first component of the *volume* geometry, I don't quite know why. The fix works with the release version of ASTRA. I added a test that catches this stuff.
I'll keep in the premature parallel_vec stuff anyway. If people want to play with a dev version of ASTRA, it will use that feature, and it seems to work fine.