### PR TITLE
link prox of conjugate of linfty norm to proj_l1

### DIFF
--- a/odl/solvers/functional/default_functionals.py
+++ b/odl/solvers/functional/default_functionals.py
@@ -22,7 +22,7 @@ from odl.solvers.nonsmooth.proximal_operators import (
     proximal_l1, proximal_convex_conj_l1,
     proximal_l1_l2, proximal_convex_conj_l1_l2,
     proximal_l2, proximal_convex_conj_l2, proximal_l2_squared,
-    proximal_linfty,
+    proximal_linfty, proximal_convex_conj_linfty,
     proximal_huber,
     proximal_const_func, proximal_box_constraint,
     proximal_convex_conj_kl, proximal_convex_conj_kl_cross_entropy,
@@ -529,9 +529,11 @@ class IndicatorLpUnitBall(Functional):
             return proximal_convex_conj_l1(space=self.domain)
         elif self.exponent == 2:
             return proximal_convex_conj_l2(space=self.domain)
+        elif self.exponent == 1:
+            return proximal_convex_conj_linfty(space=self.domain)
         else:
-            raise NotImplementedError('`gradient` only implemented for p=2 or '
-                                      'p=inf')
+            raise NotImplementedError('`proximal` only implemented for p=1, '
+                                      'p=2 or p=inf')
 
     def __repr__(self):
         """Return ``repr(self)``."""

--- a/odl/solvers/functional/default_functionals.py
+++ b/odl/solvers/functional/default_functionals.py
@@ -524,6 +524,8 @@ class IndicatorLpUnitBall(Functional):
             `proximal factory` for convex conjuagte of L1-norm.
         odl.solvers.nonsmooth.proximal_operators.proximal_convex_conj_l2 :
             `proximal factory` for convex conjuagte of L2-norm.
+        odl.solvers.nonsmooth.proximal_operators.proximal_convex_conj_linfty :
+            `proximal factory` for convex conjuagte of Linfty-norm.
         """
         if self.exponent == np.inf:
             return proximal_convex_conj_l1(space=self.domain)

--- a/odl/solvers/nonsmooth/proximal_operators.py
+++ b/odl/solvers/nonsmooth/proximal_operators.py
@@ -1495,12 +1495,12 @@ def proximal_linfty(space):
 
 
 def proximal_convex_conj_linfty(space):
-    """Proximal operator factory of the Linfty norm/distance convex conjugate.
+    r"""Proximal operator factory of the Linfty norm/distance convex conjugate.
 
     Implements the proximal operator of the convex conjugate of the
     functional ::
 
-        F(x) = ||x||_\\infty
+        F(x) = \|x\|_\infty
 
     with ``x`` in ``space``.
 
@@ -1519,13 +1519,13 @@ def proximal_convex_conj_linfty(space):
     The convex conjugate :math:`F^*` of the functional
 
     .. math::
-        F(x) = ||x||_\\infty.
+        F(x) = \|x\|_\infty.
 
     is in the case of scalar-valued functions given by the indicator function
     of the unit 1-norm ball
 
     .. math::
-        F^*(y) = \\iota_{B_1} \\big( y \\big).
+        F^*(y) = \iota_{B_1} \big( y \big).
 
     See Also
     --------

--- a/odl/solvers/nonsmooth/proximal_operators.py
+++ b/odl/solvers/nonsmooth/proximal_operators.py
@@ -37,7 +37,7 @@ __all__ = ('combine_proximals', 'proximal_convex_conj', 'proximal_translation',
            'proximal_box_constraint', 'proximal_nonnegativity',
            'proximal_l1', 'proximal_convex_conj_l1',
            'proximal_l2', 'proximal_convex_conj_l2',
-           'proximal_linfty',
+           'proximal_linfty', 'proximal_convex_conj_linfty',
            'proj_simplex', 'proj_l1',
            'proximal_l2_squared', 'proximal_convex_conj_l2_squared',
            'proximal_l1_l2', 'proximal_convex_conj_l1_l2',
@@ -1492,6 +1492,67 @@ def proximal_linfty(space):
             out.lincomb(-1, out, 1, x)
 
     return ProximalLInfty
+
+
+def proximal_convex_conj_linfty(space):
+    """Proximal operator factory of the Linfty norm/distance convex conjugate.
+
+    Implements the proximal operator of the convex conjugate of the
+    functional ::
+
+        F(x) = ||x||_infty
+
+    with ``x`` in ``space``.
+
+    Parameters
+    ----------
+    space : `LinearSpace` or `ProductSpace` of `LinearSpace` spaces
+        Domain of the functional F
+
+    Returns
+    -------
+    prox_factory : function
+        Factory for the proximal operator to be initialized.
+
+    Notes
+    -----
+    The convex conjugate :math:`F^*` of the functional
+
+    .. math::
+        F(x) = \|x\|_infty.
+
+    is in the case of scalar-valued functions given by the indicator function
+    of the unit 1-norm ball
+
+    .. math::
+        F^*(y) = \iota_{B_1} \\big( y \\big).
+
+    See Also
+    --------
+    proj_l1 : orthogonal projection onto balls in the 1-norm
+    """
+
+    class ProximalConvexConjLinfty(Operator):
+
+        """Proximal operator of the Linfty norm/distance convex conjugate."""
+
+        def __init__(self, sigma):
+            """Initialize a new instance.
+
+            Parameters
+            ----------
+            sigma : positive float or pointwise positive space.element
+                Step size parameter. If scalar, it contains a global stepsize,
+                otherwise the space.element defines a stepsize for each point.
+            """
+            super(ProximalConvexConjLinfty, self).__init__(
+                domain=space, range=space, linear=False)
+
+        def _call(self, x, out):
+            """Return ``self(x, out=out)``."""
+            proj_l1(x, radius=1, out=out)
+
+    return ProximalConvexConjLinfty
 
 
 def proj_l1(x, radius=1, out=None):

--- a/odl/solvers/nonsmooth/proximal_operators.py
+++ b/odl/solvers/nonsmooth/proximal_operators.py
@@ -1500,7 +1500,7 @@ def proximal_convex_conj_linfty(space):
     Implements the proximal operator of the convex conjugate of the
     functional ::
 
-        F(x) = ||x||_infty
+        F(x) = ||x||_\\infty
 
     with ``x`` in ``space``.
 
@@ -1519,13 +1519,13 @@ def proximal_convex_conj_linfty(space):
     The convex conjugate :math:`F^*` of the functional
 
     .. math::
-        F(x) = \|x\|_infty.
+        F(x) = ||x||_\\infty.
 
     is in the case of scalar-valued functions given by the indicator function
     of the unit 1-norm ball
 
     .. math::
-        F^*(y) = \iota_{B_1} \\big( y \\big).
+        F^*(y) = \\iota_{B_1} \\big( y \\big).
 
     See Also
     --------


### PR DESCRIPTION
This is a super small PR, just linking the existing projection onto l1 balls to the convex conjugate of the linfty norm.

I have seen that other prox operators include scalings `lambda` and shifts `g` but I left them out here for simplicity.