### PR TITLE
BLD: make wget more quiet

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,9 +28,9 @@ addons:
 install:
     # Install miniconda according to Python version of the build (saves downloading if versions match)
     - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then
-        wget https://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh;
+        wget -q https://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh;
       else
-        wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
+        wget -q https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
       fi
     - bash miniconda.sh -b -p $HOME/miniconda
     - export PATH="$HOME/miniconda/bin:$PATH"


### PR DESCRIPTION
It's possible that the `wget` download status bar clogs the log on Travis, and that builds are stopped with too long logs. Dunno. This is an attempt to fix it. I'll merge it right away and see what happens.