### PR TITLE
TST: Blacklist pytest 3.7

### DIFF
--- a/odl/util/testutils.py
+++ b/odl/util/testutils.py
@@ -649,7 +649,7 @@ def test(arguments=None):
         raise ImportError('ODL tests cannot be run without `pytest` installed.'
                           '\nRun `$ pip install [--user] odl[testing]` in '
                           'order to install `pytest`.')
-    if not version.parse(pytest.__version__) < version.parse("3.7*"):
+    if version.parse(pytest.__version__) >= version.parse("3.7"):
         raise RuntimeError('ODL tests cannot be run with `pytest` '
                            'version `3.7` or higher.\nRun `$ pip install '
                            '"pytest<3.7"` in order to install '

--- a/odl/util/testutils.py
+++ b/odl/util/testutils.py
@@ -16,6 +16,7 @@ import sys
 import os
 import warnings
 from time import time
+from packaging import version
 
 from odl.util.utility import run_from_ipython, is_string
 
@@ -648,11 +649,11 @@ def test(arguments=None):
         raise ImportError('ODL tests cannot be run without `pytest` installed.'
                           '\nRun `$ pip install [--user] odl[testing]` in '
                           'order to install `pytest`.')
-    if pytest.__version__ in ['3.7.0', '3.7.1']:
-        raise ImportError('ODL tests cannot be run with `pytest` '
-                          'versions `3.7.0` and `3.7.1`.\nRun `$ pip install '
-                          '[--user] odl[testing]` in order to install '
-                          '`pytest`.')
+    if not version.parse(pytest.__version__) < version.parse("3.7*"):
+        raise RuntimeError('ODL tests cannot be run with `pytest` '
+                           'version `3.7` or higher.\nRun `$ pip install '
+                           '"pytest<3.7"` in order to install '
+                           'a suitable version of `pytest`.')
 
     from .pytest_plugins import collect_ignore
 

--- a/odl/util/testutils.py
+++ b/odl/util/testutils.py
@@ -648,6 +648,11 @@ def test(arguments=None):
         raise ImportError('ODL tests cannot be run without `pytest` installed.'
                           '\nRun `$ pip install [--user] odl[testing]` in '
                           'order to install `pytest`.')
+    if pytest.__version__ in ['3.7.0', '3.7.1']:
+        raise ImportError('ODL tests cannot be run with `pytest` '
+                          'versions `3.7.0` and `3.7.1`.\nRun `$ pip install '
+                          '[--user] odl[testing]` in order to install '
+                          '`pytest`.')
 
     from .pytest_plugins import collect_ignore
 

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,4 +1,4 @@
-pytest >=3.0.3,!=3.7.0,!=3.7.1
+pytest >=3.0.3,<3.7
 pytest-pep8
 pytest-cov
 coverage >=4.0

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,5 +1,5 @@
-pytest >= 3.0.3
+pytest >=3.0.3,!=3.7.0,!=3.7.1
 pytest-pep8
 pytest-cov
-coverage >= 4.0
+coverage >=4.0
 coveralls


### PR DESCRIPTION
This pull request blacklists those `pytest` versions which cause an infinite recursion (see the discussion in #1416). The `pytest` issue was fixed here https://github.com/pytest-dev/pytest/pull/3771 and should be included in version `3.7.2`.