### PR TITLE
ENH: Use contextlib to make context managers

### DIFF
--- a/examples/space/simple_rn.py
+++ b/examples/space/simple_rn.py
@@ -6,7 +6,7 @@ Including some benchmarks with an optimized version.
 import numpy as np
 import odl
 from odl.space.base_tensors import TensorSpace, Tensor
-from odl.util.testutils import Timer
+from odl.util.testutils import timer
 
 
 class SimpleRn(TensorSpace):
@@ -86,54 +86,54 @@ if 'cuda' in odl.space.entry_points.tensor_space_impl_names():
                   cu_spc.element(z.copy()))
 
 print(" lincomb:")
-with Timer("SimpleRn"):
+with timer("SimpleRn"):
     for _ in range(iterations):
         simple_spc.lincomb(2.13, sx, 3.14, sy, out=sz)
 print("result: {}".format(sz[1:5]))
 
-with Timer("odl numpy"):
+with timer("odl numpy"):
     for _ in range(iterations):
         opt_spc.lincomb(2.13, ox, 3.14, oy, out=oz)
 print("result: {}".format(oz[1:5]))
 
 if 'cuda' in odl.space.entry_points.tensor_space_impl_names():
-    with Timer("odl cuda"):
+    with timer("odl cuda"):
         for _ in range(iterations):
             cu_spc.lincomb(2.13, cx, 3.14, cy, out=cz)
     print("result: {}".format(cz[1:5]))
 
 
 print("\n Norm:")
-with Timer("SimpleRn"):
+with timer("SimpleRn"):
     for _ in range(iterations):
         result = sz.norm()
 print("result: {}".format(result))
 
-with Timer("odl numpy"):
+with timer("odl numpy"):
     for _ in range(iterations):
         result = oz.norm()
 print("result: {}".format(result))
 
 if 'cuda' in odl.space.entry_points.tensor_space_impl_names():
-    with Timer("odl cuda"):
+    with timer("odl cuda"):
         for _ in range(iterations):
             result = cz.norm()
     print("result: {}".format(result))
 
 
 print("\n Inner:")
-with Timer("SimpleRn"):
+with timer("SimpleRn"):
     for _ in range(iterations):
         result = sz.inner(sx)
 print("result: {}".format(result))
 
-with Timer("odl numpy"):
+with timer("odl numpy"):
     for _ in range(iterations):
         result = oz.inner(ox)
 print("result: {}".format(result))
 
 if 'cuda' in odl.space.entry_points.tensor_space_impl_names():
-    with Timer("odl cuda"):
+    with timer("odl cuda"):
         for _ in range(iterations):
             result = cz.inner(cx)
     print("result: {}".format(result))

--- a/examples/tomo/backends/astra_performance_cpu_parallel_2d_cg.py
+++ b/examples/tomo/backends/astra_performance_cpu_parallel_2d_cg.py
@@ -14,6 +14,7 @@ import numpy as np
 import matplotlib.pyplot as plt
 import scipy.misc
 import odl
+from odl.util.testutils import timer
 
 
 # Common geometry parameters
@@ -53,7 +54,7 @@ cfg['ProjectorId'] = proj_id
 # Create the algorithm object from the configuration structure
 alg_id = astra.algorithm.create(cfg)
 
-with odl.util.Timer('ASTRA Run'):
+with timer('ASTRA Run'):
     # Run the algorithm
     astra.algorithm.run(alg_id, niter)
 
@@ -82,7 +83,7 @@ data = ray_trafo(phantom)
 
 # Solve with CGLS (aka CGN)
 x = reco_space.zero()
-with odl.util.Timer('ODL Run'):
+with timer('ODL Run'):
     odl.solvers.conjugate_gradient_normal(ray_trafo, x, data, niter=niter)
 
 # Display results for comparison

--- a/examples/tomo/backends/astra_performance_cuda_cone_3d_cg.py
+++ b/examples/tomo/backends/astra_performance_cuda_cone_3d_cg.py
@@ -13,6 +13,7 @@ import astra
 import numpy as np
 import matplotlib.pyplot as plt
 import odl
+from odl.util.testutils import timer
 
 
 # Common geometry parameters
@@ -70,7 +71,7 @@ cfg['ProjectorId'] = proj_id
 # Create the algorithm object from the configuration structure
 alg_id = astra.algorithm.create(cfg)
 
-with odl.util.Timer('ASTRA Run'):
+with timer('ASTRA Run'):
     # Run the algorithm
     astra.algorithm.run(alg_id, niter)
 
@@ -93,7 +94,7 @@ data = ray_trafo(phantom)
 
 # Solve with CGLS (aka CGN)
 x = reco_space.zero()
-with odl.util.Timer('ODL Run'):
+with timer('ODL Run'):
     odl.solvers.conjugate_gradient_normal(ray_trafo, x, data, niter=niter)
 
 coords = (slice(None), slice(None), 128)

--- a/examples/tomo/backends/astra_performance_cuda_parallel_2d_cg.py
+++ b/examples/tomo/backends/astra_performance_cuda_parallel_2d_cg.py
@@ -14,6 +14,7 @@ import numpy as np
 import matplotlib.pyplot as plt
 import scipy.misc
 import odl
+from odl.util.testutils import timer
 
 
 # Common geometry parameters
@@ -53,7 +54,7 @@ cfg['ProjectorId'] = proj_id
 # Create the algorithm object from the configuration structure
 alg_id = astra.algorithm.create(cfg)
 
-with odl.util.Timer('ASTRA Run'):
+with timer('ASTRA Run'):
     # Run the algorithm
     astra.algorithm.run(alg_id, niter)
 
@@ -82,7 +83,7 @@ data = ray_trafo(phantom)
 
 # Solve with CGLS (aka CGN)
 x = reco_space.zero()
-with odl.util.Timer('ODL Run'):
+with timer('ODL Run'):
     odl.solvers.conjugate_gradient_normal(ray_trafo, x, data, niter=niter)
 
 # Display results for comparison

--- a/odl/diagnostics/operator.py
+++ b/odl/diagnostics/operator.py
@@ -98,9 +98,10 @@ class OperatorTest(object):
         right_inner_vals = []
 
         with fail_counter(
-                test_name='Verifying the identity <Ax, y> = <x, Ay>',
-                err_msg='error = |<Ax, y> - <x, Ay>| / ||A|| ||x|| ||y||',
-                logger=self.log) as counter:
+            test_name='Verifying the identity <Ax, y> = <x, Ay>',
+            err_msg='error = |<Ax, y> - <x, Ay>| / ||A|| ||x|| ||y||',
+            logger=self.log
+        ) as counter:
 
             for [name_x, x], [name_y, y] in samples(self.operator.domain,
                                                     self.operator.range):
@@ -130,9 +131,10 @@ class OperatorTest(object):
         right_inner_vals = []
 
         with fail_counter(
-                test_name='Verifying the identity <Ax, y> = <x, A^T y>',
-                err_msg='error = |<Ax, y< - <x, A^* y>| / ||A|| ||x|| ||y||',
-                logger=self.log) as counter:
+            test_name='Verifying the identity <Ax, y> = <x, A^T y>',
+            err_msg='error = |<Ax, y< - <x, A^* y>| / ||A|| ||x|| ||y||',
+            logger=self.log
+        ) as counter:
 
             for [name_x, x], [name_y, y] in samples(self.operator.domain,
                                                     self.operator.range):
@@ -169,9 +171,10 @@ class OperatorTest(object):
             return
 
         with fail_counter(
-                test_name='\nVerifying the identity Ax = (A^*)^* x',
-                err_msg='error = ||Ax - (A^*)^* x|| / ||A|| ||x||',
-                logger=self.log) as counter:
+            test_name='\nVerifying the identity Ax = (A^*)^* x',
+            err_msg='error = ||Ax - (A^*)^* x|| / ||A|| ||x||',
+            logger=self.log
+        ) as counter:
             for [name_x, x] in self.operator.domain.examples:
                 opx = self.operator(x)
                 op_adj_adj_x = self.operator.adjoint.adjoint(x)
@@ -230,10 +233,11 @@ class OperatorTest(object):
         for ``c --> 0``.
         """
         with fail_counter(
-                test_name='Verifying that derivative is a first-order '
-                          'approximation',
-                err_msg="error = inf_c ||A(x+c*p)-A(x)-A'(x)(c*p)|| / c",
-                logger=self.log) as counter:
+            test_name='Verifying that derivative is a first-order '
+                      'approximation',
+            err_msg="error = inf_c ||A(x+c*p)-A(x)-A'(x)(c*p)|| / c",
+            logger=self.log
+        ) as counter:
             for [name_x, x], [name_dx, dx] in samples(self.operator.domain,
                                                       self.operator.domain):
                 # Precompute some values
@@ -302,9 +306,10 @@ class OperatorTest(object):
     def _scale_invariance(self):
         """Verify ``A(c*x) = c * A(x)``."""
         with fail_counter(
-                test_name='Verifying homogeneity under scalar multiplication',
-                err_msg='error = ||A(c*x)-c*A(x)|| / |c| ||A|| ||x||',
-                logger=self.log) as counter:
+            test_name='Verifying homogeneity under scalar multiplication',
+            err_msg='error = ||A(c*x)-c*A(x)|| / |c| ||A|| ||x||',
+            logger=self.log
+        ) as counter:
             for [name_x, x], [_, scale] in samples(self.operator.domain,
                                                    self.operator.domain.field):
                 opx = self.operator(x)
@@ -321,10 +326,11 @@ class OperatorTest(object):
     def _addition_invariance(self):
         """Verify ``A(x+y) = A(x) + A(y)``."""
         with fail_counter(
-                test_name='Verifying distributivity under vector addition',
-                err_msg='error = ||A(x+y) - A(x) - A(y)|| / '
-                        '||A||(||x|| + ||y||)',
-                logger=self.log) as counter:
+            test_name='Verifying distributivity under vector addition',
+            err_msg='error = ||A(x+y) - A(x) - A(y)|| / '
+                    '||A||(||x|| + ||y||)',
+            logger=self.log
+        ) as counter:
             for [name_x, x], [name_y, y] in samples(self.operator.domain,
                                                     self.operator.domain):
                 opx = self.operator(x)

--- a/odl/diagnostics/operator.py
+++ b/odl/diagnostics/operator.py
@@ -14,7 +14,7 @@ import numpy as np
 
 from odl.diagnostics.examples import samples
 from odl.operator import power_method_opnorm
-from odl.util.testutils import FailCounter
+from odl.util.testutils import fail_counter
 
 
 __all__ = ('OperatorTest',)
@@ -97,7 +97,7 @@ class OperatorTest(object):
         left_inner_vals = []
         right_inner_vals = []
 
-        with FailCounter(
+        with fail_counter(
                 test_name='Verifying the identity <Ax, y> = <x, Ay>',
                 err_msg='error = |<Ax, y> - <x, Ay>| / ||A|| ||x|| ||y||',
                 logger=self.log) as counter:
@@ -129,7 +129,7 @@ class OperatorTest(object):
         left_inner_vals = []
         right_inner_vals = []
 
-        with FailCounter(
+        with fail_counter(
                 test_name='Verifying the identity <Ax, y> = <x, A^T y>',
                 err_msg='error = |<Ax, y< - <x, A^* y>| / ||A|| ||x|| ||y||',
                 logger=self.log) as counter:
@@ -168,7 +168,7 @@ class OperatorTest(object):
             self.log('(A^*)^* == A')
             return
 
-        with FailCounter(
+        with fail_counter(
                 test_name='\nVerifying the identity Ax = (A^*)^* x',
                 err_msg='error = ||Ax - (A^*)^* x|| / ||A|| ||x||',
                 logger=self.log) as counter:
@@ -229,7 +229,7 @@ class OperatorTest(object):
 
         for ``c --> 0``.
         """
-        with FailCounter(
+        with fail_counter(
                 test_name='Verifying that derivative is a first-order '
                           'approximation',
                 err_msg="error = inf_c ||A(x+c*p)-A(x)-A'(x)(c*p)|| / c",
@@ -301,7 +301,7 @@ class OperatorTest(object):
 
     def _scale_invariance(self):
         """Verify ``A(c*x) = c * A(x)``."""
-        with FailCounter(
+        with fail_counter(
                 test_name='Verifying homogeneity under scalar multiplication',
                 err_msg='error = ||A(c*x)-c*A(x)|| / |c| ||A|| ||x||',
                 logger=self.log) as counter:
@@ -320,7 +320,7 @@ class OperatorTest(object):
 
     def _addition_invariance(self):
         """Verify ``A(x+y) = A(x) + A(y)``."""
-        with FailCounter(
+        with fail_counter(
                 test_name='Verifying distributivity under vector addition',
                 err_msg='error = ||A(x+y) - A(x) - A(y)|| / '
                         '||A||(||x|| + ||y||)',

--- a/odl/diagnostics/operator.py
+++ b/odl/diagnostics/operator.py
@@ -1,4 +1,4 @@
-﻿# Copyright 2014-2017 The ODL contributors
+# Copyright 2014-2019 The ODL contributors
 #
 # This file is part of ODL.
 #
@@ -8,14 +8,15 @@
 
 """Standardized tests for `Operator`'s."""
 
-from __future__ import print_function, division, absolute_import
+from __future__ import absolute_import, division, print_function
+
 from builtins import object
+
 import numpy as np
 
 from odl.diagnostics.examples import samples
 from odl.operator import power_method_opnorm
 from odl.util.testutils import fail_counter
-
 
 __all__ = ('OperatorTest',)
 

--- a/odl/diagnostics/space.py
+++ b/odl/diagnostics/space.py
@@ -1,4 +1,4 @@
-﻿# Copyright 2014-2017 The ODL contributors
+# Copyright 2014-2019 The ODL contributors
 #
 # This file is part of ODL.
 #
@@ -8,14 +8,14 @@
 
 """Standardized tests for ``LinearSpace``."""
 
-from __future__ import print_function, division, absolute_import
+from __future__ import absolute_import, division, print_function
+
 from builtins import object
 from copy import copy, deepcopy
 
-from odl.set import Field
 from odl.diagnostics.examples import samples
+from odl.set import Field
 from odl.util.testutils import fail_counter
-
 
 __all__ = ('SpaceTest',)
 

--- a/odl/diagnostics/space.py
+++ b/odl/diagnostics/space.py
@@ -14,7 +14,7 @@ from copy import copy, deepcopy
 
 from odl.set import Field
 from odl.diagnostics.examples import samples
-from odl.util.testutils import FailCounter
+from odl.util.testutils import fail_counter
 
 
 __all__ = ('SpaceTest',)
@@ -73,7 +73,7 @@ class SpaceTest(object):
 
     def element_method(self):
         """Verify `LinearSpace.element`."""
-        with FailCounter(test_name='Verifying element method',
+        with fail_counter(test_name='Verifying element method',
                          logger=self.log) as counter:
             try:
                 elem = self.space.element()
@@ -86,7 +86,7 @@ class SpaceTest(object):
 
     def field(self):
         """Verify `LinearSpace.field`."""
-        with FailCounter(test_name='Verifying field property',
+        with fail_counter(test_name='Verifying field property',
                          logger=self.log) as counter:
             try:
                 field = self.space.field
@@ -136,7 +136,7 @@ class SpaceTest(object):
 
     def _associativity_of_addition(self):
         """Verify addition associativity."""
-        with FailCounter(
+        with fail_counter(
                 test_name='Verifying associativity of addition',
                 err_msg='error = dist(x + (y + z), (x + y) + z)',
                 logger=self.log) as counter:
@@ -151,7 +151,7 @@ class SpaceTest(object):
 
     def _commutativity_of_addition(self):
         """Verify addition commutativity."""
-        with FailCounter(
+        with fail_counter(
                 test_name='Verifying commutativity of addition',
                 err_msg='error = dist(x + y, y + x)',
                 logger=self.log) as counter:
@@ -170,7 +170,7 @@ class SpaceTest(object):
             print('*** SPACE HAS NO ZERO VECTOR ***')
             return
 
-        with FailCounter(
+        with fail_counter(
                 test_name='Verifying identity element of addition',
                 err_msg='error = dist(x + 0, x)',
                 logger=self.log) as counter:
@@ -188,7 +188,7 @@ class SpaceTest(object):
             print('*** SPACE HAS NO ZERO VECTOR ***')
             return
 
-        with FailCounter(
+        with fail_counter(
                 test_name='Verifying inverse element of addition',
                 err_msg='error = dist(x + (-x), 0)',
                 logger=self.log) as counter:
@@ -200,7 +200,7 @@ class SpaceTest(object):
 
     def _commutativity_of_scalar_mult(self):
         """Verify scalar multiplication commutativity."""
-        with FailCounter(
+        with fail_counter(
                 test_name='Verifying commutativity of scalar multiplication',
                 err_msg='error = dist(a * (b * x), (a * b) * x)',
                 logger=self.log) as counter:
@@ -215,7 +215,7 @@ class SpaceTest(object):
 
     def _identity_of_mult(self):
         """Verify multiplicative neutral element ('one')."""
-        with FailCounter(
+        with fail_counter(
                 test_name='Verifying identity element of multiplication',
                 err_msg='error = dist(1 * x, x)',
                 logger=self.log) as counter:
@@ -227,7 +227,7 @@ class SpaceTest(object):
 
     def _distributivity_of_mult_vector(self):
         """Verify scalar multiplication distributivity wrt vector addition."""
-        with FailCounter(
+        with fail_counter(
                 test_name='Verifying distributivity of scalar multiplication '
                           'under vector addition',
                 err_msg='error = dist(a * (x + y), a * x + a * y)',
@@ -243,7 +243,7 @@ class SpaceTest(object):
 
     def _distributivity_of_mult_scalar(self):
         """Verify scalar multiplication distributivity wrt scalar addition."""
-        with FailCounter(
+        with fail_counter(
                 test_name='Verifying distributivity of scalar multiplication '
                           'under scalar addition',
                 err_msg='error = dist((a + b) * x, a * x + b * x)',
@@ -259,7 +259,7 @@ class SpaceTest(object):
 
     def _subtraction(self):
         """Verify element subtraction as addition of additive inverse."""
-        with FailCounter(
+        with fail_counter(
                 test_name='Verifying element subtraction',
                 err_msg='error = dist(x - y, x + (-1 * y))',
                 logger=self.log) as counter:
@@ -273,7 +273,7 @@ class SpaceTest(object):
 
     def _division(self):
         """Verify scalar division as multiplication with mult. inverse."""
-        with FailCounter(
+        with fail_counter(
                 test_name='Verifying scalar division',
                 err_msg='error = dist(x / a, x * (1/a))',
                 logger=self.log) as counter:
@@ -287,7 +287,7 @@ class SpaceTest(object):
 
     def _lincomb_aliased(self):
         """Verify several scenarios of aliased linear combination."""
-        with FailCounter(
+        with fail_counter(
                 test_name='Verifying linear combination with aliased input',
                 err_msg='error = dist(aliased, non-aliased)',
                 logger=self.log) as counter:
@@ -346,7 +346,7 @@ class SpaceTest(object):
 
     def _inner_linear_scalar(self):
         """Verify homogeneity of the inner product in the first argument."""
-        with FailCounter(
+        with fail_counter(
                 test_name='Verifying homogeneity of the inner product in the '
                           'first argument',
                 err_msg='error = |<a*x, y> - a*<x, y>|',
@@ -362,7 +362,7 @@ class SpaceTest(object):
 
     def _inner_conjugate_symmetry(self):
         """Verify conjugate symmetry of the inner product."""
-        with FailCounter(
+        with fail_counter(
                 test_name='Verifying conjugate symmetry of the inner product',
                 err_msg='error = |<x, y> - <y, x>.conj()|',
                 logger=self.log) as counter:
@@ -375,7 +375,7 @@ class SpaceTest(object):
 
     def _inner_linear_sum(self):
         """Verify distributivity of the inner product in the first argument."""
-        with FailCounter(
+        with fail_counter(
                 test_name='Verifying distributivity of the inner product'
                           'in the first argument',
                 err_msg='error = |<x+y, z> - (<x, z> + <y, z>)|',
@@ -391,7 +391,7 @@ class SpaceTest(object):
 
     def _inner_positive(self):
         """Verify positive definiteness of the inner product."""
-        with FailCounter(
+        with fail_counter(
                 test_name='Verifying positive definiteness of the inner '
                           'product',
                 logger=self.log) as counter:
@@ -452,7 +452,7 @@ class SpaceTest(object):
 
     def _norm_positive(self):
         """Verify positive definiteness of the norm."""
-        with FailCounter(
+        with fail_counter(
                 test_name='Verifying positive definiteness of the norm',
                 logger=self.log) as counter:
 
@@ -469,7 +469,7 @@ class SpaceTest(object):
 
     def _norm_subadditive(self):
         """Verify subadditivity of the norm."""
-        with FailCounter(
+        with fail_counter(
                 test_name='Verifying sub-additivity of the norm',
                 err_msg='error = max(||x+y|| - (||x|| + ||y||), 0)',
                 logger=self.log) as counter:
@@ -487,7 +487,7 @@ class SpaceTest(object):
 
     def _norm_homogeneity(self):
         """Verify positive homogeneity of the norm."""
-        with FailCounter(
+        with fail_counter(
                 test_name='Verifying positive homogeneity of the norm',
                 err_msg='error = | ||a*x|| - |a|*||x|| |',
                 logger=self.log) as counter:
@@ -507,7 +507,7 @@ class SpaceTest(object):
             self.log('Space has no inner product')
             return
 
-        with FailCounter(
+        with fail_counter(
                 test_name='Verifying compatibility of norm and inner product',
                 err_msg='error = | ||x||^2 - <x, x> |',
                 logger=self.log) as counter:
@@ -568,7 +568,7 @@ class SpaceTest(object):
     def _dist_positivity(self):
         """Verify nonnegativity of the distance."""
 
-        with FailCounter(
+        with fail_counter(
                 test_name='Verifying nonnegativity of the distance',
                 logger=self.log) as counter:
 
@@ -584,7 +584,7 @@ class SpaceTest(object):
 
     def _dist_symmetric(self):
         """Verify symmetry of the distance."""
-        with FailCounter(
+        with fail_counter(
                 test_name='Verifying symmetry of the distance',
                 err_msg='error = |d(x, y) - d(y, x)|',
                 logger=self.log) as counter:
@@ -600,7 +600,7 @@ class SpaceTest(object):
 
     def _dist_subtransitive(self):
         """Verify sub-transitivity of the distance."""
-        with FailCounter(
+        with fail_counter(
                 test_name='Verifying sub-additivity of the distance',
                 err_msg='error = max(d(x,z) - (d(x, y) + d(y, z)), 0)',
                 logger=self.log) as counter:
@@ -625,7 +625,7 @@ class SpaceTest(object):
             self.log('Space has no norm')
             return
 
-        with FailCounter(
+        with fail_counter(
                 test_name='Verifying compatibility of distance and norm',
                 err_msg='error = |d(x, y) - ||x-y|| |',
                 logger=self.log) as counter:
@@ -689,7 +689,7 @@ class SpaceTest(object):
             print('*** SPACE HAS NO ZERO VECTOR ***')
             return
 
-        with FailCounter(
+        with fail_counter(
                 test_name='Verifying vector multiplication with zero',
                 err_msg='error = ||x * 0||',
                 logger=self.log) as counter:
@@ -702,7 +702,7 @@ class SpaceTest(object):
 
     def _multiply_commutative(self):
         """Verify commutativity of vector multiplication."""
-        with FailCounter(
+        with fail_counter(
                 test_name='Verifying commutativity of vector multiplication',
                 err_msg='error = dist(x * y, y * x)',
                 logger=self.log) as counter:
@@ -717,7 +717,7 @@ class SpaceTest(object):
 
     def _multiply_associative(self):
         """Verify associativity of vector multiplication."""
-        with FailCounter(
+        with fail_counter(
                 test_name='Verifying associativity of vector multiplication',
                 err_msg='error = dist(x * (y * z), (x * y) * z)',
                 logger=self.log) as counter:
@@ -732,7 +732,7 @@ class SpaceTest(object):
 
     def _multiply_distributive_scalar(self):
         """Verify distributivity of scalar multiplication."""
-        with FailCounter(
+        with fail_counter(
                 test_name='Verifying distributivity of vector multiplication '
                           'under scalar multiplication',
                 err_msg='error = dist(a * (x + y), a * x + a * y)',
@@ -748,7 +748,7 @@ class SpaceTest(object):
 
     def _multiply_distributive_vector(self):
         """Verify distributivity of vector multiplication."""
-        with FailCounter(
+        with fail_counter(
                 test_name='Verifying distributivity of vector multiplication '
                           'under vector multiplication',
                 err_msg='error = dist(x * (y + z), x * y + x * z)',
@@ -822,7 +822,7 @@ class SpaceTest(object):
         if self.space != deepcopy(self.space):
             print('** space == deepcopy(space) failed***')
 
-        with FailCounter(
+        with fail_counter(
                 test_name='Verify behavior of `space == obj` when `obj` '
                           'is not a space',
                 logger=self.log) as counter:
@@ -838,7 +838,7 @@ class SpaceTest(object):
 
     def contains(self):
         """Verify `LinearSpace.__contains__`."""
-        with FailCounter(
+        with fail_counter(
                 test_name='Verify behavior of `obj in space`',
                 logger=self.log) as counter:
 
@@ -862,7 +862,7 @@ class SpaceTest(object):
 
     def element_assign(self):
         """Verify `LinearSpaceElement.assign`."""
-        with FailCounter(
+        with fail_counter(
                 test_name='Verify behavior of `LinearSpaceElement.assign`',
                 logger=self.log) as counter:
 
@@ -876,7 +876,7 @@ class SpaceTest(object):
 
     def element_copy(self):
         """Verify `LinearSpaceElement.copy`."""
-        with FailCounter(
+        with fail_counter(
                 test_name='Verify behavior of `LinearSpaceElement.copy`',
                 logger=self.log) as counter:
 
@@ -903,7 +903,7 @@ class SpaceTest(object):
             print('*** SPACE HAS NO ZERO VECTOR ***')
             return
 
-        with FailCounter(
+        with fail_counter(
                 test_name='Verify behavior of `LinearSpaceElement.set_zero`',
                 logger=self.log) as counter:
 
@@ -928,7 +928,7 @@ class SpaceTest(object):
             self.log('Vector has no __eq__')
             return
 
-        with FailCounter(
+        with fail_counter(
                 test_name='Verify behavior of `element1 == element2`',
                 logger=self.log) as counter:
 
@@ -953,7 +953,7 @@ class SpaceTest(object):
 
     def element_space(self):
         """Verify `LinearSpaceElement.space`."""
-        with FailCounter(
+        with fail_counter(
                 test_name='Verify `LinearSpaceElement.space`',
                 logger=self.log) as counter:
 

--- a/odl/diagnostics/space.py
+++ b/odl/diagnostics/space.py
@@ -73,8 +73,9 @@ class SpaceTest(object):
 
     def element_method(self):
         """Verify `LinearSpace.element`."""
-        with fail_counter(test_name='Verifying element method',
-                         logger=self.log) as counter:
+        with fail_counter(
+            test_name='Verifying element method', logger=self.log
+        ) as counter:
             try:
                 elem = self.space.element()
             except NotImplementedError:
@@ -86,8 +87,9 @@ class SpaceTest(object):
 
     def field(self):
         """Verify `LinearSpace.field`."""
-        with fail_counter(test_name='Verifying field property',
-                         logger=self.log) as counter:
+        with fail_counter(
+            test_name='Verifying field property', logger=self.log
+        ) as counter:
             try:
                 field = self.space.field
             except NotImplementedError:
@@ -137,9 +139,10 @@ class SpaceTest(object):
     def _associativity_of_addition(self):
         """Verify addition associativity."""
         with fail_counter(
-                test_name='Verifying associativity of addition',
-                err_msg='error = dist(x + (y + z), (x + y) + z)',
-                logger=self.log) as counter:
+            test_name='Verifying associativity of addition',
+            err_msg='error = dist(x + (y + z), (x + y) + z)',
+            logger=self.log
+        ) as counter:
 
             for [n_x, x], [n_y, y], [n_z, z] in samples(self.space,
                                                         self.space,
@@ -152,9 +155,10 @@ class SpaceTest(object):
     def _commutativity_of_addition(self):
         """Verify addition commutativity."""
         with fail_counter(
-                test_name='Verifying commutativity of addition',
-                err_msg='error = dist(x + y, y + x)',
-                logger=self.log) as counter:
+            test_name='Verifying commutativity of addition',
+            err_msg='error = dist(x + y, y + x)',
+            logger=self.log
+        ) as counter:
 
             for [n_x, x], [n_y, y] in samples(self.space, self.space):
                 correct = _approx_equal(x + y, y + x, self.tol)
@@ -171,9 +175,10 @@ class SpaceTest(object):
             return
 
         with fail_counter(
-                test_name='Verifying identity element of addition',
-                err_msg='error = dist(x + 0, x)',
-                logger=self.log) as counter:
+            test_name='Verifying identity element of addition',
+            err_msg='error = dist(x + 0, x)',
+            logger=self.log
+        ) as counter:
 
             for [n_x, x] in samples(self.space):
                 correct = _approx_equal(x + zero, x, self.tol)
@@ -189,9 +194,10 @@ class SpaceTest(object):
             return
 
         with fail_counter(
-                test_name='Verifying inverse element of addition',
-                err_msg='error = dist(x + (-x), 0)',
-                logger=self.log) as counter:
+            test_name='Verifying inverse element of addition',
+            err_msg='error = dist(x + (-x), 0)',
+            logger=self.log
+        ) as counter:
 
             for [n_x, x] in samples(self.space):
                 correct = _approx_equal(x + (-x), zero, self.tol)
@@ -201,9 +207,10 @@ class SpaceTest(object):
     def _commutativity_of_scalar_mult(self):
         """Verify scalar multiplication commutativity."""
         with fail_counter(
-                test_name='Verifying commutativity of scalar multiplication',
-                err_msg='error = dist(a * (b * x), (a * b) * x)',
-                logger=self.log) as counter:
+            test_name='Verifying commutativity of scalar multiplication',
+            err_msg='error = dist(a * (b * x), (a * b) * x)',
+            logger=self.log
+        ) as counter:
 
             for [n_x, x], [_, a], [_, b] in samples(self.space,
                                                     self.space.field,
@@ -216,9 +223,10 @@ class SpaceTest(object):
     def _identity_of_mult(self):
         """Verify multiplicative neutral element ('one')."""
         with fail_counter(
-                test_name='Verifying identity element of multiplication',
-                err_msg='error = dist(1 * x, x)',
-                logger=self.log) as counter:
+            test_name='Verifying identity element of multiplication',
+            err_msg='error = dist(1 * x, x)',
+            logger=self.log
+        ) as counter:
 
             for [n_x, x] in samples(self.space):
                 correct = _approx_equal(1 * x, x, self.tol)
@@ -228,10 +236,11 @@ class SpaceTest(object):
     def _distributivity_of_mult_vector(self):
         """Verify scalar multiplication distributivity wrt vector addition."""
         with fail_counter(
-                test_name='Verifying distributivity of scalar multiplication '
-                          'under vector addition',
-                err_msg='error = dist(a * (x + y), a * x + a * y)',
-                logger=self.log) as counter:
+            test_name='Verifying distributivity of scalar multiplication '
+                      'under vector addition',
+            err_msg='error = dist(a * (x + y), a * x + a * y)',
+            logger=self.log
+        ) as counter:
 
             for [n_x, x], [n_y, y], [_, a] in samples(self.space,
                                                       self.space,
@@ -244,10 +253,11 @@ class SpaceTest(object):
     def _distributivity_of_mult_scalar(self):
         """Verify scalar multiplication distributivity wrt scalar addition."""
         with fail_counter(
-                test_name='Verifying distributivity of scalar multiplication '
-                          'under scalar addition',
-                err_msg='error = dist((a + b) * x, a * x + b * x)',
-                logger=self.log) as counter:
+            test_name='Verifying distributivity of scalar multiplication '
+                      'under scalar addition',
+            err_msg='error = dist((a + b) * x, a * x + b * x)',
+            logger=self.log
+        ) as counter:
 
             for [n_x, x], [_, a], [_, b] in samples(self.space,
                                                     self.space.field,
@@ -260,9 +270,10 @@ class SpaceTest(object):
     def _subtraction(self):
         """Verify element subtraction as addition of additive inverse."""
         with fail_counter(
-                test_name='Verifying element subtraction',
-                err_msg='error = dist(x - y, x + (-1 * y))',
-                logger=self.log) as counter:
+            test_name='Verifying element subtraction',
+            err_msg='error = dist(x - y, x + (-1 * y))',
+            logger=self.log
+        ) as counter:
 
             for [n_x, x], [n_y, y] in samples(self.space, self.space):
                 correct = (_approx_equal(x - y, x + (-1 * y), self.tol) and
@@ -274,9 +285,10 @@ class SpaceTest(object):
     def _division(self):
         """Verify scalar division as multiplication with mult. inverse."""
         with fail_counter(
-                test_name='Verifying scalar division',
-                err_msg='error = dist(x / a, x * (1/a))',
-                logger=self.log) as counter:
+            test_name='Verifying scalar division',
+            err_msg='error = dist(x / a, x * (1/a))',
+            logger=self.log
+        ) as counter:
 
             for [n_x, x], [_, a] in samples(self.space, self.space.field):
                 if a != 0:
@@ -288,9 +300,10 @@ class SpaceTest(object):
     def _lincomb_aliased(self):
         """Verify several scenarios of aliased linear combination."""
         with fail_counter(
-                test_name='Verifying linear combination with aliased input',
-                err_msg='error = dist(aliased, non-aliased)',
-                logger=self.log) as counter:
+            test_name='Verifying linear combination with aliased input',
+            err_msg='error = dist(aliased, non-aliased)',
+            logger=self.log
+        ) as counter:
 
             for [n_x, x_in], [n_y, y] in samples(self.space, self.space):
                 x = x_in.copy()
@@ -347,10 +360,11 @@ class SpaceTest(object):
     def _inner_linear_scalar(self):
         """Verify homogeneity of the inner product in the first argument."""
         with fail_counter(
-                test_name='Verifying homogeneity of the inner product in the '
-                          'first argument',
-                err_msg='error = |<a*x, y> - a*<x, y>|',
-                logger=self.log) as counter:
+            test_name='Verifying homogeneity of the inner product in the '
+                      'first argument',
+            err_msg='error = |<a*x, y> - a*<x, y>|',
+            logger=self.log
+        ) as counter:
 
             for [n_x, x], [n_y, y], [_, a] in samples(self.space,
                                                       self.space,
@@ -363,9 +377,10 @@ class SpaceTest(object):
     def _inner_conjugate_symmetry(self):
         """Verify conjugate symmetry of the inner product."""
         with fail_counter(
-                test_name='Verifying conjugate symmetry of the inner product',
-                err_msg='error = |<x, y> - <y, x>.conj()|',
-                logger=self.log) as counter:
+            test_name='Verifying conjugate symmetry of the inner product',
+            err_msg='error = |<x, y> - <y, x>.conj()|',
+            logger=self.log
+        ) as counter:
 
             for [n_x, x], [n_y, y] in samples(self.space, self.space):
                 error = abs((x).inner(y) - y.inner(x).conjugate())
@@ -376,10 +391,11 @@ class SpaceTest(object):
     def _inner_linear_sum(self):
         """Verify distributivity of the inner product in the first argument."""
         with fail_counter(
-                test_name='Verifying distributivity of the inner product'
-                          'in the first argument',
-                err_msg='error = |<x+y, z> - (<x, z> + <y, z>)|',
-                logger=self.log) as counter:
+            test_name='Verifying distributivity of the inner product'
+                      'in the first argument',
+            err_msg='error = |<x+y, z> - (<x, z> + <y, z>)|',
+            logger=self.log
+        ) as counter:
 
             for [n_x, x], [n_y, y], [n_z, z] in samples(self.space,
                                                         self.space,
@@ -392,9 +408,10 @@ class SpaceTest(object):
     def _inner_positive(self):
         """Verify positive definiteness of the inner product."""
         with fail_counter(
-                test_name='Verifying positive definiteness of the inner '
-                          'product',
-                logger=self.log) as counter:
+            test_name='Verifying positive definiteness of the inner '
+                      'product',
+            logger=self.log
+        ) as counter:
 
             for [n_x, x] in samples(self.space):
                 inner = x.inner(x)
@@ -453,8 +470,9 @@ class SpaceTest(object):
     def _norm_positive(self):
         """Verify positive definiteness of the norm."""
         with fail_counter(
-                test_name='Verifying positive definiteness of the norm',
-                logger=self.log) as counter:
+            test_name='Verifying positive definiteness of the norm',
+            logger=self.log
+        ) as counter:
 
             for [n_x, x] in samples(self.space):
                 norm = x.norm()
@@ -470,9 +488,10 @@ class SpaceTest(object):
     def _norm_subadditive(self):
         """Verify subadditivity of the norm."""
         with fail_counter(
-                test_name='Verifying sub-additivity of the norm',
-                err_msg='error = max(||x+y|| - (||x|| + ||y||), 0)',
-                logger=self.log) as counter:
+            test_name='Verifying sub-additivity of the norm',
+            err_msg='error = max(||x+y|| - (||x|| + ||y||), 0)',
+            logger=self.log
+        ) as counter:
 
             for [n_x, x], [n_y, y] in samples(self.space, self.space):
                 norm_x = x.norm()
@@ -488,9 +507,10 @@ class SpaceTest(object):
     def _norm_homogeneity(self):
         """Verify positive homogeneity of the norm."""
         with fail_counter(
-                test_name='Verifying positive homogeneity of the norm',
-                err_msg='error = | ||a*x|| - |a|*||x|| |',
-                logger=self.log) as counter:
+            test_name='Verifying positive homogeneity of the norm',
+            err_msg='error = | ||a*x|| - |a|*||x|| |',
+            logger=self.log
+        ) as counter:
 
             for [n_x, x], [_, a] in samples(self.space, self.space.field):
                 error = abs((a * x).norm() - abs(a) * x.norm())
@@ -508,9 +528,10 @@ class SpaceTest(object):
             return
 
         with fail_counter(
-                test_name='Verifying compatibility of norm and inner product',
-                err_msg='error = | ||x||^2 - <x, x> |',
-                logger=self.log) as counter:
+            test_name='Verifying compatibility of norm and inner product',
+            err_msg='error = | ||x||^2 - <x, x> |',
+            logger=self.log
+        ) as counter:
 
             for [n_x, x] in samples(self.space):
                 error = abs(x.norm() ** 2 - x.inner(x))
@@ -569,8 +590,9 @@ class SpaceTest(object):
         """Verify nonnegativity of the distance."""
 
         with fail_counter(
-                test_name='Verifying nonnegativity of the distance',
-                logger=self.log) as counter:
+            test_name='Verifying nonnegativity of the distance',
+            logger=self.log
+        ) as counter:
 
             for [n_x, x], [n_y, y] in samples(self.space, self.space):
                 dist = x.dist(y)
@@ -585,9 +607,10 @@ class SpaceTest(object):
     def _dist_symmetric(self):
         """Verify symmetry of the distance."""
         with fail_counter(
-                test_name='Verifying symmetry of the distance',
-                err_msg='error = |d(x, y) - d(y, x)|',
-                logger=self.log) as counter:
+            test_name='Verifying symmetry of the distance',
+            err_msg='error = |d(x, y) - d(y, x)|',
+            logger=self.log
+        ) as counter:
 
             for [n_x, x], [n_y, y] in samples(self.space, self.space):
                 dist_1 = x.dist(y)
@@ -601,9 +624,10 @@ class SpaceTest(object):
     def _dist_subtransitive(self):
         """Verify sub-transitivity of the distance."""
         with fail_counter(
-                test_name='Verifying sub-additivity of the distance',
-                err_msg='error = max(d(x,z) - (d(x, y) + d(y, z)), 0)',
-                logger=self.log) as counter:
+            test_name='Verifying sub-additivity of the distance',
+            err_msg='error = max(d(x,z) - (d(x, y) + d(y, z)), 0)',
+            logger=self.log
+        ) as counter:
 
             for [n_x, x], [n_y, y], [n_z, z] in samples(self.space,
                                                         self.space,
@@ -626,9 +650,10 @@ class SpaceTest(object):
             return
 
         with fail_counter(
-                test_name='Verifying compatibility of distance and norm',
-                err_msg='error = |d(x, y) - ||x-y|| |',
-                logger=self.log) as counter:
+            test_name='Verifying compatibility of distance and norm',
+            err_msg='error = |d(x, y) - ||x-y|| |',
+            logger=self.log
+        ) as counter:
 
             for [n_x, x], [n_y, y] in samples(self.space,
                                               self.space):
@@ -690,9 +715,10 @@ class SpaceTest(object):
             return
 
         with fail_counter(
-                test_name='Verifying vector multiplication with zero',
-                err_msg='error = ||x * 0||',
-                logger=self.log) as counter:
+            test_name='Verifying vector multiplication with zero',
+            err_msg='error = ||x * 0||',
+            logger=self.log
+        ) as counter:
             for [n_x, x] in samples(self.space):
                 error = (zero * x).norm()
 
@@ -703,9 +729,10 @@ class SpaceTest(object):
     def _multiply_commutative(self):
         """Verify commutativity of vector multiplication."""
         with fail_counter(
-                test_name='Verifying commutativity of vector multiplication',
-                err_msg='error = dist(x * y, y * x)',
-                logger=self.log) as counter:
+            test_name='Verifying commutativity of vector multiplication',
+            err_msg='error = dist(x * y, y * x)',
+            logger=self.log
+        ) as counter:
 
             for [n_x, x], [n_y, y], _ in samples(self.space,
                                                  self.space,
@@ -718,9 +745,10 @@ class SpaceTest(object):
     def _multiply_associative(self):
         """Verify associativity of vector multiplication."""
         with fail_counter(
-                test_name='Verifying associativity of vector multiplication',
-                err_msg='error = dist(x * (y * z), (x * y) * z)',
-                logger=self.log) as counter:
+            test_name='Verifying associativity of vector multiplication',
+            err_msg='error = dist(x * (y * z), (x * y) * z)',
+            logger=self.log
+        ) as counter:
 
             for [n_x, x], [n_y, y], [n_z, z] in samples(self.space,
                                                         self.space,
@@ -733,10 +761,11 @@ class SpaceTest(object):
     def _multiply_distributive_scalar(self):
         """Verify distributivity of scalar multiplication."""
         with fail_counter(
-                test_name='Verifying distributivity of vector multiplication '
-                          'under scalar multiplication',
-                err_msg='error = dist(a * (x + y), a * x + a * y)',
-                logger=self.log) as counter:
+            test_name='Verifying distributivity of vector multiplication '
+                      'under scalar multiplication',
+            err_msg='error = dist(a * (x + y), a * x + a * y)',
+            logger=self.log
+        ) as counter:
 
             for [n_x, x], [n_y, y], [_, a] in samples(self.space,
                                                       self.space,
@@ -749,10 +778,11 @@ class SpaceTest(object):
     def _multiply_distributive_vector(self):
         """Verify distributivity of vector multiplication."""
         with fail_counter(
-                test_name='Verifying distributivity of vector multiplication '
-                          'under vector multiplication',
-                err_msg='error = dist(x * (y + z), x * y + x * z)',
-                logger=self.log) as counter:
+            test_name='Verifying distributivity of vector multiplication '
+                      'under vector multiplication',
+            err_msg='error = dist(x * (y + z), x * y + x * z)',
+            logger=self.log
+        ) as counter:
 
             for [n_x, x], [n_y, y], [n_z, z] in samples(self.space,
                                                         self.space,
@@ -823,9 +853,10 @@ class SpaceTest(object):
             print('** space == deepcopy(space) failed***')
 
         with fail_counter(
-                test_name='Verify behavior of `space == obj` when `obj` '
-                          'is not a space',
-                logger=self.log) as counter:
+            test_name='Verify behavior of `space == obj` when `obj` '
+                      'is not a space',
+            logger=self.log
+        ) as counter:
 
             for obj in [[1, 2], list(), tuple(), dict(), 5.0]:
                 if self.space == obj:
@@ -839,8 +870,9 @@ class SpaceTest(object):
     def contains(self):
         """Verify `LinearSpace.__contains__`."""
         with fail_counter(
-                test_name='Verify behavior of `obj in space`',
-                logger=self.log) as counter:
+            test_name='Verify behavior of `obj in space`',
+            logger=self.log
+        ) as counter:
 
             for [n_x, x] in samples(self.space):
                 if x not in self.space:
@@ -863,8 +895,9 @@ class SpaceTest(object):
     def element_assign(self):
         """Verify `LinearSpaceElement.assign`."""
         with fail_counter(
-                test_name='Verify behavior of `LinearSpaceElement.assign`',
-                logger=self.log) as counter:
+            test_name='Verify behavior of `LinearSpaceElement.assign`',
+            logger=self.log
+        ) as counter:
 
             for [n_x, x], [n_y, y] in samples(self.space,
                                               self.space):
@@ -877,8 +910,9 @@ class SpaceTest(object):
     def element_copy(self):
         """Verify `LinearSpaceElement.copy`."""
         with fail_counter(
-                test_name='Verify behavior of `LinearSpaceElement.copy`',
-                logger=self.log) as counter:
+            test_name='Verify behavior of `LinearSpaceElement.copy`',
+            logger=self.log
+        ) as counter:
 
             for [n_x, x] in samples(self.space):
                 # equal after copy
@@ -904,8 +938,9 @@ class SpaceTest(object):
             return
 
         with fail_counter(
-                test_name='Verify behavior of `LinearSpaceElement.set_zero`',
-                logger=self.log) as counter:
+            test_name='Verify behavior of `LinearSpaceElement.set_zero`',
+            logger=self.log
+        ) as counter:
 
             for [n_x, x] in samples(self.space):
                 x.set_zero()
@@ -929,8 +964,9 @@ class SpaceTest(object):
             return
 
         with fail_counter(
-                test_name='Verify behavior of `element1 == element2`',
-                logger=self.log) as counter:
+            test_name='Verify behavior of `element1 == element2`',
+            logger=self.log
+        ) as counter:
 
             for [n_x, x], [n_y, y] in samples(self.space,
                                               self.space):
@@ -954,8 +990,9 @@ class SpaceTest(object):
     def element_space(self):
         """Verify `LinearSpaceElement.space`."""
         with fail_counter(
-                test_name='Verify `LinearSpaceElement.space`',
-                logger=self.log) as counter:
+            test_name='Verify `LinearSpaceElement.space`',
+            logger=self.log
+        ) as counter:
 
             for [n_x, x] in samples(self.space):
                 if x.space != self.space:

--- a/odl/phantom/noise.py
+++ b/odl/phantom/noise.py
@@ -8,11 +8,11 @@
 
 """Functions to create noise samples of different distributions."""
 
-from __future__ import print_function, division, absolute_import
+from __future__ import absolute_import, division, print_function
+
 import numpy as np
 
-from odl.util import NumpyRandomSeed
-
+from odl.util import npy_random_seed
 
 __all__ = ('white_noise', 'poisson_noise', 'salt_pepper_noise',
            'uniform_noise')
@@ -49,7 +49,7 @@ def white_noise(space, mean=0, stddev=1, seed=None):
     """
     from odl.space import ProductSpace
 
-    with NumpyRandomSeed(seed):
+    with npy_random_seed(seed):
         if isinstance(space, ProductSpace):
             values = [white_noise(subspace, mean, stddev)
                       for subspace in space]
@@ -101,7 +101,7 @@ def uniform_noise(space, low=0, high=1, seed=None):
     """
     from odl.space import ProductSpace
 
-    with NumpyRandomSeed(seed):
+    with npy_random_seed(seed):
         if isinstance(space, ProductSpace):
             values = [uniform_noise(subspace, low, high)
                       for subspace in space]
@@ -155,7 +155,7 @@ def poisson_noise(intensity, seed=None):
     """
     from odl.space import ProductSpace
 
-    with NumpyRandomSeed(seed):
+    with npy_random_seed(seed):
         if isinstance(intensity.space, ProductSpace):
             values = [poisson_noise(subintensity)
                       for subintensity in intensity]
@@ -218,7 +218,7 @@ def salt_pepper_noise(vector, fraction=0.05, salt_vs_pepper=0.5,
         raise ValueError('`salt_vs_pepper` ({}) should be a float in the '
                          'interval [0, 1]'.format(salt_vs_pepper_in))
 
-    with NumpyRandomSeed(seed):
+    with npy_random_seed(seed):
         if isinstance(vector.space, ProductSpace):
             values = [salt_pepper_noise(subintensity, fraction, salt_vs_pepper,
                                         low_val, high_val)

--- a/odl/space/base_tensors.py
+++ b/odl/space/base_tensors.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2018 The ODL contributors
+# Copyright 2014-2019 The ODL contributors
 #
 # This file is part of ODL.
 #
@@ -8,20 +8,20 @@
 
 """Base classes for implementations of tensor spaces."""
 
-from __future__ import print_function, division, absolute_import
-from builtins import object
+from __future__ import absolute_import, division, print_function
+
 from numbers import Integral
+
 import numpy as np
 
-from odl.set.sets import RealNumbers, ComplexNumbers
+from odl.set.sets import ComplexNumbers, RealNumbers
 from odl.set.space import LinearSpace, LinearSpaceElement
 from odl.util import (
-    is_numeric_dtype, is_real_dtype, is_floating_dtype,
-    is_real_floating_dtype, is_complex_floating_dtype, safe_int_conv,
-    array_str, dtype_str, signature_string, indent, writable_array)
+    array_str, dtype_str, indent, is_complex_floating_dtype, is_floating_dtype,
+    is_numeric_dtype, is_real_dtype, is_real_floating_dtype, safe_int_conv,
+    signature_string, writable_array)
 from odl.util.ufuncs import TensorSpaceUfuncs
-from odl.util.utility import TYPE_MAP_R2C, TYPE_MAP_C2R
-
+from odl.util.utility import TYPE_MAP_C2R, TYPE_MAP_R2C, none_context
 
 __all__ = ('TensorSpace',)
 
@@ -815,26 +815,11 @@ numpy.ufunc.reduceat.html
 
         # --- Evaluate ufunc --- #
 
-        # Trivial context used to create a single code path for the ufunc
-        # evaluation. For `None` output parameter(s), this is used instead of
-        # `writable_array`.
-        class CtxNone(object):
-            """Trivial context manager class.
-
-            When used as ::
-
-                with CtxNone() as obj:
-                    # do stuff with `obj`
-
-            the returned ``obj`` is ``None``.
-            """
-            __enter__ = __exit__ = lambda *_: None
-
         if method == '__call__':
             if ufunc.nout == 1:
                 # Make context for output (trivial one returns `None`)
                 if out is None:
-                    out_ctx = CtxNone()
+                    out_ctx = none_context()
                 else:
                     out_ctx = writable_array(out, **array_kwargs)
 
@@ -851,11 +836,11 @@ numpy.ufunc.reduceat.html
                 if out1 is not None:
                     out1_ctx = writable_array(out1, **array_kwargs)
                 else:
-                    out1_ctx = CtxNone()
+                    out1_ctx = none_context()
                 if out2 is not None:
                     out2_ctx = writable_array(out2, **array_kwargs)
                 else:
-                    out2_ctx = CtxNone()
+                    out2_ctx = none_context()
 
                 # Evaluate ufunc
                 with out1_ctx as out1_arr, out2_ctx as out2_arr:
@@ -872,7 +857,7 @@ numpy.ufunc.reduceat.html
         else:  # method != '__call__'
             # Make context for output (trivial one returns `None`)
             if out is None:
-                out_ctx = CtxNone()
+                out_ctx = none_context()
             else:
                 out_ctx = writable_array(out, **array_kwargs)
 

--- a/odl/space/npy_tensors.py
+++ b/odl/space/npy_tensors.py
@@ -8,23 +8,24 @@
 
 """NumPy implementation of tensor spaces."""
 
-from __future__ import print_function, division, absolute_import
+from __future__ import absolute_import, division, print_function
 from future.utils import native
-from builtins import object
+
 import ctypes
+from builtins import object
 from functools import partial
+
 import numpy as np
 
-from odl.set.sets import RealNumbers, ComplexNumbers
+from odl.set.sets import ComplexNumbers, RealNumbers
 from odl.set.space import LinearSpaceTypeError
-from odl.space.base_tensors import TensorSpace, Tensor
+from odl.space.base_tensors import Tensor, TensorSpace
 from odl.space.weighting import (
-    Weighting, ArrayWeighting, ConstWeighting,
-    CustomInner, CustomNorm, CustomDist)
+    ArrayWeighting, ConstWeighting, CustomDist, CustomInner, CustomNorm,
+    Weighting)
 from odl.util import (
-    dtype_str, signature_string, is_real_dtype, is_numeric_dtype,
-    writable_array, is_floating_dtype)
-
+    dtype_str, is_floating_dtype, is_numeric_dtype, is_real_dtype,
+    none_context, signature_string, writable_array)
 
 __all__ = ('NumpyTensorSpace',)
 
@@ -1654,26 +1655,11 @@ numpy.ufunc.reduceat.html
 
         # --- Evaluate ufunc --- #
 
-        # Trivial context used to create a single code path for the ufunc
-        # evaluation. For `None` output parameter(s), this is used instead of
-        # `writable_array`.
-        class CtxNone(object):
-            """Trivial context manager class.
-
-            When used as ::
-
-                with CtxNone() as obj:
-                    # do stuff with `obj`
-
-            the returned ``obj`` is ``None``.
-            """
-            __enter__ = __exit__ = lambda *_: None
-
         if method == '__call__':
             if ufunc.nout == 1:
                 # Make context for output (trivial one returns `None`)
                 if out is None:
-                    out_ctx = CtxNone()
+                    out_ctx = none_context()
                 else:
                     out_ctx = writable_array(out, **array_kwargs)
 
@@ -1701,11 +1687,11 @@ numpy.ufunc.reduceat.html
                 if out1 is not None:
                     out1_ctx = writable_array(out1, **array_kwargs)
                 else:
-                    out1_ctx = CtxNone()
+                    out1_ctx = none_context()
                 if out2 is not None:
                     out2_ctx = writable_array(out2, **array_kwargs)
                 else:
-                    out2_ctx = CtxNone()
+                    out2_ctx = none_context()
 
                 # Evaluate ufunc
                 with out1_ctx as out1_arr, out2_ctx as out2_arr:
@@ -1731,7 +1717,7 @@ numpy.ufunc.reduceat.html
         else:  # method != '__call__'
             # Make context for output (trivial one returns `None`)
             if out is None:
-                out_ctx = CtxNone()
+                out_ctx = none_context()
             else:
                 out_ctx = writable_array(out, **array_kwargs)
 

--- a/odl/util/testutils.py
+++ b/odl/util/testutils.py
@@ -477,7 +477,7 @@ def fail_counter(test_name, err_msg=None, logger=print):
         *** FAILED 1 TEST CASE(S) ***
     """
 
-    class _Counter(object):
+    class _FailCounter(object):
 
         def __init__(self):
             self.num_failed = 0
@@ -491,19 +491,16 @@ def fail_counter(test_name, err_msg=None, logger=print):
                 self.fail_strings.append(str(string))
 
     try:
-        counter = _Counter()
+        counter = _FailCounter()
         yield counter
-
     finally:
 
         if counter.num_failed == 0:
             logger('{:<70}: Completed all test cases.'.format(test_name))
         else:
             print(test_name)
-
             for fail_string in counter.fail_strings:
                 print(fail_string)
-
             if err_msg is not None:
                 print(err_msg)
             print('*** FAILED {} TEST CASE(S) ***'.format(counter.num_failed))
@@ -523,15 +520,12 @@ def timer(name=None):
     if name is None:
         name = "Elapsed"
 
-    tstart = None
     try:
         tstart = time()
         yield
-
     finally:
-        if tstart is not None:
-            time_str = '{:.3f}'.format(time() - tstart)
-            print('{:>30s} : {:>10s} '.format(name, time_str))
+        time_str = '{:.3f}'.format(time() - tstart)
+        print('{:>30s} : {:>10s} '.format(name, time_str))
 
 
 def timeit(arg):
@@ -550,13 +544,13 @@ def timeit(arg):
 
     if callable(arg):
         def timed_function(*args, **kwargs):
-            with Timer(str(arg)):
+            with timer(str(arg)):
                 return arg(*args, **kwargs)
         return timed_function
     else:
         def _timeit_helper(func):
             def timed_function(*args, **kwargs):
-                with Timer(arg):
+                with timer(arg):
                     return func(*args, **kwargs)
             return timed_function
         return _timeit_helper

--- a/odl/util/utility.py
+++ b/odl/util/utility.py
@@ -9,13 +9,13 @@
 """Utilities mainly for internal use."""
 
 from __future__ import absolute_import, division, print_function
+from future.moves.itertools import zip_longest
 
 import inspect
 import sys
-from builtins import object
 from collections import OrderedDict
+from contextlib import contextmanager
 from functools import wraps
-from future.moves.itertools import zip_longest
 from itertools import product
 
 import numpy as np
@@ -27,7 +27,7 @@ __all__ = (
     'is_numeric_dtype', 'is_int_dtype', 'is_floating_dtype', 'is_real_dtype',
     'is_real_floating_dtype', 'is_complex_floating_dtype',
     'real_dtype', 'complex_dtype', 'is_string', 'nd_iterator', 'conj_exponent',
-    'writable_array', 'run_from_ipython', 'NumpyRandomSeed',
+    'writable_array', 'run_from_ipython', 'npy_random_seed',
     'cache_arguments', 'unique',
     'REPR_PRECISION')
 
@@ -158,9 +158,9 @@ def dedent(string, indent_str='   ', max_levels=None):
     return '\n'.join(line[dedent_len:] for line in lines)
 
 
-class npy_printoptions(object):
-
-    """Context manager to temporarily set Numpy print options.
+@contextmanager
+def npy_printoptions(**extra_opts):
+    """Context manager to temporarily set NumPy print options.
 
     See Also
     --------
@@ -178,18 +178,16 @@ class npy_printoptions(object):
     ...     print(np.array([np.nan, 1.00001]))
     [  whoah!  1.00001]
     """
+    orig_opts = np.get_printoptions()
 
-    def __init__(self, **extra_opts):
-        self.extra_opts = extra_opts
-        self.orig_opts = np.get_printoptions()
-
-    def __enter__(self):
-        new_opts = self.orig_opts.copy()
-        new_opts.update(self.extra_opts)
+    try:
+        new_opts = orig_opts.copy()
+        new_opts.update(extra_opts)
         np.set_printoptions(**new_opts)
+        yield
 
-    def __exit__(self, type, value, traceback):
-        np.set_printoptions(**self.orig_opts)
+    finally:
+        np.set_printoptions(**orig_opts)
 
 
 def array_str(a, nprint=6):
@@ -648,85 +646,67 @@ def preload_first_arg(instance, mode):
     return decorator
 
 
-class writable_array(object):
-    """Context manager that casts obj to a `numpy.array` and saves changes."""
+@contextmanager
+def none_context(*args, **kwargs):
+    """Trivial context manager, accepts arbitrary args and returns ``None``."""
+    yield
 
-    def __init__(self, obj, **kwargs):
-        """initialize a new instance.
 
-        Parameters
-        ----------
-        obj : `array-like`
-            Object that should be made available as writable array.
-            It must be valid as input to `numpy.asarray` and needs to
-            support the syntax ``obj[:] = arr``.
-        kwargs :
-            Keyword arguments that should be passed to `numpy.asarray`.
+@contextmanager
+def writable_array(obj, **kwargs):
+    """Context manager that casts obj to a `numpy.array` and saves changes.
 
-        Examples
-        --------
-        Convert list to array and use with numpy:
+    Parameters
+    ----------
+    obj : `array-like`
+        Object that should be made available as writable array.
+        It must be valid as input to `numpy.asarray` and needs to
+        support the syntax ``obj[:] = arr``.
+    kwargs :
+        Keyword arguments that should be passed to `numpy.asarray`.
 
-        >>> lst = [1, 2, 3]
-        >>> with writable_array(lst) as arr:
-        ...    arr *= 2
-        >>> lst
-        [2, 4, 6]
+    Examples
+    --------
+    Convert list to array and use with numpy:
 
-        Usage with ODL vectors:
+    >>> lst = [1, 2, 3]
+    >>> with writable_array(lst) as arr:
+    ...    arr *= 2
+    >>> lst
+    [2, 4, 6]
 
-        >>> space = odl.uniform_discr(0, 1, 3)
-        >>> x = space.element([1, 2, 3])
-        >>> with writable_array(x) as arr:
-        ...    arr += [1, 1, 1]
-        >>> x
-        uniform_discr(0.0, 1.0, 3).element([ 2.,  3.,  4.])
+    Usage with ODL vectors:
 
-        Additional keyword arguments are passed to `numpy.asarray`:
+    >>> space = odl.uniform_discr(0, 1, 3)
+    >>> x = space.element([1, 2, 3])
+    >>> with writable_array(x) as arr:
+    ...     arr += [1, 1, 1]
+    >>> x
+    uniform_discr(0.0, 1.0, 3).element([ 2.,  3.,  4.])
 
-        >>> lst = [1, 2, 3]
-        >>> with writable_array(lst, dtype='complex') as arr:
-        ...    arr  # print array
-        array([ 1.+0.j,  2.+0.j,  3.+0.j])
+    Additional keyword arguments are passed to `numpy.asarray`:
 
-        Note that the changes are only saved upon exiting the context
-        manger exits. Before, the input object is unchanged:
+    >>> lst = [1, 2, 3]
+    >>> with writable_array(lst, dtype='complex') as arr:
+    ...     print(arr)
+    [ 1.+0.j  2.+0.j  3.+0.j]
 
-        >>> lst = [1, 2, 3]
-        >>> with writable_array(lst) as arr:
-        ...    arr *= 2
-        ...    lst  # print content of lst before exiting
-        [1, 2, 3]
-        >>> lst  # print content of lst after exit
-        [2, 4, 6]
-        """
-        self.obj = obj
-        self.kwargs = kwargs
-        self.arr = None
+    Note that the changes are only saved upon exiting the context
+    manger exits. Before, the input object is unchanged:
 
-    def __enter__(self):
-        """called by ``with writable_array(obj):``.
-
-        Returns
-        -------
-        arr : `numpy.ndarray`
-            Array representing ``self.obj``, created by calling
-            ``numpy.asarray``. Any changes to ``arr`` will be passed through
-            to ``self.obj`` after the context manager exits.
-        """
-        self.arr = np.asarray(self.obj, **self.kwargs)
-        return self.arr
-
-    def __exit__(self, type, value, traceback):
-        """called when ``with writable_array(obj):`` ends.
-
-        Saves any changes to ``self.arr`` to ``self.obj``, also "frees"
-        self.arr in case the manager is used multiple times.
-
-        Extra arguments are ignored, any exceptions are passed through.
-        """
-        self.obj[:] = self.arr
-        self.arr = None
+    >>> lst = [1, 2, 3]
+    >>> with writable_array(lst) as arr:
+    ...     arr *= 2
+    ...     print(lst)
+    [1, 2, 3]
+    >>> print(lst)
+    [2, 4, 6]
+    """
+    try:
+        arr = np.asarray(obj, **kwargs)
+        yield arr
+    finally:
+        obj[:] = arr
 
 
 def signature_string(posargs, optargs, sep=', ', mod='!r'):
@@ -974,7 +954,7 @@ def signature_string_parts(posargs, optargs, mod='!r'):
         elif (np.isscalar(arg) and
               np.array(arg).real.astype('int64') != arg and
               modifier in ('', '!s', '!r')):
-            # Floating point value, use Numpy print option 'precision'
+            # Floating point value, use numpy print option 'precision'
             fmt = '{{:.{}}}'.format(precision)
             posargs_conv.append(fmt.format(arg))
         else:
@@ -1533,41 +1513,37 @@ def pkg_supports(feature, pkg_version, pkg_feat_dict):
     return False
 
 
-class NumpyRandomSeed(object):
-    """Context manager for Numpy random seeds."""
+@contextmanager
+def npy_random_seed(seed):
+    """Context manager to temporarily set the NumPy random generator seed.
 
-    def __init__(self, seed):
-        """Initialize an instance.
+    Parameters
+    ----------
+    seed : int or None
+        Seed value for the random number generator.
+        ``None`` is interpreted as keeping the current seed.
 
-        Parameters
-        ----------
-        seed : int or None
-            Seed value for the random number generator.
-            ``None`` is interpreted as keeping the current seed.
+    Examples
+    --------
+    Use this to make drawing pseudo-random numbers repeatable:
 
-        Examples
-        --------
-        Use this to make drawing pseudo-random numbers repeatable:
+    >>> with npy_random_seed(42):
+    ...     rand_int = np.random.randint(10)
+    >>> with npy_random_seed(42):
+    ...     same_rand_int = np.random.randint(10)
+    >>> rand_int == same_rand_int
+    True
+    """
+    do_seed = seed is not None
+    try:
+        if do_seed:
+            orig_rng_state = np.random.get_state()
+            np.random.seed(seed)
+        yield
 
-        >>> with NumpyRandomSeed(42):
-        ...     rand_int = np.random.randint(10)
-        >>> with NumpyRandomSeed(42):
-        ...     same_rand_int = np.random.randint(10)
-        >>> rand_int == same_rand_int
-        True
-        """
-        self.seed = seed
-
-    def __enter__(self):
-        """Called by ``with`` command."""
-        if self.seed is not None:
-            self.startstate = np.random.get_state()
-            np.random.seed(self.seed)
-
-    def __exit__(self, exc_type, exc_value, traceback):
-        """Called upon exiting ``with`` command."""
-        if self.seed is not None:
-            np.random.set_state(self.startstate)
+    finally:
+        if do_seed:
+            np.random.set_state(orig_rng_state)
 
 
 def unique(seq):

--- a/odl/util/utility.py
+++ b/odl/util/utility.py
@@ -21,15 +21,36 @@ from itertools import product
 import numpy as np
 
 __all__ = (
-    'array_str', 'dtype_str', 'dtype_repr', 'npy_printoptions',
-    'signature_string', 'signature_string_parts', 'repr_string',
-    'indent', 'dedent', 'attribute_repr_string', 'method_repr_string',
-    'is_numeric_dtype', 'is_int_dtype', 'is_floating_dtype', 'is_real_dtype',
-    'is_real_floating_dtype', 'is_complex_floating_dtype',
-    'real_dtype', 'complex_dtype', 'is_string', 'nd_iterator', 'conj_exponent',
-    'writable_array', 'run_from_ipython', 'npy_random_seed',
-    'cache_arguments', 'unique',
-    'REPR_PRECISION')
+    'REPR_PRECISION',
+    'indent',
+    'dedent',
+    'npy_printoptions',
+    'array_str',
+    'dtype_repr',
+    'dtype_str',
+    'cache_arguments',
+    'is_numeric_dtype',
+    'is_int_dtype',
+    'is_floating_dtype',
+    'is_real_dtype',
+    'is_real_floating_dtype',
+    'is_complex_floating_dtype',
+    'real_dtype',
+    'complex_dtype',
+    'is_string',
+    'nd_iterator',
+    'conj_exponent',
+    'none_context',
+    'writable_array',
+    'signature_string',
+    'signature_string_parts',
+    'repr_string',
+    'attribute_repr_string',
+    'method_repr_string',
+    'run_from_ipython',
+    'npy_random_seed',
+    'unique',
+)
 
 
 REPR_PRECISION = 4  # For printing scalars and array entries

--- a/odl/util/utility.py
+++ b/odl/util/utility.py
@@ -1561,7 +1561,6 @@ def npy_random_seed(seed):
             orig_rng_state = np.random.get_state()
             np.random.seed(seed)
         yield
-
     finally:
         if do_seed:
             np.random.set_state(orig_rng_state)


### PR DESCRIPTION
Using `contextlib.contextmanager`, we can scrap the boilerplate stuff (`__enter__` and `__exit__`, `__init__`) and write context managers in a much more straightforward way with plain functions and `try...finally`. A side benefit is that their usage looks more like a function call than a class creation.

All of our current custom context managers have been ported.