### PR TITLE
MAINT: remove BOMs

### DIFF
--- a/examples/solvers/deconvolution_1d.py
+++ b/examples/solvers/deconvolution_1d.py
@@ -1,4 +1,4 @@
-﻿"""Example of a deconvolution problem with different solvers (CPU)."""
+"""Example of a deconvolution problem with different solvers (CPU)."""
 
 import numpy as np
 import matplotlib.pyplot as plt

--- a/examples/space/simple_r.py
+++ b/examples/space/simple_r.py
@@ -1,4 +1,4 @@
-﻿"""An example of a very simple space, the real numbers."""
+"""An example of a very simple space, the real numbers."""
 
 import odl
 

--- a/odl/diagnostics/operator.py
+++ b/odl/diagnostics/operator.py
@@ -1,4 +1,4 @@
-﻿# Copyright 2014-2017 The ODL contributors
+# Copyright 2014-2019 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/diagnostics/space.py
+++ b/odl/diagnostics/space.py
@@ -1,4 +1,4 @@
-﻿# Copyright 2014-2017 The ODL contributors
+# Copyright 2014-2019 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/discr/__init__.py
+++ b/odl/discr/__init__.py
@@ -1,4 +1,4 @@
-﻿# Copyright 2014-2017 The ODL contributors
+# Copyright 2014-2019 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/discr/diff_ops.py
+++ b/odl/discr/diff_ops.py
@@ -1,4 +1,4 @@
-﻿# Copyright 2014-2017 The ODL contributors
+# Copyright 2014-2019 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/operator/__init__.py
+++ b/odl/operator/__init__.py
@@ -1,4 +1,4 @@
-﻿# Copyright 2014-2017 The ODL contributors
+# Copyright 2014-2019 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/operator/operator.py
+++ b/odl/operator/operator.py
@@ -1,4 +1,4 @@
-﻿# Copyright 2014-2019 The ODL contributors
+# Copyright 2014-2019 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/operator/pspace_ops.py
+++ b/odl/operator/pspace_ops.py
@@ -1,4 +1,4 @@
-﻿# Copyright 2014-2019 The ODL contributors
+# Copyright 2014-2019 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/phantom/emission.py
+++ b/odl/phantom/emission.py
@@ -1,4 +1,4 @@
-﻿# Copyright 2014-2017 The ODL contributors
+# Copyright 2014-2019 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/phantom/misc_phantoms.py
+++ b/odl/phantom/misc_phantoms.py
@@ -1,4 +1,4 @@
-﻿# Copyright 2014-2017 The ODL contributors
+# Copyright 2014-2019 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/phantom/phantom_utils.py
+++ b/odl/phantom/phantom_utils.py
@@ -1,4 +1,4 @@
-﻿# Copyright 2014-2017 The ODL contributors
+# Copyright 2014-2019 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/set/__init__.py
+++ b/odl/set/__init__.py
@@ -1,4 +1,4 @@
-﻿# Copyright 2014-2017 The ODL contributors
+# Copyright 2014-2019 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/set/domain.py
+++ b/odl/set/domain.py
@@ -1,4 +1,4 @@
-﻿# Copyright 2014-2017 The ODL contributors
+# Copyright 2014-2019 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/set/sets.py
+++ b/odl/set/sets.py
@@ -1,4 +1,4 @@
-﻿# Copyright 2014-2017 The ODL contributors
+# Copyright 2014-2019 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/space/fspace.py
+++ b/odl/space/fspace.py
@@ -1,4 +1,4 @@
-﻿# Copyright 2014-2017 The ODL contributors
+# Copyright 2014-2019 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/space/pspace.py
+++ b/odl/space/pspace.py
@@ -1,4 +1,4 @@
-﻿# Copyright 2014-2019 The ODL contributors
+# Copyright 2014-2019 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/space/space_utils.py
+++ b/odl/space/space_utils.py
@@ -1,4 +1,4 @@
-﻿# Copyright 2014-2017 The ODL contributors
+# Copyright 2014-2019 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/space/weighting.py
+++ b/odl/space/weighting.py
@@ -1,4 +1,4 @@
-﻿# Copyright 2014-2017 The ODL contributors
+# Copyright 2014-2019 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/test/discr/lp_discr_test.py
+++ b/odl/test/discr/lp_discr_test.py
@@ -1,4 +1,4 @@
-﻿# Copyright 2014-2018 The ODL contributors
+# Copyright 2014-2019 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/test/operator/operator_test.py
+++ b/odl/test/operator/operator_test.py
@@ -1,4 +1,4 @@
-﻿# Copyright 2014-2017 The ODL contributors
+# Copyright 2014-2019 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/test/space/fspace_test.py
+++ b/odl/test/space/fspace_test.py
@@ -1,4 +1,4 @@
-﻿# Copyright 2014-2017 The ODL contributors
+# Copyright 2014-2019 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/test/space/space_utils_test.py
+++ b/odl/test/space/space_utils_test.py
@@ -1,4 +1,4 @@
-﻿# Copyright 2014-2017 The ODL contributors
+# Copyright 2014-2019 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/ufunc_ops/__init__.py
+++ b/odl/ufunc_ops/__init__.py
@@ -1,4 +1,4 @@
-﻿# Copyright 2014-2017 The ODL contributors
+# Copyright 2014-2019 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/util/__init__.py
+++ b/odl/util/__init__.py
@@ -1,4 +1,4 @@
-﻿# Copyright 2014-2019 The ODL contributors
+# Copyright 2014-2019 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/util/normalize.py
+++ b/odl/util/normalize.py
@@ -1,4 +1,4 @@
-﻿# Copyright 2014-2017 The ODL contributors
+# Copyright 2014-2019 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/util/npy_compat.py
+++ b/odl/util/npy_compat.py
@@ -1,4 +1,4 @@
-﻿# Copyright 2014-2017 The ODL contributors
+# Copyright 2014-2019 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/util/numerics.py
+++ b/odl/util/numerics.py
@@ -1,4 +1,4 @@
-﻿# Copyright 2014-2017 The ODL contributors
+# Copyright 2014-2019 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/util/testutils.py
+++ b/odl/util/testutils.py
@@ -1,4 +1,4 @@
-﻿# Copyright 2014-2019 The ODL contributors
+# Copyright 2014-2019 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/util/ufuncs.py
+++ b/odl/util/ufuncs.py
@@ -1,4 +1,4 @@
-﻿# Copyright 2014-2017 The ODL contributors
+# Copyright 2014-2019 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/util/utility.py
+++ b/odl/util/utility.py
@@ -1,4 +1,4 @@
-﻿# Copyright 2014-2018 The ODL contributors
+# Copyright 2014-2019 The ODL contributors
 #
 # This file is part of ODL.
 #

--- a/odl/util/vectorization.py
+++ b/odl/util/vectorization.py
@@ -1,4 +1,4 @@
-﻿# Copyright 2014-2017 The ODL contributors
+# Copyright 2014-2019 The ODL contributors
 #
 # This file is part of ODL.
 #


### PR DESCRIPTION
Trivial PR that removes those annoying BOM unicode characters. Some tools get tripped by them.

(For the modified files, I've also updated the copyright years.)