### PR TITLE
BLD: use pip for pywavelets

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,7 +55,7 @@ install:
     # Install packages with pip if possible, it's way faster
     - pip install "numpy==$NUMPY_VERSION" scipy future packaging scikit-image pywavelets pytest pytest-cov;
     # Building pyfftw wheels sometimes fails, using a conda-forge version instead
-    - conda install -c conda-forge pyfftw
+    - conda install -c conda-forge --no-update-deps pyfftw
 
     # Doc dependencies
     - if [[ "$BUILD_DOCS" == "true" ]]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -54,8 +54,10 @@ install:
     - source activate testenv
     # Install packages with pip if possible, it's way faster
     - pip install "numpy==$NUMPY_VERSION" scipy future packaging scikit-image pywavelets pytest pytest-cov;
-    # Building pyfftw wheels sometimes fails, using a conda-forge version instead
-    - conda install -c conda-forge --no-update-deps pyfftw
+    # Building pyfftw wheels sometimes fails, using a conda-forge version instead;
+    # To avoid a lower version of NumPy being installed over the pip one, we exclude all dependencies
+    # (PyFFTW only depends on NumPy)
+    - conda install -c conda-forge --no-deps pyfftw
 
     # Doc dependencies
     - if [[ "$BUILD_DOCS" == "true" ]]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,10 +50,10 @@ install:
 
     # Install dependencies and enter test environment. Use conda for the minimal stuff to
     # make it run faster and avoid downloading big stuff like mkl
-    - conda create -n testenv python=$TRAVIS_PYTHON_VERSION nomkl pywavelets
+    - conda create -n testenv python=$TRAVIS_PYTHON_VERSION nomkl
     - source activate testenv
     # Install packages with pip if possible, it's way faster
-    - pip install "numpy==$NUMPY_VERSION" scipy future packaging scikit-image pytest pytest-cov;
+    - pip install "numpy==$NUMPY_VERSION" scipy future packaging scikit-image pywavelets pytest pytest-cov;
     # Building pyfftw wheels sometimes fails, using a conda-forge version instead
     - conda install -c conda-forge pyfftw
 


### PR DESCRIPTION
PyWavelets now provide wheels so we can use pip without worries. This also removes the implicit Numpy installation from the `conda create` build step, which often used the (for us) broken 1.14.2.

Trivial fix, will merge this if CI is happy.