### PR TITLE
DOC/TST: Add rounding in doctest of power_method_opnorm. Closes #1361.

### DIFF
--- a/odl/operator/oputils.py
+++ b/odl/operator/oputils.py
@@ -154,11 +154,12 @@ def power_method_opnorm(op, xstart=None, maxiter=100, rtol=1e-05, atol=1e-08,
 
     Examples
     --------
-    Verify that the identity operator has norm 1:
+    Verify that the identity operator has norm 1 (within a precision of 0.001):
 
     >>> space = odl.uniform_discr(0, 1, 5)
     >>> id = odl.IdentityOperator(space)
-    >>> power_method_opnorm(id)
+    >>> estimation = power_method_opnorm(id)
+    >>> round(estimation, 3)
     1.0
 
     Notes


### PR DESCRIPTION
I rounded the result in the doctest to three decimals to obtain a stable result. Maybe this is not the most elegant thing to do in a doctest, but it seems to solve the problem reliably.