### PR TITLE
BUG: Fix bug with missing impl_in in RayTransform

### DIFF
--- a/odl/tomo/operators/ray_trafo.py
+++ b/odl/tomo/operators/ray_trafo.py
@@ -144,12 +144,12 @@ class RayTransformBase(Operator):
                         RuntimeWarning)
             else:
                 raise RuntimeError('bad impl')
-        else:
-            impl, impl_in = str(impl).lower(), impl
-            if impl not in _SUPPORTED_IMPL:
-                raise ValueError('`impl` {!r} not understood'.format(impl_in))
-            if impl not in _AVAILABLE_IMPLS:
-                raise ValueError('{!r} back-end not available'.format(impl))
+
+        impl, impl_in = str(impl).lower(), impl
+        if impl not in _SUPPORTED_IMPL:
+            raise ValueError('`impl` {!r} not understood'.format(impl_in))
+        if impl not in _AVAILABLE_IMPLS:
+            raise ValueError('{!r} back-end not available'.format(impl))
 
         # Cache for input/output arrays of transforms
         self.use_cache = kwargs.pop('use_cache', True)


### PR DESCRIPTION
This makes some checks redundant, but they are actually needed in some cases, and worst case we initialize impl_in which is needed later on.