### PR TITLE
BUG: fix DiscreteLp.astype from bool

### DIFF
--- a/odl/space/fspace.py
+++ b/odl/space/fspace.py
@@ -702,17 +702,24 @@ class FunctionSpace(LinearSpace):
         if out_dtype == self.out_dtype:
             return self
 
-        # Caching for real and complex versions (exact dtyoe mappings)
-        if out_dtype == self.real_out_dtype:
-            if self.__real_space is None:
-                self.__real_space = self._astype(out_dtype)
-            return self.__real_space
-        elif out_dtype == self.complex_out_dtype:
-            if self.__complex_space is None:
-                self.__complex_space = self._astype(out_dtype)
-            return self.__complex_space
-        else:
+        # Try to use caching for real and complex versions (exact dtype
+        # mappings). This may fail for certain dtype, in which case we
+        # just go to `_astype` directly.
+        try:
+            real_dtype = self.real_out_dtype
+        except TypeError:
             return self._astype(out_dtype)
+        else:
+            if out_dtype == real_dtype:
+                if self.__real_space is None:
+                    self.__real_space = self._astype(out_dtype)
+                return self.__real_space
+            elif out_dtype == self.complex_out_dtype:
+                if self.__complex_space is None:
+                    self.__complex_space = self._astype(out_dtype)
+                return self.__complex_space
+            else:
+                return self._astype(out_dtype)
 
     def _lincomb(self, a, f1, b, f2, out):
         """Linear combination of ``f1`` and ``f2``.

--- a/odl/space/fspace.py
+++ b/odl/space/fspace.py
@@ -279,7 +279,9 @@ class FunctionSpace(LinearSpace):
     def real_out_dtype(self):
         """The real dtype corresponding to this space's `out_dtype`."""
         if self.__real_out_dtype is None:
-            raise TypeError('no real variant of output dtype defined')
+            raise AttributeError(
+                'no real variant of output dtype {} defined'
+                ''.format(dtype_repr(self.scalar_out_dtype)))
         else:
             return self.__real_out_dtype
 
@@ -287,7 +289,9 @@ class FunctionSpace(LinearSpace):
     def complex_out_dtype(self):
         """The complex dtype corresponding to this space's `out_dtype`."""
         if self.__complex_out_dtype is None:
-            raise TypeError('no complex variant of output dtype defined')
+            raise AttributeError(
+                'no complex variant of output dtype {} defined'
+                ''.format(dtype_repr(self.scalar_out_dtype)))
         else:
             return self.__complex_out_dtype
 
@@ -705,9 +709,8 @@ class FunctionSpace(LinearSpace):
         # Try to use caching for real and complex versions (exact dtype
         # mappings). This may fail for certain dtype, in which case we
         # just go to `_astype` directly.
-        try:
-            real_dtype = self.real_out_dtype
-        except TypeError:
+        real_dtype = getattr(self, 'real_out_dtype', None)
+        if real_dtype is None:
             return self._astype(out_dtype)
         else:
             if out_dtype == real_dtype:

--- a/odl/test/discr/lp_discr_test.py
+++ b/odl/test/discr/lp_discr_test.py
@@ -754,6 +754,15 @@ def test_astype():
     assert cdiscr.astype('float64') == rdiscr
     assert cdiscr.real_space == rdiscr
 
+    # More exotic dtype
+    discr = odl.uniform_discr([0, 0], [1, 1], [2, 2], dtype=bool)
+    as_float = discr.astype(float)
+    assert as_float.dtype == float
+    assert not as_float.is_weighted
+    as_complex = discr.astype(complex)
+    assert as_complex.dtype == complex
+    assert not as_complex.is_weighted
+
 
 def test_ufuncs(tspace_impl, ufunc):
     """Test ufuncs in ``x.ufuncs`` against direct Numpy ufuncs."""

--- a/odl/test/space/fspace_test.py
+++ b/odl/test/space/fspace_test.py
@@ -416,9 +416,9 @@ def test_fspace_attributes():
     assert fspace_c.real_out_dtype == float
     assert fspace_c.complex_out_dtype == complex
     assert fspace_s.out_dtype == np.dtype('U1')
-    with pytest.raises(TypeError):
+    with pytest.raises(AttributeError):
         fspace_s.real_out_dtype
-    with pytest.raises(TypeError):
+    with pytest.raises(AttributeError):
         fspace_s.complex_out_dtype
 
     assert all(spc.scalar_out_dtype == spc.out_dtype for spc in scalar_spaces)


### PR DESCRIPTION
The issue was that the real/complex space caching
mechanism would look up space.real_space, which
failed with a TypeError.