### PR TITLE
Issue 1467  reduction operator separable sum

### DIFF
--- a/odl/operator/pspace_ops.py
+++ b/odl/operator/pspace_ops.py
@@ -899,6 +899,7 @@ class ReductionOperator(Operator):
     ProductSpaceOperator : More general case, used as backend.
     BroadcastOperator : Calls several operators with same argument.
     DiagonalOperator : Case where each operator should have its own argument.
+    SeparableSum : Corresponding construction for functionals.
     """
     def __init__(self, *operators):
         """Initialize a new instance.

--- a/odl/solvers/functional/default_functionals.py
+++ b/odl/solvers/functional/default_functionals.py
@@ -1661,7 +1661,6 @@ class SeparableSum(Functional):
                 isinstance(functionals[1], Integral)):
             functionals = [functionals[0]] * functionals[1]
 
-        # Check that all elements of `functionals` are indeed functionals
         if not all(isinstance(op, Functional) for op in functionals):
             raise TypeError('all arguments must be `Functional` instances')
 

--- a/odl/solvers/functional/default_functionals.py
+++ b/odl/solvers/functional/default_functionals.py
@@ -1661,6 +1661,10 @@ class SeparableSum(Functional):
                 isinstance(functionals[1], Integral)):
             functionals = [functionals[0]] * functionals[1]
 
+        # Check that all elements of `functionals` are indeed functionals
+        if not all(isinstance(op, Functional) for op in functionals):
+            raise TypeError('all arguments must be `Functional` instances')
+
         domains = [func.domain for func in functionals]
         domain = ProductSpace(*domains)
         linear = all(func.is_linear for func in functionals)


### PR DESCRIPTION
The problem with creating a `ReductionOperator` from functionals boils down to `RealNumbers` not being a `LinearSpace` in ODL. I suppose we do not want to change that, so I simply added a reference to `SeparableSum` in the docstring of `ReductionOperator`.