### PR TITLE
MAINT: avoid ambiguous list indexing, closes #1413

### DIFF
--- a/odl/contrib/solvers/spdhg/misc.py
+++ b/odl/contrib/solvers/spdhg/misc.py
@@ -65,13 +65,13 @@ def partition_1d(arr, slices):
 def partition_equally_1d(arr, nparts, order='interlaced'):
     if order == 'block':
         stride = int(np.ceil(arr.size / nparts))
-        slc_list = [slice(i * stride, (i + 1) * stride) for i in range(nparts)]
+        slices = [slice(i * stride, (i + 1) * stride) for i in range(nparts)]
     elif order == 'interlaced':
-        slc_list = [slice(i, len(arr), nparts) for i in range(nparts)]
+        slices = [slice(i, len(arr), nparts) for i in range(nparts)]
     else:
         raise ValueError
 
-    return partition_1d(arr, slc_list)
+    return partition_1d(arr, tuple(slices))
 
 
 def divide_1Darray_equally(ind, nsub):

--- a/odl/discr/discr_mappings.py
+++ b/odl/discr/discr_mappings.py
@@ -779,6 +779,7 @@ scipy.interpolate.RegularGridInterpolator.html>`_ class.
                 idx_res.append(np.where(yi <= .5, i, i + 1))
             else:
                 idx_res.append(np.where(yi < .5, i, i + 1))
+        idx_res = tuple(idx_res)
         if out is not None:
             out[:] = self.values[idx_res]
             return out

--- a/odl/discr/grid.py
+++ b/odl/discr/grid.py
@@ -54,7 +54,7 @@ def sparse_meshgrid(*x):
         xi = np.asarray(xi)
         slc = [None] * n
         slc[ax] = slice(None)
-        mesh.append(np.ascontiguousarray(xi[slc]))
+        mesh.append(np.ascontiguousarray(xi[tuple(slc)]))
 
     return tuple(mesh)
 

--- a/odl/phantom/geometric.py
+++ b/odl/phantom/geometric.py
@@ -318,7 +318,7 @@ def _getshapes_2d(center, max_radius, shape):
     idx = [slice(minx, maxx) for minx, maxx in zip(min_idx, max_idx)]
     shapes = [(idx[0], slice(None)),
               (slice(None), idx[1])]
-    return idx, shapes
+    return tuple(idx), tuple(shapes)
 
 
 def _ellipse_phantom_2d(space, ellipses):
@@ -443,7 +443,7 @@ def _getshapes_3d(center, max_radius, shape):
     shapes = [(idx[0], slice(None), slice(None)),
               (slice(None), idx[1], slice(None)),
               (slice(None), slice(None), idx[2])]
-    return idx, shapes
+    return tuple(idx), tuple(shapes)
 
 
 def _ellipsoid_phantom_3d(space, ellipsoids):

--- a/odl/solvers/nonsmooth/proximal_operators.py
+++ b/odl/solvers/nonsmooth/proximal_operators.py
@@ -1917,12 +1917,12 @@ def proximal_huber(space, gamma):
             else:
                 norm = x.ufuncs.absolute()
 
-            idx = norm.ufuncs.less_equal(gamma + self.sigma)
-            out[idx] = gamma / (gamma + self.sigma) * x[idx]
+            mask = norm.ufuncs.less_equal(gamma + self.sigma)
+            out[mask] = gamma / (gamma + self.sigma) * x[mask]
 
-            idx.ufuncs.logical_not(out=idx)
+            mask.ufuncs.logical_not(out=mask)
             sign_x = x.ufuncs.sign()
-            out[idx] = x[idx] - self.sigma * sign_x[idx]
+            out[mask] = x[mask] - self.sigma * sign_x[mask]
 
             return out
 

--- a/odl/space/base_tensors.py
+++ b/odl/space/base_tensors.py
@@ -968,8 +968,9 @@ numpy.ufunc.reduceat.html
 
         # Default to showing x-y slice "in the middle"
         if indices is None and self.ndim >= 3:
-            indices = (slice(None),) * 2
-            indices += tuple(n // 2 for n in self.space.shape[2:])
+            indices = tuple(
+                [slice(None)] * 2 + [n // 2 for n in self.space.shape[2:]]
+            )
 
         if isinstance(indices, (Integral, slice)):
             indices = (indices,)

--- a/odl/space/npy_tensors.py
+++ b/odl/space/npy_tensors.py
@@ -1074,8 +1074,7 @@ class NumpyTensor(Tensor):
              [ 5.,  6.]]
         )
 
-        Slices can be assigned to, except if lists are used for
-        indexing:
+        Slices can be assigned to, except if lists are used for indexing:
 
         >>> y = x[:, ::2]  # view into x
         >>> y[:] = -9
@@ -1084,7 +1083,7 @@ class NumpyTensor(Tensor):
             [[-9.,  2., -9.],
              [-9.,  5., -9.]]
         )
-        >>> y = x[[[0, 1], [1, 2]]]  # not a view, won't modify x
+        >>> y = x[[0, 1], [1, 2]]  # not a view, won't modify x
         >>> y
         rn(2).element([ 2., -9.])
         >>> y[:] = 0

--- a/odl/space/pspace.py
+++ b/odl/space/pspace.py
@@ -730,7 +730,7 @@ class ProductSpace(LinearSpace):
 
         else:
             raise TypeError('`indices` must be integer, slice, tuple or '
-                            'or list, got {!r}'.format(indices))
+                            'list, got {!r}'.format(indices))
 
     def __str__(self):
         """Return ``str(self)``."""
@@ -1479,7 +1479,9 @@ class ProductSpaceElement(LinearSpaceElement):
         return tuple(figs)
 
 
-# --- Add arithmetic operators that broadcast ---
+# --- Add arithmetic operators that broadcast --- #
+
+
 def _broadcast_arithmetic(op):
     """Return ``op(self, other)`` with broadcasting.
 

--- a/odl/test/discr/lp_discr_test.py
+++ b/odl/test/discr/lp_discr_test.py
@@ -775,7 +775,7 @@ def test_astype():
     assert not as_complex.is_weighted
 
 
-def testodl_ufuncs(odl_tspace_impl, odl_ufunc):
+def test_ufuncs(odl_tspace_impl, odl_ufunc):
     """Test ufuncs in ``x.ufuncs`` against direct Numpy ufuncs."""
     impl = odl_tspace_impl
     space = odl.uniform_discr([0, 0], [1, 1], (2, 3), impl=impl)
@@ -896,8 +896,8 @@ def testodl_ufuncs(odl_tspace_impl, odl_ufunc):
 
     if USE_ARRAY_UFUNCS_INTERFACE:
         # Check `ufunc.at`
-        indices = [[0, 0, 1],
-                   [0, 1, 2]]
+        indices = ([0, 0, 1],
+                   [0, 1, 2])
 
         mod_array = in_arrays[0].copy()
         mod_elem = in_elems_new[0].copy()

--- a/odl/test/space/space_utils_test.py
+++ b/odl/test/space/space_utils_test.py
@@ -8,7 +8,6 @@
 
 from __future__ import division
 import numpy as np
-from past.builtins import basestring
 
 import odl
 from odl import vector
@@ -51,24 +50,22 @@ def test_vector_numpy():
     x = vector([1, 2, 3], dtype='complex64')
     assert isinstance(x, NumpyTensor)
 
-    # Fn
+    # Generic TensorSpace
     inp = [1, 2, 3]
-
     x = vector(inp)
     assert isinstance(x, NumpyTensor)
     assert x.dtype == np.dtype('int')
     assert all_equal(x, inp)
 
-    # Tensors
     inp = ['a', 'b', 'c']
     x = vector(inp)
     assert isinstance(x, NumpyTensor)
-    assert np.issubdtype(x.dtype, basestring)
+    assert np.issubdtype(x.dtype, np.str_)
     assert all_equal(x, inp)
 
     x = vector([1, 2, 'inf'])  # Becomes string type
     assert isinstance(x, NumpyTensor)
-    assert np.issubdtype(x.dtype, basestring)
+    assert np.issubdtype(x.dtype, np.str_)
     assert all_equal(x, ['1', '2', 'inf'])
 
     # Scalar or empty input

--- a/odl/test/space/tensors_test.py
+++ b/odl/test/space/tensors_test.py
@@ -88,7 +88,7 @@ setitem_indices_params = [
 setitem_indices = simple_fixture('indices', setitem_indices_params)
 
 getitem_indices_params = (setitem_indices_params +
-                          [[[0, 1, 1, 0], [0, 1, 1, 2]], (Ellipsis, None)])
+                          [([0, 1, 1, 0], [0, 1, 1, 2]), (Ellipsis, None)])
 getitem_indices = simple_fixture('indices', getitem_indices_params)
 
 weight_params = [1.0, 0.5, _pos_array(odl.tensor_space((3, 4)))]
@@ -363,7 +363,9 @@ def _test_lincomb(space, a, b, discontig):
     """Validate lincomb against direct result using arrays."""
     # Set slice for discontiguous arrays and get result space of slicing
     if discontig:
-        slc = [slice(None)] * (space.ndim - 1) + [slice(None, None, 2)]
+        slc = tuple(
+            [slice(None)] * (space.ndim - 1) + [slice(None, None, 2)]
+        )
         res_space = space.element()[slc].space
     else:
         res_space = space
@@ -1356,7 +1358,7 @@ def test_custom_dist(tspace):
 # --- Ufuncs & Reductions --- #
 
 
-def testodl_ufuncs(tspace, odl_ufunc):
+def test_ufuncs(tspace, odl_ufunc):
     """Test ufuncs in ``x.ufuncs`` against direct Numpy ufuncs."""
     name = odl_ufunc
 
@@ -1476,8 +1478,8 @@ def testodl_ufuncs(tspace, odl_ufunc):
 
     if USE_ARRAY_UFUNCS_INTERFACE:
         # Check `ufunc.at`
-        indices = [[0, 0, 1],
-                   [0, 1, 2]]
+        indices = ([0, 0, 1],
+                   [0, 1, 2])
 
         mod_array = in_arrays[0].copy()
         mod_elem = in_elems_new[0].copy()

--- a/odl/util/numerics.py
+++ b/odl/util/numerics.py
@@ -663,9 +663,9 @@ def _apply_padding(lhs_arr, rhs_arr, offset, pad_mode, direction):
                                  ''.format(axis, lr, pad_len, n_rhs))
 
         # Slice tuples used to index LHS and RHS for left and right padding,
-        # respectively.
-        lhs_slc_l, lhs_slc_r = list(working_slc), list(working_slc)
-        rhs_slc_l, rhs_slc_r = list(working_slc), list(working_slc)
+        # respectively; we make 4 copies of `working_slc` as lists
+        lhs_slc_l, lhs_slc_r, rhs_slc_l, rhs_slc_r = map(
+            list, [working_slc] * 4)
 
         # We're always using the outer (excess) parts involved in padding
         # on the LHS of the assignment, so we set them here.
@@ -746,17 +746,19 @@ def _apply_padding(lhs_arr, rhs_arr, offset, pad_mode, direction):
             # Create slice tuples for indexing of the boundary values
             bdry_slc_l = list(working_slc)
             bdry_slc_l[axis] = left_slc
+            bdry_slc_l = tuple(bdry_slc_l)
             bdry_slc_r = list(working_slc)
             bdry_slc_r[axis] = right_slc
-            bdry_slc_l, bdry_slc_r = map(tuple, [bdry_slc_l, bdry_slc_r])
+            bdry_slc_r = tuple(bdry_slc_r)
 
             # For the slope at the boundary, we need two neighboring points.
             # We create the corresponding slices from the boundary slices.
             slope_slc_l = list(working_slc)
             slope_slc_l[axis] = slice(left_slc.start, left_slc.stop + 1)
+            slope_slc_l = tuple(slope_slc_l)
             slope_slc_r = list(working_slc)
             slope_slc_r[axis] = slice(right_slc.start - 1, right_slc.stop)
-            slope_slc_l, slope_slc_r = map(tuple, [slope_slc_l, slope_slc_r])
+            slope_slc_r = tuple(slope_slc_r)
 
             # The `np.arange`s, broadcast along `axis`, are used to create the
             # constant-slope continuation (forward) or to calculate the

--- a/odl/util/numerics.py
+++ b/odl/util/numerics.py
@@ -138,6 +138,8 @@ def apply_on_boundary(array, func, only_once=True, which_boundaries=None,
         slc_l[ax] = 0
         slc_r[ax] = -1
 
+        slc_l, slc_r = tuple(slc_l), tuple(slc_r)
+
         try:
             # Tuple of functions in this axis
             func_l, func_r = function
@@ -257,7 +259,7 @@ def fast_1d_tensor_mult(ndarr, onedim_arrs, axes=None, out=None):
             # Meshgrid-style slice
             slc = [None] * out.ndim
             slc[ax] = slice(None)
-            factor = factor * arr[slc]
+            factor = factor * arr[tuple(slc)]
 
         out *= factor
 
@@ -277,14 +279,14 @@ def fast_1d_tensor_mult(ndarr, onedim_arrs, axes=None, out=None):
 
             slc = [None] * out.ndim
             slc[ax] = slice(None)
-            factor = factor * arr[slc]
+            factor = factor * arr[tuple(slc)]
 
         out *= factor
 
         # Finally multiply by the remaining 1d array
         slc = [None] * out.ndim
         slc[last_ax] = slice(None)
-        out *= last_arr[slc]
+        out *= last_arr[tuple(slc)]
 
     return out
 
@@ -661,17 +663,12 @@ def _apply_padding(lhs_arr, rhs_arr, offset, pad_mode, direction):
                                  ''.format(axis, lr, pad_len, n_rhs))
 
         # Slice tuples used to index LHS and RHS for left and right padding,
-        # respectively. Since `lhs_arr` is used on both sides of the
-        # assignments, full slices are used in all axes except `axis`.
-        # TODO: change comment
-
-        # TODO: use working_slc instead of full_slc
+        # respectively.
         lhs_slc_l, lhs_slc_r = list(working_slc), list(working_slc)
         rhs_slc_l, rhs_slc_r = list(working_slc), list(working_slc)
 
         # We're always using the outer (excess) parts involved in padding
         # on the LHS of the assignment, so we set them here.
-        # TODO: change comment
         pad_slc_outer_l, pad_slc_outer_r = _padding_slices_outer(
             lhs_arr, rhs_arr, axis, offset)
 
@@ -692,15 +689,19 @@ def _apply_padding(lhs_arr, rhs_arr, offset, pad_mode, direction):
             if direction == 'forward':
                 rhs_slc_l[axis] = pad_slc_inner_l
                 rhs_slc_r[axis] = pad_slc_inner_r
+                lhs_slc_l, rhs_slc_l, lhs_slc_r, rhs_slc_r = map(
+                    tuple, [lhs_slc_l, rhs_slc_l, lhs_slc_r, rhs_slc_r])
 
-                lhs_arr[tuple(lhs_slc_l)] = lhs_arr[tuple(rhs_slc_l)]
-                lhs_arr[tuple(lhs_slc_r)] = lhs_arr[tuple(rhs_slc_r)]
+                lhs_arr[lhs_slc_l] = lhs_arr[rhs_slc_l]
+                lhs_arr[lhs_slc_r] = lhs_arr[rhs_slc_r]
             else:
                 lhs_slc_l[axis] = pad_slc_inner_l
                 lhs_slc_r[axis] = pad_slc_inner_r
+                lhs_slc_l, rhs_slc_l, lhs_slc_r, rhs_slc_r = map(
+                    tuple, [lhs_slc_l, rhs_slc_l, lhs_slc_r, rhs_slc_r])
 
-                lhs_arr[tuple(lhs_slc_l)] += lhs_arr[tuple(rhs_slc_l)]
-                lhs_arr[tuple(lhs_slc_r)] += lhs_arr[tuple(rhs_slc_r)]
+                lhs_arr[lhs_slc_l] += lhs_arr[rhs_slc_l]
+                lhs_arr[lhs_slc_r] += lhs_arr[rhs_slc_r]
 
         elif pad_mode == 'order0':
             # The `_padding_slices_inner` helper returns the slices for the
@@ -711,18 +712,22 @@ def _apply_padding(lhs_arr, rhs_arr, offset, pad_mode, direction):
             if direction == 'forward':
                 rhs_slc_l[axis] = left_slc
                 rhs_slc_r[axis] = right_slc
+                lhs_slc_l, rhs_slc_l, lhs_slc_r, rhs_slc_r = map(
+                    tuple, [lhs_slc_l, rhs_slc_l, lhs_slc_r, rhs_slc_r])
 
-                lhs_arr[tuple(lhs_slc_l)] = lhs_arr[tuple(rhs_slc_l)]
-                lhs_arr[tuple(lhs_slc_r)] = lhs_arr[tuple(rhs_slc_r)]
+                lhs_arr[lhs_slc_l] = lhs_arr[rhs_slc_l]
+                lhs_arr[lhs_slc_r] = lhs_arr[rhs_slc_r]
             else:
                 lhs_slc_l[axis] = left_slc
                 lhs_slc_r[axis] = right_slc
+                lhs_slc_l, rhs_slc_l, lhs_slc_r, rhs_slc_r = map(
+                    tuple, [lhs_slc_l, rhs_slc_l, lhs_slc_r, rhs_slc_r])
 
-                lhs_arr[tuple(lhs_slc_l)] += np.sum(
-                    lhs_arr[tuple(rhs_slc_l)],
+                lhs_arr[lhs_slc_l] += np.sum(
+                    lhs_arr[rhs_slc_l],
                     axis=axis, keepdims=True, dtype=lhs_arr.dtype)
-                lhs_arr[tuple(lhs_slc_r)] += np.sum(
-                    lhs_arr[tuple(rhs_slc_r)],
+                lhs_arr[lhs_slc_r] += np.sum(
+                    lhs_arr[rhs_slc_r],
                     axis=axis, keepdims=True, dtype=lhs_arr.dtype)
 
         elif pad_mode == 'order1':
@@ -732,6 +737,7 @@ def _apply_padding(lhs_arr, rhs_arr, offset, pad_mode, direction):
             # Slice for broadcasting of a 1D array along `axis`
             bcast_slc = [None] * lhs_arr.ndim
             bcast_slc[axis] = slice(None)
+            bcast_slc = tuple(bcast_slc)
 
             # Slices for the boundary in `axis`
             left_slc, right_slc = _padding_slices_inner(
@@ -742,6 +748,7 @@ def _apply_padding(lhs_arr, rhs_arr, offset, pad_mode, direction):
             bdry_slc_l[axis] = left_slc
             bdry_slc_r = list(working_slc)
             bdry_slc_r[axis] = right_slc
+            bdry_slc_l, bdry_slc_r = map(tuple, [bdry_slc_l, bdry_slc_r])
 
             # For the slope at the boundary, we need two neighboring points.
             # We create the corresponding slices from the boundary slices.
@@ -749,6 +756,7 @@ def _apply_padding(lhs_arr, rhs_arr, offset, pad_mode, direction):
             slope_slc_l[axis] = slice(left_slc.start, left_slc.stop + 1)
             slope_slc_r = list(working_slc)
             slope_slc_r[axis] = slice(right_slc.start - 1, right_slc.stop)
+            slope_slc_l, slope_slc_r = map(tuple, [slope_slc_l, slope_slc_r])
 
             # The `np.arange`s, broadcast along `axis`, are used to create the
             # constant-slope continuation (forward) or to calculate the
@@ -758,6 +766,9 @@ def _apply_padding(lhs_arr, rhs_arr, offset, pad_mode, direction):
             arange_r = np.arange(1, n_pad_r + 1,
                                  dtype=lhs_arr.dtype)[bcast_slc]
 
+            lhs_slc_l, rhs_slc_l, lhs_slc_r, rhs_slc_r = map(
+                tuple, [lhs_slc_l, rhs_slc_l, lhs_slc_r, rhs_slc_r])
+
             if direction == 'forward':
                 # Take first order difference to get the derivative
                 # along `axis`.
@@ -765,24 +776,22 @@ def _apply_padding(lhs_arr, rhs_arr, offset, pad_mode, direction):
                 slope_r = np.diff(lhs_arr[slope_slc_r], n=1, axis=axis)
 
                 # Finally assign the constant slope values
-                lhs_arr[tuple(lhs_slc_l)] = (
-                    lhs_arr[tuple(bdry_slc_l)] + arange_l * slope_l)
-                lhs_arr[tuple(lhs_slc_r)] = (
-                    lhs_arr[tuple(bdry_slc_r)] + arange_r * slope_r)
+                lhs_arr[lhs_slc_l] = lhs_arr[bdry_slc_l] + arange_l * slope_l
+                lhs_arr[lhs_slc_r] = lhs_arr[bdry_slc_r] + arange_r * slope_r
             else:
                 # Same as in 'order0'
-                lhs_arr[tuple(bdry_slc_l)] += np.sum(
-                    lhs_arr[tuple(rhs_slc_l)],
-                    axis=axis, keepdims=True, dtype=lhs_arr.dtype)
-                lhs_arr[tuple(bdry_slc_r)] += np.sum(
-                    lhs_arr[tuple(rhs_slc_r)],
-                    axis=axis, keepdims=True, dtype=lhs_arr.dtype)
+                lhs_arr[bdry_slc_l] += np.sum(lhs_arr[rhs_slc_l],
+                                              axis=axis, keepdims=True,
+                                              dtype=lhs_arr.dtype)
+                lhs_arr[bdry_slc_r] += np.sum(lhs_arr[rhs_slc_r],
+                                              axis=axis, keepdims=True,
+                                              dtype=lhs_arr.dtype)
 
                 # Calculate the order 1 moments
-                moment1_l = np.sum(arange_l * lhs_arr[tuple(rhs_slc_l)],
+                moment1_l = np.sum(arange_l * lhs_arr[rhs_slc_l],
                                    axis=axis, keepdims=True,
                                    dtype=lhs_arr.dtype)
-                moment1_r = np.sum(arange_r * lhs_arr[tuple(rhs_slc_r)],
+                moment1_r = np.sum(arange_r * lhs_arr[rhs_slc_r],
                                    axis=axis, keepdims=True,
                                    dtype=lhs_arr.dtype)
 


### PR DESCRIPTION
We had a few places where we explicitly created index lists that shouldn't be lists. The unit tests unearthed a whole bunch of them, but there might be more. 
I guess we can go ahead with this (assuming the tests go green) and fix other places that trigger warnings later on.