### PR TITLE
ENH: Improve matrix_representation to also handle tensors

### DIFF
--- a/odl/discr/discretization.py
+++ b/odl/discr/discretization.py
@@ -387,7 +387,7 @@ class DiscretizedSpaceElement(Tensor):
         """
         if isinstance(indices, type(self)):
             indices = indices.tensor
-        return self.tensor.__getitem__(indices)
+        return self.tensor[indices]
 
     def __setitem__(self, indices, values):
         """Implement ``self[indices] = values``.

--- a/odl/operator/oputils.py
+++ b/odl/operator/oputils.py
@@ -50,13 +50,34 @@ def matrix_representation(op):
            [4, 5, 6],
            [7, 8, 9]])
 
-    Works with product spaces:
+    It also works with `ProductSpace`s and higher dimensional `TensorSpace`s.
+    In this case, the returned "matrix" will also be higher dimensional:
 
-    >>> prod_ft = odl.DiagonalOperator(op)
-    >>> matrix_representation(op)
-    array([[1, 2, 3],
-           [4, 5, 6],
-           [7, 8, 9]])
+    >>> space = odl.uniform_discr([0, 0], [2, 2], (2, 2))
+    >>> grad = odl.Gradient(space)
+    >>> tensor = odl.matrix_representation(grad)
+    >>> tensor.shape
+    (2L, 2L, 2L, 2L, 2L)
+
+    Since the "matrix" is now higher dimensional, we need to use e.g.
+    `numpy.tensordot` if we want to compute with the matrix representation:
+
+    >>> x = space.element(lambda x: x[0] ** 2 + 2 * x[1] ** 2)
+    >>> grad(x)
+    ProductSpace(uniform_discr([ 0.,  0.], [ 2.,  2.], (2, 2)), 2).element([
+    <BLANKLINE>
+            [[ 2.  ,  2.  ],
+             [-2.75, -6.75]],
+    <BLANKLINE>
+            [[ 4.  , -4.75],
+             [ 4.  , -6.75]]
+    ])
+    >>> np.tensordot(tensor, x, axes=grad.domain.ndim)
+    array([[[ 2.  ,  2.  ],
+            [-2.75, -6.75]],
+    <BLANKLINE>
+            [[ 4.  , -4.75],
+             [ 4.  , -6.75]]])
 
     Notes
     ----------

--- a/odl/operator/oputils.py
+++ b/odl/operator/oputils.py
@@ -56,8 +56,8 @@ def matrix_representation(op):
     >>> space = odl.uniform_discr([0, 0], [2, 2], (2, 2))
     >>> grad = odl.Gradient(space)
     >>> tensor = odl.matrix_representation(grad)
-    >>> tensor.shape
-    (2L, 2L, 2L, 2L, 2L)
+    >>> tensor.shape == (2, 2, 2, 2, 2)
+    True
 
     Since the "matrix" is now higher dimensional, we need to use e.g.
     `numpy.tensordot` if we want to compute with the matrix representation:
@@ -76,8 +76,8 @@ def matrix_representation(op):
     array([[[ 2.  ,  2.  ],
             [-2.75, -6.75]],
     <BLANKLINE>
-            [[ 4.  , -4.75],
-             [ 4.  , -6.75]]])
+           [[ 4.  , -4.75],
+            [ 4.  , -6.75]]])
 
     Notes
     ----------

--- a/odl/test/operator/oputils_test.py
+++ b/odl/test/operator/oputils_test.py
@@ -18,8 +18,7 @@ from odl.util.testutils import almost_equal
 
 
 def test_matrix_representation():
-    # Verify that the matrix representation function returns the correct matrix
-
+    """Verify that the matrix repr returns the correct matrix"""
     n = 3
     A = np.random.rand(n, n)
 
@@ -30,119 +29,85 @@ def test_matrix_representation():
 
 
 def test_matrix_representation_product_to_lin_space():
-    # Verify that the matrix representation function returns the correct matrix
+    """Verify that the matrix repr works for product spaces.
 
+    Here, since the domain shape ``(2, 3)`` and the range has shape ``(1, 3)``,
+    the shape of the matrix representation will be ``(2, 3, 1, 3)``.
+    """
     n = 3
-    rn = odl.rn(n)
-    A = np.random.rand(n, n)
-    Aop = odl.MatrixOperator(A)
-
-    m = 2
-    rm = odl.rn(m)
-    B = np.random.rand(n, m)
-    Bop = odl.MatrixOperator(B)
-
-    dom = ProductSpace(rn, rm)
-    ran = ProductSpace(rn, 1)
-
-    AB_matrix = np.hstack([A, B])
-    ABop = ProductSpaceOperator([[Aop, Bop]], dom, ran)
-
-    matrix_repr = matrix_representation(ABop)
-
-    assert almost_equal(np.sum(np.abs(AB_matrix - matrix_repr)), 1e-6)
-
-
-def test_matrix_representation_lin_space_to_product():
-    # Verify that the matrix representation function returns the correct matrix
-
-    n = 3
-    rn = odl.rn(n)
-    A = np.random.rand(n, n)
-    Aop = odl.MatrixOperator(A)
-
-    m = 2
-    rm = odl.rn(m)
-    B = np.random.rand(m, n)
-    Bop = odl.MatrixOperator(B)
-
-    dom = ProductSpace(rn, 1)
-    ran = ProductSpace(rn, rm)
-
-    AB_matrix = np.vstack([A, B])
-    ABop = ProductSpaceOperator([[Aop], [Bop]], dom, ran)
-
-    matrix_repr = matrix_representation(ABop)
-
-    assert almost_equal(np.sum(np.abs(AB_matrix - matrix_repr)), 1e-6)
-
-
-def test_matrix_representation_product_to_product():
-    # Verify that the matrix representation function returns the correct matrix
-
-    n = 3
-    rn = odl.rn(n)
-    A = np.random.rand(n, n)
-    Aop = odl.MatrixOperator(A)
-
-    m = 2
-    rm = odl.rn(m)
-    B = np.random.rand(m, m)
-    Bop = odl.MatrixOperator(B)
-
-    ran_and_dom = ProductSpace(rn, rm)
-
-    AB_matrix = np.vstack([np.hstack([A, np.zeros((n, m))]),
-                           np.hstack([np.zeros((m, n)), B])])
-    ABop = ProductSpaceOperator([[Aop, 0],
-                                 [0, Bop]],
-                                ran_and_dom, ran_and_dom)
-    matrix_repr = matrix_representation(ABop)
-
-    assert almost_equal(np.sum(np.abs(AB_matrix - matrix_repr)), 1e-6)
-
-
-def test_matrix_representation_product_to_product_two():
-    # Verify that the matrix representation function returns the correct matrix
-
-    n = 3
-    rn = odl.rn(n)
     A = np.random.rand(n, n)
     Aop = odl.MatrixOperator(A)
 
     B = np.random.rand(n, n)
     Bop = odl.MatrixOperator(B)
 
-    ran_and_dom = ProductSpace(rn, 2)
-
-    AB_matrix = np.vstack([np.hstack([A, np.zeros((n, n))]),
-                           np.hstack([np.zeros((n, n)), B])])
-    ABop = ProductSpaceOperator([[Aop, 0],
-                                 [0, Bop]],
-                                ran_and_dom, ran_and_dom)
+    ABop = ProductSpaceOperator([[Aop, Bop]])
     matrix_repr = matrix_representation(ABop)
 
-    assert almost_equal(np.sum(np.abs(AB_matrix - matrix_repr)), 1e-6)
+    assert matrix_repr.shape == (1, n, 2, n)
+    assert np.linalg.norm(A - matrix_repr[0, :, 0, :]) == pytest.approx(0)
+    assert np.linalg.norm(B - matrix_repr[0, :, 1, :]) == pytest.approx(0)
+
+
+def test_matrix_representation_lin_space_to_product():
+    """Verify that the matrix repr works for product spaces.
+
+    Here, since the domain shape ``(1, 3)`` and the range has shape ``(2, 3)``,
+    the shape of the matrix representation will be ``(2, 3, 1, 3)``.
+    """
+    n = 3
+    A = np.random.rand(n, n)
+    Aop = odl.MatrixOperator(A)
+
+    B = np.random.rand(n, n)
+    Bop = odl.MatrixOperator(B)
+
+    ABop = ProductSpaceOperator([[Aop],
+                                 [Bop]])
+
+    matrix_repr = matrix_representation(ABop)
+
+    assert matrix_repr.shape == (2, n, 1, n)
+    assert np.linalg.norm(A - matrix_repr[0, :, 0, :]) == pytest.approx(0)
+    assert np.linalg.norm(B - matrix_repr[1, :, 0, :]) == pytest.approx(0)
+
+
+def test_matrix_representation_product_to_product():
+    """Verify that the matrix repr works for product spaces.
+
+    Here, since the domain and range has shape ``(2, 3)``, the shape of the
+    matrix representation will be ``(2, 3, 2, 3)``.
+    """
+    n = 3
+    A = np.random.rand(n, n)
+    Aop = odl.MatrixOperator(A)
+
+    B = np.random.rand(n, n)
+    Bop = odl.MatrixOperator(B)
+
+    ABop = ProductSpaceOperator([[Aop, 0],
+                                 [0, Bop]])
+    matrix_repr = matrix_representation(ABop)
+
+    assert matrix_repr.shape == (2, n, 2, n)
+    assert np.linalg.norm(A - matrix_repr[0, :, 0, :]) == pytest.approx(0)
+    assert np.linalg.norm(B - matrix_repr[1, :, 1, :]) == pytest.approx(0)
 
 
 def test_matrix_representation_not_linear_op():
-    # Verify that the matrix representation function gives correct error
+    """Verify error when operator is non-linear"""
     class MyNonLinOp(odl.Operator):
         """Small nonlinear test operator."""
-        def __init__(self):
-            super(MyNonLinOp, self).__init__(
-                domain=odl.rn(3), range=odl.rn(4), linear=False)
-
         def _call(self, x):
             return x ** 2
 
-    nonlin_op = MyNonLinOp()
+    nonlin_op = MyNonLinOp(domain=odl.rn(3), range=odl.rn(3), linear=False)
     with pytest.raises(ValueError):
         matrix_representation(nonlin_op)
 
 
 def test_matrix_representation_wrong_domain():
-    # Verify that the matrix representation function gives correct error
+    """Verify that the matrix representation function gives correct error"""
     class MyOp(odl.Operator):
         """Small test operator."""
         def __init__(self):
@@ -160,7 +125,7 @@ def test_matrix_representation_wrong_domain():
 
 
 def test_matrix_representation_wrong_range():
-    # Verify that the matrix representation function gives correct error
+    """Verify that the matrix representation function gives correct error"""
     class MyOp(odl.Operator):
         """Small test operator."""
         def __init__(self):
@@ -178,8 +143,7 @@ def test_matrix_representation_wrong_range():
 
 
 def test_power_method_opnorm_symm():
-    # Test the power method on a matrix operator
-
+    """Test the power method on a symmetrix matrix operator"""
     # Test matrix with eigenvalues 1 and -2
     # Rather nasty case since the eigenvectors are almost parallel
     mat = np.array([[10, -18],
@@ -197,8 +161,7 @@ def test_power_method_opnorm_symm():
 
 
 def test_power_method_opnorm_nonsymm():
-    # Test the power method on a matrix operator
-
+    """Test the power method on a nonsymmetrix matrix operator"""
     # Singular values 5.5 and 6
     mat = np.array([[-1.52441557, 5.04276365],
                     [1.90246927, 2.54424763],
@@ -218,8 +181,7 @@ def test_power_method_opnorm_nonsymm():
 
 
 def test_power_method_opnorm_exceptions():
-    # Test the exceptions
-
+    """Test the exceptions"""
     space = odl.rn(2)
     op = odl.IdentityOperator(space)
 

--- a/odl/util/utility.py
+++ b/odl/util/utility.py
@@ -12,6 +12,7 @@ from __future__ import print_function, division, absolute_import
 from builtins import object
 from collections import OrderedDict
 from functools import wraps
+from itertools import product
 import inspect
 import numpy as np
 import sys
@@ -22,8 +23,9 @@ __all__ = ('array_str', 'dtype_str', 'dtype_repr', 'npy_printoptions',
            'is_numeric_dtype', 'is_int_dtype', 'is_floating_dtype',
            'is_real_dtype', 'is_real_floating_dtype',
            'is_complex_floating_dtype', 'real_dtype', 'complex_dtype',
-           'is_string', 'conj_exponent', 'writable_array',
+           'is_string', 'nd_iterator', 'conj_exponent', 'writable_array',
            'run_from_ipython', 'NumpyRandomSeed', 'cache_arguments', 'unique')
+
 
 TYPE_MAP_R2C = {np.dtype(dtype): np.result_type(dtype, 1j)
                 for dtype in np.sctypes['float']}
@@ -438,6 +440,26 @@ def is_string(obj):
         return False
     else:
         return True
+
+
+def nd_iterator(shape):
+    """Iterator over n-d cube with shape.
+
+    Parameters
+    ----------
+    shape : sequence of int
+        The number of points per axis
+
+    Examples
+    --------
+    >>> for pt in nd_iterator([2, 2]):
+    ...     print(pt)
+    (0, 0)
+    (0, 1)
+    (1, 0)
+    (1, 1)
+    """
+    return product(*map(range, shape))
 
 
 def conj_exponent(exp):

--- a/odl/util/utility.py
+++ b/odl/util/utility.py
@@ -450,6 +450,11 @@ def nd_iterator(shape):
     shape : sequence of int
         The number of points per axis
 
+    Returns
+    -------
+    nd_iterator : generator
+        Generator returning tuples of integers of length ``len(shape)``.
+
     Examples
     --------
     >>> for pt in nd_iterator([2, 2]):


### PR DESCRIPTION
Some would call this a "vast simplification", doable because we now have proper indexing for product spaces etc.

This contains some "major" changes.

* For linear domains and ranges (e.g. 1d rn or uniform_discr) nothing changes.
* For domain/range with higher dimensional shapes, the function new computes a tensor of shape `range.shape + domain.shape`
* The above change made some previously usable modes (e.g. `rn(2) * rn(3)`) non-usable (since it does not have a proper shape), and I simply removed that feature.