### PR TITLE
ENH: make FOMs accept array-like inputs

### DIFF
--- a/odl/contrib/fom/supervised.py
+++ b/odl/contrib/fom/supervised.py
@@ -867,7 +867,9 @@ def noise_power_spectrum(data, ground_truth, radial=False,
         assert isinstance(space, odl.DiscreteLp)
     except (AttributeError, AssertionError):
         data = np.asarray(data)
-        space = odl.uniform_discr([0] * data.ndim, data.shape, data.shape, data.dtype)
+        space = odl.uniform_discr(
+            [0] * data.ndim, data.shape, data.shape, data.dtype
+        )
         data = space.element(data)
 
     ft = odl.trafos.FourierTransform(space, halfcomplex=False)

--- a/odl/contrib/fom/test/test_supervised.py
+++ b/odl/contrib/fom/test/test_supervised.py
@@ -77,6 +77,12 @@ def test_general(space, scalar_fom):
                 <= scalar_fom(ground_truth + 2 * noise, ground_truth)
             )
 
+        # Check that supplying arrays works as well
+        assert (
+            scalar_fom(ground_truth.asarray(), ground_truth.asarray())
+            <= scalar_fom(data.asarray(), ground_truth.asarray())
+        )
+
 
 def filter_image(image, fh, fv):
     """Reference filtering function using ``scipy.signal.convolve``."""
@@ -120,7 +126,6 @@ def test_mean_absolute_error(space):
 
 def test_psnr(space):
     """Test the ``psnr`` fom."""
-
     true = odl.phantom.white_noise(space)
     data = odl.phantom.white_noise(space)
     zero = space.zero()
@@ -137,6 +142,10 @@ def test_psnr(space):
 
     # Test regular call
     result = fom.psnr(data, true)
+    assert result == pytest.approx(expected, abs=1e-6)
+
+    # Test with arrays as input
+    result = fom.psnr(data.asarray(), true.asarray())
     assert result == pytest.approx(expected, abs=1e-6)
 
     # Test with force_lower_is_better giving negative of expected


### PR DESCRIPTION
With this change, all supervised FOMs accept array-like input, instead of insisting on ODL space elements. Makes them much more useful. (And many don't even depend on space properties.)

Unit tests added, they pass, and the doctests still work as well.