### PR TITLE
ENH: add `binning` function

### DIFF
--- a/odl/test/util/numerics_test.py
+++ b/odl/test/util/numerics_test.py
@@ -587,6 +587,7 @@ def test_binning(binning_setup):
     if len(bin_sizes) != arr.ndim:
         with pytest.raises(ValueError):
             binning(arr, bin_size, bin_reduction)
+        return
     if any(b > n for b, n in zip(bin_sizes, arr.shape)):
         # Bin size larger than array size not allowed
         with pytest.raises(ValueError):

--- a/odl/test/util/numerics_test.py
+++ b/odl/test/util/numerics_test.py
@@ -601,5 +601,20 @@ def test_binning(binning_setup):
     assert out_arr.dtype == true_out_arr.dtype
 
 
+def test_binning_corner_cases():
+    # 0-dim
+    arr = np.array(1.0)
+    assert binning(arr, 2) == 1.0  # ok since there are no axes
+    with pytest.raises(ValueError):
+        binning(arr, [2])  # not ok, too many binning values
+
+    # 0 in shape, never ok
+    arr = np.ones((4, 0))
+    with pytest.raises(ValueError):
+        binning(arr, 2)
+    with pytest.raises(ValueError):
+        binning(arr, [1, 1])
+
+
 if __name__ == '__main__':
     odl.util.test_file(__file__)

--- a/odl/test/util/numerics_test.py
+++ b/odl/test/util/numerics_test.py
@@ -126,7 +126,7 @@ def resize_setup(padding, variant):
 
 
 bin_size = simple_fixture(
-    'bin_size', [0, 1, 2, 3, (1, 2), (4, 2), (8, 1), (2, 0)]
+    'bin_size', [0, 1, 2, 3, (1, 2), (4, 2), (8, 1), (2, 0), (2, 2, 2)]
 )
 bin_reduction = simple_fixture(
     'bin_reduction', [np.sum, np.max, np.mean], fmt=' {name}={value.__name__} '
@@ -584,6 +584,9 @@ def test_binning(binning_setup):
         with pytest.raises(ValueError):
             binning(arr, bin_size, bin_reduction)
         return
+    if len(bin_sizes) != arr.ndim:
+        with pytest.raises(ValueError):
+            binning(arr, bin_size, bin_reduction)
     if any(b > n for b, n in zip(bin_sizes, arr.shape)):
         # Bin size larger than array size not allowed
         with pytest.raises(ValueError):

--- a/odl/util/numerics.py
+++ b/odl/util/numerics.py
@@ -860,7 +860,7 @@ def binning(arr, bin_size, reduction=np.sum):
         The array that should be binned.
     bin_size : positive int or sequence
         Size or per-axis sizes of the bins.
-    reduction: callable
+    reduction: callable, optional
         Function used to perform the binning by reduction over temporary
         axes of size ``bin_size``. It is called as ::
 
@@ -868,6 +868,8 @@ def binning(arr, bin_size, reduction=np.sum):
 
         hence it must support this signature. The function is expected to
         collapse ``reduction_axes``.
+
+        Default: `numpy.sum`
 
     Returns
     -------
@@ -914,9 +916,9 @@ def binning(arr, bin_size, reduction=np.sum):
     if not all(b > 0 for b in bin_sizes):
         raise ValueError('expected positive `bin_size`, got {}'
                          ''.format(bin_size))
-    if len(bin_sizes) > d:
+    if len(bin_sizes) != d:
         raise ValueError(
-            'more bin sizes ({}) than array axes ({})'
+            '`len(bin_sizes)` must be equal to `arr.ndim`, but {} != {}'
             ''.format(len(bin_sizes), d)
         )
     if any(b > n for n, b in zip(arr.shape, bin_sizes)):

--- a/odl/util/numerics.py
+++ b/odl/util/numerics.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2019 The ODL contributors
+# Copyright 2014-2020 The ODL contributors
 #
 # This file is part of ODL.
 #
@@ -8,14 +8,18 @@
 
 """Numerical helper functions for convenience or speed."""
 
-from __future__ import print_function, division, absolute_import
-import numpy as np
+from __future__ import absolute_import, division, print_function
 
+import numpy as np
 from odl.util.normalize import normalized_scalar_param_list, safe_int_conv
 
-
-__all__ = ('apply_on_boundary', 'fast_1d_tensor_mult', 'resize_array',
-           'zscore')
+__all__ = (
+    'apply_on_boundary',
+    'fast_1d_tensor_mult',
+    'resize_array',
+    'zscore',
+    'binning',
+)
 
 
 _SUPPORTED_RESIZE_PAD_MODES = ('constant', 'symmetric', 'periodic',
@@ -847,11 +851,6 @@ def zscore(arr):
     return arr
 
 
-if __name__ == '__main__':
-    from odl.util.testutils import run_doctests
-    run_doctests()
-
-
 def binning(arr, bin_size, reduction=np.sum):
     """Bin an array by a factor.
 
@@ -948,3 +947,8 @@ def binning(arr, bin_size, reduction=np.sum):
                          ''.format(out_shp, arr.shape, bin_size))
 
     return red_arr
+
+
+if __name__ == '__main__':
+    from odl.util.testutils import run_doctests
+    run_doctests()

--- a/odl/util/numerics.py
+++ b/odl/util/numerics.py
@@ -914,12 +914,24 @@ def binning(arr, bin_size, reduction=np.sum):
     if not all(b > 0 for b in bin_sizes):
         raise ValueError('expected positive `bin_size`, got {}'
                          ''.format(bin_size))
-
+    if len(bin_sizes) > d:
+        raise ValueError(
+            'more bin sizes ({}) than array axes ({})'
+            ''.format(len(bin_sizes), d)
+        )
+    if any(b > n for n, b in zip(arr.shape, bin_sizes)):
+        raise ValueError(
+            '`bin_size` {} may not exceed array shape {} in any axis'
+            ''.format(bin_size, arr.shape)
+        )
     if not all(n % b == 0 for n, b in zip(arr.shape, bin_sizes)):
-        raise ValueError('`bin_size` must divide `arr.shape` evenly, but '
-                         '`{} / {}` has a remainder of {}'
-                         ''.format(arr.shape, bin_size,
-                                   tuple(np.remainder(arr.shape, bin_sizes))))
+        raise ValueError(
+            '`bin_size` must divide `arr.shape` evenly, but `{} / {}` has a '
+            'remainder of {}'
+            ''.format(
+                arr.shape, bin_size, tuple(np.remainder(arr.shape, bin_sizes))
+            )
+        )
 
     red_shp = []
     red_axes = []


### PR DESCRIPTION
I didn't add any unit tests since the doctests pretty much covers it. Although it might be useful to look at corner cases (`arr.ndim == 0`, `0 in arr.shape`, `bin_size == 1`)... I'll add those.

**TODO**

- [x] Unit test