### PR TITLE
BUG: Fix bug in NumpyTensorSpace.available_dtypes

### DIFF
--- a/odl/space/npy_tensors.py
+++ b/odl/space/npy_tensors.py
@@ -484,7 +484,7 @@ class NumpyTensorSpace(TensorSpace):
                     all_dtypes.append(np.dtype(dtype))
         # Need to add these manually since np.sctypes['others'] will only
         # contain one of them (depending on Python version)
-        lst.extend([np.dtype('S'), np.dtype('U')])
+        all_dtypes.extend([np.dtype('S'), np.dtype('U')])
         return tuple(sorted(set(all_dtypes)))
 
     @staticmethod


### PR DESCRIPTION
So this was an obvious misstake (and frankly an error on numpys side for using a mutable dtype).

Basically we kept increasing the number of dtypes available in numpy. This was actually observed by @aringh in some other PR, but we couldn't figure out why.