### PR TITLE
BUG: Handle list of length one appropriately for SamplingOperator.adj…

### DIFF
--- a/odl/operator/tensor_ops.py
+++ b/odl/operator/tensor_ops.py
@@ -998,8 +998,14 @@ def _normalize_sampling_points(sampling_points, ndim):
     elif ndim == 1:
         if isinstance(sampling_points, Integral):
             sampling_points = (sampling_points,)
-        sampling_points = [np.array(sampling_points, dtype=int, copy=False,
-                                    ndmin=1)]
+        sampling_points = np.array(sampling_points, dtype=int, copy=False,
+                                   ndmin=1)
+
+        # Handle possible list of length one
+        if sampling_points.ndim == 2 and sampling_points.shape[0] == 1:
+            sampling_points = sampling_points[0]
+
+        sampling_points = [sampling_points]
         if sampling_points[0].ndim > 1:
             raise ValueError('expected 1D index (array), got {}'
                              ''.format(sampling_points_in))

--- a/odl/test/operator/tensor_ops_test.py
+++ b/odl/test/operator/tensor_ops_test.py
@@ -734,5 +734,32 @@ def test_matrix_op_inverse():
     assert all_almost_equal(x, minv_m_x)
 
 
+def test_sampling_operator_adjoint():
+    """Validate basic properties of `SamplingOperator.adjoint`."""
+    # 1d space
+    space = odl.uniform_discr([-1], [1], shape=(3))
+    sampling_points = [[0, 1, 1, 0]]
+    x = space.element([1, 2, 3])
+    op = odl.SamplingOperator(space, sampling_points)
+    assert op.adjoint(op(x)).inner(x) == pytest.approx(op(x).inner(op(x)))
+
+    op = odl.SamplingOperator(space, sampling_points, variant='integrate')
+    assert op.adjoint(op(x)).inner(x) == pytest.approx(op(x).inner(op(x)))
+
+    # 2d space
+    space = odl.uniform_discr([-1, -1], [1, 1], shape=(2, 3))
+    x = space.element([[1, 2, 3],
+                       [4, 5, 6]])
+    sampling_points = [[0, 1, 1, 0],
+                       [0, 1, 2, 0]]
+    op = odl.SamplingOperator(space, sampling_points)
+    assert op.adjoint(op(x)).inner(x) == pytest.approx(op(x).inner(op(x)))
+
+    # The ``'integrate'`` variant adjoint puts ones at the indices in
+    # `sampling_points``, multiplied by their multiplicity:
+    op = odl.SamplingOperator(space, sampling_points, variant='integrate')
+    assert op.adjoint(op(x)).inner(x) == pytest.approx(op(x).inner(op(x)))
+
+
 if __name__ == '__main__':
     odl.util.test_file(__file__)


### PR DESCRIPTION
…oint, closes #1350