### PR TITLE
MAINT: get rid of spurious pyfftw warning, closes #1057

### DIFF
--- a/odl/set/sets.py
+++ b/odl/set/sets.py
@@ -11,7 +11,7 @@
 from __future__ import print_function, division, absolute_import
 from builtins import int, object
 from numbers import Integral, Real, Complex
-from past.builtins import basestring
+from past.types.basestring import basestring
 import numpy as np
 
 from odl.util import is_int_dtype, is_real_dtype, is_numeric_dtype, unique

--- a/odl/trafos/backends/pyfftw_bindings.py
+++ b/odl/trafos/backends/pyfftw_bindings.py
@@ -24,8 +24,8 @@ except ImportError:
     PYFFTW_AVAILABLE = False
 else:
     _maj, _min, _patch = [int(n) for n in pyfftw.__version__.split('.')[:3]]
-    if (_maj, _min, _patch) < (0, 10, 4):
-        warnings.warn('PyFFTW < 0.10.4 is known to cause problems with some '
+    if (_maj, _min, _patch) < (0, 10, 3):
+        warnings.warn('PyFFTW < 0.10.3 is known to cause problems with some '
                       'ODL functionality, see issue #1002.',
                       RuntimeWarning)
 


### PR DESCRIPTION
This removes the super-annoying pyfftw warnings when 0.10.3 or 0.10.4 is installed. We shouldn't have any problems with 0.10.3 since all version 0.10.4 does is [fix some versioning stuff](https://github.com/pyFFTW/pyFFTW/compare/7067c13...4dd6b6b). I also think that the PyPI packages for 0.10.3 and 0.10.4 are identical (use the same git tag), so we should treat them the same.