### PR TITLE
Add posibility to turn off color bar in 2d plot

### DIFF
--- a/odl/util/graphics.py
+++ b/odl/util/graphics.py
@@ -160,6 +160,11 @@ def show_discrete_data(values, grid, title=None, method='',
     axis_fontsize : int, optional
         Fontsize for the axes. Default: 16
 
+    colorbar : bool, optional
+        Argument relevant for 2d plots using ``method='imshow'``. If ``True``,
+        include a colorbar in the plot.
+        Default: True
+
     kwargs : {'figsize', 'saveto', ...}, optional
         Extra keyword arguments passed on to display method
         See the Matplotlib functions for documentation of extra
@@ -195,6 +200,7 @@ def show_discrete_data(values, grid, title=None, method='',
     saveto = kwargs.pop('saveto', None)
     interp = kwargs.pop('interp', 'nearest')
     axis_fontsize = kwargs.pop('axis_fontsize', 16)
+    colorbar = kwargs.pop('colorbar', True)
 
     # Check if we should and can update the plot in-place
     update_in_place = kwargs.pop('update_in_place', False)
@@ -409,7 +415,7 @@ def show_discrete_data(values, grid, title=None, method='',
             plt.xticks(xpts, xlabels)
             plt.yticks(ypts, ylabels)
 
-        if method == 'imshow':
+        if method == 'imshow' and colorbar:
             # Add colorbar
             # Use clim from kwargs if given
             if 'clim' not in kwargs:


### PR DESCRIPTION
Example on how #1342 could be implemented. I found no tests for `odl.util.graphics`, but a minimal working example that shows how it works is given by

```python
import odl
space = odl.uniform_discr([0,0], [1,1], [256,256])
x = odl.util.noise_element(space)
x.show()
x.show(show_2d_color_bar=False)
```

which gives the following images
![figure_1](https://user-images.githubusercontent.com/15774494/39815634-ee6c3d14-5398-11e8-923d-3717493d31e3.png)
![figure_3](https://user-images.githubusercontent.com/15774494/39815635-ee8f1622-5398-11e8-80aa-97dd7a6e700a.png)

Is this desirable? Or is it only adding unnecessary complexity to plotting?