### PR TITLE
BUG: fix RectPartition.byaxis integer indexing

### DIFF
--- a/odl/discr/partition.py
+++ b/odl/discr/partition.py
@@ -822,10 +822,11 @@ class RectPartition(object):
                 try:
                     iter(indices)
                 except TypeError:
-                    # Integer or slice
+                    # Slice or integer
                     slc = np.zeros(partition.ndim, dtype=object)
                     slc[indices] = slice(None)
-                    newpart = partition[tuple(slc)].squeeze()
+                    squeeze_axes = np.where(slc == 0)[0]
+                    newpart = partition[tuple(slc)].squeeze(squeeze_axes)
                 else:
                     # Sequence, stack together from single-integer indexing
                     indices = [int(i) for i in indices]

--- a/odl/discr/partition.py
+++ b/odl/discr/partition.py
@@ -150,11 +150,11 @@ class RectPartition(object):
 
         nodes_on_bdry = []
         for on_bdry in self.nodes_on_bdry_byaxis:
-            l, r = on_bdry
-            if l == r:
-                nodes_on_bdry.append(l)
+            left, right = on_bdry
+            if left == right:
+                nodes_on_bdry.append(left)
             else:
-                nodes_on_bdry.append((l, r))
+                nodes_on_bdry.append((left, right))
         if all(on_bdry == nodes_on_bdry[0] for on_bdry in nodes_on_bdry[1:]):
             return nodes_on_bdry[0]
         else:

--- a/odl/test/discr/partition_test.py
+++ b/odl/test/discr/partition_test.py
@@ -249,6 +249,19 @@ def test_partition_getitem():
     assert part[[0, 2]] == lst_part
 
 
+def test_partition_byaxis():
+    """Test indexing a partition along the axes."""
+    part = odl.uniform_partition([-1, -2, -3, -4], [1, 2, 3, 4], (1, 2, 4, 5))
+
+    assert part.byaxis[0] == odl.uniform_partition(-1, 1, 1)
+    assert part.byaxis[1:3] == odl.uniform_partition([-2, -3], [2, 3], (2, 4))
+    assert (part.byaxis[[1, 3, 1]] ==
+            odl.uniform_partition([-2, -4, -2], [2, 4, 2], (2, 5, 2)))
+    assert part.byaxis[[1]] == part.byaxis[1]
+    assert part.byaxis[...] == part
+    assert part.byaxis[:] == part
+
+
 def test_empty_partition():
     """Check if empty partitions behave as expected and all methods work."""
     part = odl.RectPartition(odl.IntervalProd([], []),


### PR DESCRIPTION
The issue was that `partition.byaxis[0]` would squeeze
all axes, including the one we want to keep.