### PR TITLE
ENH: Add three solvers for differences of convex functions.

### DIFF
--- a/odl/solvers/nonsmooth/__init__.py
+++ b/odl/solvers/nonsmooth/__init__.py
@@ -32,3 +32,6 @@ __all__ += proximal_gradient_solvers.__all__
 
 from .alternating_dual_updates import *
 __all__ += alternating_dual_updates.__all__
+
+from .difference_convex import *
+__all__ += difference_convex.__all__

--- a/odl/solvers/nonsmooth/difference_convex.py
+++ b/odl/solvers/nonsmooth/difference_convex.py
@@ -1,0 +1,243 @@
+# Copyright 2014-2018 The ODL contributors
+#
+# This file is part of ODL.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file, You can
+# obtain one at https://mozilla.org/MPL/2.0/.
+
+"""Solvers for the optimization of the difference of convex functions.
+
+Collection of DCA and related methods which make use of structured optimization
+if the objective function can be written as a difference of two convex
+functions.
+"""
+
+from __future__ import print_function, division, absolute_import
+
+__all__ = ('dca', 'prox_dca', 'doubleprox_dc')
+
+
+def dca(x, g, h, niter, callback=None):
+    r"""Subgradient DCA of Tao and An.
+
+    This algorithm solves a problem of the form::
+
+        min_x g(x) - h(x),
+
+    where ``g`` and ``h`` are proper, convex and lower semicontinuous
+    functions.
+
+    Parameters
+    ----------
+    x : `LinearSpaceElement`
+        Initial point, updated in-place.
+    g : `Functional`
+        Convex part. Needs to provide a `Functional.convex_conj` with a
+        `Functional.proximal` factory.
+    h : `Functional`
+        Negative of the concave part. Needs to provide a
+        `Functional.proximal` factory.
+    niter : int
+        Number of iterations.
+    callback : callable, optional
+        Function called with the current iterate after each iteration.
+
+    Notes
+    -----
+    The algorithm is described in Section 3 and in particular in Theorem 3 of
+    `[TA1997] <http://journals.math.ac.vn/acta/pdf/9701289.pdf>`_. The problem
+
+    .. math::
+        \min g(x) - h(x)
+
+    has the first-order optimality condition :math:`0 \in \partial g(x) -
+    \partial h(x)`, i.e., aims at finding an :math:`x` so that there exists a
+    common element
+
+    .. math::
+        y \in \partial g(x) \cap \partial h(x).
+
+    The element :math:`y` can be seen as a solution of the Toland dual problem
+
+    .. math::
+        \min h^*(y) - g^*(y)
+
+    and the iteration is given by
+
+    .. math::
+        y_n \in \partial h(x_n), \qquad x_{n+1} \in \partial g^*(y_n)
+
+    for :math:`n\geq 0`.
+
+    References
+    ----------
+    [TA1997] Tao, P D, and An, L T H. *Convex analysis approach to d.c.
+    programming: Theory, algorithms and applications*. Acta Mathematica
+    Vietnamica, 22.1 (1997), pp 289--355.
+
+    See also
+    --------
+    """
+#    `prox_dca`, `doubleprox_dc`
+#    """
+    space = g.domain
+    if h.domain != space:
+        raise ValueError('`g.domain` and `h.domain` need to be equal, but '
+                         '{} != {}'.format(space, h.domain))
+    for _ in range(niter):
+        g.convex_conj.gradient(h.gradient(x), out=x)
+
+        if callback is not None:
+            callback(x)
+
+
+def prox_dca(x, g, h, niter, gamma, callback=None):
+    """Proximal DCA of Sun, Sampaio and Candido.
+
+    This algorithm solves a problem of the form ::
+
+        min_x g(x) - h(x)
+
+    where ``g`` and ``h`` are two proper, convex and lower semicontinuous
+    functions.
+
+    Parameters
+    ----------
+    x : `LinearSpaceElement`
+        Initial point, updated in-place.
+    g : `Functional`
+        Convex part. Needs to provide a `Functional.convex_conj` with a
+        `Functional.proximal` factory.
+    h : `Functional`
+        The negative of the concave part. Needs to provide a
+        `Functional.proximal` factory.
+    niter : int
+        Number of iterations.
+    gamma : positive float
+        Stepsize of the proximal steps.
+    callback : callable, optional
+        Function called with the current iterate after each iteration.
+
+    Notes
+    -----
+    The algorithm was proposed as Algorithm 2.3 in
+    `[SSC2003] <http://www.global-sci.org/jcm/readabs.php?vol=21&\
+no=4&page=451&year=2003&ppage=462>`_. It solves the problem
+
+    .. math ::
+        \\min g(x) - h(x)
+
+    by involving subgradients of :math:`h` and proximal points of :math:`g^*`.
+    The iteration is given by
+
+    .. math ::
+        y_n \\in \\partial h(x_n), \\qquad x_{n+1}
+            = \\mathrm{Prox}^{\\gamma}_g(x_n + \\gamma y_n)
+
+    Here, :math:`\\gamma` is the stepsize parameter ``gamma``.
+
+    References
+    ----------
+    [SSC2003] Sun, W, Sampaio R J B, and Candido M A B. *Proximal point
+    algorithm for minimization of DC function*. Journal of Computational
+    Mathematics, 21.4 (2003), pp 451--462.
+
+    [TA1997] Tao, P D, and An, L T H. *Convex analysis approach to d.c.
+    programming: Theory, algorithms and applications*. Acta Mathematica
+    Vietnamica, 22.1 (1997), pp 289--355.
+    """
+    space = g.domain
+    if h.domain != space:
+        raise ValueError('`g.domain` and `h.domain` need to be equal, but '
+                         '{} != {}'.format(space, h.domain))
+    for _ in range(niter):
+        g.proximal(gamma)(x + gamma * h.gradient(x), out=x)
+
+        if callback is not None:
+            callback(x)
+
+
+def doubleprox_dc(x, y, g, h, phi, K, niter, gamma, mu, callback=None):
+    r"""Double-proxmial gradient d.c. algorithm of Banert and Bot.
+
+    This algorithm solves a problem of the form::
+
+        min_x g(x) + phi(x) - h(Kx).
+
+    Parameters
+    ----------
+    x : `LinearSpaceElement`
+        Initial primal guess, updated in-place.
+    y : `LinearSpaceElement`
+        Initial dual guess, updated in-place.
+    g : `Functional`
+        The nonsmooth part of the convex part of the problem. Needs to provide
+        a `Functional.proximal` factory.
+    h : `Functional`
+        The functional involved in the concave part of the problem. Needs to
+        provide a `Functional.proximal` factory.
+    phi : `Functional`
+        The smooth part of the convex part of the problem. Needs to provide a
+        `Functional.gradient`, and convergence can be guaranteed if the
+        gradient is Lipschitz continuous.
+    K : `Operator`
+        The operator involved in the concave part of the problem.
+    niter : int
+        Number of iterations.
+    gamma : positive float
+        Stepsize in the primal updates.
+    mu : positive float
+        Stepsize in the dual updates.
+    callback : callable, optional
+        Function called with the current iterate after each iteration.
+
+    Notes
+    -----
+    This algorithm is proposed in`[BB2016]
+    <https://arxiv.org/abs/1610.06538>`_ and solves the d.c. problem
+
+    .. math ::
+        \min_x g(x) + \varphi(x) - h(Kx)
+
+    together with its Toland dual
+
+    .. math ::
+        \min_y h^*(y) - (g + \varphi)^*(K^* y).
+
+    The iterations are given by
+
+    .. math ::
+        x_{n+1} &= \mathrm{Prox}_{\gamma}^g (x_n + \gamma K^* y_n
+                   - \gamma \nabla \varphi(x_n)), \\
+        y_{n+1} &= \mathrm{Prox}_{\mu}^{h^*} (y_n + \mu K x_{n+1}).
+
+    To guarantee convergence, the parameter :math:`\gamma` must satisfy
+    :math:`0 < \gamma < 2/L` where :math:`L` is the Lipschitz constant of
+    :math:`\nabla \varphi`.
+
+    References
+    ----------
+    [BB2016] Banert, S, and Bot, R I. *A general double-proximal gradient
+    algorithm for d.c. programming*. arXiv:1610.06538 [math.OC] (2016).
+    """
+    primal_space = g.domain
+    dual_space = h.domain
+
+    if phi.domain != primal_space:
+        raise ValueError('`g.domain` and `phi.domain` need to be equal, but '
+                         '{} != {}'.format(primal_space, phi.domain))
+    if K.domain != primal_space:
+        raise ValueError('`g.domain` and `K.domain` need to be equal, but '
+                         '{} != {}'.format(primal_space, K.domain))
+    if K.range != dual_space:
+        raise ValueError('`h.domain` and `K.range` need to be equal, but '
+                         '{} != {}'.format(dual_space, K.range))
+
+    for _ in range(niter):
+        g.proximal(gamma)(x + gamma * K.adjoint(y) -
+                          gamma * phi.gradient(x), out=x)
+        h.convex_conj.proximal(mu)(y + mu * K(x), out=y)
+
+        if callback is not None:
+            callback(x)

--- a/odl/solvers/nonsmooth/difference_convex.py
+++ b/odl/solvers/nonsmooth/difference_convex.py
@@ -133,9 +133,11 @@ no=4&page=451&year=2003&ppage=462>`_. It solves the problem
 
     .. math ::
         y_n \\in \\partial h(x_n), \\qquad x_{n+1}
-            = \\mathrm{Prox}^{\\gamma}_g(x_n + \\gamma y_n)
+            = \\mathrm{Prox}^{\\gamma}_g(x_n + \\gamma y_n).
 
-    Here, :math:`\\gamma` is the stepsize parameter ``gamma``.
+    In contrast to `dca`, `prox_dca` uses proximal steps with respect to the
+    convex part ``g``. Both algorithms use subgradients of the concave part
+    ``h``.
 
     References
     ----------

--- a/odl/solvers/nonsmooth/difference_convex.py
+++ b/odl/solvers/nonsmooth/difference_convex.py
@@ -21,7 +21,7 @@ __all__ = ('dca', 'prox_dca', 'doubleprox_dc')
 def dca(x, g, h, niter, callback=None):
     r"""Subgradient DCA of Tao and An.
 
-    This algorithm solves a problem of the form::
+    This algorithm solves a problem of the form ::
 
         min_x g(x) - h(x),
 
@@ -169,7 +169,7 @@ def prox_dca(x, g, h, niter, gamma, callback=None):
 def doubleprox_dc(x, y, g, phi, h, K, niter, gamma, mu, callback=None):
     r"""Double-proxmial gradient d.c. algorithm of Banert and Bot.
 
-    This algorithm solves a problem of the form::
+    This algorithm solves a problem of the form ::
 
         min_x g(x) + phi(x) - h(Kx).
 

--- a/odl/solvers/nonsmooth/difference_convex.py
+++ b/odl/solvers/nonsmooth/difference_convex.py
@@ -135,7 +135,7 @@ def prox_dca(x, g, h, niter, gamma, callback=None):
 
     .. math ::
         y_n \in \partial h(x_n), \qquad x_{n+1}
-            = \mathrm{Prox}^{\gamma}_g(x_n + \gamma y_n).
+            = \mathrm{Prox}_{\gamma g}(x_n + \gamma y_n).
 
     In contrast to `dca`, `prox_dca` uses proximal steps with respect to the
     convex part ``g``. Both algorithms use subgradients of the concave part
@@ -166,7 +166,7 @@ def prox_dca(x, g, h, niter, gamma, callback=None):
             callback(x)
 
 
-def doubleprox_dc(x, y, g, h, phi, K, niter, gamma, mu, callback=None):
+def doubleprox_dc(x, y, g, phi, h, K, niter, gamma, mu, callback=None):
     r"""Double-proxmial gradient d.c. algorithm of Banert and Bot.
 
     This algorithm solves a problem of the form::
@@ -181,11 +181,11 @@ def doubleprox_dc(x, y, g, h, phi, K, niter, gamma, mu, callback=None):
         Initial dual guess, updated in-place.
     g : `Functional`
         Convex functional. Needs to implement ``g.proximal``.
-    h : `Functional`
-        Convex functional. Needs to implement ``h.convex_conj.proximal``.
     phi : `Functional`
         Convex functional. Needs to implement ``phi.gradient``.
         Convergence can be guaranteed if the gradient is Lipschitz continuous.
+    h : `Functional`
+        Convex functional. Needs to implement ``h.convex_conj.proximal``.
     K : `Operator`
         Linear operator. Needs to implement ``K.adjoint``
     niter : int
@@ -213,9 +213,9 @@ def doubleprox_dc(x, y, g, h, phi, K, niter, gamma, mu, callback=None):
     The iterations are given by
 
     .. math ::
-        x_{n+1} &= \mathrm{Prox}_{\gamma}^g (x_n + \gamma (K^* y_n
+        x_{n+1} &= \mathrm{Prox}_{\gamma g} (x_n + \gamma (K^* y_n
                    - \nabla \varphi(x_n))), \\
-        y_{n+1} &= \mathrm{Prox}_{\mu}^{h^*} (y_n + \mu K x_{n+1}).
+        y_{n+1} &= \mathrm{Prox}_{\mu h^*} (y_n + \mu K x_{n+1}).
 
     To guarantee convergence, the parameter :math:`\gamma` must satisfy
     :math:`0 < \gamma < 2/L` where :math:`L` is the Lipschitz constant of
@@ -258,7 +258,7 @@ def doubleprox_dc(x, y, g, h, phi, K, niter, gamma, mu, callback=None):
             callback(x)
 
 
-def doubleprox_dc_simple(x, y, g, h, phi, K, niter, gamma, mu):
+def doubleprox_dc_simple(x, y, g, phi, h, K, niter, gamma, mu):
     """Non-optimized version of ``doubleprox_dc``.
     This function is intended for debugging. It makes a lot of copies and
     performs no error checking.

--- a/odl/solvers/nonsmooth/difference_convex.py
+++ b/odl/solvers/nonsmooth/difference_convex.py
@@ -94,7 +94,7 @@ def dca(x, g, h, niter, callback=None):
 
 
 def prox_dca(x, g, h, niter, gamma, callback=None):
-    """Proximal DCA of Sun, Sampaio and Candido.
+    r"""Proximal DCA of Sun, Sampaio and Candido.
 
     This algorithm solves a problem of the form ::
 
@@ -123,18 +123,19 @@ def prox_dca(x, g, h, niter, gamma, callback=None):
     Notes
     -----
     The algorithm was proposed as Algorithm 2.3 in
-    `[SSC2003] <http://www.global-sci.org/jcm/readabs.php?vol=21&\
-no=4&page=451&year=2003&ppage=462>`_. It solves the problem
+    `[SSC2003]
+    <http://www.global-sci.org/jcm/readabs.php?vol=21&no=4&page=451&year=2003&ppage=462>`_.
+    It solves the problem
 
     .. math ::
-        \\min g(x) - h(x)
+        \min g(x) - h(x)
 
     by involving subgradients of :math:`h` and proximal points of :math:`g^*`.
     The iteration is given by
 
     .. math ::
-        y_n \\in \\partial h(x_n), \\qquad x_{n+1}
-            = \\mathrm{Prox}^{\\gamma}_g(x_n + \\gamma y_n).
+        y_n \in \partial h(x_n), \qquad x_{n+1}
+            = \mathrm{Prox}^{\gamma}_g(x_n + \gamma y_n).
 
     In contrast to `dca`, `prox_dca` uses proximal steps with respect to the
     convex part ``g``. Both algorithms use subgradients of the concave part

--- a/odl/solvers/nonsmooth/difference_convex.py
+++ b/odl/solvers/nonsmooth/difference_convex.py
@@ -116,7 +116,7 @@ def prox_dca(x, g, h, niter, gamma, callback=None):
     niter : int
         Number of iterations.
     gamma : positive float
-        Stepsize of the proximal steps.
+        Stepsize in the primal updates.
     callback : callable, optional
         Function called with the current iterate after each iteration.
 

--- a/odl/solvers/nonsmooth/difference_convex.py
+++ b/odl/solvers/nonsmooth/difference_convex.py
@@ -144,10 +144,6 @@ no=4&page=451&year=2003&ppage=462>`_. It solves the problem
     [SSC2003] Sun, W, Sampaio R J B, and Candido M A B. *Proximal point
     algorithm for minimization of DC function*. Journal of Computational
     Mathematics, 21.4 (2003), pp 451--462.
-
-    [TA1997] Tao, P D, and An, L T H. *Convex analysis approach to d.c.
-    programming: Theory, algorithms and applications*. Acta Mathematica
-    Vietnamica, 22.1 (1997), pp 289--355.
     """
     space = g.domain
     if h.domain != space:

--- a/odl/solvers/nonsmooth/difference_convex.py
+++ b/odl/solvers/nonsmooth/difference_convex.py
@@ -34,10 +34,10 @@ def dca(x, g, h, niter, callback=None):
         Initial point, updated in-place.
     g : `Functional`
         Convex part. Needs to provide a `Functional.convex_conj` with a
-        `Functional.proximal` factory.
+        `Functional.gradient` method.
     h : `Functional`
         Negative of the concave part. Needs to provide a
-        `Functional.proximal` factory.
+        `Functional.gradient` method.
     niter : int
         Number of iterations.
     callback : callable, optional
@@ -66,9 +66,10 @@ def dca(x, g, h, niter, callback=None):
     and the iteration is given by
 
     .. math::
-        y_n \in \partial h(x_n), \qquad x_{n+1} \in \partial g^*(y_n)
+        y_n \in \partial h(x_n), \qquad x_{n+1} \in \partial g^*(y_n),
 
-    for :math:`n\geq 0`.
+    for :math:`n\geq 0`. Here, a subgradient is found by evaluating the
+    gradient method of the respective functionals.
 
     References
     ----------

--- a/odl/solvers/nonsmooth/difference_convex.py
+++ b/odl/solvers/nonsmooth/difference_convex.py
@@ -207,8 +207,8 @@ def doubleprox_dc(x, y, g, h, phi, K, niter, gamma, mu, callback=None):
     The iterations are given by
 
     .. math ::
-        x_{n+1} &= \mathrm{Prox}_{\gamma}^g (x_n + \gamma K^* y_n
-                   - \gamma \nabla \varphi(x_n)), \\
+        x_{n+1} &= \mathrm{Prox}_{\gamma}^g (x_n + \gamma (K^* y_n
+                   - \nabla \varphi(x_n))), \\
         y_{n+1} &= \mathrm{Prox}_{\mu}^{h^*} (y_n + \mu K x_{n+1}).
 
     To guarantee convergence, the parameter :math:`\gamma` must satisfy

--- a/odl/solvers/nonsmooth/difference_convex.py
+++ b/odl/solvers/nonsmooth/difference_convex.py
@@ -8,9 +8,9 @@
 
 """Solvers for the optimization of the difference of convex functions.
 
-Collection of DCA and related methods which make use of structured optimization
-if the objective function can be written as a difference of two convex
-functions.
+Collection of DCA (d.c. algorithms) and related methods which make use of
+structured optimization if the objective function can be written as a
+difference of two convex functions.
 """
 
 from __future__ import print_function, division, absolute_import
@@ -33,11 +33,10 @@ def dca(x, g, h, niter, callback=None):
     x : `LinearSpaceElement`
         Initial point, updated in-place.
     g : `Functional`
-        Convex part. Needs to provide a `Functional.convex_conj` with a
+        Convex functional. Needs to provide a `Functional.convex_conj` with a
         `Functional.gradient` method.
     h : `Functional`
-        Negative of the concave part. Needs to provide a
-        `Functional.gradient` method.
+        Convex functional. Needs to provide a `Functional.gradient` method.
     niter : int
         Number of iterations.
     callback : callable, optional
@@ -79,9 +78,12 @@ def dca(x, g, h, niter, callback=None):
 
     See also
     --------
+    dca :
+        Solver with subgradinet steps for all the functionals.
+    doubleprox_dc :
+        Solver with proximal steps for all the nonsmooth convex functionals
+        and a gradient step for a smooth functional.
     """
-#    `prox_dca`, `doubleprox_dc`
-#    """
     space = g.domain
     if h.domain != space:
         raise ValueError('`g.domain` and `h.domain` need to be equal, but '
@@ -108,11 +110,10 @@ def prox_dca(x, g, h, niter, gamma, callback=None):
     x : `LinearSpaceElement`
         Initial point, updated in-place.
     g : `Functional`
-        Convex part. Needs to provide a `Functional.convex_conj` with a
+        Convex functional. Needs to provide a `Functional.convex_conj` with a
         `Functional.proximal` factory.
     h : `Functional`
-        The negative of the concave part. Needs to provide a
-        `Functional.gradient` method.
+        Convex functional. Needs to provide a `Functional.gradient` method.
     niter : int
         Number of iterations.
     gamma : positive float
@@ -130,7 +131,7 @@ def prox_dca(x, g, h, niter, gamma, callback=None):
     .. math ::
         \min g(x) - h(x)
 
-    by involving subgradients of :math:`h` and proximal points of :math:`g^*`.
+    by using subgradients of :math:`h` and proximal points of :math:`g^*`.
     The iteration is given by
 
     .. math ::
@@ -146,6 +147,14 @@ def prox_dca(x, g, h, niter, gamma, callback=None):
     [SSC2003] Sun, W, Sampaio R J B, and Candido M A B. *Proximal point
     algorithm for minimization of DC function*. Journal of Computational
     Mathematics, 21.4 (2003), pp 451--462.
+
+    See also
+    --------
+    prox_dca :
+        Solver with a proximal step for ``g`` and a subgradient step for ``h``.
+    doubleprox_dc :
+        Solver with proximal steps for all the nonsmooth convex functionals
+        and a gradient step for a smooth functional.
     """
     space = g.domain
     if h.domain != space:
@@ -172,17 +181,14 @@ def doubleprox_dc(x, y, g, h, phi, K, niter, gamma, mu, callback=None):
     y : `LinearSpaceElement`
         Initial dual guess, updated in-place.
     g : `Functional`
-        The nonsmooth part of the convex part of the problem. Needs to provide
-        a `Functional.proximal` factory.
+        Convex functional. Needs to provide a `Functional.proximal` factory.
     h : `Functional`
-        The functional involved in the concave part of the problem. Needs to
-        provide a `Functional.proximal` factory.
+        Convex functional. Needs to provide a `Functional.proximal` factory.
     phi : `Functional`
-        The smooth part of the convex part of the problem. Needs to provide a
-        `Functional.gradient`, and convergence can be guaranteed if the
-        gradient is Lipschitz continuous.
+        Convex functional. Needs to provide a `Functional.gradient`, and
+        convergence can be guaranteed if the gradient is Lipschitz continuous.
     K : `Operator`
-        The operator involved in the concave part of the problem.
+        Linear operator.
     niter : int
         Number of iterations.
     gamma : positive float
@@ -220,6 +226,14 @@ def doubleprox_dc(x, y, g, h, phi, K, niter, gamma, mu, callback=None):
     ----------
     [BB2016] Banert, S, and Bot, R I. *A general double-proximal gradient
     algorithm for d.c. programming*. arXiv:1610.06538 [math.OC] (2016).
+
+    See also
+    --------
+    prox_dca :
+        Solver with a proximal step for ``g`` and a subgradient step for ``h``.
+    doubleprox_dc :
+        Solver with proximal steps for all the nonsmooth convex functionals
+        and a gradient step for a smooth functional.
     """
     primal_space = g.domain
     dual_space = h.domain

--- a/odl/solvers/nonsmooth/difference_convex.py
+++ b/odl/solvers/nonsmooth/difference_convex.py
@@ -193,7 +193,7 @@ def doubleprox_dc(x, y, g, h, phi, K, niter, gamma, mu, callback=None):
 
     Notes
     -----
-    This algorithm is proposed in`[BB2016]
+    This algorithm is proposed in `[BB2016]
     <https://arxiv.org/abs/1610.06538>`_ and solves the d.c. problem
 
     .. math ::

--- a/odl/solvers/nonsmooth/difference_convex.py
+++ b/odl/solvers/nonsmooth/difference_convex.py
@@ -151,7 +151,7 @@ no=4&page=451&year=2003&ppage=462>`_. It solves the problem
         raise ValueError('`g.domain` and `h.domain` need to be equal, but '
                          '{} != {}'.format(space, h.domain))
     for _ in range(niter):
-        g.proximal(gamma)(x + gamma * h.gradient(x), out=x)
+        g.proximal(gamma)(x.lincomb(1, x, gamma, h.gradient(x)), out=x)
 
         if callback is not None:
             callback(x)
@@ -234,9 +234,10 @@ def doubleprox_dc(x, y, g, h, phi, K, niter, gamma, mu, callback=None):
                          '{} != {}'.format(dual_space, K.range))
 
     for _ in range(niter):
-        g.proximal(gamma)(x + gamma * K.adjoint(y) -
-                          gamma * phi.gradient(x), out=x)
-        h.convex_conj.proximal(mu)(y + mu * K(x), out=y)
+        g.proximal(gamma)(x.lincomb(1, x,
+                                    gamma, K.adjoint(y) - phi.gradient(x)),
+                          out=x)
+        h.convex_conj.proximal(mu)(y.lincomb(1, y, mu, K(x)), out=y)
 
         if callback is not None:
             callback(x)

--- a/odl/solvers/nonsmooth/difference_convex.py
+++ b/odl/solvers/nonsmooth/difference_convex.py
@@ -241,3 +241,14 @@ def doubleprox_dc(x, y, g, h, phi, K, niter, gamma, mu, callback=None):
 
         if callback is not None:
             callback(x)
+
+
+def doubleprox_dc_simple(x, y, g, h, phi, K, niter, gamma, mu):
+    """Non-optimized version of ``doubleprox_dc``.
+    This function is intended for debugging. It makes a lot of copies and
+    performs no error checking.
+    """
+    for _ in range(niter):
+        g.proximal(gamma)(x + gamma * K.adjoint(y) -
+                          gamma * phi.gradient(x), out=x)
+        h.convex_conj.proximal(mu)(y + mu * K(x), out=y)

--- a/odl/solvers/nonsmooth/difference_convex.py
+++ b/odl/solvers/nonsmooth/difference_convex.py
@@ -112,7 +112,7 @@ def prox_dca(x, g, h, niter, gamma, callback=None):
         `Functional.proximal` factory.
     h : `Functional`
         The negative of the concave part. Needs to provide a
-        `Functional.proximal` factory.
+        `Functional.gradient` method.
     niter : int
         Number of iterations.
     gamma : positive float

--- a/odl/solvers/nonsmooth/difference_convex.py
+++ b/odl/solvers/nonsmooth/difference_convex.py
@@ -33,10 +33,9 @@ def dca(x, g, h, niter, callback=None):
     x : `LinearSpaceElement`
         Initial point, updated in-place.
     g : `Functional`
-        Convex functional. Needs to provide a `Functional.convex_conj` with a
-        `Functional.gradient` method.
+        Convex functional. Needs to implement ``g.convex_conj.gradient``.
     h : `Functional`
-        Convex functional. Needs to provide a `Functional.gradient` method.
+        Convex functional. Needs to implement ``h.gradient``.
     niter : int
         Number of iterations.
     callback : callable, optional
@@ -110,10 +109,9 @@ def prox_dca(x, g, h, niter, gamma, callback=None):
     x : `LinearSpaceElement`
         Initial point, updated in-place.
     g : `Functional`
-        Convex functional. Needs to provide a `Functional.convex_conj` with a
-        `Functional.proximal` factory.
+        Convex functional. Needs to implement ``g.proximal``.
     h : `Functional`
-        Convex functional. Needs to provide a `Functional.gradient` method.
+        Convex functional. Needs to implement ``h.gradient``.
     niter : int
         Number of iterations.
     gamma : positive float
@@ -181,14 +179,14 @@ def doubleprox_dc(x, y, g, h, phi, K, niter, gamma, mu, callback=None):
     y : `LinearSpaceElement`
         Initial dual guess, updated in-place.
     g : `Functional`
-        Convex functional. Needs to provide a `Functional.proximal` factory.
+        Convex functional. Needs to implement ``g.proximal``.
     h : `Functional`
-        Convex functional. Needs to provide a `Functional.proximal` factory.
+        Convex functional. Needs to implement ``h.convex_conj.proximal``.
     phi : `Functional`
-        Convex functional. Needs to provide a `Functional.gradient`, and
-        convergence can be guaranteed if the gradient is Lipschitz continuous.
+        Convex functional. Needs to implement ``phi.gradient``.
+        Convergence can be guaranteed if the gradient is Lipschitz continuous.
     K : `Operator`
-        Linear operator.
+        Linear operator. Needs to implement ``K.adjoint``
     niter : int
         Number of iterations.
     gamma : positive float

--- a/odl/solvers/nonsmooth/difference_convex.py
+++ b/odl/solvers/nonsmooth/difference_convex.py
@@ -87,8 +87,9 @@ def dca(x, g, h, niter, callback=None):
     if h.domain != space:
         raise ValueError('`g.domain` and `h.domain` need to be equal, but '
                          '{} != {}'.format(space, h.domain))
+    g_convex_conj = g.convex_conj
     for _ in range(niter):
-        g.convex_conj.gradient(h.gradient(x), out=x)
+        g_convex_conj.gradient(h.gradient(x), out=x)
 
         if callback is not None:
             callback(x)
@@ -246,11 +247,12 @@ def doubleprox_dc(x, y, g, h, phi, K, niter, gamma, mu, callback=None):
         raise ValueError('`h.domain` and `K.range` need to be equal, but '
                          '{} != {}'.format(dual_space, K.range))
 
+    h_convex_conj = h.convex_conj
     for _ in range(niter):
         g.proximal(gamma)(x.lincomb(1, x,
                                     gamma, K.adjoint(y) - phi.gradient(x)),
                           out=x)
-        h.convex_conj.proximal(mu)(y.lincomb(1, y, mu, K(x)), out=y)
+        h_convex_conj.proximal(mu)(y.lincomb(1, y, mu, K(x)), out=y)
 
         if callback is not None:
             callback(x)

--- a/odl/test/solvers/nonsmooth/difference_convex_test.py
+++ b/odl/test/solvers/nonsmooth/difference_convex_test.py
@@ -51,8 +51,8 @@ def test_dca():
     b = 0.5
     # This means -1/a = -2 < b = 0.5 < 1/a = 2.
     space = odl.rn(1)
-    g = a / 2 * odl.solvers.L2NormSquared(space).translated(b)
-    h = odl.solvers.L1Norm(space)
+    f = a / 2 * odl.solvers.L2NormSquared(space).translated(b)
+    g = odl.solvers.L1Norm(space)
     niter = 50
 
     # Set up some space elements for the solvers to use
@@ -70,10 +70,10 @@ def test_dca():
     mu = 1
     K = odl.IdentityOperator(space)
 
-    dca(x_dca, g, h, niter)
-    prox_dca(x_prox_dca, g, h, niter, gamma)
-    doubleprox_dc(x_doubleprox, y, g, phi, h, K, niter, gamma, mu)
-    doubleprox_dc_simple(x_simpl, y_simpl, g, phi, h, K, niter, gamma, mu)
+    dca(x_dca, f, g, niter)
+    prox_dca(x_prox_dca, f, g, niter, gamma)
+    doubleprox_dc(x_doubleprox, y, f, phi, g, K, niter, gamma, mu)
+    doubleprox_dc_simple(x_simpl, y_simpl, f, phi, g, K, niter, gamma, mu)
     expected = np.asarray([b - 1 / a, 0, b + 1 / a])
 
     dist_dca = np.min(np.abs(expected - float(x_dca)))

--- a/odl/test/solvers/nonsmooth/difference_convex_test.py
+++ b/odl/test/solvers/nonsmooth/difference_convex_test.py
@@ -1,0 +1,78 @@
+# Copyright 2014-2018 The ODL contributors
+#
+# This file is part of ODL
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file, You can
+# obtain one at https://mozilla.org/MPL/2.0/.
+
+"""Tests for the d.c. solvers."""
+
+from __future__ import division
+import odl
+from odl.solvers import (dca, prox_dca, doubleprox_dc)
+import numpy as np
+import pytest
+
+
+# Places for the accepted error when comparing results
+HIGH_ACCURACY = 8
+LOW_ACCURACY = 4
+
+
+def test_dca():
+    """Test the dca method for the following simple problem:
+
+    Let a > 0, and let b be a real number. Solve
+
+    min_x a/2 (x - b)^2 - |x|
+
+    For finding possible (local) solutions, we consider several cases:
+    * x > 0 ==> ∂|.|(x) = 1, i.e., a necessary optimality condition is
+      0 = a (x - b) - 1 ==> x = b + 1/a. This only happens if b > -1/a.
+    * x < 0 ==> ∂|.|(x) = -1, i.e., a necessary optimality condition is
+      0 = a (x - b) + 1 ==> x = b - 1/a. This only happens if b < 1/a.
+    * x = 0 ==> ∂|.|(x) = [-1, 1], i.e., a necessary optimality condition is
+      0 = a (x - b) + [-1, 1] ==> b - 1/a <= x = 0 <= b + 1/a.
+
+    To summarize, we might find the following solution sets:
+    * {b - 1/a} if b < -1/a,
+    * {-2/a, 0} if b = -1/a,
+    * {b - 1/a, 0, b + 1/a} if -1/a < b < 1/a,
+    * {0, 2/a} if b = 1/a,
+    * {b + 1/a} if b > 1/a.
+    """
+
+    # Set the problem parameters
+    a = 0.5
+    b = 0.5
+    space = odl.rn(1)
+    g = a / 2 * odl.solvers.L2NormSquared(space).translated(b)
+    h = odl.solvers.L1Norm(space)
+    niter = 50
+
+    # Set up some space elements for the solvers to use
+    x = space.element(-0.5)
+    x_dca = x.copy()
+    x_prox_dca = x.copy()
+    x_doubleprox = x.copy()
+
+    # Some additional parameters for some of the solvers
+    phi = odl.solvers.ZeroFunctional(space)
+    y = space.element(3)
+    gamma = 1
+    mu = 1
+    K = odl.IdentityOperator(space)
+
+    dca(x_dca, g, h, niter)
+    prox_dca(x_prox_dca, g, h, niter, gamma)
+    doubleprox_dc(x_doubleprox, y, g, h, phi, K, niter, gamma, mu)
+    expected = np.asarray([b - 1 / a, 0, b + 1 / a])
+
+    dist_dca = np.min(np.abs(expected - float(x_dca)))
+    dist_prox_cda = np.min(np.abs(expected - float(x_prox_dca)))
+    dist_prox_doubleprox = np.min(np.abs(expected - float(x_doubleprox)))
+
+    assert dist_dca == pytest.approx(0, abs=1e-6)
+    assert dist_prox_cda == pytest.approx(0, abs=1e-6)
+    assert dist_prox_doubleprox == pytest.approx(0, abs=1e-6)

--- a/odl/test/solvers/nonsmooth/difference_convex_test.py
+++ b/odl/test/solvers/nonsmooth/difference_convex_test.py
@@ -12,7 +12,7 @@
 
 from __future__ import division
 import odl
-from odl.solvers import (dca, prox_dca, doubleprox_dc)
+from odl.solvers import dca, prox_dca, doubleprox_dc
 from odl.solvers.nonsmooth.difference_convex import doubleprox_dc_simple
 import numpy as np
 import pytest
@@ -86,6 +86,8 @@ def test_dca():
     assert float(y_simpl) == pytest.approx(float(y))
 
     # All methods should give approximately one solution of the problem.
+    # For 50 iterations, the methods have been tested to achieve an absolute
+    # accuracy of at least 1/10^6.
     assert dist_dca == pytest.approx(0, abs=1e-6)
     assert dist_prox_cda == pytest.approx(0, abs=1e-6)
     assert dist_prox_doubleprox == pytest.approx(0, abs=1e-6)

--- a/odl/test/solvers/nonsmooth/difference_convex_test.py
+++ b/odl/test/solvers/nonsmooth/difference_convex_test.py
@@ -49,6 +49,7 @@ def test_dca():
     # Set the problem parameters
     a = 0.5
     b = 0.5
+    # This means -1/a = -2 < b = 0.5 < 1/a = 2.
     space = odl.rn(1)
     g = a / 2 * odl.solvers.L2NormSquared(space).translated(b)
     h = odl.solvers.L1Norm(space)

--- a/odl/test/solvers/nonsmooth/difference_convex_test.py
+++ b/odl/test/solvers/nonsmooth/difference_convex_test.py
@@ -1,3 +1,5 @@
+# coding=utf-8
+
 # Copyright 2014-2018 The ODL contributors
 #
 # This file is part of ODL

--- a/odl/test/solvers/nonsmooth/difference_convex_test.py
+++ b/odl/test/solvers/nonsmooth/difference_convex_test.py
@@ -71,8 +71,8 @@ def test_dca():
 
     dca(x_dca, g, h, niter)
     prox_dca(x_prox_dca, g, h, niter, gamma)
-    doubleprox_dc(x_doubleprox, y, g, h, phi, K, niter, gamma, mu)
-    doubleprox_dc_simple(x_simpl, y_simpl, g, h, phi, K, niter, gamma, mu)
+    doubleprox_dc(x_doubleprox, y, g, phi, h, K, niter, gamma, mu)
+    doubleprox_dc_simple(x_simpl, y_simpl, g, phi, h, K, niter, gamma, mu)
     expected = np.asarray([b - 1 / a, 0, b + 1 / a])
 
     dist_dca = np.min(np.abs(expected - float(x_dca)))

--- a/odl/test/solvers/nonsmooth/difference_convex_test.py
+++ b/odl/test/solvers/nonsmooth/difference_convex_test.py
@@ -88,6 +88,6 @@ def test_dca():
     # All methods should give approximately one solution of the problem.
     # For 50 iterations, the methods have been tested to achieve an absolute
     # accuracy of at least 1/10^6.
-    assert dist_dca == pytest.approx(0, abs=1e-6)
-    assert dist_prox_dca == pytest.approx(0, abs=1e-6)
-    assert dist_prox_doubleprox == pytest.approx(0, abs=1e-6)
+    assert float(dist_dca) == pytest.approx(0, abs=1e-6)
+    assert float(dist_prox_dca) == pytest.approx(0, abs=1e-6)
+    assert float(dist_prox_doubleprox) == pytest.approx(0, abs=1e-6)

--- a/odl/test/solvers/nonsmooth/difference_convex_test.py
+++ b/odl/test/solvers/nonsmooth/difference_convex_test.py
@@ -77,7 +77,7 @@ def test_dca():
     expected = np.asarray([b - 1 / a, 0, b + 1 / a])
 
     dist_dca = np.min(np.abs(expected - float(x_dca)))
-    dist_prox_cda = np.min(np.abs(expected - float(x_prox_dca)))
+    dist_prox_dca = np.min(np.abs(expected - float(x_prox_dca)))
     dist_prox_doubleprox = np.min(np.abs(expected - float(x_doubleprox)))
 
     # Optimized and simplified versions of doubleprox_dc should give
@@ -89,5 +89,5 @@ def test_dca():
     # For 50 iterations, the methods have been tested to achieve an absolute
     # accuracy of at least 1/10^6.
     assert dist_dca == pytest.approx(0, abs=1e-6)
-    assert dist_prox_cda == pytest.approx(0, abs=1e-6)
+    assert dist_prox_dca == pytest.approx(0, abs=1e-6)
     assert dist_prox_doubleprox == pytest.approx(0, abs=1e-6)


### PR DESCRIPTION
This family of solvers allows to handle e.g. nonconvex regularizers like the difference of two convex minimizers. The three solvers differ in the use of proximals and subgradients for the different parts of the problem.

The main restriction is that there is no solver which can handle  objective functions whose convex part is the composition of a functional with a linear operator.