### PR TITLE
DOC: Typos in forward backward

### DIFF
--- a/odl/solvers/nonsmooth/forward_backward.py
+++ b/odl/solvers/nonsmooth/forward_backward.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2017 The ODL contributors
+# Copyright 2014-2018 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/solvers/nonsmooth/forward_backward.py
+++ b/odl/solvers/nonsmooth/forward_backward.py
@@ -21,12 +21,12 @@ def forward_backward_pd(x, f, g, L, h, tau, sigma, niter,
     """The forward-backward primal-dual splitting algorithm.
 
     The algorithm minimizes the sum of several convex functionals composed with
-    linear operators,::
+    linear operators::
 
         min_x f(x) + sum_i g_i(L_i x) + h(x)
 
     where ``f``, ``g_i`` are convex functionals, ``L_i`` are linear
-    operator's, and ``h`` is a convex and differentiable functional.
+    operators, and ``h`` is a convex and differentiable functional.
 
     The method can also be used to solve the more general problem::
 
@@ -38,7 +38,7 @@ def forward_backward_pd(x, f, g, L, h, tau, sigma, niter,
         (g @ l)(x) = inf_y { g(y) + l(x-y) }
 
     Note that the strong convexity of ``l_i`` makes the convex conjugate
-    ``l_i^*`` differentialbe; see the Notes section for more information on
+    ``l_i^*`` differentiable; see the Notes section for more information on
     this.
 
     Parameters

--- a/odl/solvers/nonsmooth/forward_backward.py
+++ b/odl/solvers/nonsmooth/forward_backward.py
@@ -18,7 +18,7 @@ __all__ = ('forward_backward_pd',)
 
 def forward_backward_pd(x, f, g, L, h, tau, sigma, niter,
                         callback=None, **kwargs):
-    """The forward-backward primal-dual splitting algorithm.
+    r"""The forward-backward primal-dual splitting algorithm.
 
     The algorithm minimizes the sum of several convex functionals composed with
     linear operators::
@@ -85,32 +85,32 @@ def forward_backward_pd(x, f, g, L, h, tau, sigma, niter,
 
     The exact conditions on the involved functionals are as follows: :math:`f`
     and :math:`g_i` are proper, convex and lower semicontinuous, and :math:`h`
-    is convex and differentiable with :math:`\\eta^{-1}`-Lipschitz continuous
-    gradient, :math:`\\eta > 0`.
+    is convex and differentiable with :math:`\eta^{-1}`-Lipschitz continuous
+    gradient, :math:`\eta > 0`.
 
-    The optional operators :math:`\\nabla l_i^*` need to be
-    :math:`\\nu_i`-Lipschitz continuous. Note that in the paper, the condition
+    The optional operators :math:`\nabla l_i^*` need to be
+    :math:`\nu_i`-Lipschitz continuous. Note that in the paper, the condition
     is formulated as :math:`l_i` being proper, lower
-    semicontinuous, and :math:`\\nu_i^{-1}`-strongly convex, which implies that
-    :math:`l_i^*` have :math:`\\nu_i`-Lipschitz continuous gradients.
+    semicontinuous, and :math:`\nu_i^{-1}`-strongly convex, which implies that
+    :math:`l_i^*` have :math:`\nu_i`-Lipschitz continuous gradients.
 
-    If the optional operators :math:`\\nabla l_i^*` are omitted, the simpler
+    If the optional operators :math:`\nabla l_i^*` are omitted, the simpler
     problem without :math:`l_i` will be considered. Mathematically, this is
     done by taking :math:`l_i` to be the functionals that are zero only in the
-    zero element and :math:`\\infty` otherwise. This gives that :math:`l_i^*`
+    zero element and :math:`\infty` otherwise. This gives that :math:`l_i^*`
     are the zero functionals, and hence the corresponding gradients are the
     zero operators.
 
-    To guarantee convergence, the parameters :math:`\\tau`, :math:`\\sigma` and
+    To guarantee convergence, the parameters :math:`\tau`, :math:`\sigma` and
     :math:`L_i` need to satisfy
 
     .. math::
-       2 \min \{ \\frac{1}{\\tau}, \\frac{1}{\sigma_1}, \\ldots,
-       \\frac{1}{\sigma_m} \} \cdot \min\{ \\eta, \\nu_1, \\ldots, \\nu_m  \}
-       \cdot \\sqrt{1 - \\tau \\sum_{i=1}^n \\sigma_i ||L_i||^2} > 1,
+       2 \min \{ \frac{1}{\tau}, \frac{1}{\sigma_1}, \ldots,
+       \frac{1}{\sigma_m} \} \cdot \min\{ \eta, \nu_1, \ldots, \nu_m  \}
+       \cdot \sqrt{1 - \tau \sum_{i=1}^n \sigma_i ||L_i||^2} > 1,
 
-    where, if the simpler problem is considered, all :math:`\\nu_i` can be
-    considered to be :math:`\\infty`.
+    where, if the simpler problem is considered, all :math:`\nu_i` can be
+    considered to be :math:`\infty`.
 
     For reference on the forward-backward primal-dual algorithm, see [BC2015].
 


### PR DESCRIPTION
Besides the typos, this removes the double backslashes and sets the year to 2018.