### PR TITLE
Update astra_cuda.py

### DIFF
--- a/odl/tomo/backends/astra_cuda.py
+++ b/odl/tomo/backends/astra_cuda.py
@@ -422,7 +422,7 @@ def astra_cuda_bp_scaling_factor(proj_space, reco_space, geometry):
             # missing factor src_radius ** 2 in the ASTRA BP with
             # density weighting.
             det_px_area = geometry.det_partition.cell_volume
-            scaling_factor *= (src_radius ** 2 * det_px_area ** 2 )
+            scaling_factor *= (src_radius ** 2 * det_px_area ** 2)
     else:
         if isinstance(geometry, Parallel2dGeometry):
             # Scales with 1 / cell_volume

--- a/odl/tomo/backends/astra_cuda.py
+++ b/odl/tomo/backends/astra_cuda.py
@@ -393,7 +393,36 @@ def astra_cuda_bp_scaling_factor(proj_space, reco_space, geometry):
             src_radius = geometry.src_radius
             det_radius = geometry.det_radius
             scaling_factor *= ((src_radius + det_radius) / src_radius) ** 2
+    # Check if the development version of astra is used
+    if parse_version(ASTRA_VERSION) == parse_version('1.9.0dev'):
+        if isinstance(geometry, Parallel2dGeometry):
+            # Scales with 1 / cell_volume
+            scaling_factor *= float(reco_space.cell_volume)
+        elif isinstance(geometry, FanFlatGeometry):
+            # Scales with 1 / cell_volume
+            scaling_factor *= float(reco_space.cell_volume)
+            # Magnification correction
+            src_radius = geometry.src_radius
+            det_radius = geometry.det_radius
+            scaling_factor *= ((src_radius + det_radius) / src_radius)
+        elif isinstance(geometry, Parallel3dAxisGeometry):
+            # Scales with cell volume
+            # currently only square voxels are supported
+            scaling_factor /= reco_space.cell_volume
+        elif isinstance(geometry, ConeFlatGeometry):
+            # Scales with cell volume
+            scaling_factor /= reco_space.cell_volume
+            # Magnification correction (scaling = 1 / magnification ** 2)
+            src_radius = geometry.src_radius
+            det_radius = geometry.det_radius
+            scaling_factor *= ((src_radius + det_radius) / src_radius) ** 2
 
+            # Correction for scaled 1/r^2 factor in ASTRA's density weighting.
+            # This compensates for scaled voxels and pixels, as well as a
+            # missing factor src_radius ** 2 in the ASTRA BP with
+            # density weighting.
+            det_px_area = geometry.det_partition.cell_volume
+            scaling_factor *= (src_radius ** 2 * det_px_area ** 2 )
     else:
         if isinstance(geometry, Parallel2dGeometry):
             # Scales with 1 / cell_volume


### PR DESCRIPTION
Added a check for development ASTRA_VERSION = '1.9.0dev' and added the correct scaling to the backprojection.

In the development version '1.9.0dev' of astra-toolbox, the scaling of the backprojection is changed. I added a check in the 'astra_cuda_bp_scaling_factor' function to determine if this version is used and changed the scaling to such that the backprojection is scaled correctly.
Running this:
```
odl.diagnostics.OperatorTest(backprojection_op).adjoint()
```
With the suggested change gives:
```
== Verifying operator adjoint ==

Domain and range of adjoint are OK.
Verifying the identity <Ax, y> = <x, A^T y>
x=One                       y=One                       : error=0.00069
x=One                       y=Step                      : error=0.00048
x=One                       y=Cube                      : error=0.00006
x=One                       y=Ball                      : error=0.00001
x=One                       y=Gaussian                  : error=0.00027
x=One                       y=Grad 0                    : error=0.00054
x=One                       y=Grad 1                    : error=0.00054
x=One                       y=Grad 2                    : error=0.00055
x=One                       y=Grad all                  : error=0.00061
x=Step                      y=One                       : error=0.00043
x=Step                      y=Step                      : error=0.00030
x=Step                      y=Cube                      : error=0.00004
x=Step                      y=Ball                      : error=0.00002
x=Step                      y=Gaussian                  : error=0.00019
x=Step                      y=Grad 0                    : error=0.00039
x=Step                      y=Grad 1                    : error=0.00038
x=Step                      y=Grad 2                    : error=0.00039
x=Step                      y=Grad all                  : error=0.00043
x=Cube                      y=One                       : error=0.00023
x=Cube                      y=Step                      : error=0.00016
x=Cube                      y=Cube                      : error=0.00008
x=Cube                      y=Ball                      : error=0.00004
x=Cube                      y=Gaussian                  : error=0.00018
x=Cube                      y=Grad 0                    : error=0.00020
x=Cube                      y=Grad 1                    : error=0.00021
x=Cube                      y=Grad 2                    : error=0.00020
x=Cube                      y=Grad all                  : error=0.00023
x=Ball                      y=One                       : error=0.00011
x=Ball                      y=Step                      : error=0.00008
x=Ball                      y=Cube                      : error=0.00006
x=Ball                      y=Ball                      : error=0.00004
x=Ball                      y=Gaussian                  : error=0.00012
x=Ball                      y=Grad 0                    : error=0.00010
x=Ball                      y=Grad 1                    : error=0.00010
x=Ball                      y=Grad 2                    : error=0.00010
x=Ball                      y=Grad all                  : error=0.00011
x=Gaussian                  y=One                       : error=0.00048
x=Gaussian                  y=Step                      : error=0.00034
x=Gaussian                  y=Cube                      : error=0.00009
x=Gaussian                  y=Ball                      : error=0.00004
x=Gaussian                  y=Gaussian                  : error=0.00026
x=Gaussian                  y=Grad 0                    : error=0.00041
x=Gaussian                  y=Grad 1                    : error=0.00041
x=Gaussian                  y=Grad 2                    : error=0.00042
x=Gaussian                  y=Grad all                  : error=0.00046
x=Grad 0                    y=One                       : error=0.00055
x=Grad 0                    y=Step                      : error=0.00038
x=Grad 0                    y=Cube                      : error=0.00005
x=Grad 0                    y=Ball                      : error=0.00002
x=Grad 0                    y=Gaussian                  : error=0.00024
x=Grad 0                    y=Grad 0                    : error=0.00047
x=Grad 0                    y=Grad 1                    : error=0.00047
x=Grad 0                    y=Grad 2                    : error=0.00048
x=Grad 0                    y=Grad all                  : error=0.00052
x=Grad 1                    y=One                       : error=0.00062
x=Grad 1                    y=Step                      : error=0.00042
x=Grad 1                    y=Cube                      : error=0.00005
x=Grad 1                    y=Ball                      : error=0.00001
x=Grad 1                    y=Gaussian                  : error=0.00023
x=Grad 1                    y=Grad 0                    : error=0.00048
x=Grad 1                    y=Grad 1                    : error=0.00048
x=Grad 1                    y=Grad 2                    : error=0.00048
x=Grad 1                    y=Grad all                  : error=0.00052
x=Grad 2                    y=One                       : error=0.00055
x=Grad 2                    y=Step                      : error=0.00039
x=Grad 2                    y=Cube                      : error=0.00005
x=Grad 2                    y=Ball                      : error=0.00002
x=Grad 2                    y=Gaussian                  : error=0.00023
x=Grad 2                    y=Grad 0                    : error=0.00047
x=Grad 2                    y=Grad 1                    : error=0.00047
x=Grad 2                    y=Grad 2                    : error=0.00071
x=Grad 2                    y=Grad all                  : error=0.00060
x=Grad all                  y=One                       : error=0.00061
x=Grad all                  y=Step                      : error=0.00043
x=Grad all                  y=Cube                      : error=0.00005
x=Grad all                  y=Ball                      : error=0.00002
x=Grad all                  y=Gaussian                  : error=0.00026
x=Grad all                  y=Grad 0                    : error=0.00052
x=Grad all                  y=Grad 1                    : error=0.00052
x=Grad all                  y=Grad 2                    : error=0.00060
x=Grad all                  y=Grad all                  : error=0.00060
error = |<Ax, y< - <x, A^* y>| / ||A|| ||x|| ||y||
*** FAILED 81 TEST CASE(S) ***

The adjoint seems to be scaled according to:
(x, A^T y) / (Ax, y) = 1.0008501000870365. Should be 1.0

Verifying the identity Ax = (A^*)^* x                                : Completed all test cases.
```

It still fails a lot of the test cases, but that is most likely due to the mismatch in interpolation kernels in ASTRA.