### PR TITLE
ENH: make pspace op matrix generation more robust

### DIFF
--- a/odl/operator/pspace_ops.py
+++ b/odl/operator/pspace_ops.py
@@ -94,7 +94,7 @@ class ProductSpaceOperator(Operator):
         Parameters
         ----------
         operators : `array-like`
-            An array of `Operator`'s
+            An array of `Operator`'s, must be 2-dimensional.
         domain : `ProductSpace`, optional
             Domain of the operator. If not provided, it is tried to be
             inferred from the operators. This requires each **column**
@@ -112,9 +112,9 @@ class ProductSpaceOperator(Operator):
         >>> x = pspace.element([[1, 2, 3],
         ...                     [4, 5, 6]])
 
-        Sum of elements:
+        Create an operator that sums two inputs:
 
-        >>> prod_op = ProductSpaceOperator([I, I])
+        >>> prod_op = odl.ProductSpaceOperator([[I, I]])
         >>> prod_op(x)
         ProductSpace(rn(3), 1).element([
             [ 5.,  7.,  9.]
@@ -123,20 +123,30 @@ class ProductSpaceOperator(Operator):
         Diagonal operator -- 0 or ``None`` means ignore, or the implicit
         zero operator:
 
-        >>> prod_op = ProductSpaceOperator([[I, 0], [0, I]])
+        >>> prod_op = odl.ProductSpaceOperator([[I, 0],
+        ...                                     [0, I]])
         >>> prod_op(x)
         ProductSpace(rn(3), 2).element([
             [ 1.,  2.,  3.],
             [ 4.,  5.,  6.]
         ])
 
-        Complicated combinations:
+        If a column is empty, the operator domain must be specified. The
+        same holds for an empty row and the range of the operator:
 
-        >>> prod_op = ProductSpaceOperator([[I, I], [I, 0]])
+        >>> prod_op = odl.ProductSpaceOperator([[I, 0],
+        ...                                     [I, 0]], domain=r3 ** 2)
+        >>> prod_op(x)
+        ProductSpace(rn(3), 2).element([
+            [ 1.,  2.,  3.],
+            [ 1.,  2.,  3.]
+        ])
+        >>> prod_op = odl.ProductSpaceOperator([[I, I],
+        ...                                     [0, 0]], range=r3 ** 2)
         >>> prod_op(x)
         ProductSpace(rn(3), 2).element([
             [ 5.,  7.,  9.],
-            [ 1.,  2.,  3.]
+            [ 0.,  0.,  0.]
         ])
         """
         # Lazy import to improve `import odl` time

--- a/odl/test/operator/oputils_test.py
+++ b/odl/test/operator/oputils_test.py
@@ -46,7 +46,7 @@ def test_matrix_representation_product_to_lin_space():
     ran = ProductSpace(rn, 1)
 
     AB_matrix = np.hstack([A, B])
-    ABop = ProductSpaceOperator([Aop, Bop], dom, ran)
+    ABop = ProductSpaceOperator([[Aop, Bop]], dom, ran)
 
     matrix_repr = matrix_representation(ABop)
 

--- a/odl/test/operator/pspace_ops_test.py
+++ b/odl/test/operator/pspace_ops_test.py
@@ -58,17 +58,17 @@ def test_pspace_op_weighted_init():
 
     r3 = odl.rn(3)
     ran = odl.ProductSpace(r3, 2, weighting=[1, 2])
-    I = odl.IdentityOperator(r3)
+    A = odl.IdentityOperator(r3)
 
     with pytest.raises(NotImplementedError):
-        odl.ProductSpaceOperator([[I],
+        odl.ProductSpaceOperator([[A],
                                   [0]], range=ran)
 
 
 def test_pspace_op_sum_call():
     r3 = odl.rn(3)
-    I = odl.IdentityOperator(r3)
-    op = odl.ProductSpaceOperator([[I, I]])
+    A = odl.IdentityOperator(r3)
+    op = odl.ProductSpaceOperator([[A, A]])
 
     x = r3.element([1, 2, 3])
     y = r3.element([7, 8, 9])
@@ -80,9 +80,9 @@ def test_pspace_op_sum_call():
 
 def test_pspace_op_project_call():
     r3 = odl.rn(3)
-    I = odl.IdentityOperator(r3)
-    op = odl.ProductSpaceOperator([[I],
-                                   [I]])
+    A = odl.IdentityOperator(r3)
+    op = odl.ProductSpaceOperator([[A],
+                                   [A]])
 
     x = r3.element([1, 2, 3])
     z = op.domain.element([x])
@@ -95,9 +95,9 @@ def test_pspace_op_project_call():
 
 def test_pspace_op_diagonal_call():
     r3 = odl.rn(3)
-    I = odl.IdentityOperator(r3)
-    op = odl.ProductSpaceOperator([[I, 0],
-                                   [0, I]])
+    A = odl.IdentityOperator(r3)
+    op = odl.ProductSpaceOperator([[A, 0],
+                                   [0, A]])
 
     x = r3.element([1, 2, 3])
     y = r3.element([7, 8, 9])
@@ -109,9 +109,9 @@ def test_pspace_op_diagonal_call():
 
 def test_pspace_op_swap_call():
     r3 = odl.rn(3)
-    I = odl.IdentityOperator(r3)
-    op = odl.ProductSpaceOperator([[0, I],
-                                   [I, 0]])
+    A = odl.IdentityOperator(r3)
+    op = odl.ProductSpaceOperator([[0, A],
+                                   [A, 0]])
 
     x = r3.element([1, 2, 3])
     y = r3.element([7, 8, 9])


### PR DESCRIPTION
This also invalidates the syntax `ProductSpaceOperator([A, B, C])` (with a 1D sequence), which I think was not valid in the first place, according to the documentation. It may break other stuff, let's see.