### PR TITLE
ENH: allow choice of ASTRA projector type

### DIFF
--- a/odl/test/tomo/backends/astra_setup_test.py
+++ b/odl/test/tomo/backends/astra_setup_test.py
@@ -14,7 +14,9 @@ import numpy as np
 import pytest
 
 import odl
-from odl.tomo.backends.astra_setup import astra_supports
+from odl.tomo.backends.astra_setup import (
+    astra_algorithm, astra_data, astra_projection_geometry, astra_projector,
+    astra_supports, astra_volume_geometry)
 from odl.util.testutils import is_subdict
 
 try:
@@ -87,7 +89,7 @@ def test_vol_geom_2d():
             'WindowMinY': -1.0,  # x_min
             'WindowMaxY': 1.0}}  # x_amx
 
-    vol_geom = odl.tomo.astra_volume_geometry(discr_dom)
+    vol_geom = astra_volume_geometry(discr_dom)
     assert vol_geom == correct_dict
 
     # Anisotropic voxel case
@@ -102,11 +104,11 @@ def test_vol_geom_2d():
             'WindowMaxY': 1.0}}  # x_amx
 
     if astra_supports('anisotropic_voxels_2d'):
-        vol_geom = odl.tomo.astra_volume_geometry(discr_dom)
+        vol_geom = astra_volume_geometry(discr_dom)
         assert vol_geom == correct_dict
     else:
         with pytest.raises(NotImplementedError):
-            odl.tomo.astra_volume_geometry(discr_dom)
+            astra_volume_geometry(discr_dom)
 
 
 def test_vol_geom_3d():
@@ -130,7 +132,7 @@ def test_vol_geom_3d():
             'WindowMinZ': -1.0,  # x_min
             'WindowMaxZ': 1.0}}  # x_amx
 
-    vol_geom = odl.tomo.astra_volume_geometry(discr_dom)
+    vol_geom = astra_volume_geometry(discr_dom)
     assert vol_geom == correct_dict
 
     discr_dom = _discrete_domain_anisotropic(3, 'nearest')
@@ -148,11 +150,11 @@ def test_vol_geom_3d():
             'WindowMaxZ': 1.0}}  # x_amx
 
     if astra_supports('anisotropic_voxels_3d'):
-        vol_geom = odl.tomo.astra_volume_geometry(discr_dom)
+        vol_geom = astra_volume_geometry(discr_dom)
         assert vol_geom == correct_dict
     else:
         with pytest.raises(NotImplementedError):
-            odl.tomo.astra_volume_geometry(discr_dom)
+            astra_volume_geometry(discr_dom)
 
 
 def test_proj_geom_parallel_2d():
@@ -162,7 +164,7 @@ def test_proj_geom_parallel_2d():
     dpart = odl.uniform_partition(-1, 1, 10)
     geom = odl.tomo.Parallel2dGeometry(apart, dpart)
 
-    proj_geom = odl.tomo.astra_projection_geometry(geom)
+    proj_geom = astra_projection_geometry(geom)
 
     correct_subdict = {
         'type': 'parallel',
@@ -176,7 +178,7 @@ def test_astra_projection_geometry():
     """Create ASTRA projection geometry from geometry objects."""
 
     with pytest.raises(TypeError):
-        odl.tomo.astra_projection_geometry(None)
+        astra_projection_geometry(None)
 
     apart = odl.uniform_partition(0, 2 * np.pi, 5)
     dpart = odl.uniform_partition(-40, 40, 10)
@@ -186,42 +188,42 @@ def test_astra_projection_geometry():
                                 odl.RectGrid([0, 1, 3]))
     geom_p2d = odl.tomo.Parallel2dGeometry(apart, dpart=dpart_0)
     with pytest.raises(ValueError):
-        odl.tomo.astra_projection_geometry(geom_p2d)
+        astra_projection_geometry(geom_p2d)
 
     # detector sampling grid, motion sampling grid
     geom_p2d = odl.tomo.Parallel2dGeometry(apart, dpart)
-    odl.tomo.astra_projection_geometry(geom_p2d)
+    astra_projection_geometry(geom_p2d)
 
     # Parallel 2D geometry
     geom_p2d = odl.tomo.Parallel2dGeometry(apart, dpart)
-    astra_geom = odl.tomo.astra_projection_geometry(geom_p2d)
+    astra_geom = astra_projection_geometry(geom_p2d)
     assert astra_geom['type'] == 'parallel'
 
     # Fan flat
     src_rad = 10
     det_rad = 5
     geom_ff = odl.tomo.FanBeamGeometry(apart, dpart, src_rad, det_rad)
-    astra_geom = odl.tomo.astra_projection_geometry(geom_ff)
+    astra_geom = astra_projection_geometry(geom_ff)
     assert astra_geom['type'] == 'fanflat_vec'
 
     dpart = odl.uniform_partition([-40, -3], [40, 3], (10, 5))
 
     # Parallel 3D geometry
     geom_p3d = odl.tomo.Parallel3dAxisGeometry(apart, dpart)
-    odl.tomo.astra_projection_geometry(geom_p3d)
-    astra_geom = odl.tomo.astra_projection_geometry(geom_p3d)
+    astra_projection_geometry(geom_p3d)
+    astra_geom = astra_projection_geometry(geom_p3d)
     assert astra_geom['type'] == 'parallel3d_vec'
 
     # Circular conebeam flat
     geom_ccf = odl.tomo.ConeBeamGeometry(apart, dpart, src_rad, det_rad)
-    astra_geom = odl.tomo.astra_projection_geometry(geom_ccf)
+    astra_geom = astra_projection_geometry(geom_ccf)
     assert astra_geom['type'] == 'cone_vec'
 
     # Helical conebeam flat
     pitch = 1
     geom_hcf = odl.tomo.ConeBeamGeometry(apart, dpart, src_rad, det_rad,
                                          pitch=pitch)
-    astra_geom = odl.tomo.astra_projection_geometry(geom_hcf)
+    astra_geom = astra_projection_geometry(geom_hcf)
     assert astra_geom['type'] == 'cone_vec'
 
 
@@ -235,14 +237,14 @@ def test_volume_data_2d():
     """Create ASTRA data structure in 2D."""
 
     # From scratch
-    data_id = odl.tomo.astra_data(VOL_GEOM_2D, 'volume', ndim=2)
+    data_id = astra_data(VOL_GEOM_2D, 'volume', ndim=2)
     data_out = astra.data2d.get_shared(data_id)
     assert data_out.shape == (10, 20)
 
     # From existing
     discr_dom = _discrete_domain(2, 'nearest')
     data_in = discr_dom.element(np.ones((10, 20), dtype='float32'))
-    data_id = odl.tomo.astra_data(VOL_GEOM_2D, 'volume', data=data_in)
+    data_id = astra_data(VOL_GEOM_2D, 'volume', data=data_in)
     data_out = astra.data2d.get_shared(data_id)
     assert data_out.shape == (10, 20)
 
@@ -256,14 +258,14 @@ def test_volume_data_3d():
     """Create ASTRA data structure in 2D."""
 
     # From scratch
-    data_id = odl.tomo.astra_data(VOL_GEOM_3D, 'volume', ndim=3)
+    data_id = astra_data(VOL_GEOM_3D, 'volume', ndim=3)
     data_out = astra.data3d.get_shared(data_id)
     assert data_out.shape == (10, 20, 30)
 
     # From existing
     discr_dom = _discrete_domain(3, 'nearest')
     data_in = discr_dom.element(np.ones((10, 20, 30), dtype='float32'))
-    data_id = odl.tomo.astra_data(VOL_GEOM_3D, 'volume', data=data_in)
+    data_id = astra_data(VOL_GEOM_3D, 'volume', data=data_in)
     data_out = astra.data3d.get_shared(data_id)
     assert data_out.shape == (10, 20, 30)
 
@@ -283,31 +285,27 @@ PROJ_GEOM_3D = {
 def test_parallel_2d_projector():
     """Create ASTRA 2D projectors."""
     # We can just test if it runs
-    odl.tomo.astra_projector('line', VOL_GEOM_2D, PROJ_GEOM_2D, ndim=2)
-    odl.tomo.astra_projector('linear', VOL_GEOM_2D, PROJ_GEOM_2D, ndim=2)
+    astra_projector('line', VOL_GEOM_2D, PROJ_GEOM_2D, ndim=2)
+    astra_projector('linear', VOL_GEOM_2D, PROJ_GEOM_2D, ndim=2)
 
     with pytest.raises(ValueError):
-        odl.tomo.astra_projector(
-            'line_fanflat', VOL_GEOM_2D, PROJ_GEOM_2D, ndim=2
-        )
+        astra_projector('line_fanflat', VOL_GEOM_2D, PROJ_GEOM_2D, ndim=2)
     with pytest.raises(ValueError):
-        odl.tomo.astra_projector(
-            'linearcone', VOL_GEOM_2D, PROJ_GEOM_2D, ndim=2
-        )
+        astra_projector('linearcone', VOL_GEOM_2D, PROJ_GEOM_2D, ndim=2)
 
 
 @pytest.mark.xfail(reason='3D CPU projectors not supported by ASTRA')
 def test_parallel_3d_projector():
     """Create ASTRA 3D projectors."""
     # We can just test if it runs
-    odl.tomo.astra_projector('linear3d', VOL_GEOM_3D, PROJ_GEOM_3D, ndim=3)
+    astra_projector('linear3d', VOL_GEOM_3D, PROJ_GEOM_3D, ndim=3)
 
 
 @pytest.mark.skipif(not odl.tomo.ASTRA_CUDA_AVAILABLE,
-                    reason="ASTRA cuda not available")
+                    reason="ASTRA CUDA not available")
 def test_parallel_3d_projector_gpu():
     """Create ASTRA 3D projectors on GPU."""
-    odl.tomo.astra_projector('cuda3d', VOL_GEOM_3D, PROJ_GEOM_3D, ndim=3)
+    astra_projector('cuda3d', VOL_GEOM_3D, PROJ_GEOM_3D, ndim=3)
 
 
 def test_astra_algorithm():
@@ -315,33 +313,31 @@ def test_astra_algorithm():
     direction = 'forward'
     ndim = 2
     impl = 'cpu'
-    vol_id = odl.tomo.astra_data(VOL_GEOM_2D, 'volume', ndim=ndim)
-    sino_id = odl.tomo.astra_data(PROJ_GEOM_2D, 'projection', ndim=ndim)
-    proj_id = odl.tomo.astra_projector(
-        'linear', VOL_GEOM_2D, PROJ_GEOM_2D, ndim=ndim
-    )
+    vol_id = astra_data(VOL_GEOM_2D, 'volume', ndim=ndim)
+    sino_id = astra_data(PROJ_GEOM_2D, 'projection', ndim=ndim)
+    proj_id = astra_projector('linear', VOL_GEOM_2D, PROJ_GEOM_2D, ndim=ndim)
 
     # Checks
     with pytest.raises(ValueError):
-        odl.tomo.astra_algorithm('none', ndim, vol_id, sino_id, proj_id, impl)
+        astra_algorithm('none', ndim, vol_id, sino_id, proj_id, impl)
     with pytest.raises(ValueError):
-        odl.tomo.astra_algorithm(direction, 0, vol_id, sino_id, proj_id, impl)
+        astra_algorithm(direction, 0, vol_id, sino_id, proj_id, impl)
     with pytest.raises(ValueError):
-        odl.tomo.astra_algorithm('none', ndim, vol_id, sino_id, proj_id,
-                                 'none')
+        astra_algorithm('none', ndim, vol_id, sino_id, proj_id, 'none')
     with pytest.raises(ValueError):
-        odl.tomo.astra_algorithm('backward', ndim, vol_id, sino_id,
-                                 proj_id=None, impl='cpu')
-    alg_id = odl.tomo.astra_algorithm(direction, ndim, vol_id, sino_id,
-                                      proj_id, impl)
+        astra_algorithm(
+            'backward', ndim, vol_id, sino_id, proj_id=None, impl='cpu'
+        )
+    alg_id = astra_algorithm(direction, ndim, vol_id, sino_id, proj_id, impl)
     astra.algorithm.delete(alg_id)
 
     # 2D CPU
     ndim = 2
     impl = 'cpu'
     for direction in {'forward', 'backward'}:
-        alg_id = odl.tomo.astra_algorithm(direction, ndim, vol_id, sino_id,
-                                          proj_id, impl)
+        alg_id = astra_algorithm(
+            direction, ndim, vol_id, sino_id, proj_id, impl
+        )
         astra.algorithm.delete(alg_id)
 
 
@@ -352,37 +348,39 @@ def test_astra_algorithm_gpu():
 
     direction = 'forward'
     ndim = 2
-    vol_id = odl.tomo.astra_data(VOL_GEOM_2D, 'volume', ndim=ndim)
-    rec_id = odl.tomo.astra_data(VOL_GEOM_2D, 'volume', ndim=ndim)
-    sino_id = odl.tomo.astra_data(PROJ_GEOM_2D, 'projection', ndim=ndim)
+    vol_id = astra_data(VOL_GEOM_2D, 'volume', ndim=ndim)
+    rec_id = astra_data(VOL_GEOM_2D, 'volume', ndim=ndim)
+    sino_id = astra_data(PROJ_GEOM_2D, 'projection', ndim=ndim)
 
     # 2D CUDA
-    proj_id = odl.tomo.astra_projector('nearest', VOL_GEOM_2D, PROJ_GEOM_2D,
-                                       ndim=ndim, impl='cuda')
+    proj_id = astra_projector('cuda', VOL_GEOM_2D, PROJ_GEOM_2D, ndim=ndim)
 
     # 2D CUDA FP
-    alg_id = odl.tomo.astra_algorithm('forward', ndim, vol_id, sino_id,
-                                      proj_id=proj_id, impl='cuda')
+    alg_id = astra_algorithm(
+        'forward', ndim, vol_id, sino_id, proj_id=proj_id, impl='cuda'
+    )
     astra.algorithm.delete(alg_id)
 
     # 2D CUDA BP
-    alg_id = odl.tomo.astra_algorithm('backward', ndim, rec_id, sino_id,
-                                      proj_id=proj_id, impl='cuda')
+    alg_id = astra_algorithm(
+        'backward', ndim, rec_id, sino_id, proj_id=proj_id, impl='cuda'
+    )
     astra.algorithm.delete(alg_id)
 
     ndim = 3
-    vol_id = odl.tomo.astra_data(VOL_GEOM_3D, 'volume', ndim=ndim)
-    sino_id = odl.tomo.astra_data(PROJ_GEOM_3D, 'projection', ndim=ndim)
-    proj_id = odl.tomo.astra_projector('nearest', VOL_GEOM_3D, PROJ_GEOM_3D,
-                                       ndim=ndim, impl='cuda')
+    vol_id = astra_data(VOL_GEOM_3D, 'volume', ndim=ndim)
+    sino_id = astra_data(PROJ_GEOM_3D, 'projection', ndim=ndim)
+    proj_id = astra_projector('cuda3d', VOL_GEOM_3D, PROJ_GEOM_3D, ndim=ndim)
 
     with pytest.raises(NotImplementedError):
-        odl.tomo.astra_algorithm(direction, ndim, vol_id, sino_id,
-                                 proj_id=proj_id, impl='cpu')
+        astra_algorithm(
+            direction, ndim, vol_id, sino_id, proj_id=proj_id, impl='cpu'
+        )
 
     for direction in {'forward', 'backward'}:
-        odl.tomo.astra_algorithm(direction, ndim, vol_id, sino_id,
-                                 proj_id=proj_id, impl='cuda')
+        astra_algorithm(
+            direction, ndim, vol_id, sino_id, proj_id=proj_id, impl='cuda'
+        )
 
 
 def test_geom_to_vec():

--- a/odl/test/tomo/backends/astra_setup_test.py
+++ b/odl/test/tomo/backends/astra_setup_test.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2017 The ODL contributors
+# Copyright 2014-2019 The ODL contributors
 #
 # This file is part of ODL.
 #
@@ -6,20 +6,21 @@
 # v. 2.0. If a copy of the MPL was not distributed with this file, You can
 # obtain one at https://mozilla.org/MPL/2.0/.
 
-"""Test astra setup functions."""
+"""Test ASTRA setup functions."""
 
 from __future__ import division
+
 import numpy as np
 import pytest
-try:
-    import astra
-except ImportError:
-    pass
 
 import odl
 from odl.tomo.backends.astra_setup import astra_supports
 from odl.util.testutils import is_subdict
 
+try:
+    import astra
+except ImportError:
+    pass
 
 pytestmark = pytest.mark.skipif("not odl.tomo.ASTRA_AVAILABLE")
 
@@ -40,7 +41,7 @@ def _discrete_domain(ndim, interp):
         Returns a `DiscreteLp` instance
     """
     max_pt = np.arange(1, ndim + 1)
-    min_pt = - max_pt
+    min_pt = -max_pt
     shape = np.arange(1, ndim + 1) * 10
 
     return odl.uniform_discr(min_pt, max_pt, shape=shape, interp=interp,
@@ -281,46 +282,44 @@ PROJ_GEOM_3D = {
 
 def test_parallel_2d_projector():
     """Create ASTRA 2D projectors."""
-
     # We can just test if it runs
-    odl.tomo.astra_projector('nearest', VOL_GEOM_2D, PROJ_GEOM_2D,
-                             ndim=2, impl='cpu')
-    odl.tomo.astra_projector('linear', VOL_GEOM_2D, PROJ_GEOM_2D,
-                             ndim=2, impl='cpu')
+    odl.tomo.astra_projector('line', VOL_GEOM_2D, PROJ_GEOM_2D, ndim=2)
+    odl.tomo.astra_projector('linear', VOL_GEOM_2D, PROJ_GEOM_2D, ndim=2)
+
+    with pytest.raises(AssertionError):
+        odl.tomo.astra_projector(
+            'line_fanflat', VOL_GEOM_2D, PROJ_GEOM_2D, ndim=2
+        )
+    with pytest.raises(AssertionError):
+        odl.tomo.astra_projector(
+            'linearcone', VOL_GEOM_2D, PROJ_GEOM_2D, ndim=2
+        )
 
 
+@pytest.mark.xfail(reason='3D CPU projectors not supported by ASTRA')
 def test_parallel_3d_projector():
     """Create ASTRA 3D projectors."""
-
-    # Run as a real test once ASTRA supports this construction
-    with pytest.raises(ValueError):
-        odl.tomo.astra_projector('nearest', VOL_GEOM_3D, PROJ_GEOM_3D,
-                                 ndim=3, impl='cpu')
-
-    with pytest.raises(ValueError):
-        odl.tomo.astra_projector('linear', VOL_GEOM_3D, PROJ_GEOM_3D,
-                                 ndim=3, impl='cpu')
+    # We can just test if it runs
+    odl.tomo.astra_projector('linear3d', VOL_GEOM_3D, PROJ_GEOM_3D, ndim=3)
 
 
 @pytest.mark.skipif(not odl.tomo.ASTRA_CUDA_AVAILABLE,
                     reason="ASTRA cuda not available")
 def test_parallel_3d_projector_gpu():
     """Create ASTRA 3D projectors on GPU."""
-
-    odl.tomo.astra_projector('nearest', VOL_GEOM_3D, PROJ_GEOM_3D, ndim=3,
-                             impl='cuda')
+    odl.tomo.astra_projector('cuda3d', VOL_GEOM_3D, PROJ_GEOM_3D, ndim=3)
 
 
 def test_astra_algorithm():
     """Create ASTRA algorithm object."""
-
     direction = 'forward'
     ndim = 2
     impl = 'cpu'
     vol_id = odl.tomo.astra_data(VOL_GEOM_2D, 'volume', ndim=ndim)
     sino_id = odl.tomo.astra_data(PROJ_GEOM_2D, 'projection', ndim=ndim)
-    proj_id = odl.tomo.astra_projector('nearest', VOL_GEOM_2D, PROJ_GEOM_2D,
-                                       ndim=ndim, impl=impl)
+    proj_id = odl.tomo.astra_projector(
+        'linear', VOL_GEOM_2D, PROJ_GEOM_2D, ndim=ndim
+    )
 
     # Checks
     with pytest.raises(ValueError):

--- a/odl/test/tomo/backends/astra_setup_test.py
+++ b/odl/test/tomo/backends/astra_setup_test.py
@@ -286,11 +286,11 @@ def test_parallel_2d_projector():
     odl.tomo.astra_projector('line', VOL_GEOM_2D, PROJ_GEOM_2D, ndim=2)
     odl.tomo.astra_projector('linear', VOL_GEOM_2D, PROJ_GEOM_2D, ndim=2)
 
-    with pytest.raises(AssertionError):
+    with pytest.raises(ValueError):
         odl.tomo.astra_projector(
             'line_fanflat', VOL_GEOM_2D, PROJ_GEOM_2D, ndim=2
         )
-    with pytest.raises(AssertionError):
+    with pytest.raises(ValueError):
         odl.tomo.astra_projector(
             'linearcone', VOL_GEOM_2D, PROJ_GEOM_2D, ndim=2
         )

--- a/odl/test/tomo/backends/skimage_test.py
+++ b/odl/test/tomo/backends/skimage_test.py
@@ -13,7 +13,7 @@ import numpy as np
 
 import odl
 from odl.tomo.backends.skimage_radon import (
-    skimage_radon_forward, skimage_radon_back_projector)
+    skimage_radon_forward_projector, skimage_radon_back_projector)
 from odl.tomo.util.testutils import skip_if_no_skimage
 
 
@@ -34,7 +34,7 @@ def test_skimage_radon_projector_parallel2d():
     proj_space = odl.uniform_discr_frompartition(geom.partition)
 
     # Forward evaluation
-    proj_data = skimage_radon_forward(phantom, geom, proj_space)
+    proj_data = skimage_radon_forward_projector(phantom, geom, proj_space)
     assert proj_data.shape == proj_space.shape
     assert proj_data.norm() > 0
 

--- a/odl/tomo/__init__.py
+++ b/odl/tomo/__init__.py
@@ -23,11 +23,12 @@ from .analytic import *
 __all__ += analytic.__all__
 
 from .backends import (
-    ASTRA_AVAILABLE, ASTRA_CUDA_AVAILABLE, astra_conebeam_2d_geom_to_vec,
-    astra_conebeam_3d_geom_to_vec)
+    ASTRA_AVAILABLE, ASTRA_CUDA_AVAILABLE, SKIMAGE_AVAILABLE,
+    astra_conebeam_2d_geom_to_vec, astra_conebeam_3d_geom_to_vec)
 __all__ += (
     'ASTRA_AVAILABLE',
     'ASTRA_CUDA_AVAILABLE',
+    'SKIMAGE_AVAILABLE',
     'astra_conebeam_2d_geom_to_vec',
     'astra_conebeam_3d_geom_to_vec',
 )

--- a/odl/tomo/__init__.py
+++ b/odl/tomo/__init__.py
@@ -16,11 +16,18 @@ __all__ = ()
 from .geometry import *
 __all__ += geometry.__all__
 
-from .backends import *
-__all__ += backends.__all__
-
 from .operators import *
 __all__ += operators.__all__
 
 from .analytic import *
 __all__ += analytic.__all__
+
+from .backends import (
+    ASTRA_AVAILABLE, ASTRA_CUDA_AVAILABLE, astra_conebeam_2d_geom_to_vec,
+    astra_conebeam_3d_geom_to_vec)
+__all__ += (
+    'ASTRA_AVAILABLE',
+    'ASTRA_CUDA_AVAILABLE',
+    'astra_conebeam_2d_geom_to_vec',
+    'astra_conebeam_3d_geom_to_vec',
+)

--- a/odl/tomo/backends/astra_cpu.py
+++ b/odl/tomo/backends/astra_cpu.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2017 The ODL contributors
+# Copyright 2014-2019 The ODL contributors
 #
 # This file is part of ODL.
 #
@@ -8,41 +8,60 @@
 
 """Backend for ASTRA using CPU."""
 
-from __future__ import print_function, division, absolute_import
+from __future__ import absolute_import, division, print_function
+
 import numpy as np
+
+from odl.discr import DiscreteLp, DiscreteLpElement
+from odl.tomo.backends.astra_setup import (
+    astra_algorithm, astra_data, astra_projection_geometry, astra_projector,
+    astra_volume_geometry)
+from odl.tomo.geometry import (
+    DivergentBeamGeometry, Geometry, ParallelBeamGeometry)
+from odl.util import writable_array
+
 try:
     import astra
 except ImportError:
     pass
 
-from odl.discr import DiscreteLp, DiscreteLpElement
-from odl.tomo.backends.astra_setup import (
-    astra_projection_geometry, astra_volume_geometry, astra_data,
-    astra_projector, astra_algorithm)
-from odl.tomo.geometry import Geometry
-from odl.util import writable_array
-
 
 __all__ = ('astra_cpu_forward_projector', 'astra_cpu_back_projector')
 
 
-# TODO: use context manager when creating data structures
-# TODO: is magnification scaling at the right place?
+def _default_proj_type(geom):
+    """Return the default projector type for a given geometry."""
+    if isinstance(geom, ParallelBeamGeometry):
+        return 'linear' if geom.ndim == 2 else 'linear3d'
+    elif isinstance(geom, DivergentBeamGeometry):
+        return 'line_fanflat' if geom.ndim == 2 else 'linearcone'
+    else:
+        raise TypeError(
+            'no default exists for {}, `proj_type` must be given explicitly'
+            ''.format(type(geom))
+        )
 
-def astra_cpu_forward_projector(vol_data, geometry, proj_space, out=None):
+
+def astra_cpu_forward_projector(vol_data, geometry, proj_space, out=None,
+                                proj_type=None):
     """Run an ASTRA forward projection on the given data using the CPU.
 
     Parameters
     ----------
     vol_data : `DiscreteLpElement`
-        Volume data to which the forward projector is applied
+        Volume data to which the forward projector is applied.
     geometry : `Geometry`
-        Geometry defining the tomographic setup
+        Geometry defining the tomographic setup.
     proj_space : `DiscreteLp`
-        Space to which the calling operator maps
+        Space to which the calling operator maps.
     out : ``proj_space`` element, optional
         Element of the projection space to which the result is written. If
         ``None``, an element in ``proj_space`` is created.
+    proj_type : str, optional
+        Type of projector that should be used. See `the ASTRA documentation
+        <http://www.astra-toolbox.com/docs/proj2d.html>`_ for details.
+        By default, a suitable projector type for the given geometry is
+        selected.
 
     Returns
     -------
@@ -83,13 +102,9 @@ def astra_cpu_forward_projector(vol_data, geometry, proj_space, out=None):
     proj_geom = astra_projection_geometry(geometry)
 
     # Create projector
-    if not all(s == vol_data.space.interp_byaxis[0]
-               for s in vol_data.space.interp_byaxis):
-        raise ValueError('volume interpolation must be the same in each '
-                         'dimension, got {}'.format(vol_data.space.interp))
-    vol_interp = vol_data.space.interp
-    proj_id = astra_projector(vol_interp, vol_geom, proj_geom, ndim,
-                              impl='cpu')
+    if proj_type is None:
+        proj_type = _default_proj_type(geometry)
+    proj_id = astra_projector(proj_type, vol_geom, proj_geom, ndim)
 
     # Create ASTRA data structures
     vol_data_arr = np.asarray(vol_data)
@@ -115,24 +130,30 @@ def astra_cpu_forward_projector(vol_data, geometry, proj_space, out=None):
     return out
 
 
-def astra_cpu_back_projector(proj_data, geometry, reco_space, out=None):
+def astra_cpu_back_projector(proj_data, geometry, vol_space, out=None,
+                             proj_type=None):
     """Run an ASTRA back-projection on the given data using the CPU.
 
     Parameters
     ----------
     proj_data : `DiscreteLpElement`
-        Projection data to which the back-projector is applied
+        Projection data to which the back-projector is applied.
     geometry : `Geometry`
-        Geometry defining the tomographic setup
-    reco_space : `DiscreteLp`
-        Space to which the calling operator maps
-    out : ``reco_space`` element, optional
+        Geometry defining the tomographic setup.
+    vol_space : `DiscreteLp`
+        Space to which the calling operator maps.
+    out : ``vol_space`` element, optional
         Element of the reconstruction space to which the result is written.
-        If ``None``, an element in ``reco_space`` is created.
+        If ``None``, an element in ``vol_space`` is created.
+    proj_type : str, optional
+        Type of projector that should be used. See `the ASTRA documentation
+        <http://www.astra-toolbox.com/docs/proj2d.html>`_ for details.
+        By default, a suitable projector type for the given geometry is
+        selected.
 
     Returns
     -------
-    out : ``reco_space`` element
+    out : ``vol_space`` element
         Reconstruction data resulting from the application of the backward
         projector. If ``out`` was provided, the returned object is a
         reference to it.
@@ -147,27 +168,27 @@ def astra_cpu_back_projector(proj_data, geometry, reco_space, out=None):
     if not isinstance(geometry, Geometry):
         raise TypeError('geometry  {!r} is not a Geometry instance'
                         ''.format(geometry))
-    if not isinstance(reco_space, DiscreteLp):
-        raise TypeError('reconstruction space {!r} is not a DiscreteLp '
-                        'instance'.format(reco_space))
-    if reco_space.impl != 'numpy':
-        raise TypeError("`reco_space.impl` must be 'numpy', got {!r}"
-                        "".format(reco_space.impl))
-    if reco_space.ndim != geometry.ndim:
+    if not isinstance(vol_space, DiscreteLp):
+        raise TypeError('volume space {!r} is not a DiscreteLp '
+                        'instance'.format(vol_space))
+    if vol_space.impl != 'numpy':
+        raise TypeError("`vol_space.impl` must be 'numpy', got {!r}"
+                        "".format(vol_space.impl))
+    if vol_space.ndim != geometry.ndim:
         raise ValueError('dimensions {} of reconstruction space and {} of '
                          'geometry do not match'.format(
-                             reco_space.ndim, geometry.ndim))
+                             vol_space.ndim, geometry.ndim))
     if out is None:
-        out = reco_space.element()
+        out = vol_space.element()
     else:
-        if out not in reco_space:
+        if out not in vol_space:
             raise TypeError('`out` {} is neither None nor a '
                             'DiscreteLpElement instance'.format(out))
 
     ndim = proj_data.ndim
 
     # Create astra geometries
-    vol_geom = astra_volume_geometry(reco_space)
+    vol_geom = astra_volume_geometry(vol_space)
     proj_geom = astra_projection_geometry(geometry)
 
     # Create ASTRA data structure
@@ -175,20 +196,14 @@ def astra_cpu_back_projector(proj_data, geometry, reco_space, out=None):
                          allow_copy=True)
 
     # Create projector
-    # TODO: implement with different schemes for angles and detector
-    if not all(s == proj_data.space.interp_byaxis[0]
-               for s in proj_data.space.interp_byaxis):
-        raise ValueError('data interpolation must be the same in each '
-                         'dimension, got {}'
-                         ''.format(proj_data.space.interp_byaxis))
-    proj_interp = proj_data.space.interp
-    proj_id = astra_projector(proj_interp, vol_geom, proj_geom, ndim,
-                              impl='cpu')
+    if proj_type is None:
+        proj_type = _default_proj_type(geometry)
+    proj_id = astra_projector(proj_type, vol_geom, proj_geom, ndim)
 
     # Convert out to correct dtype and order if needed.
     with writable_array(out, dtype='float32', order='C') as out_arr:
         vol_id = astra_data(vol_geom, datatype='volume', data=out_arr,
-                            ndim=reco_space.ndim)
+                            ndim=vol_space.ndim)
         # Create algorithm
         algo_id = astra_algorithm('backward', ndim, vol_id, sino_id, proj_id,
                                   impl='cpu')
@@ -198,7 +213,7 @@ def astra_cpu_back_projector(proj_data, geometry, reco_space, out=None):
 
     # Weight the adjoint by appropriate weights
     scaling_factor = float(proj_data.space.weighting.const)
-    scaling_factor /= float(reco_space.weighting.const)
+    scaling_factor /= float(vol_space.weighting.const)
 
     out *= scaling_factor
 

--- a/odl/tomo/backends/astra_cuda.py
+++ b/odl/tomo/backends/astra_cuda.py
@@ -66,8 +66,7 @@ class AstraCudaProjectorImpl(object):
 
         self.create_ids()
 
-        # Create a mutually exclusive lock so that two callers cant use the
-        # same shared resource at the same time.
+        # ASTRA projectors are not thread-safe, thus we need to lock ourselves
         self._mutex = Lock()
 
     def call_forward(self, vol_data, out=None):

--- a/odl/tomo/backends/astra_cuda.py
+++ b/odl/tomo/backends/astra_cuda.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2018 The ODL contributors
+# Copyright 2014-2019 The ODL contributors
 #
 # This file is part of ODL.
 #
@@ -8,26 +8,27 @@
 
 """Backend for ASTRA using CUDA."""
 
-from __future__ import print_function, division, absolute_import
+from __future__ import absolute_import, division, print_function
+
 from builtins import object
 from multiprocessing import Lock
+
 import numpy as np
 from packaging.version import parse as parse_version
+
+from odl.discr import DiscreteLp
+from odl.tomo.backends.astra_setup import (
+    ASTRA_VERSION, astra_algorithm, astra_data, astra_projection_geometry,
+    astra_projector, astra_volume_geometry)
+from odl.tomo.geometry import (
+    ConeBeamGeometry, FanBeamGeometry, Geometry, Parallel2dGeometry,
+    Parallel3dAxisGeometry)
 
 try:
     import astra
     ASTRA_CUDA_AVAILABLE = astra.astra.use_cuda()
 except ImportError:
     ASTRA_CUDA_AVAILABLE = False
-
-from odl.discr import DiscreteLp
-from odl.tomo.backends.astra_setup import (
-    ASTRA_VERSION,
-    astra_projection_geometry, astra_volume_geometry, astra_projector,
-    astra_data, astra_algorithm)
-from odl.tomo.geometry import (
-    Geometry, Parallel2dGeometry, FanBeamGeometry, Parallel3dAxisGeometry,
-    ConeBeamGeometry)
 
 
 __all__ = ('ASTRA_CUDA_AVAILABLE',
@@ -153,8 +154,10 @@ class AstraCudaProjectorImpl(object):
                                  data=self.in_array,
                                  allow_copy=False)
 
-        self.proj_id = astra_projector('nearest', vol_geom, proj_geom,
-                                       ndim=proj_ndim, impl='cuda')
+        proj_type = 'cuda' if proj_ndim == 2 else 'cuda3d'
+        self.proj_id = astra_projector(
+            proj_type, vol_geom, proj_geom, proj_ndim
+        )
 
         self.sino_id = astra_data(proj_geom,
                                   datatype='projection',
@@ -303,8 +306,10 @@ class AstraCudaBackProjectorImpl(object):
                                   ndim=proj_ndim,
                                   allow_copy=False)
 
-        self.proj_id = astra_projector('nearest', vol_geom, proj_geom,
-                                       proj_ndim, impl='cuda')
+        proj_type = 'cuda' if proj_ndim == 2 else 'cuda3d'
+        self.proj_id = astra_projector(
+            proj_type, vol_geom, proj_geom, proj_ndim
+        )
 
         self.vol_id = astra_data(vol_geom,
                                  datatype='volume',

--- a/odl/tomo/backends/astra_cuda.py
+++ b/odl/tomo/backends/astra_cuda.py
@@ -30,9 +30,11 @@ try:
 except ImportError:
     ASTRA_CUDA_AVAILABLE = False
 
-
-__all__ = ('ASTRA_CUDA_AVAILABLE',
-           'AstraCudaProjectorImpl', 'AstraCudaBackProjectorImpl')
+__all__ = (
+    'ASTRA_CUDA_AVAILABLE',
+    'AstraCudaProjectorImpl',
+    'AstraCudaBackProjectorImpl',
+)
 
 
 class AstraCudaProjectorImpl(object):

--- a/odl/tomo/backends/astra_setup.py
+++ b/odl/tomo/backends/astra_setup.py
@@ -620,7 +620,7 @@ def astra_projector(vol_interp, astra_vol_geom, astra_proj_geom, ndim, impl):
     # Mapping from interpolation type and geometry to ASTRA projector type.
     # "I" means probably mathematically inconsistent. Some projectors are
     # not implemented, e.g. CPU 3d projectors in general.
-    type_map_cpu = {'parallel': {'nearest': 'line',
+    type_map_cpu = {'parallel': {'nearest': 'linear',  # I
                                  'linear': 'linear'},  # I
                     'fanflat': {'nearest': 'line_fanflat',
                                 'linear': 'line_fanflat'},  # I

--- a/odl/tomo/backends/astra_setup.py
+++ b/odl/tomo/backends/astra_setup.py
@@ -23,9 +23,19 @@ ODL geometry representation to ASTRA's data structures, including:
 `ASTRA on GitHub <https://github.com/astra-toolbox/>`_.
 """
 
-from __future__ import print_function, division, absolute_import
-import numpy as np
+from __future__ import absolute_import, division, print_function
+
 import warnings
+
+import numpy as np
+
+from odl.discr import DiscreteLp, DiscreteLpElement
+from odl.tomo.geometry import (
+    DivergentBeamGeometry, Flat1dDetector, Flat2dDetector, Geometry,
+    ParallelBeamGeometry)
+from odl.tomo.util.utility import euler_matrix
+from odl.util.npy_compat import moveaxis
+
 try:
     import astra
 except ImportError:
@@ -34,12 +44,6 @@ except ImportError:
 else:
     ASTRA_AVAILABLE = True
 
-from odl.discr import DiscreteLp, DiscreteLpElement
-from odl.tomo.geometry import (
-    Geometry, DivergentBeamGeometry, ParallelBeamGeometry,
-    Flat1dDetector, Flat2dDetector)
-from odl.tomo.util.utility import euler_matrix
-from odl.util.npy_compat import moveaxis
 
 # Make sure that ASTRA >= 1.7 is used
 if ASTRA_AVAILABLE:
@@ -699,7 +703,7 @@ def astra_algorithm(direction, ndim, vol_id, sino_id, proj_id, impl):
     algo_cfg = {'type': algo_map[direction][ndim][impl],
                 'ProjectorId': proj_id,
                 'ProjectionDataId': sino_id}
-    if direction is 'forward':
+    if direction == 'forward':
         algo_cfg['VolumeDataId'] = vol_id
     else:
         algo_cfg['ReconstructionDataId'] = vol_id

--- a/odl/tomo/backends/skimage_radon.py
+++ b/odl/tomo/backends/skimage_radon.py
@@ -46,11 +46,11 @@ def clamped_interpolation(skimage_proj_space, sinogram):
     min_x = skimage_proj_space.domain.min()[1]
     max_x = skimage_proj_space.domain.max()[1]
 
-    def interpolation_wrapper(x):
+    def interpolator(x):
         x = (x[0], np.maximum(min_x, np.minimum(max_x, x[1])))
-        return sinogram.interpolation(x)
+        return sinogram.interpolation(x, bounds_check=False)
 
-    return interpolation_wrapper
+    return interpolator
 
 
 def skimage_radon_forward_projector(volume, geometry, proj_space, out=None):

--- a/odl/tomo/backends/skimage_radon.py
+++ b/odl/tomo/backends/skimage_radon.py
@@ -91,7 +91,9 @@ def skimage_radon_forward_projector(volume, geometry, proj_space, out=None):
     if out is None:
         out = proj_space.element()
 
-    out.sampling(clamped_interpolation(skimage_range, sinogram))
+    out.sampling(
+        clamped_interpolation(skimage_range, sinogram), bounds_check=False
+    )
 
     scale = volume.space.cell_sides[0]
     out *= scale
@@ -126,7 +128,9 @@ def skimage_radon_back_projector(sinogram, geometry, vol_space, out=None):
     skimage_range = skimage_proj_space(geometry, vol_space, sinogram.space)
 
     skimage_sinogram = skimage_range.element()
-    skimage_sinogram.sampling(clamped_interpolation(skimage_range, sinogram))
+    skimage_sinogram.sampling(
+        clamped_interpolation(skimage_range, sinogram), bounds_check=False
+    )
 
     if out is None:
         out = vol_space.element()

--- a/odl/tomo/backends/skimage_radon.py
+++ b/odl/tomo/backends/skimage_radon.py
@@ -40,14 +40,13 @@ def skimage_proj_space(geometry, volume_space, proj_space):
 def clamped_interpolation(skimage_proj_space, sinogram):
     """Interpolate in a possibly smaller space.
 
-    Sets all points that would be outside the domain to match the
-    boundary values.
+    Clip all points to fit within the bounds of the given space.
     """
     min_x = skimage_proj_space.domain.min()[1]
     max_x = skimage_proj_space.domain.max()[1]
 
     def interpolator(x):
-        x = (x[0], np.maximum(min_x, np.minimum(max_x, x[1])))
+        x = (x[0], np.clip(x[1], min_x, max_x))
         return sinogram.interpolation(x, bounds_check=False)
 
     return interpolator

--- a/odl/tomo/backends/skimage_radon.py
+++ b/odl/tomo/backends/skimage_radon.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2017 The ODL contributors
+# Copyright 2014-2019 The ODL contributors
 #
 # This file is part of ODL.
 #
@@ -9,76 +9,69 @@
 """Radon transform (ray transform) in 2d using skimage.transform."""
 
 from __future__ import division
+
 import numpy as np
+
+from odl.discr import uniform_discr_frompartition, uniform_partition
+
 try:
     import skimage
     SKIMAGE_AVAILABLE = True
 except ImportError:
     SKIMAGE_AVAILABLE = False
 
-from odl.discr import uniform_discr_frompartition, uniform_partition
-
-__all__ = ('skimage_radon_forward', 'skimage_radon_back_projector',
+__all__ = ('skimage_radon_forward_projector', 'skimage_radon_back_projector',
            'SKIMAGE_AVAILABLE')
 
 
-def skimage_theta(geometry):
-    """Calculate angles in degrees with ODL skimage conventions."""
-    return geometry.angles * 180.0 / np.pi
-
-
-def skimage_sinogram_space(geometry, volume_space, sinogram_space):
-    """Create a range adapted to the skimage radon geometry."""
+def skimage_proj_space(geometry, volume_space, proj_space):
+    """Create a projection space adapted to the skimage radon geometry."""
     padded_size = int(np.ceil(volume_space.shape[0] * np.sqrt(2)))
     det_width = volume_space.domain.extent[0] * np.sqrt(2)
-    skimage_detector_part = uniform_partition(-det_width / 2.0,
-                                              det_width / 2.0,
-                                              padded_size)
+    det_part = uniform_partition(-det_width / 2, det_width / 2, padded_size)
 
-    skimage_range_part = geometry.motion_partition.insert(
-        1, skimage_detector_part)
-
-    skimage_range = uniform_discr_frompartition(skimage_range_part,
-                                                interp=sinogram_space.interp,
-                                                dtype=sinogram_space.dtype)
-
-    return skimage_range
+    part = geometry.motion_partition.insert(1, det_part)
+    space = uniform_discr_frompartition(
+        part, interp=proj_space.interp, dtype=proj_space.dtype
+    )
+    return space
 
 
-def clamped_interpolation(skimage_range, sinogram):
+def clamped_interpolation(skimage_proj_space, sinogram):
     """Interpolate in a possibly smaller space.
 
     Sets all points that would be outside the domain to match the
     boundary values.
     """
-    min_x = skimage_range.domain.min()[1]
-    max_x = skimage_range.domain.max()[1]
+    min_x = skimage_proj_space.domain.min()[1]
+    max_x = skimage_proj_space.domain.max()[1]
 
     def interpolation_wrapper(x):
         x = (x[0], np.maximum(min_x, np.minimum(max_x, x[1])))
-
         return sinogram.interpolation(x)
+
     return interpolation_wrapper
 
 
-def skimage_radon_forward(volume, geometry, range, out=None):
+def skimage_radon_forward_projector(volume, geometry, proj_space, out=None):
     """Calculate forward projection using skimage.
 
     Parameters
     ----------
     volume : `DiscreteLpElement`
-        The volume to project
+        The volume to project.
     geometry : `Geometry`
-        The projection geometry to use
-    range : `DiscreteLp`
-        range of this projection (sinogram space)
-    out : ``range`` element, optional
-        An element in range that the result should be written to
+        The projection geometry to use.
+    proj_space : `DiscreteLp`
+        Space in which the projections (sinograms) live.
+    out : ``proj_space`` element, optional
+        Element to which the result should be written.
 
     Returns
     -------
-    sinogram : ``range`` element
-        Sinogram given by the projection.
+    sinogram : ``proj_space`` element
+        Result of the forward projection. If ``out`` was given, the returned
+        object is a reference to it.
     """
     # Lazy import due to significant import time
     from skimage.transform import radon
@@ -86,27 +79,27 @@ def skimage_radon_forward(volume, geometry, range, out=None):
     # Check basic requirements. Fully checking should be in wrapper
     assert volume.shape[0] == volume.shape[1]
 
-    theta = skimage_theta(geometry)
-    skimage_range = skimage_sinogram_space(geometry, volume.space, range)
+    theta = np.degrees(geometry.angles)
+    skimage_range = skimage_proj_space(geometry, volume.space, proj_space)
 
-    # Rotate volume from (x, y) to (rows, cols)
-    sino_arr = radon(np.rot90(volume.asarray(), 1),
-                     theta=theta, circle=False)
+    # Rotate volume from (x, y) to (rows, cols), then project
+    sino_arr = radon(
+        np.rot90(volume.asarray(), 1), theta=theta, circle=False
+    )
     sinogram = skimage_range.element(sino_arr.T)
 
     if out is None:
-        out = range.element()
+        out = proj_space.element()
 
     out.sampling(clamped_interpolation(skimage_range, sinogram))
 
     scale = volume.space.cell_sides[0]
-
     out *= scale
 
     return out
 
 
-def skimage_radon_back_projector(sinogram, geometry, range, out=None):
+def skimage_radon_back_projector(sinogram, geometry, vol_space, out=None):
     """Calculate forward projection using skimage.
 
     Parameters
@@ -115,48 +108,52 @@ def skimage_radon_back_projector(sinogram, geometry, range, out=None):
         Sinogram (projections) to backproject.
     geometry : `Geometry`
         The projection geometry to use.
-    range : `DiscreteLp`
-        range of this projection (volume space).
-    out : ``range`` element, optional
-        An element in range that the result should be written to.
+    vol_space : `DiscreteLp`
+        Space in which reconstructed volumes live.
+    out : ``vol_space`` element, optional
+        An element to which the result should be written.
 
     Returns
     -------
-    sinogram : ``range`` element
-        Sinogram given by the projection.
+    volume : ``vol_space`` element
+        Result of the back-projection. If ``out`` was given, the returned
+        object is a reference to it.
     """
     # Lazy import due to significant import time
     from skimage.transform import iradon
 
-    theta = skimage_theta(geometry)
-    skimage_range = skimage_sinogram_space(geometry, range, sinogram.space)
+    theta = np.degrees(geometry.angles)
+    skimage_range = skimage_proj_space(geometry, vol_space, sinogram.space)
 
     skimage_sinogram = skimage_range.element()
-    skimage_sinogram.sampling(clamped_interpolation(range, sinogram))
+    skimage_sinogram.sampling(clamped_interpolation(vol_space, sinogram))
 
     if out is None:
-        out = range.element()
+        out = vol_space.element()
     else:
         # Only do asserts here since these are backend functions
-        assert out in range
+        assert out in vol_space
 
-    # Rotate back from (rows, cols) to (x, y)
-    backproj = iradon(skimage_sinogram.asarray().T, theta,
-                      output_size=range.shape[0], filter=None, circle=False)
+    # Rotate back from (rows, cols) to (x, y), then back-project (no filter)
+    backproj = iradon(
+        skimage_sinogram.asarray().T,
+        theta,
+        output_size=vol_space.shape[0],
+        filter=None,
+        circle=False,
+    )
     out[:] = np.rot90(backproj, -1)
 
     # Empirically determined value, gives correct scaling
-    scaling_factor = 4.0 * float(geometry.motion_params.length) / (2 * np.pi)
+    scaling_factor = 4 * geometry.motion_params.length / (2 * np.pi)
 
     # Correct in case of non-weighted spaces
-    proj_extent = float(sinogram.space.partition.extent.prod())
-    proj_size = float(sinogram.space.partition.size)
-    proj_weighting = proj_extent / proj_size
+    proj_volume = np.prod(sinogram.space.partition.extent)
+    proj_size = sinogram.space.partition.size
+    proj_weighting = proj_volume / proj_size
 
-    scaling_factor *= (sinogram.space.weighting.const /
-                       proj_weighting)
-    scaling_factor /= (range.weighting.const /
-                       range.cell_volume)
+    scaling_factor *= sinogram.space.weighting.const / proj_weighting
+    scaling_factor /= vol_space.weighting.const / vol_space.cell_volume
 
     # Correctly scale the output
     out *= scaling_factor

--- a/odl/tomo/backends/skimage_radon.py
+++ b/odl/tomo/backends/skimage_radon.py
@@ -126,7 +126,7 @@ def skimage_radon_back_projector(sinogram, geometry, vol_space, out=None):
     skimage_range = skimage_proj_space(geometry, vol_space, sinogram.space)
 
     skimage_sinogram = skimage_range.element()
-    skimage_sinogram.sampling(clamped_interpolation(vol_space, sinogram))
+    skimage_sinogram.sampling(clamped_interpolation(skimage_range, sinogram))
 
     if out is None:
         out = vol_space.element()

--- a/odl/tomo/operators/ray_trafo.py
+++ b/odl/tomo/operators/ray_trafo.py
@@ -22,7 +22,8 @@ from odl.tomo.backends import (
     ASTRA_AVAILABLE, ASTRA_CUDA_AVAILABLE, ASTRA_VERSION, SKIMAGE_AVAILABLE,
     AstraCudaBackProjectorImpl, AstraCudaProjectorImpl,
     astra_cpu_back_projector, astra_cpu_forward_projector, astra_supports,
-    skimage_radon_back_projector, skimage_radon_forward_projector)
+    astra_versions_supporting, skimage_radon_back_projector,
+    skimage_radon_forward_projector)
 from odl.tomo.geometry import (
     Geometry, Parallel2dGeometry, Parallel3dAxisGeometry)
 
@@ -161,8 +162,13 @@ class RayTransformBase(Operator):
             # Print a warning if the detector midpoint normal vector at any
             # angle is perpendicular to the geometry axis in parallel 3d
             # single-axis geometry -- this is broken in some ASTRA versions
-            if (isinstance(geometry, Parallel3dAxisGeometry) and
-                    not astra_supports('par3d_det_mid_pt_perp_to_axis')):
+            if (
+                isinstance(geometry, Parallel3dAxisGeometry) and
+                not astra_supports('par3d_det_mid_pt_perp_to_axis')
+            ):
+                req_ver = astra_versions_supporting(
+                    'par3d_det_mid_pt_perp_to_axis'
+                )
                 axis = geometry.axis
                 mid_pt = geometry.det_params.mid_pt
                 for i, angle in enumerate(geometry.angles):
@@ -172,9 +178,9 @@ class RayTransformBase(Operator):
                             'angle {}: detector midpoint normal {} is '
                             'perpendicular to the geometry axis {} in '
                             '`Parallel3dAxisGeometry`; this is broken in '
-                            'ASTRA v{}, please upgrade to v1.8 or later'
+                            'ASTRA {}, please upgrade to ASTRA {}'
                             ''.format(i, geometry.det_to_src(angle, mid_pt),
-                                      axis, ASTRA_VERSION),
+                                      axis, ASTRA_VERSION, req_ver),
                             RuntimeWarning)
                         break
 

--- a/odl/tomo/operators/ray_trafo.py
+++ b/odl/tomo/operators/ray_trafo.py
@@ -72,10 +72,6 @@ class RayTransformBase(Operator):
             For the default ``None``, the fastest available back-end is
             used.
 
-        interp : {'nearest', 'linear'}, optional
-            Interpolation type for the discretization of the projection
-            space. This has no effect if ``proj_space`` is given explicitly.
-            Default: ``'nearest'``
         proj_space : `DiscreteLp`, optional
             Discretized projection (sinogram) space, the range of the forward
             operator or the domain of the adjoint (back-projection).
@@ -86,6 +82,8 @@ class RayTransformBase(Operator):
             and on the CPU, since a full volume and a projection dataset
             are stored. That may be prohibitive in 3D.
             Default: True
+        kwargs
+            Further keyword arguments passed to the projector backend.
 
         Notes
         -----
@@ -143,7 +141,7 @@ class RayTransformBase(Operator):
                         "`impl='skimage'`.",
                         RuntimeWarning)
             else:
-                raise RuntimeError('bad impl')
+                raise RuntimeError('no backend')
 
         impl, impl_in = str(impl).lower(), impl
         if impl not in _SUPPORTED_IMPL:
@@ -362,10 +360,6 @@ class RayTransform(RayTransformBase):
 
             For the default ``None``, the fastest available back-end is
             used, tried in the above order.
-        interp : {'nearest', 'linear'}, optional
-            Interpolation type for the discretization of the operator
-            range. This has no effect if ``range`` is given explicitly.
-            Default: ``'nearest'``
         range : `DiscreteLp`, optional
             Discretized projection (sinogram) space, the range of the
             forward projector.
@@ -376,11 +370,20 @@ class RayTransform(RayTransformBase):
             and on the CPU, since a full volume and a projection dataset
             are stored. That may be prohibitive in 3D.
             Default: True
+        kwargs
+            Further keyword arguments passed to the projector backend.
 
         Notes
         -----
-        The ASTRA backend is faster if data is given with ``dtype`` 'float32'
-        and storage order 'C'. Otherwise copies will be needed.
+        The ASTRA backend is faster if data are given with
+        ``dtype='float32'`` and storage order 'C'. Otherwise copies will be
+        needed.
+
+        See Also
+        --------
+        astra_cpu_forward_projector
+        AstraCudaProjectorImpl
+        skimage_radon_forward_projector
         """
         range = kwargs.pop('range', None)
         super(RayTransform, self).__init__(
@@ -398,7 +401,8 @@ class RayTransform(RayTransformBase):
 
             if data_impl == 'cpu':
                 return astra_cpu_forward_projector(
-                    x_real, self.geometry, self.range.real_space, out_real)
+                    x_real, self.geometry, self.range.real_space, out_real,
+                    **kwargs)
 
             elif data_impl == 'cuda':
                 if self._astra_wrapper is None:
@@ -410,7 +414,7 @@ class RayTransform(RayTransformBase):
                 else:
                     astra_wrapper = self._astra_wrapper
 
-                return astra_wrapper.call_forward(x_real, out_real)
+                return astra_wrapper.call_forward(x_real, out_real, **kwargs)
             else:
                 # Should never happen
                 raise RuntimeError('bad `impl` {!r}'.format(self.impl))
@@ -472,10 +476,6 @@ class RayBackProjection(RayTransformBase):
             For the default ``None``, the fastest available back-end is
             used, tried in the above order.
 
-        interp : {'nearest', 'linear'}, optional
-            Interpolation type for the discretization of the operator
-            domain. This has no effect if ``domain`` is given explicitly.
-            Default: ``'nearest'``
         domain : `DiscreteLp`, optional
             Discretized projection (sinogram) space, the domain of the
             backprojection operator.
@@ -486,18 +486,27 @@ class RayBackProjection(RayTransformBase):
             and on the CPU, since a full volume and a projection dataset
             are stored. That may be prohibitive in 3D.
             Default: True
+        kwargs
+            Further keyword arguments passed to the projector backend.
 
         Notes
         -----
-        The ASTRA backend is faster if data is given with ``dtype`` 'float32'
-        and storage order 'C'. Otherwise copies will be needed.
+        The ASTRA backend is faster if data are given with
+        ``dtype='float32'`` and storage order 'C'. Otherwise copies will be
+        needed.
+
+        See Also
+        --------
+        astra_cpu_back_projector
+        AstraCudaBackProjectorImpl
+        skimage_radon_back_projector
         """
         domain = kwargs.pop('domain', None)
         super(RayBackProjection, self).__init__(
             reco_space=range, proj_space=domain, geometry=geometry,
             variant='backward', **kwargs)
 
-    def _call_real(self, x_real, out_real):
+    def _call_real(self, x_real, out_real, **kwargs):
         """Real-space back-projection for the current set-up.
 
         This method also sets ``self._astra_backprojector`` for
@@ -506,9 +515,9 @@ class RayBackProjection(RayTransformBase):
         if self.impl.startswith('astra'):
             backend, data_impl = self.impl.split('_')
             if data_impl == 'cpu':
-                return astra_cpu_back_projector(x_real, self.geometry,
-                                                self.range.real_space,
-                                                out_real)
+                return astra_cpu_back_projector(
+                    x_real, self.geometry, self.range.real_space, out_real,
+                    **kwargs)
             elif data_impl == 'cuda':
                 if self._astra_wrapper is None:
                     astra_wrapper = AstraCudaBackProjectorImpl(
@@ -519,15 +528,15 @@ class RayBackProjection(RayTransformBase):
                 else:
                     astra_wrapper = self._astra_wrapper
 
-                return astra_wrapper.call_backward(x_real, out_real)
+                return astra_wrapper.call_backward(x_real, out_real, **kwargs)
             else:
                 # Should never happen
                 raise RuntimeError('bad `impl` {!r}'.format(self.impl))
 
         elif self.impl == 'skimage':
-            return skimage_radon_back_projector(x_real, self.geometry,
-                                                self.range.real_space,
-                                                out_real)
+            return skimage_radon_back_projector(
+                x_real, self.geometry, self.range.real_space, out_real,
+                **kwargs)
         else:
             # Should never happen
             raise RuntimeError('bad `impl` {!r}'.format(self.impl))


### PR DESCRIPTION
I suggest we switch to the `linear` for 2D parallel beam projections. The CPU line kernel gives quite bad results in terms of interpolation artifacts (@wjp: is that to be expected? I didn't imagine it to be this severe.). For comparison a projection-backprojection cycle:

**Line kernel**
![line](https://user-images.githubusercontent.com/5030250/54788294-cba05600-4c2e-11e9-927a-38111813d832.png)

**Linear kernel**
![linear](https://user-images.githubusercontent.com/5030250/54788305-d65aeb00-4c2e-11e9-8c74-db4d014a2667.png)
