### PR TITLE
Update copyright year to 2018

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2017 The ODL contributors
+# Copyright 2014-2018 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/doc/source/generate_doc.py
+++ b/doc/source/generate_doc.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2017 The ODL contributors
+# Copyright 2014-2018 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/__init__.py
+++ b/odl/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2017 The ODL contributors
+# Copyright 2014-2018 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/contrib/__init__.py
+++ b/odl/contrib/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2017 The ODL contributors
+# Copyright 2014-2018 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/contrib/datasets/__init__.py
+++ b/odl/contrib/datasets/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2017 The ODL contributors
+# Copyright 2014-2018 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/contrib/datasets/ct/__init__.py
+++ b/odl/contrib/datasets/ct/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2017 The ODL contributors
+# Copyright 2014-2018 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/contrib/datasets/ct/fips.py
+++ b/odl/contrib/datasets/ct/fips.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2017 The ODL contributors
+# Copyright 2014-2018 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/contrib/datasets/images/__init__.py
+++ b/odl/contrib/datasets/images/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2017 The ODL contributors
+# Copyright 2014-2018 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/contrib/datasets/images/cambridge.py
+++ b/odl/contrib/datasets/images/cambridge.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2017 The ODL contributors
+# Copyright 2014-2018 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/contrib/datasets/mri/__init__.py
+++ b/odl/contrib/datasets/mri/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2017 The ODL contributors
+# Copyright 2014-2018 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/contrib/datasets/mri/tugraz.py
+++ b/odl/contrib/datasets/mri/tugraz.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2017 The ODL contributors
+# Copyright 2014-2018 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/contrib/datasets/util.py
+++ b/odl/contrib/datasets/util.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2017 The ODL contributors
+# Copyright 2014-2018 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/contrib/fom/__init__.py
+++ b/odl/contrib/fom/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2017 The ODL contributors
+# Copyright 2014-2018 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/contrib/fom/supervised.py
+++ b/odl/contrib/fom/supervised.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2017 The ODL contributors
+# Copyright 2014-2018 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/contrib/fom/test/test_supervised.py
+++ b/odl/contrib/fom/test/test_supervised.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2017 The ODL contributors
+# Copyright 2014-2018 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/contrib/fom/test/test_unsupervised.py
+++ b/odl/contrib/fom/test/test_unsupervised.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2017 The ODL contributors
+# Copyright 2014-2018 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/contrib/fom/unsupervised.py
+++ b/odl/contrib/fom/unsupervised.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2017 The ODL contributors
+# Copyright 2014-2018 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/contrib/fom/util.py
+++ b/odl/contrib/fom/util.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2017 The ODL contributors
+# Copyright 2014-2018 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/contrib/mrc/__init__.py
+++ b/odl/contrib/mrc/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2017 The ODL contributors
+# Copyright 2014-2018 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/contrib/mrc/mrc.py
+++ b/odl/contrib/mrc/mrc.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2017 The ODL contributors
+# Copyright 2014-2018 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/contrib/mrc/test/mrc_test.py
+++ b/odl/contrib/mrc/test/mrc_test.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2017 The ODL contributors
+# Copyright 2014-2018 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/contrib/mrc/test/uncompr_bin_test.py
+++ b/odl/contrib/mrc/test/uncompr_bin_test.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2017 The ODL contributors
+# Copyright 2014-2018 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/contrib/mrc/uncompr_bin.py
+++ b/odl/contrib/mrc/uncompr_bin.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2017 The ODL contributors
+# Copyright 2014-2018 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/contrib/pyshearlab/__init__.py
+++ b/odl/contrib/pyshearlab/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2017 The ODL contributors
+# Copyright 2014-2018 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/contrib/pyshearlab/pyshearlab_operator.py
+++ b/odl/contrib/pyshearlab/pyshearlab_operator.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2017 The ODL contributors
+# Copyright 2014-2018 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/contrib/pyshearlab/test/operator_test.py
+++ b/odl/contrib/pyshearlab/test/operator_test.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2017 The ODL contributors
+# Copyright 2014-2018 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/contrib/solvers/__init__.py
+++ b/odl/contrib/solvers/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2017 The ODL contributors
+# Copyright 2014-2018 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/contrib/solvers/functional/__init__.py
+++ b/odl/contrib/solvers/functional/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2017 The ODL contributors
+# Copyright 2014-2018 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/contrib/solvers/functional/nonlocalmeans_functionals.py
+++ b/odl/contrib/solvers/functional/nonlocalmeans_functionals.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2017 The ODL contributors
+# Copyright 2014-2018 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/contrib/tensorflow/__init__.py
+++ b/odl/contrib/tensorflow/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2017 The ODL contributors
+# Copyright 2014-2018 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/contrib/tensorflow/layer.py
+++ b/odl/contrib/tensorflow/layer.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2017 The ODL contributors
+# Copyright 2014-2018 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/contrib/tensorflow/operator.py
+++ b/odl/contrib/tensorflow/operator.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2017 The ODL contributors
+# Copyright 2014-2018 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/contrib/tensorflow/space.py
+++ b/odl/contrib/tensorflow/space.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2017 The ODL contributors
+# Copyright 2014-2018 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/contrib/tensorflow/test/tensorflow_test.py
+++ b/odl/contrib/tensorflow/test/tensorflow_test.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2017 The ODL contributors
+# Copyright 2014-2018 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/contrib/theano/__init__.py
+++ b/odl/contrib/theano/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2017 The ODL contributors
+# Copyright 2014-2018 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/contrib/theano/layer.py
+++ b/odl/contrib/theano/layer.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2017 The ODL contributors
+# Copyright 2014-2018 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/contrib/theano/test/theano_test.py
+++ b/odl/contrib/theano/test/theano_test.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2017 The ODL contributors
+# Copyright 2014-2018 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/contrib/tomo/__init__.py
+++ b/odl/contrib/tomo/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2017 The ODL contributors
+# Copyright 2014-2018 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/contrib/tomo/elekta.py
+++ b/odl/contrib/tomo/elekta.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2017 The ODL contributors
+# Copyright 2014-2018 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/contrib/torch/__init__.py
+++ b/odl/contrib/torch/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2017 The ODL contributors
+# Copyright 2014-2018 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/contrib/torch/operator.py
+++ b/odl/contrib/torch/operator.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2017 The ODL contributors
+# Copyright 2014-2018 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/contrib/torch/test/test_operator.py
+++ b/odl/contrib/torch/test/test_operator.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2017 The ODL contributors
+# Copyright 2014-2018 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/deform/__init__.py
+++ b/odl/deform/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2017 The ODL contributors
+# Copyright 2014-2018 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/deform/linearized.py
+++ b/odl/deform/linearized.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2017 The ODL contributors
+# Copyright 2014-2018 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/diagnostics/__init__.py
+++ b/odl/diagnostics/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2017 The ODL contributors
+# Copyright 2014-2018 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/diagnostics/examples.py
+++ b/odl/diagnostics/examples.py
@@ -1,4 +1,4 @@
-﻿# Copyright 2014-2017 The ODL contributors
+﻿# Copyright 2014-2018 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/diagnostics/operator.py
+++ b/odl/diagnostics/operator.py
@@ -1,4 +1,4 @@
-﻿# Copyright 2014-2017 The ODL contributors
+﻿# Copyright 2014-2018 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/diagnostics/space.py
+++ b/odl/diagnostics/space.py
@@ -1,4 +1,4 @@
-﻿# Copyright 2014-2017 The ODL contributors
+﻿# Copyright 2014-2018 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/discr/__init__.py
+++ b/odl/discr/__init__.py
@@ -1,4 +1,4 @@
-﻿# Copyright 2014-2017 The ODL contributors
+﻿# Copyright 2014-2018 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/discr/diff_ops.py
+++ b/odl/discr/diff_ops.py
@@ -1,4 +1,4 @@
-﻿# Copyright 2014-2017 The ODL contributors
+﻿# Copyright 2014-2018 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/discr/discr_mappings.py
+++ b/odl/discr/discr_mappings.py
@@ -1,4 +1,4 @@
-﻿# Copyright 2014-2017 The ODL contributors
+﻿# Copyright 2014-2018 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/discr/discr_ops.py
+++ b/odl/discr/discr_ops.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2017 The ODL contributors
+# Copyright 2014-2018 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/discr/discretization.py
+++ b/odl/discr/discretization.py
@@ -1,4 +1,4 @@
-﻿# Copyright 2014-2017 The ODL contributors
+﻿# Copyright 2014-2018 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/discr/grid.py
+++ b/odl/discr/grid.py
@@ -1,4 +1,4 @@
-﻿# Copyright 2014-2017 The ODL contributors
+﻿# Copyright 2014-2018 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/discr/lp_discr.py
+++ b/odl/discr/lp_discr.py
@@ -1,4 +1,4 @@
-﻿# Copyright 2014-2017 The ODL contributors
+﻿# Copyright 2014-2018 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/discr/partition.py
+++ b/odl/discr/partition.py
@@ -1,4 +1,4 @@
-﻿# Copyright 2014-2017 The ODL contributors
+﻿# Copyright 2014-2018 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/operator/__init__.py
+++ b/odl/operator/__init__.py
@@ -1,4 +1,4 @@
-﻿# Copyright 2014-2017 The ODL contributors
+﻿# Copyright 2014-2018 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/operator/default_ops.py
+++ b/odl/operator/default_ops.py
@@ -1,6 +1,6 @@
 ﻿# coding=utf-8
 
-# Copyright 2014-2017 The ODL contributors
+# Copyright 2014-2018 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/operator/operator.py
+++ b/odl/operator/operator.py
@@ -1,4 +1,4 @@
-﻿# Copyright 2014-2017 The ODL contributors
+﻿# Copyright 2014-2018 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/operator/oputils.py
+++ b/odl/operator/oputils.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2017 The ODL contributors
+# Copyright 2014-2018 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/operator/pspace_ops.py
+++ b/odl/operator/pspace_ops.py
@@ -1,4 +1,4 @@
-﻿# Copyright 2014-2017 The ODL contributors
+﻿# Copyright 2014-2018 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/operator/tensor_ops.py
+++ b/odl/operator/tensor_ops.py
@@ -1,4 +1,4 @@
-﻿# Copyright 2014-2017 The ODL contributors
+﻿# Copyright 2014-2018 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/phantom/__init__.py
+++ b/odl/phantom/__init__.py
@@ -1,4 +1,4 @@
-﻿# Copyright 2014-2017 The ODL contributors
+﻿# Copyright 2014-2018 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/phantom/emission.py
+++ b/odl/phantom/emission.py
@@ -1,4 +1,4 @@
-﻿# Copyright 2014-2017 The ODL contributors
+﻿# Copyright 2014-2018 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/phantom/geometric.py
+++ b/odl/phantom/geometric.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2017 The ODL contributors
+# Copyright 2014-2018 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/phantom/misc_phantoms.py
+++ b/odl/phantom/misc_phantoms.py
@@ -1,4 +1,4 @@
-﻿# Copyright 2014-2017 The ODL contributors
+﻿# Copyright 2014-2018 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/phantom/noise.py
+++ b/odl/phantom/noise.py
@@ -1,4 +1,4 @@
-﻿# Copyright 2014-2017 The ODL contributors
+﻿# Copyright 2014-2018 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/phantom/phantom_utils.py
+++ b/odl/phantom/phantom_utils.py
@@ -1,4 +1,4 @@
-﻿# Copyright 2014-2017 The ODL contributors
+﻿# Copyright 2014-2018 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/phantom/transmission.py
+++ b/odl/phantom/transmission.py
@@ -1,4 +1,4 @@
-﻿# Copyright 2014-2017 The ODL contributors
+﻿# Copyright 2014-2018 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/set/__init__.py
+++ b/odl/set/__init__.py
@@ -1,4 +1,4 @@
-﻿# Copyright 2014-2017 The ODL contributors
+﻿# Copyright 2014-2018 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/set/domain.py
+++ b/odl/set/domain.py
@@ -1,4 +1,4 @@
-﻿# Copyright 2014-2017 The ODL contributors
+﻿# Copyright 2014-2018 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/set/sets.py
+++ b/odl/set/sets.py
@@ -1,4 +1,4 @@
-﻿# Copyright 2014-2017 The ODL contributors
+﻿# Copyright 2014-2018 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/set/space.py
+++ b/odl/set/space.py
@@ -1,4 +1,4 @@
-﻿# Copyright 2014-2017 The ODL contributors
+﻿# Copyright 2014-2018 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/solvers/__init__.py
+++ b/odl/solvers/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2017 The ODL contributors
+# Copyright 2014-2018 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/solvers/functional/__init__.py
+++ b/odl/solvers/functional/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2017 The ODL contributors
+# Copyright 2014-2018 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/solvers/functional/default_functionals.py
+++ b/odl/solvers/functional/default_functionals.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2017 The ODL contributors
+# Copyright 2014-2018 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/solvers/functional/derivatives.py
+++ b/odl/solvers/functional/derivatives.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2017 The ODL contributors
+# Copyright 2014-2018 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/solvers/functional/example_funcs.py
+++ b/odl/solvers/functional/example_funcs.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2017 The ODL contributors
+# Copyright 2014-2018 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/solvers/functional/functional.py
+++ b/odl/solvers/functional/functional.py
@@ -1,6 +1,6 @@
 # coding=utf-8
 
-# Copyright 2014-2017 The ODL contributors
+# Copyright 2014-2018 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/solvers/iterative/__init__.py
+++ b/odl/solvers/iterative/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2017 The ODL contributors
+# Copyright 2014-2018 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/solvers/iterative/iterative.py
+++ b/odl/solvers/iterative/iterative.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2017 The ODL contributors
+# Copyright 2014-2018 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/solvers/iterative/statistical.py
+++ b/odl/solvers/iterative/statistical.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2017 The ODL contributors
+# Copyright 2014-2018 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/solvers/nonsmooth/__init__.py
+++ b/odl/solvers/nonsmooth/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2017 The ODL contributors
+# Copyright 2014-2018 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/solvers/nonsmooth/alternating_dual_updates.py
+++ b/odl/solvers/nonsmooth/alternating_dual_updates.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2017 The ODL contributors
+# Copyright 2014-2018 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/solvers/nonsmooth/douglas_rachford.py
+++ b/odl/solvers/nonsmooth/douglas_rachford.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2017 The ODL contributors
+# Copyright 2014-2018 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/solvers/nonsmooth/forward_backward.py
+++ b/odl/solvers/nonsmooth/forward_backward.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2017 The ODL contributors
+# Copyright 2014-2018 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/solvers/nonsmooth/primal_dual_hybrid_gradient.py
+++ b/odl/solvers/nonsmooth/primal_dual_hybrid_gradient.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2017 The ODL contributors
+# Copyright 2014-2018 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/solvers/nonsmooth/proximal_gradient_solvers.py
+++ b/odl/solvers/nonsmooth/proximal_gradient_solvers.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2017 The ODL contributors
+# Copyright 2014-2018 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/solvers/nonsmooth/proximal_operators.py
+++ b/odl/solvers/nonsmooth/proximal_operators.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2017 The ODL contributors
+# Copyright 2014-2018 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/solvers/smooth/__init__.py
+++ b/odl/solvers/smooth/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2017 The ODL contributors
+# Copyright 2014-2018 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/solvers/smooth/gradient.py
+++ b/odl/solvers/smooth/gradient.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2017 The ODL contributors
+# Copyright 2014-2018 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/solvers/smooth/newton.py
+++ b/odl/solvers/smooth/newton.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2017 The ODL contributors
+# Copyright 2014-2018 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/solvers/smooth/nonlinear_cg.py
+++ b/odl/solvers/smooth/nonlinear_cg.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2017 The ODL contributors
+# Copyright 2014-2018 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/solvers/util/__init__.py
+++ b/odl/solvers/util/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2017 The ODL contributors
+# Copyright 2014-2018 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/solvers/util/callback.py
+++ b/odl/solvers/util/callback.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2017 The ODL contributors
+# Copyright 2014-2018 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/solvers/util/steplen.py
+++ b/odl/solvers/util/steplen.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2017 The ODL contributors
+# Copyright 2014-2018 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/space/__init__.py
+++ b/odl/space/__init__.py
@@ -1,4 +1,4 @@
-﻿# Copyright 2014-2017 The ODL contributors
+﻿# Copyright 2014-2018 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/space/base_tensors.py
+++ b/odl/space/base_tensors.py
@@ -1,4 +1,4 @@
-﻿# Copyright 2014-2017 The ODL contributors
+﻿# Copyright 2014-2018 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/space/entry_points.py
+++ b/odl/space/entry_points.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2017 The ODL contributors
+# Copyright 2014-2018 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/space/fspace.py
+++ b/odl/space/fspace.py
@@ -1,4 +1,4 @@
-﻿# Copyright 2014-2017 The ODL contributors
+﻿# Copyright 2014-2018 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/space/npy_tensors.py
+++ b/odl/space/npy_tensors.py
@@ -1,4 +1,4 @@
-﻿# Copyright 2014-2017 The ODL contributors
+﻿# Copyright 2014-2018 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/space/pspace.py
+++ b/odl/space/pspace.py
@@ -1,4 +1,4 @@
-﻿# Copyright 2014-2017 The ODL contributors
+﻿# Copyright 2014-2018 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/space/space_utils.py
+++ b/odl/space/space_utils.py
@@ -1,4 +1,4 @@
-﻿# Copyright 2014-2017 The ODL contributors
+﻿# Copyright 2014-2018 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/space/weighting.py
+++ b/odl/space/weighting.py
@@ -1,4 +1,4 @@
-﻿# Copyright 2014-2017 The ODL contributors
+﻿# Copyright 2014-2018 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/test/deform/linearized_deform_test.py
+++ b/odl/test/deform/linearized_deform_test.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2017 The ODL contributors
+# Copyright 2014-2018 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/test/discr/diff_ops_test.py
+++ b/odl/test/discr/diff_ops_test.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2017 The ODL contributors
+# Copyright 2014-2018 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/test/discr/discr_mappings_test.py
+++ b/odl/test/discr/discr_mappings_test.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2017 The ODL contributors
+# Copyright 2014-2018 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/test/discr/discr_ops_test.py
+++ b/odl/test/discr/discr_ops_test.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2017 The ODL contributors
+# Copyright 2014-2018 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/test/discr/grid_test.py
+++ b/odl/test/discr/grid_test.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2017 The ODL contributors
+# Copyright 2014-2018 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/test/discr/lp_discr_test.py
+++ b/odl/test/discr/lp_discr_test.py
@@ -1,4 +1,4 @@
-﻿# Copyright 2014-2017 The ODL contributors
+﻿# Copyright 2014-2018 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/test/discr/partition_test.py
+++ b/odl/test/discr/partition_test.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2017 The ODL contributors
+# Copyright 2014-2018 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/test/largescale/solvers/nonsmooth/default_functionals_slow_test.py
+++ b/odl/test/largescale/solvers/nonsmooth/default_functionals_slow_test.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2017 The ODL contributors
+# Copyright 2014-2018 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/test/largescale/space/tensor_space_slow_test.py
+++ b/odl/test/largescale/space/tensor_space_slow_test.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2017 The ODL contributors
+# Copyright 2014-2018 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/test/largescale/tomo/analytic_slow_test.py
+++ b/odl/test/largescale/tomo/analytic_slow_test.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2017 The ODL contributors
+# Copyright 2014-2018 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/test/largescale/tomo/ray_transform_slow_test.py
+++ b/odl/test/largescale/tomo/ray_transform_slow_test.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2017 The ODL contributors
+# Copyright 2014-2018 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/test/largescale/tomo/stir_slow_test.py
+++ b/odl/test/largescale/tomo/stir_slow_test.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2017 The ODL contributors
+# Copyright 2014-2018 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/test/largescale/trafos/fourier_slow_test.py
+++ b/odl/test/largescale/trafos/fourier_slow_test.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2017 The ODL contributors
+# Copyright 2014-2018 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/test/operator/operator_test.py
+++ b/odl/test/operator/operator_test.py
@@ -1,4 +1,4 @@
-﻿# Copyright 2014-2017 The ODL contributors
+﻿# Copyright 2014-2018 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/test/operator/oputils_test.py
+++ b/odl/test/operator/oputils_test.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2017 The ODL contributors
+# Copyright 2014-2018 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/test/operator/pspace_ops_test.py
+++ b/odl/test/operator/pspace_ops_test.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2017 The ODL contributors
+# Copyright 2014-2018 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/test/operator/tensor_ops_test.py
+++ b/odl/test/operator/tensor_ops_test.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2017 The ODL contributors
+# Copyright 2014-2018 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/test/set/domain_test.py
+++ b/odl/test/set/domain_test.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2017 The ODL contributors
+# Copyright 2014-2018 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/test/set/sets_test.py
+++ b/odl/test/set/sets_test.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2017 The ODL contributors
+# Copyright 2014-2018 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/test/set/space_test.py
+++ b/odl/test/set/space_test.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2017 The ODL contributors
+# Copyright 2014-2018 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/test/solvers/functional/default_functionals_test.py
+++ b/odl/test/solvers/functional/default_functionals_test.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2017 The ODL contributors
+# Copyright 2014-2018 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/test/solvers/functional/functional_test.py
+++ b/odl/test/solvers/functional/functional_test.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2017 The ODL contributors
+# Copyright 2014-2018 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/test/solvers/iterative/iterative_test.py
+++ b/odl/test/solvers/iterative/iterative_test.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2017 The ODL contributors
+# Copyright 2014-2018 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/test/solvers/nonsmooth/admm_test.py
+++ b/odl/test/solvers/nonsmooth/admm_test.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2017 The ODL contributors
+# Copyright 2014-2018 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/test/solvers/nonsmooth/alternating_dual_updates_test.py
+++ b/odl/test/solvers/nonsmooth/alternating_dual_updates_test.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2017 The ODL contributors
+# Copyright 2014-2018 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/test/solvers/nonsmooth/douglas_rachford_test.py
+++ b/odl/test/solvers/nonsmooth/douglas_rachford_test.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2017 The ODL contributors
+# Copyright 2014-2018 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/test/solvers/nonsmooth/forward_backward_test.py
+++ b/odl/test/solvers/nonsmooth/forward_backward_test.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2017 The ODL contributors
+# Copyright 2014-2018 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/test/solvers/nonsmooth/primal_dual_hybrid_gradient_test.py
+++ b/odl/test/solvers/nonsmooth/primal_dual_hybrid_gradient_test.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2017 The ODL contributors
+# Copyright 2014-2018 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/test/solvers/nonsmooth/proximal_operator_test.py
+++ b/odl/test/solvers/nonsmooth/proximal_operator_test.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2017 The ODL contributors
+# Copyright 2014-2018 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/test/solvers/nonsmooth/proximal_utils_test.py
+++ b/odl/test/solvers/nonsmooth/proximal_utils_test.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2017 The ODL contributors
+# Copyright 2014-2018 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/test/solvers/smooth/smooth_test.py
+++ b/odl/test/solvers/smooth/smooth_test.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2017 The ODL contributors
+# Copyright 2014-2018 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/test/solvers/util/steplen_test.py
+++ b/odl/test/solvers/util/steplen_test.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2017 The ODL contributors
+# Copyright 2014-2018 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/test/space/fspace_test.py
+++ b/odl/test/space/fspace_test.py
@@ -1,4 +1,4 @@
-﻿# Copyright 2014-2017 The ODL contributors
+﻿# Copyright 2014-2018 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/test/space/pspace_test.py
+++ b/odl/test/space/pspace_test.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2017 The ODL contributors
+# Copyright 2014-2018 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/test/space/space_utils_test.py
+++ b/odl/test/space/space_utils_test.py
@@ -1,4 +1,4 @@
-﻿# Copyright 2014-2017 The ODL contributors
+﻿# Copyright 2014-2018 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/test/space/tensors_test.py
+++ b/odl/test/space/tensors_test.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2017 The ODL contributors
+# Copyright 2014-2018 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/test/system/import_test.py
+++ b/odl/test/system/import_test.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2017 The ODL contributors
+# Copyright 2014-2018 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/test/test_doc.py
+++ b/odl/test/test_doc.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2017 The ODL contributors
+# Copyright 2014-2018 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/test/test_examples.py
+++ b/odl/test/test_examples.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2017 The ODL contributors
+# Copyright 2014-2018 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/test/tomo/backends/astra_cpu_test.py
+++ b/odl/test/tomo/backends/astra_cpu_test.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2017 The ODL contributors
+# Copyright 2014-2018 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/test/tomo/backends/astra_cuda_test.py
+++ b/odl/test/tomo/backends/astra_cuda_test.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2017 The ODL contributors
+# Copyright 2014-2018 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/test/tomo/backends/astra_setup_test.py
+++ b/odl/test/tomo/backends/astra_setup_test.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2017 The ODL contributors
+# Copyright 2014-2018 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/test/tomo/backends/skimage_test.py
+++ b/odl/test/tomo/backends/skimage_test.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2017 The ODL contributors
+# Copyright 2014-2018 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/test/tomo/geometry/geometry_test.py
+++ b/odl/test/tomo/geometry/geometry_test.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2017 The ODL contributors
+# Copyright 2014-2018 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/test/tomo/geometry/spect_geometry_test.py
+++ b/odl/test/tomo/geometry/spect_geometry_test.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2017 The ODL contributors
+# Copyright 2014-2018 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/test/tomo/operators/ray_trafo_test.py
+++ b/odl/test/tomo/operators/ray_trafo_test.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2017 The ODL contributors
+# Copyright 2014-2018 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/test/trafos/backends/pyfftw_bindings_test.py
+++ b/odl/test/trafos/backends/pyfftw_bindings_test.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2017 The ODL contributors
+# Copyright 2014-2018 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/test/trafos/backends/pywt_bindings_test.py
+++ b/odl/test/trafos/backends/pywt_bindings_test.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2017 The ODL contributors
+# Copyright 2014-2018 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/test/trafos/fourier_test.py
+++ b/odl/test/trafos/fourier_test.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2017 The ODL contributors
+# Copyright 2014-2018 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/test/trafos/util/ft_utils_test.py
+++ b/odl/test/trafos/util/ft_utils_test.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2017 The ODL contributors
+# Copyright 2014-2018 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/test/trafos/wavelet_test.py
+++ b/odl/test/trafos/wavelet_test.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2017 The ODL contributors
+# Copyright 2014-2018 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/test/util/normalize_test.py
+++ b/odl/test/util/normalize_test.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2017 The ODL contributors
+# Copyright 2014-2018 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/test/util/numerics_test.py
+++ b/odl/test/util/numerics_test.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2017 The ODL contributors
+# Copyright 2014-2018 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/test/util/utility_test.py
+++ b/odl/test/util/utility_test.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2017 The ODL contributors
+# Copyright 2014-2018 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/test/util/vectorization_test.py
+++ b/odl/test/util/vectorization_test.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2017 The ODL contributors
+# Copyright 2014-2018 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/tomo/__init__.py
+++ b/odl/tomo/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2017 The ODL contributors
+# Copyright 2014-2018 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/tomo/analytic/__init__.py
+++ b/odl/tomo/analytic/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2017 The ODL contributors
+# Copyright 2014-2018 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/tomo/analytic/filtered_back_projection.py
+++ b/odl/tomo/analytic/filtered_back_projection.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2017 The ODL contributors
+# Copyright 2014-2018 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/tomo/backends/__init__.py
+++ b/odl/tomo/backends/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2017 The ODL contributors
+# Copyright 2014-2018 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/tomo/backends/astra_cpu.py
+++ b/odl/tomo/backends/astra_cpu.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2017 The ODL contributors
+# Copyright 2014-2018 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/tomo/backends/astra_cuda.py
+++ b/odl/tomo/backends/astra_cuda.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2017 The ODL contributors
+# Copyright 2014-2018 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/tomo/backends/astra_setup.py
+++ b/odl/tomo/backends/astra_setup.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2017 The ODL contributors
+# Copyright 2014-2018 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/tomo/backends/skimage_radon.py
+++ b/odl/tomo/backends/skimage_radon.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2017 The ODL contributors
+# Copyright 2014-2018 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/tomo/backends/stir_bindings.py
+++ b/odl/tomo/backends/stir_bindings.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2017 The ODL contributors
+# Copyright 2014-2018 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/tomo/geometry/__init__.py
+++ b/odl/tomo/geometry/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2017 The ODL contributors
+# Copyright 2014-2018 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/tomo/geometry/conebeam.py
+++ b/odl/tomo/geometry/conebeam.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2017 The ODL contributors
+# Copyright 2014-2018 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/tomo/geometry/detector.py
+++ b/odl/tomo/geometry/detector.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2017 The ODL contributors
+# Copyright 2014-2018 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/tomo/geometry/geometry.py
+++ b/odl/tomo/geometry/geometry.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2017 The ODL contributors
+# Copyright 2014-2018 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/tomo/geometry/parallel.py
+++ b/odl/tomo/geometry/parallel.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2017 The ODL contributors
+# Copyright 2014-2018 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/tomo/geometry/spect.py
+++ b/odl/tomo/geometry/spect.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2017 The ODL contributors
+# Copyright 2014-2018 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/tomo/operators/__init__.py
+++ b/odl/tomo/operators/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2017 The ODL contributors
+# Copyright 2014-2018 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/tomo/operators/ray_trafo.py
+++ b/odl/tomo/operators/ray_trafo.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2017 The ODL contributors
+# Copyright 2014-2018 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/tomo/util/__init__.py
+++ b/odl/tomo/util/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2017 The ODL contributors
+# Copyright 2014-2018 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/tomo/util/testutils.py
+++ b/odl/tomo/util/testutils.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2017 The ODL contributors
+# Copyright 2014-2018 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/tomo/util/utility.py
+++ b/odl/tomo/util/utility.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2017 The ODL contributors
+# Copyright 2014-2018 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/trafos/__init__.py
+++ b/odl/trafos/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2017 The ODL contributors
+# Copyright 2014-2018 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/trafos/backends/__init__.py
+++ b/odl/trafos/backends/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2017 The ODL contributors
+# Copyright 2014-2018 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/trafos/backends/pyfftw_bindings.py
+++ b/odl/trafos/backends/pyfftw_bindings.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2017 The ODL contributors
+# Copyright 2014-2018 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/trafos/backends/pywt_bindings.py
+++ b/odl/trafos/backends/pywt_bindings.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2017 The ODL contributors
+# Copyright 2014-2018 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/trafos/fourier.py
+++ b/odl/trafos/fourier.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2017 The ODL contributors
+# Copyright 2014-2018 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/trafos/util/__init__.py
+++ b/odl/trafos/util/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2017 The ODL contributors
+# Copyright 2014-2018 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/trafos/util/ft_utils.py
+++ b/odl/trafos/util/ft_utils.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2017 The ODL contributors
+# Copyright 2014-2018 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/trafos/wavelet.py
+++ b/odl/trafos/wavelet.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2017 The ODL contributors
+# Copyright 2014-2018 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/ufunc_ops/__init__.py
+++ b/odl/ufunc_ops/__init__.py
@@ -1,4 +1,4 @@
-﻿# Copyright 2014-2017 The ODL contributors
+﻿# Copyright 2014-2018 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/ufunc_ops/ufunc_ops.py
+++ b/odl/ufunc_ops/ufunc_ops.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2017 The ODL contributors
+# Copyright 2014-2018 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/util/__init__.py
+++ b/odl/util/__init__.py
@@ -1,4 +1,4 @@
-﻿# Copyright 2014-2017 The ODL contributors
+﻿# Copyright 2014-2018 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/util/graphics.py
+++ b/odl/util/graphics.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2017 The ODL contributors
+# Copyright 2014-2018 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/util/normalize.py
+++ b/odl/util/normalize.py
@@ -1,4 +1,4 @@
-﻿# Copyright 2014-2017 The ODL contributors
+﻿# Copyright 2014-2018 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/util/npy_compat.py
+++ b/odl/util/npy_compat.py
@@ -1,4 +1,4 @@
-﻿# Copyright 2014-2017 The ODL contributors
+﻿# Copyright 2014-2018 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/util/numerics.py
+++ b/odl/util/numerics.py
@@ -1,4 +1,4 @@
-﻿# Copyright 2014-2017 The ODL contributors
+﻿# Copyright 2014-2018 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/util/pytest_plugins.py
+++ b/odl/util/pytest_plugins.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2017 The ODL contributors
+# Copyright 2014-2018 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/util/testutils.py
+++ b/odl/util/testutils.py
@@ -1,4 +1,4 @@
-﻿# Copyright 2014-2017 The ODL contributors
+﻿# Copyright 2014-2018 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/util/ufuncs.py
+++ b/odl/util/ufuncs.py
@@ -1,4 +1,4 @@
-﻿# Copyright 2014-2017 The ODL contributors
+﻿# Copyright 2014-2018 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/util/utility.py
+++ b/odl/util/utility.py
@@ -1,4 +1,4 @@
-﻿# Copyright 2014-2017 The ODL contributors
+﻿# Copyright 2014-2018 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/util/vectorization.py
+++ b/odl/util/vectorization.py
@@ -1,4 +1,4 @@
-﻿# Copyright 2014-2017 The ODL contributors
+﻿# Copyright 2014-2018 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2017 The ODL contributors
+# Copyright 2014-2018 The ODL contributors
 #
 # This file is part of ODL.
 #


### PR DESCRIPTION
From the root folder of `odl`, this was done with 
```
$ find . -type f -print0 | xargs -0 sed -i '' -e 's/Copyright 2014-2017/Copyright 2014-2018/g'
```
see, e.g., [this stack exchange question](https://superuser.com/questions/428493/how-can-i-do-a-recursive-find-and-replace-from-the-command-line). To check that nothing has been missed, I also ran
```
grep -rnw . -e "2017"
```
see, e.g., [this stack exchange question](https://stackoverflow.com/questions/16956810/how-do-i-find-all-files-containing-specific-text-on-linux).