### PR TITLE
Issue 564 functionals on product spaces

### DIFF
--- a/odl/solvers/functional/default_functionals.py
+++ b/odl/solvers/functional/default_functionals.py
@@ -1244,7 +1244,8 @@ class KullbackLeiblerConvexConj(Functional):
         import scipy.special
 
         if self.prior is None:
-            tmp = -1.0 * (np.log(1 - x)).inner(self.domain.one())
+            tmp = self.domain.element(
+                -1.0 * (np.log(1 - x))).inner(self.domain.one())
         else:
             tmp = (-scipy.special.xlogy(self.prior,
                                         1 - x)).inner(self.domain.one())
@@ -1510,7 +1511,7 @@ class KullbackLeiblerCrossEntropyConvexConj(Functional):
     def _call(self, x):
         """Return the value in the point ``x``."""
         if self.prior is None:
-            tmp = (np.exp(x) - 1).inner(self.domain.one())
+            tmp = self.domain.element((np.exp(x) - 1)).inner(self.domain.one())
         else:
             tmp = (self.prior * (np.exp(x) - 1)).inner(self.domain.one())
         return tmp

--- a/odl/solvers/functional/default_functionals.py
+++ b/odl/solvers/functional/default_functionals.py
@@ -1247,8 +1247,8 @@ class KullbackLeiblerConvexConj(Functional):
             tmp = self.domain.element(
                 -1.0 * (np.log(1 - x))).inner(self.domain.one())
         else:
-            tmp = (-scipy.special.xlogy(self.prior,
-                                        1 - x)).inner(self.domain.one())
+            tmp = self.domain.element(-scipy.special.xlogy(
+                self.prior, 1 - x)).inner(self.domain.one())
         if np.isnan(tmp):
             # In this case, some element was larger than or equal to one
             return np.inf
@@ -1534,7 +1534,7 @@ class KullbackLeiblerCrossEntropyConvexConj(Functional):
             def _call(self, x):
                 """Apply the gradient operator to the given point."""
                 if functional.prior is None:
-                    return np.exp(x)
+                    return self.domain.element(np.exp(x))
                 else:
                     return functional.prior * np.exp(x)
 

--- a/odl/solvers/nonsmooth/proximal_operators.py
+++ b/odl/solvers/nonsmooth/proximal_operators.py
@@ -1687,6 +1687,8 @@ def proximal_convex_conj_kl_cross_entropy(space, lam=1, g=None):
             if not np.issubsctype(self.domain.dtype, np.complexfloating):
                 lambw = lambw.real
 
+            lambw = x.space.element(lambw)
+
             out.lincomb(1, x, -lam, lambw)
 
     return ProximalConvexConjKLCrossEntropy

--- a/odl/test/solvers/functional/functional_test.py
+++ b/odl/test/solvers/functional/functional_test.py
@@ -31,7 +31,7 @@ from odl.solvers.functional.default_functionals import (
 scalar = simple_fixture('scalar', [0.01, 2.7, 10, -2, -0.2, -7.1, 0])
 sigma = simple_fixture('sigma', [0.001, 2.7, np.array(0.5), 10])
 
-space_params = ['r10', 'uniform_discr']
+space_params = ['r10', 'uniform_discr', 'power_space_unif_discr']
 space_ids = [' space={} '.format(p) for p in space_params]
 
 
@@ -44,6 +44,10 @@ def space(request, tspace_impl):
     elif name == 'uniform_discr':
         # Discretization parameters
         return odl.uniform_discr(0, 1, 7, impl=tspace_impl)
+    elif name == 'power_space_unif_discr':
+        # Discretization parameters
+        space = odl.uniform_discr(0, 1, 7, impl=tspace_impl)
+        return odl.ProductSpace(space, 2)
 
 
 func_params = ['l1 ', 'l2', 'l2^2', 'constant', 'zero', 'ind_unit_ball_1',
@@ -95,6 +99,8 @@ def functional(request, space):
     elif name == 'huber':
         func = odl.solvers.Huber(space, gamma=0.1)
     elif name == 'groupl1':
+        if isinstance(space, odl.ProductSpace):
+            pytest.skip("The `GroupL1Norm` is not supported on `ProductSpace`")
         space = odl.ProductSpace(space, 3)
         func = odl.solvers.GroupL1Norm(space)
     else:


### PR DESCRIPTION
To close #564. This includes

- [X] add test for power space,
- [ ] add test for product space.

The first one is completed, however it does not work for the `GroupL1Norm` (see #564). Currently that test is simply skipped. Do we want to solve the underlying problem? Or will the `GroupL1Norm` only be defined on `DiscreteLp`  spaces?

 For general product spaces several test fails.