### PR TITLE
Remove ascii and simple example

### DIFF
--- a/odl/contrib/solvers/spdhg/README.md
+++ b/odl/contrib/solvers/spdhg/README.md
@@ -4,7 +4,7 @@ This package contains an ODL compatible implementation of the Stochastic Primal-
 	min_x sum_{i=1}^n f_i(A_i x) + g(x)
 where f_i and g are closed, proper and convex functionals and A_i are linear operators.
 
-It has been successfully used for PET image reconstruction (from the Siemens Biograph mMR) [SPIE](https://www.spiedigitallibrary.org/conference-proceedings-of-spie/10394/103941O/Faster-PET-reconstruction-with-a-stochastic-primal-dual-hybrid-gradient/10.1117/12.2272946.full). Watch [this](https://www.youtube.com/watch?v=iZc2eFqS2l4) if you want to have an introduction to SPDHG by [Peter Richtárik](http://www.maths.ed.ac.uk/~prichtar/).
+It has been successfully used for PET image reconstruction (from the Siemens Biograph mMR) [SPIE](https://www.spiedigitallibrary.org/conference-proceedings-of-spie/10394/103941O/Faster-PET-reconstruction-with-a-stochastic-primal-dual-hybrid-gradient/10.1117/12.2272946.full). Watch [this](https://www.youtube.com/watch?v=iZc2eFqS2l4) if you want to have an introduction to SPDHG by [Peter Richtarik](http://www.maths.ed.ac.uk/~prichtar/).
 
 Original contribution by: @mehrhardt
 
@@ -17,6 +17,10 @@ Original contribution by: @mehrhardt
 ## Example usage
 
 The [examples](examples) folder contains examples on how to use the above functionality. The PET examples are based on [ASTRA](https://www.astra-toolbox.com/) to compute the line integrals in the forward operator.
+
+* [get_started.py](examples/get_started.py) shows the usage of SPDHG as simple as possible.
+
+More involved examples include:
 
 * [PET_1k.py](examples/PET_1k.py) shows an example for PET reconstruction (from simulated data) with total variation regularization where the algorithm is proven to converge with rate O(1/k) in the partial primal-dual gap.
 * [ROF_1k2_primal.py](examples/ROF_1k2_primal.py) shows primal acceleration for ROF denoising (Gaussian noise; squared L2-norm + total variation) where the algorithm is proven to converge with rate O(1/k^2) in squared norm to the primal solution.

--- a/odl/contrib/solvers/spdhg/__init__.py
+++ b/odl/contrib/solvers/spdhg/__init__.py
@@ -8,14 +8,14 @@
 
 """Contributed code for the stochastic PDHG.
 
-[1] A. Chambolle, M. J. Ehrhardt, P. Richtárik and C.-B. Schönlieb (2017).
-Stochastic Primal-Dual Hybrid Gradient Algorithm with Arbitrary Sampling and
-Imaging Applications. http://arxiv.org/abs/1706.04957
+    [CERS2017] A. Chambolle, M. J. Ehrhardt, P. Richtarik and C.-B. Schoenlieb,
+    *Stochastic Primal-Dual Hybrid Gradient Algorithm with Arbitrary Sampling
+    and Imaging Applications*. ArXiv: http://arxiv.org/abs/1706.04957 (2017).
 
-[2] M. J. Ehrhardt, P. J. Markiewicz, P. Richtárik, J. Schott, A. Chambolle
-and C.-B. Schönlieb (2017). Faster PET Reconstruction with a Stochastic
-Primal-Dual Hybrid Gradient Method. Wavelets and Sparsity XVII, 58
-http://doi.org/10.1117/12.2272946.
+    [E+2017] M. J. Ehrhardt, P. J. Markiewicz, P. Richtarik, J. Schott,
+    A. Chambolle and C.-B. Schoenlieb, *Faster PET reconstruction with a
+    stochastic primal-dual hybrid gradient method*. Wavelets and Sparsity XVII,
+    58 (2017) http://doi.org/10.1117/12.2272946.
 """
 
 from __future__ import absolute_import

--- a/odl/contrib/solvers/spdhg/examples/PET_1k.py
+++ b/odl/contrib/solvers/spdhg/examples/PET_1k.py
@@ -10,15 +10,15 @@
 problem with total variation prior. As we do not exploit any smoothness here we
 only expect a 1/k convergence of the ergodic sequence in a Bregman sense. We
 compare different algorithms for this problem and visualize the results as in
-[1].
+[CERS2017].
 
 Note that this example uses the ASTRA toolbox https://www.astra-toolbox.com/.
 
 Reference
 ---------
-[1] A. Chambolle, M. J. Ehrhardt, P. Richtárik and C.-B. Schönlieb (2017).
-Stochastic Primal-Dual Hybrid Gradient Algorithm with Arbitrary Sampling and
-Imaging Applications. http://arxiv.org/abs/1706.04957
+    [CERS2017] A. Chambolle, M. J. Ehrhardt, P. Richtarik and C.-B. Schoenlieb,
+    *Stochastic Primal-Dual Hybrid Gradient Algorithm with Arbitrary Sampling
+    and Imaging Applications*. ArXiv: http://arxiv.org/abs/1706.04957 (2017).
 """
 
 from __future__ import division, print_function

--- a/odl/contrib/solvers/spdhg/examples/PET_1k.py
+++ b/odl/contrib/solvers/spdhg/examples/PET_1k.py
@@ -16,9 +16,9 @@ Note that this example uses the ASTRA toolbox https://www.astra-toolbox.com/.
 
 Reference
 ---------
-    [CERS2017] A. Chambolle, M. J. Ehrhardt, P. Richtarik and C.-B. Schoenlieb,
-    *Stochastic Primal-Dual Hybrid Gradient Algorithm with Arbitrary Sampling
-    and Imaging Applications*. ArXiv: http://arxiv.org/abs/1706.04957 (2017).
+[CERS2017] A. Chambolle, M. J. Ehrhardt, P. Richtarik and C.-B. Schoenlieb,
+*Stochastic Primal-Dual Hybrid Gradient Algorithm with Arbitrary Sampling
+and Imaging Applications*. ArXiv: http://arxiv.org/abs/1706.04957 (2017).
 """
 
 from __future__ import division, print_function

--- a/odl/contrib/solvers/spdhg/examples/PET_linear_rate.py
+++ b/odl/contrib/solvers/spdhg/examples/PET_linear_rate.py
@@ -10,15 +10,15 @@
 problem with a strongly convex total variation prior. We exploit the smoothness
 of the data term and the strong convexity of the prior to obtain a linearly
 convergent algorithm. We compare different algorithms for this problem and
-visualize the results as in [1].
+visualize the results as in [CERS2017].
 
 Note that this example uses the ASTRA toolbox https://www.astra-toolbox.com/.
 
 Reference
 ---------
-[1] A. Chambolle, M. J. Ehrhardt, P. Richtárik and C.-B. Schönlieb (2017).
-Stochastic Primal-Dual Hybrid Gradient Algorithm with Arbitrary Sampling and
-Imaging Applications. http://arxiv.org/abs/1706.04957
+    [CERS2017] A. Chambolle, M. J. Ehrhardt, P. Richtarik and C.-B. Schoenlieb,
+    *Stochastic Primal-Dual Hybrid Gradient Algorithm with Arbitrary Sampling
+    and Imaging Applications*. ArXiv: http://arxiv.org/abs/1706.04957 (2017).
 """
 
 from __future__ import division, print_function

--- a/odl/contrib/solvers/spdhg/examples/PET_linear_rate.py
+++ b/odl/contrib/solvers/spdhg/examples/PET_linear_rate.py
@@ -16,9 +16,9 @@ Note that this example uses the ASTRA toolbox https://www.astra-toolbox.com/.
 
 Reference
 ---------
-    [CERS2017] A. Chambolle, M. J. Ehrhardt, P. Richtarik and C.-B. Schoenlieb,
-    *Stochastic Primal-Dual Hybrid Gradient Algorithm with Arbitrary Sampling
-    and Imaging Applications*. ArXiv: http://arxiv.org/abs/1706.04957 (2017).
+[CERS2017] A. Chambolle, M. J. Ehrhardt, P. Richtarik and C.-B. Schoenlieb,
+*Stochastic Primal-Dual Hybrid Gradient Algorithm with Arbitrary Sampling
+and Imaging Applications*. ArXiv: http://arxiv.org/abs/1706.04957 (2017).
 """
 
 from __future__ import division, print_function

--- a/odl/contrib/solvers/spdhg/examples/ROF_1k2_primal.py
+++ b/odl/contrib/solvers/spdhg/examples/ROF_1k2_primal.py
@@ -9,13 +9,13 @@
 """An example of using the SPDHG algorithm to solve a TV denoising problem
 with Gaussian noise. We exploit the strong convexity of the data term to get
 1/k^2 convergence on the primal part. We compare different algorithms for this
-problem and visualize the results as in [1].
+problem and visualize the results as in [CERS2017].
 
 Reference
 ---------
-[1] A. Chambolle, M. J. Ehrhardt, P. Richtárik and C.-B. Schönlieb (2017).
-Stochastic Primal-Dual Hybrid Gradient Algorithm with Arbitrary Sampling and
-Imaging Applications. http://arxiv.org/abs/1706.04957
+    [CERS2017] A. Chambolle, M. J. Ehrhardt, P. Richtarik and C.-B. Schoenlieb,
+    *Stochastic Primal-Dual Hybrid Gradient Algorithm with Arbitrary Sampling
+    and Imaging Applications*. ArXiv: http://arxiv.org/abs/1706.04957 (2017).
 """
 
 from __future__ import division, print_function

--- a/odl/contrib/solvers/spdhg/examples/ROF_1k2_primal.py
+++ b/odl/contrib/solvers/spdhg/examples/ROF_1k2_primal.py
@@ -13,9 +13,9 @@ problem and visualize the results as in [CERS2017].
 
 Reference
 ---------
-    [CERS2017] A. Chambolle, M. J. Ehrhardt, P. Richtarik and C.-B. Schoenlieb,
-    *Stochastic Primal-Dual Hybrid Gradient Algorithm with Arbitrary Sampling
-    and Imaging Applications*. ArXiv: http://arxiv.org/abs/1706.04957 (2017).
+[CERS2017] A. Chambolle, M. J. Ehrhardt, P. Richtarik and C.-B. Schoenlieb,
+*Stochastic Primal-Dual Hybrid Gradient Algorithm with Arbitrary Sampling
+and Imaging Applications*. ArXiv: http://arxiv.org/abs/1706.04957 (2017).
 """
 
 from __future__ import division, print_function

--- a/odl/contrib/solvers/spdhg/examples/deblurring_1k2_dual.py
+++ b/odl/contrib/solvers/spdhg/examples/deblurring_1k2_dual.py
@@ -14,9 +14,9 @@ and visualize the results as in [CERS2017].
 
 Reference
 ---------
-    [CERS2017] A. Chambolle, M. J. Ehrhardt, P. Richtarik and C.-B. Schoenlieb,
-    *Stochastic Primal-Dual Hybrid Gradient Algorithm with Arbitrary Sampling
-    and Imaging Applications*. ArXiv: http://arxiv.org/abs/1706.04957 (2017).
+[CERS2017] A. Chambolle, M. J. Ehrhardt, P. Richtarik and C.-B. Schoenlieb,
+*Stochastic Primal-Dual Hybrid Gradient Algorithm with Arbitrary Sampling
+and Imaging Applications*. ArXiv: http://arxiv.org/abs/1706.04957 (2017).
 """
 
 from __future__ import division, print_function

--- a/odl/contrib/solvers/spdhg/examples/deblurring_1k2_dual.py
+++ b/odl/contrib/solvers/spdhg/examples/deblurring_1k2_dual.py
@@ -9,14 +9,14 @@
 """An example of using the SPDHG algorithm to solve a TV deblurring problem
 with Poisson noise. We exploit the smoothness of the data term to get 1/k^2
 convergence on the dual part. We compare different algorithms for this problem
-and visualize the results as in [1].
+and visualize the results as in [CERS2017].
 
 
 Reference
 ---------
-[1] A. Chambolle, M. J. Ehrhardt, P. Richtárik and C.-B. Schönlieb (2017).
-Stochastic Primal-Dual Hybrid Gradient Algorithm with Arbitrary Sampling and
-Imaging Applications. http://arxiv.org/abs/1706.04957
+    [CERS2017] A. Chambolle, M. J. Ehrhardt, P. Richtarik and C.-B. Schoenlieb,
+    *Stochastic Primal-Dual Hybrid Gradient Algorithm with Arbitrary Sampling
+    and Imaging Applications*. ArXiv: http://arxiv.org/abs/1706.04957 (2017).
 """
 
 from __future__ import division, print_function

--- a/odl/contrib/solvers/spdhg/examples/get_started.py
+++ b/odl/contrib/solvers/spdhg/examples/get_started.py
@@ -1,0 +1,66 @@
+# Copyright 2014-2018 The ODL contributors
+#
+# This file is part of ODL.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file, You can
+# obtain one at https://mozilla.org/MPL/2.0/.
+
+"""A simple example to get started with SPDHG [CERS2017]. The example at hand
+solves the ROF denoising problem.
+
+Reference
+---------
+[CERS2017] A. Chambolle, M. J. Ehrhardt, P. Richtarik and C.-B. Schoenlieb,
+*Stochastic Primal-Dual Hybrid Gradient Algorithm with Arbitrary Sampling
+and Imaging Applications*. ArXiv: http://arxiv.org/abs/1706.04957 (2017).
+"""
+
+from __future__ import division, print_function
+import odl
+import odl.contrib.solvers.spdhg as spdhg
+import odl.contrib.datasets.images as images
+import numpy as np
+
+# set ground truth and data
+image_gray = images.building(gray=True)
+X = odl.uniform_discr([0, 0], image_gray.shape, image_gray.shape)
+groundtruth = X.element(image_gray)
+data = odl.phantom.white_noise(X, mean=groundtruth, stddev=0.1, seed=1807)
+
+# set parameter
+alpha = .12  # regularisation parameter
+nepoch = 100
+
+# set functionals and operator
+A = odl.BroadcastOperator(*[odl.PartialDerivative(X, d, pad_mode='symmetric')
+                            for d in [0, 1]])
+f = odl.solvers.SeparableSum(*[odl.solvers.L1Norm(Yi) for Yi in A.range])
+g = 1 / (2 * alpha) * odl.solvers.L2NormSquared(X).translated(data)
+
+# set sampling
+n = 2  # number of subsets
+prob = [1 / n] * n  # probablity that a subset gets selected
+S = [[0], [1]]  # all possible subsets to select from
+def fun_select(k):  # subset selection function
+    return S[int(np.random.choice(n, 1, p=prob))]
+
+# set parameters for algorithm
+Ai_norm = [2, 2]
+gamma = 0.99
+sigma = [gamma / a for a in Ai_norm]
+tau = gamma / (n * max(Ai_norm))
+
+# callback for output during the iterations
+cb = (odl.solvers.CallbackPrintIteration(fmt='iter:{:4d}', step=n, end=', ') &
+      odl.solvers.CallbackPrintTiming(fmt='time: {:5.2f} s', cumulative=True,
+                                      step=n))
+
+# initialise variable and run algorithm
+x = X.zero()
+niter = 2 * nepoch
+spdhg.spdhg(x, f, g, A, tau, sigma, niter, prob, fun_select, callback=cb)
+
+# show data and output
+data.show()
+x.show()

--- a/odl/contrib/solvers/spdhg/misc.py
+++ b/odl/contrib/solvers/spdhg/misc.py
@@ -460,10 +460,9 @@ class KullbackLeiblerSmooth(odl.solvers.Functional):
 
     References
     ----------
-    [CERS2017] Chambolle, A., Ehrhardt, M. J., Richtárik, P. and
-    Schönlieb, C.-B. *Stochastic Primal-Dual Hybrid Gradient Algorithm with
-    Arbitrary Sampling and Imaging Applications*.
-    ArXiv: http://arxiv.org/abs/1706.04957, 2017
+    [CERS2017] A. Chambolle, M. J. Ehrhardt, P. Richtarik and C.-B. Schoenlieb,
+    *Stochastic Primal-Dual Hybrid Gradient Algorithm with Arbitrary Sampling
+    and Imaging Applications*. ArXiv: http://arxiv.org/abs/1706.04957 (2017).
     """
 
     def __init__(self, space, data, background):
@@ -585,10 +584,9 @@ class KullbackLeiblerSmoothConvexConj(odl.solvers.Functional):
 
     References
     ----------
-    [CERS2017] Chambolle, A., Ehrhardt, M. J., Richtárik, P. and
-    Schönlieb, C.-B. *Stochastic Primal-Dual Hybrid Gradient Algorithm with
-    Arbitrary Sampling and Imaging Applications*.
-    ArXiv: http://arxiv.org/abs/1706.04957, 2017
+    [CERS2017] A. Chambolle, M. J. Ehrhardt, P. Richtarik and C.-B. Schoenlieb,
+    *Stochastic Primal-Dual Hybrid Gradient Algorithm with Arbitrary Sampling
+    and Imaging Applications*. ArXiv: http://arxiv.org/abs/1706.04957 (2017).
     """
 
     def __init__(self, space, data, background):

--- a/odl/contrib/solvers/spdhg/stochastic_primal_dual_hybrid_gradient.py
+++ b/odl/contrib/solvers/spdhg/stochastic_primal_dual_hybrid_gradient.py
@@ -135,13 +135,12 @@ def spdhg(x, f, g, A, tau, sigma, niter, prob, fun_select, **kwargs):
 
     References
     ----------
-    [CERS2017] Chambolle, A., Ehrhardt, M. J., Richtárik, P., and
-    Schoenlieb, C.-B. *Stochastic Primal-Dual Hybrid Gradient Algorithm with
-    Arbitrary Sampling and Imaging Applications*.
-    ArXiv: http://arxiv.org/abs/1706.04957 (2017).
+    [CERS2017] A. Chambolle, M. J. Ehrhardt, P. Richtarik and C.-B. Schoenlieb,
+    *Stochastic Primal-Dual Hybrid Gradient Algorithm with Arbitrary Sampling
+    and Imaging Applications*. ArXiv: http://arxiv.org/abs/1706.04957 (2017).
 
-    [E+2017] Ehrhardt, M. J., Markiewicz, P. J., Richtárik, P., Schott, J.,
-    Chambolle, A. and Schoenlieb, C.-B. *Faster PET reconstruction with a
+    [E+2017] M. J. Ehrhardt, P. J. Markiewicz, P. Richtarik, J. Schott,
+    A. Chambolle and C.-B. Schoenlieb, *Faster PET reconstruction with a
     stochastic primal-dual hybrid gradient method*. Wavelets and Sparsity XVII,
     58 (2017) http://doi.org/10.1117/12.2272946.
     """
@@ -198,10 +197,9 @@ def pa_spdhg(x, f, g, A, tau, sigma, niter, prob, mu_g, fun_select, **kwargs):
 
     References
     ----------
-    [CERS2017] Chambolle, A., Ehrhardt, M. J., Richtárik, P., and
-    Schoenlieb, C.-B. *Stochastic Primal-Dual Hybrid Gradient Algorithm with
-    Arbitrary Sampling and Imaging Applications*.
-    ArXiv: http://arxiv.org/abs/1706.04957 (2017).
+    [CERS2017] A. Chambolle, M. J. Ehrhardt, P. Richtarik and C.-B. Schoenlieb,
+    *Stochastic Primal-Dual Hybrid Gradient Algorithm with Arbitrary Sampling
+    and Imaging Applications*. ArXiv: http://arxiv.org/abs/1706.04957 (2017).
     """
 
     # Dual variable
@@ -266,13 +264,12 @@ def spdhg_generic(x, f, g, A, tau, sigma, niter, fun_select, **kwargs):
 
     References
     ----------
-    [CERS2017] Chambolle, A., Ehrhardt, M. J., Richtárik, P., and
-    Schoenlieb, C.-B. *Stochastic Primal-Dual Hybrid Gradient Algorithm with
-    Arbitrary Sampling and Imaging Applications*.
-    ArXiv: http://arxiv.org/abs/1706.04957 (2017).
+    [CERS2017] A. Chambolle, M. J. Ehrhardt, P. Richtarik and C.-B. Schoenlieb,
+    *Stochastic Primal-Dual Hybrid Gradient Algorithm with Arbitrary Sampling
+    and Imaging Applications*. ArXiv: http://arxiv.org/abs/1706.04957 (2017).
 
-    [E+2017] Ehrhardt, M. J., Markiewicz, P. J., Richtárik, P., Schott, J.,
-    Chambolle, A. and Schoenlieb, C.-B. *Faster PET reconstruction with a
+    [E+2017] M. J. Ehrhardt, P. J. Markiewicz, P. Richtarik, J. Schott,
+    A. Chambolle and C.-B. Schoenlieb, *Faster PET reconstruction with a
     stochastic primal-dual hybrid gradient method*. Wavelets and Sparsity XVII,
     58 (2017) http://doi.org/10.1117/12.2272946.
     """
@@ -421,10 +418,9 @@ def da_spdhg(x, f, g, A, tau, sigma_tilde, niter, extra, prob, mu, fun_select,
 
     References
     ----------
-    [CERS2017] Chambolle, A., Ehrhardt, M. J., Richtárik, P., and
-    Schoenlieb, C.-B. *Stochastic Primal-Dual Hybrid Gradient Algorithm with
-    Arbitrary Sampling and Imaging Applications*.
-    ArXiv: http://arxiv.org/abs/1706.04957 (2017).
+    [CERS2017] A. Chambolle, M. J. Ehrhardt, P. Richtarik and C.-B. Schoenlieb,
+    *Stochastic Primal-Dual Hybrid Gradient Algorithm with Arbitrary Sampling
+    and Imaging Applications*. ArXiv: http://arxiv.org/abs/1706.04957 (2017).
     """
 
     # Callback object
@@ -542,7 +538,7 @@ def spdhg_pesquet(x, f, g, A, tau, sigma, niter, fun_select, **kwargs):
 
     References
     ----------
-    [PR2015] Pesquet, J.-C., & Repetti, A. *A Class of Randomized Primal-Dual
+    [PR2015] J.-C. Pesquet and A. Repetti. *A Class of Randomized Primal-Dual
     Algorithms for Distributed Optimization*.
     ArXiv: http://arxiv.org/abs/1406.6404 (2015).
     """


### PR DESCRIPTION
Simple PR to improve my SPDHG contribution. I removed the non-ascii characters as my spyder sometimes complained when importing. Moreover, I included a simple example to get started which does not compare algorithms and does not save anything on disk.