### PR TITLE
DIST: require numpy >=1.13.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,25 +6,26 @@ matrix:
         - python: 2.7
           env: NUMPY_VERSION='1.16.*'
 
-        - python: 3.7
+        # Using Python 3.6 as main version due to availability of wheels (SciPy, NumPy, ...)
+        - python: 3.6
           env: NUMPY_VERSION=1.13.3
 
-        - python: 3.7
+        - python: 3.6
           env: NUMPY_VERSION='1.14.*'
 
-        - python: 3.7
+        - python: 3.6
           env: NUMPY_VERSION='1.15.*'
 
-        - python: 3.7
+        - python: 3.6
           env: NUMPY_VERSION='1.16.*'
 
-        - python: 3.7
+        - python: 3.6
           env: NUMPY_VERSION='1.17.*'
 
-        - python: 3.7
+        - python: 3.6
           env: NUMPY_VERSION='1.16.*' COVERALLS=true
 
-        - python: 3.7
+        - python: 3.6
           env: NUMPY_VERSION='1.16.*' SKIP_TESTS=true BUILD_DOCS=true
 
 sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,23 +2,30 @@ language: python
 
 matrix:
     include:
+        # Note: NumPy 1.16 is the last one that supports Python 2.7
         - python: 2.7
-          env: NUMPY_VERSION='1.15.*'
+          env: NUMPY_VERSION='1.16.*'
 
-        - python: 3.6
+        - python: 3.7
           env: NUMPY_VERSION=1.13.3
 
-        - python: 3.6
+        - python: 3.7
           env: NUMPY_VERSION='1.14.*'
 
-        - python: 3.6
+        - python: 3.7
           env: NUMPY_VERSION='1.15.*'
 
-        - python: 3.6
-          env: NUMPY_VERSION='1.15.*' COVERALLS=true
+        - python: 3.7
+          env: NUMPY_VERSION='1.16.*'
 
-        - python: 3.6
-          env: NUMPY_VERSION='1.15.*' SKIP_TESTS=true BUILD_DOCS=true
+        - python: 3.7
+          env: NUMPY_VERSION='1.17.*'
+
+        - python: 3.7
+          env: NUMPY_VERSION='1.16.*' COVERALLS=true
+
+        - python: 3.7
+          env: NUMPY_VERSION='1.16.*' SKIP_TESTS=true BUILD_DOCS=true
 
 sudo: false
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,22 +3,22 @@ language: python
 matrix:
     include:
         - python: 2.7
+          env: NUMPY_VERSION='1.15.*'
+
+        - python: 3.6
+          env: NUMPY_VERSION=1.13.3
+
+        - python: 3.6
           env: NUMPY_VERSION='1.14.*'
 
         - python: 3.6
-          env: NUMPY_VERSION=1.10.1
+          env: NUMPY_VERSION='1.15.*'
 
         - python: 3.6
-          env: NUMPY_VERSION='1.12.*'
+          env: NUMPY_VERSION='1.15.*' COVERALLS=true
 
         - python: 3.6
-          env: NUMPY_VERSION='1.13.*'
-
-        - python: 3.6
-          env: NUMPY_VERSION='1.14.*' COVERALLS=true
-
-        - python: 3.6
-          env: NUMPY_VERSION='1.14.*' SKIP_TESTS=true BUILD_DOCS=true
+          env: NUMPY_VERSION='1.15.*' SKIP_TESTS=true BUILD_DOCS=true
 
 sudo: false
 

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -23,14 +23,14 @@ requirements:
         - setuptools
         - nomkl # [not win]
         - future >=0.14
-        - numpy >=1.10
+        - numpy >=1.13.3
         - scipy >=0.14
         - packaging >=15.0
 
     run:
         - python
         - future >=0.14
-        - numpy >=1.10
+        - numpy >=1.13.3
         - scipy >=0.14
         - packaging >=15.0
         - matplotlib
@@ -38,7 +38,7 @@ requirements:
 test:
     requires:
         - nomkl # [not win]
-        - pytest >=3.0.3
+        - pytest >=3.0.3,<5.1
     imports:
         - odl
     commands:

--- a/odl/contrib/datasets/mri/tugraz.py
+++ b/odl/contrib/datasets/mri/tugraz.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2018 The ODL contributors
+# Copyright 2014-2019 The ODL contributors
 #
 # This file is part of ODL.
 #
@@ -15,16 +15,9 @@
 """MRI datasets provided by TU Graz."""
 
 import numpy as np
-from packaging.version import parse as parse_version
 
-from odl.contrib.datasets.util import get_data
 import odl
-
-if parse_version(np.__version__) < parse_version('1.12'):
-    flip = odl.util.npy_compat.flip
-else:
-    flip = np.flip
-
+from odl.contrib.datasets.util import get_data
 
 __all__ = ('mri_head_data_4_channel', 'mri_head_reco_op_4_channel',
            'mri_head_data_32_channel', 'mri_head_reco_op_32_channel',
@@ -60,7 +53,7 @@ platform_aktuell.html
     dct = get_data('1_rawdata_brainT2_4ch.mat', subset=DATA_SUBSET, url=url)
 
     # Change axes to match ODL definitions
-    data = flip(np.swapaxes(dct['rawdata'], 0, -1) * 4e4, 2)
+    data = np.flip(np.swapaxes(dct['rawdata'], 0, -1) * 4e4, 2)
 
     return data
 
@@ -122,7 +115,7 @@ platform_aktuell.html
     dct = get_data('2_rawdata_brainT2_32ch.mat', subset=DATA_SUBSET, url=url)
 
     # Change axes to match ODL definitions
-    data = flip(np.swapaxes(dct['rawdata'], 0, -1) * 7e3, 2)
+    data = np.flip(np.swapaxes(dct['rawdata'], 0, -1) * 7e3, 2)
 
     return data
 
@@ -184,7 +177,7 @@ platform_aktuell.html
     dct = get_data('3_rawdata_knee_8ch.mat', subset=DATA_SUBSET, url=url)
 
     # Change axes to match ODL definitions
-    data = flip(np.swapaxes(dct['rawdata'], 0, -1) * 9e3, 2)
+    data = np.flip(np.swapaxes(dct['rawdata'], 0, -1) * 9e3, 2)
 
     return data
 

--- a/odl/operator/tensor_ops.py
+++ b/odl/operator/tensor_ops.py
@@ -8,19 +8,19 @@
 
 """Operators defined for tensor fields."""
 
-from __future__ import print_function, division, absolute_import
+from __future__ import absolute_import, division, print_function
+
 from numbers import Integral
+
 import numpy as np
-from packaging.version import parse as parse_version
 
 from odl.operator.operator import Operator
-from odl.set import RealNumbers, ComplexNumbers
+from odl.set import ComplexNumbers, RealNumbers
 from odl.space import ProductSpace, tensor_space
 from odl.space.base_tensors import TensorSpace
 from odl.space.weighting import ArrayWeighting
 from odl.util import (
-    signature_string, indent, dtype_repr, moveaxis, writable_array)
-
+    dtype_repr, indent, moveaxis, signature_string, writable_array)
 
 __all__ = ('PointwiseNorm', 'PointwiseInner', 'PointwiseSum', 'MatrixOperator',
            'SamplingOperator', 'WeightedSumSamplingOperator',
@@ -924,12 +924,6 @@ class MatrixOperator(Operator):
             if scipy.sparse.isspmatrix(self.matrix):
                 # Unfortunately, there is no native in-place dot product for
                 # sparse matrices
-                out[:] = self.matrix.dot(x)
-            elif (parse_version(np.__version__) < parse_version('1.13.0') and
-                  x is out and
-                  self.range.ndim == 1):
-                # Workaround for bug in Numpy < 1.13 with aliased in and
-                # out in np.dot
                 out[:] = self.matrix.dot(x)
             elif self.range.ndim == 1:
                 with writable_array(out) as out_arr:

--- a/odl/operator/tensor_ops.py
+++ b/odl/operator/tensor_ops.py
@@ -19,8 +19,7 @@ from odl.set import ComplexNumbers, RealNumbers
 from odl.space import ProductSpace, tensor_space
 from odl.space.base_tensors import TensorSpace
 from odl.space.weighting import ArrayWeighting
-from odl.util import (
-    dtype_repr, indent, moveaxis, signature_string, writable_array)
+from odl.util import dtype_repr, indent, signature_string, writable_array
 
 __all__ = ('PointwiseNorm', 'PointwiseInner', 'PointwiseSum', 'MatrixOperator',
            'SamplingOperator', 'WeightedSumSamplingOperator',
@@ -919,7 +918,7 @@ class MatrixOperator(Operator):
             else:
                 dot = np.tensordot(self.matrix, x, axes=(1, self.axis))
                 # New axis ends up as first, need to swap it to its place
-                out = moveaxis(dot, 0, self.axis)
+                out = np.moveaxis(dot, 0, self.axis)
         else:
             if scipy.sparse.isspmatrix(self.matrix):
                 # Unfortunately, there is no native in-place dot product for
@@ -933,7 +932,7 @@ class MatrixOperator(Operator):
                 # TODO: investigate speed issue
                 dot = np.tensordot(self.matrix, x, axes=(1, self.axis))
                 # New axis ends up as first, need to move it to its place
-                out[:] = moveaxis(dot, 0, self.axis)
+                out[:] = np.moveaxis(dot, 0, self.axis)
 
         return out
 

--- a/odl/set/sets.py
+++ b/odl/set/sets.py
@@ -8,14 +8,15 @@
 
 """Basic abstract and concrete sets."""
 
-from __future__ import print_function, division, absolute_import
+from __future__ import absolute_import, division, print_function
+
 from builtins import int, object
-from numbers import Integral, Real, Complex
-from past.types.basestring import basestring
+from numbers import Complex, Integral, Real
+
 import numpy as np
+from past.types.basestring import basestring
 
-from odl.util import is_int_dtype, is_real_dtype, is_numeric_dtype, unique
-
+from odl.util import is_int_dtype, is_numeric_dtype, is_real_dtype, unique
 
 __all__ = ('Set', 'EmptySet', 'UniversalSet', 'Field', 'Integers',
            'RealNumbers', 'ComplexNumbers', 'Strings', 'CartesianProduct',
@@ -361,16 +362,10 @@ class ComplexNumbers(Field):
 
     def element(self, inp=None):
         """Return a complex number from ``inp`` or from scratch."""
-        if inp is not None:
-            # Workaround for missing __complex__ of numpy.ndarray
-            # for Numpy version < 1.12
-            # TODO: remove when Numpy >= 1.12 is required
-            if isinstance(inp, np.ndarray):
-                return complex(inp.reshape([1])[0])
-            else:
-                return complex(inp)
-        else:
+        if inp is None:
             return complex(0.0, 0.0)
+        else:
+            return complex(inp)
 
     @property
     def examples(self):

--- a/odl/solvers/functional/default_functionals.py
+++ b/odl/solvers/functional/default_functionals.py
@@ -8,27 +8,26 @@
 
 """Default functionals defined on any space similar to R^n or L^2."""
 
-from __future__ import print_function, division, absolute_import
+from __future__ import absolute_import, division, print_function
+
 from numbers import Integral
+
 import numpy as np
 
-from odl.solvers.functional.functional import (Functional,
-                                               FunctionalQuadraticPerturb)
-from odl.space import ProductSpace
-from odl.operator import (Operator, ConstantOperator, ZeroOperator,
-                          ScalingOperator, DiagonalOperator, PointwiseNorm)
+from odl.operator import (
+    ConstantOperator, DiagonalOperator, Operator, PointwiseNorm,
+    ScalingOperator, ZeroOperator)
+from odl.solvers.functional.functional import (
+    Functional, FunctionalQuadraticPerturb)
 from odl.solvers.nonsmooth.proximal_operators import (
-    proj_simplex,
-    proximal_l1, proximal_convex_conj_l1,
-    proximal_l1_l2, proximal_convex_conj_l1_l2,
-    proximal_l2, proximal_convex_conj_l2, proximal_l2_squared,
-    proximal_linfty, proximal_convex_conj_linfty,
-    proximal_huber,
-    proximal_const_func, proximal_box_constraint,
-    proximal_convex_conj_kl, proximal_convex_conj_kl_cross_entropy,
-    combine_proximals, proximal_convex_conj)
-from odl.util import conj_exponent, moveaxis
-
+    combine_proximals, proj_simplex, proximal_box_constraint,
+    proximal_const_func, proximal_convex_conj, proximal_convex_conj_kl,
+    proximal_convex_conj_kl_cross_entropy, proximal_convex_conj_l1,
+    proximal_convex_conj_l1_l2, proximal_convex_conj_l2,
+    proximal_convex_conj_linfty, proximal_huber, proximal_l1, proximal_l1_l2,
+    proximal_l2, proximal_l2_squared, proximal_linfty)
+from odl.space import ProductSpace
+from odl.util import conj_exponent
 
 __all__ = ('ZeroFunctional', 'ConstantFunctional', 'ScalingFunctional',
            'IdentityFunctional',
@@ -2002,7 +2001,7 @@ class NuclearNorm(Functional):
 
         This is the inverse of `_asarray`.
         """
-        result = moveaxis(arr, [-2, -1], [0, 1])
+        result = np.moveaxis(arr, [-2, -1], [0, 1])
         return self.domain.element(result)
 
     def _call(self, x):
@@ -2013,7 +2012,7 @@ class NuclearNorm(Functional):
         svd_diag = np.linalg.svd(arr, compute_uv=False)
 
         # Rotate the axes so the svd-direction is first
-        s_reordered = moveaxis(svd_diag, -1, 0)
+        s_reordered = np.moveaxis(svd_diag, -1, 0)
 
         # Return nuclear norm
         return self.outernorm(self.pwisenorm(s_reordered))
@@ -2075,7 +2074,7 @@ class NuclearNorm(Functional):
                     abss = np.abs(s) - (self.sigma - eps)
                     sprox = np.sign(s) * np.maximum(abss, 0)
                 elif func.pwisenorm.exponent == 2:
-                    s_reordered = moveaxis(s, -1, 0)
+                    s_reordered = np.moveaxis(s, -1, 0)
                     snorm = func.pwisenorm(s_reordered).asarray()
                     snorm = np.maximum(self.sigma, snorm, out=snorm)
                     sprox = ((1 - eps) - self.sigma / snorm)[..., None] * s

--- a/odl/space/pspace.py
+++ b/odl/space/pspace.py
@@ -1080,6 +1080,13 @@ class ProductSpaceElement(LinearSpaceElement):
         wrapper : `ProductSpaceElement`
             Product space element wrapping ``array``.
         """
+        # HACK(kohr-h): This is to support (full) reductions like
+        # `np.sum(x)` for numpy>=1.16, where many such reductions
+        # moved from plain functions to `ufunc.reduce.*`, thus
+        # invoking the `__array__` and `__array_wrap__` machinery.
+        if array.shape == ():
+            return array.item()
+
         return self.space.element(array)
 
     @property

--- a/odl/test/discr/lp_discr_test.py
+++ b/odl/test/discr/lp_discr_test.py
@@ -7,21 +7,17 @@
 # obtain one at https://mozilla.org/MPL/2.0/.
 
 from __future__ import division
+
 import numpy as np
-from packaging.version import parse as parse_version
-import pytest
 
 import odl
+import pytest
 from odl.discr.lp_discr import DiscreteLp, DiscreteLpElement
 from odl.space.base_tensors import TensorSpace
 from odl.space.npy_tensors import NumpyTensor
 from odl.space.weighting import ConstWeighting
 from odl.util.testutils import (
-    all_equal, all_almost_equal, noise_elements, simple_fixture)
-
-
-USE_ARRAY_UFUNCS_INTERFACE = (
-    parse_version(np.__version__) >= parse_version('1.13'))
+    all_almost_equal, all_equal, noise_elements, simple_fixture)
 
 # --- Pytest fixtures --- #
 
@@ -839,85 +835,78 @@ def test_ufuncs(odl_tspace_impl, odl_ufunc):
         npy_result = npy_ufunc(*in_arrays, **out_arr_kwargs)
         odl_result_old = elem_fun_old(*in_elems_old, **out_elem_kwargs)
         assert all_almost_equal(npy_result, odl_result_old)
-        if USE_ARRAY_UFUNCS_INTERFACE:
-            # In-place will not work with Numpy < 1.13
-            odl_result_new = elem_fun_new(*in_elems_new, **out_elem_kwargs)
-            assert all_almost_equal(npy_result, odl_result_new)
+        odl_result_new = elem_fun_new(*in_elems_new, **out_elem_kwargs)
+        assert all_almost_equal(npy_result, odl_result_new)
 
     # Check that returned stuff refers to given out
     if nout == 1:
         assert odl_result_old is out_elems[0]
-        if USE_ARRAY_UFUNCS_INTERFACE:
-            assert odl_result_new is out_elems[0]
+        assert odl_result_new is out_elems[0]
     elif nout > 1:
         for i in range(nout):
             assert odl_result_old[i] is out_elems[i]
-            if USE_ARRAY_UFUNCS_INTERFACE:
-                assert odl_result_new[i] is out_elems[i]
+            assert odl_result_new[i] is out_elems[i]
 
     # In-place with Numpy array as `out` for new interface
-    if USE_ARRAY_UFUNCS_INTERFACE:
-        out_arrays_new = tuple(np.empty_like(arr) for arr in out_arrays)
-        if nout == 1:
-            out_arr_kwargs_new = {'out': out_arrays_new[0]}
-        elif nout > 1:
-            out_arr_kwargs_new = {'out': out_arrays_new[:nout]}
+    out_arrays_new = tuple(np.empty_like(arr) for arr in out_arrays)
+    if nout == 1:
+        out_arr_kwargs_new = {'out': out_arrays_new[0]}
+    elif nout > 1:
+        out_arr_kwargs_new = {'out': out_arrays_new[:nout]}
 
-        with np.errstate(all='ignore'):  # avoid pytest warnings
-            odl_result_arr_new = elem_fun_new(*in_elems_new,
-                                              **out_arr_kwargs_new)
-        assert all_almost_equal(npy_result, odl_result_arr_new)
+    with np.errstate(all='ignore'):  # avoid pytest warnings
+        odl_result_arr_new = elem_fun_new(*in_elems_new,
+                                          **out_arr_kwargs_new)
+    assert all_almost_equal(npy_result, odl_result_arr_new)
 
-        if nout == 1:
-            assert odl_result_arr_new is out_arrays_new[0]
-        elif nout > 1:
-            for i in range(nout):
-                assert odl_result_arr_new[i] is out_arrays_new[i]
+    if nout == 1:
+        assert odl_result_arr_new is out_arrays_new[0]
+    elif nout > 1:
+        for i in range(nout):
+            assert odl_result_arr_new[i] is out_arrays_new[i]
 
     # In-place with data container (tensor) as `out` for new interface
-    if USE_ARRAY_UFUNCS_INTERFACE:
-        out_tensors_new = tuple(space.tspace.element(np.empty_like(arr))
-                                for arr in out_arrays)
-        if nout == 1:
-            out_tens_kwargs_new = {'out': out_tensors_new[0]}
-        elif nout > 1:
-            out_tens_kwargs_new = {'out': out_tensors_new[:nout]}
+    out_tensors_new = tuple(space.tspace.element(np.empty_like(arr))
+                            for arr in out_arrays)
+    if nout == 1:
+        out_tens_kwargs_new = {'out': out_tensors_new[0]}
+    elif nout > 1:
+        out_tens_kwargs_new = {'out': out_tensors_new[:nout]}
 
+    with np.errstate(all='ignore'):  # avoid pytest warnings
+        odl_result_tens_new = elem_fun_new(*in_elems_new,
+                                           **out_tens_kwargs_new)
+    assert all_almost_equal(npy_result, odl_result_tens_new)
+
+    if nout == 1:
+        assert odl_result_tens_new is out_tensors_new[0]
+    elif nout > 1:
+        for i in range(nout):
+            assert odl_result_tens_new[i] is out_tensors_new[i]
+
+    # Check `ufunc.at`
+    indices = ([0, 0, 1],
+               [0, 1, 2])
+
+    mod_array = in_arrays[0].copy()
+    mod_elem = in_elems_new[0].copy()
+    if nout > 1:
+        return  # currently not supported by Numpy
+    if nin == 1:
         with np.errstate(all='ignore'):  # avoid pytest warnings
-            odl_result_tens_new = elem_fun_new(*in_elems_new,
-                                               **out_tens_kwargs_new)
-        assert all_almost_equal(npy_result, odl_result_tens_new)
+            npy_result = npy_ufunc.at(mod_array, indices)
+            odl_result = npy_ufunc.at(mod_elem, indices)
+    elif nin == 2:
+        other_array = in_arrays[1][indices]
+        other_elem = in_elems_new[1][indices]
+        with np.errstate(all='ignore'):  # avoid pytest warnings
+            npy_result = npy_ufunc.at(mod_array, indices, other_array)
+            odl_result = npy_ufunc.at(mod_elem, indices, other_elem)
 
-        if nout == 1:
-            assert odl_result_tens_new is out_tensors_new[0]
-        elif nout > 1:
-            for i in range(nout):
-                assert odl_result_tens_new[i] is out_tensors_new[i]
-
-    if USE_ARRAY_UFUNCS_INTERFACE:
-        # Check `ufunc.at`
-        indices = ([0, 0, 1],
-                   [0, 1, 2])
-
-        mod_array = in_arrays[0].copy()
-        mod_elem = in_elems_new[0].copy()
-        if nout > 1:
-            return  # currently not supported by Numpy
-        if nin == 1:
-            with np.errstate(all='ignore'):  # avoid pytest warnings
-                npy_result = npy_ufunc.at(mod_array, indices)
-                odl_result = npy_ufunc.at(mod_elem, indices)
-        elif nin == 2:
-            other_array = in_arrays[1][indices]
-            other_elem = in_elems_new[1][indices]
-            with np.errstate(all='ignore'):  # avoid pytest warnings
-                npy_result = npy_ufunc.at(mod_array, indices, other_array)
-                odl_result = npy_ufunc.at(mod_elem, indices, other_elem)
-
-        assert all_almost_equal(odl_result, npy_result)
+    assert all_almost_equal(odl_result, npy_result)
 
     # Check `ufunc.reduce`
-    if nin == 2 and nout == 1 and USE_ARRAY_UFUNCS_INTERFACE:
+    if nin == 2 and nout == 1:
         in_array = in_arrays[0]
         in_elem = in_elems_new[0]
 

--- a/odl/test/operator/tensor_ops_test.py
+++ b/odl/test/operator/tensor_ops_test.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2017 The ODL contributors
+# Copyright 2014-2019 The ODL contributors
 #
 # This file is part of ODL.
 #
@@ -9,17 +9,17 @@
 """Unit tests for `tensor_ops`."""
 
 from __future__ import division
-import pytest
+
 import numpy as np
 import scipy.sparse
 
 import odl
+import pytest
 from odl.operator.tensor_ops import (
-    PointwiseNorm, PointwiseInner, PointwiseSum, MatrixOperator)
+    MatrixOperator, PointwiseInner, PointwiseNorm, PointwiseSum)
 from odl.space.pspace import ProductSpace
 from odl.util.testutils import (
-    all_almost_equal, all_equal, simple_fixture, noise_element, noise_elements)
-
+    all_almost_equal, all_equal, noise_element, noise_elements, simple_fixture)
 
 matrix_dtype = simple_fixture(
     name='matrix_dtype',

--- a/odl/test/operator/tensor_ops_test.py
+++ b/odl/test/operator/tensor_ops_test.py
@@ -17,7 +17,6 @@ import odl
 from odl.operator.tensor_ops import (
     PointwiseNorm, PointwiseInner, PointwiseSum, MatrixOperator)
 from odl.space.pspace import ProductSpace
-from odl.util import moveaxis
 from odl.util.testutils import (
     all_almost_equal, all_equal, simple_fixture, noise_element, noise_elements)
 
@@ -652,7 +651,7 @@ def test_matrix_op_call(matrix):
     domain = odl.rn((2, 2, 4))
     mat_op = MatrixOperator(dense_matrix, domain, axis=2)
     xarr, x = noise_elements(mat_op.domain)
-    true_result = moveaxis(np.tensordot(dense_matrix, xarr, (1, 2)), 0, 2)
+    true_result = np.moveaxis(np.tensordot(dense_matrix, xarr, (1, 2)), 0, 2)
     assert all_almost_equal(mat_op(x), true_result)
     out = mat_op.range.element()
     mat_op(x, out=out)

--- a/odl/test/space/pspace_test.py
+++ b/odl/test/space/pspace_test.py
@@ -955,6 +955,14 @@ def test_reductions():
     assert x.ufuncs.max() == 3.0
 
 
+def test_np_reductions():
+    """Check that reductions via NumPy functions work."""
+    H = odl.ProductSpace(odl.rn(2), 3)
+    x = 2 * H.one()
+    assert np.sum(x) == 2 * 6
+    assert np.prod(x) == 2 ** 6
+
+
 def test_array_wrap_method():
     """Verify that the __array_wrap__ method for NumPy works."""
     space = odl.ProductSpace(odl.uniform_discr(0, 1, 10), 2)

--- a/odl/test/space/tensors_test.py
+++ b/odl/test/space/tensors_test.py
@@ -31,8 +31,10 @@ from odl.util.ufuncs import UFUNCS
 
 PYTHON2 = sys.version_info.major < 3
 
+
 # Functions to return arrays and classes corresponding to impls. Extend
 # when a new impl is available.
+
 
 def _pos_array(space):
     """Create an array with positive real entries in ``space``."""

--- a/odl/tomo/backends/astra_setup.py
+++ b/odl/tomo/backends/astra_setup.py
@@ -34,7 +34,6 @@ from odl.tomo.geometry import (
     DivergentBeamGeometry, Flat1dDetector, Flat2dDetector, Geometry,
     ParallelBeamGeometry)
 from odl.tomo.util.utility import euler_matrix
-from odl.util.npy_compat import moveaxis
 
 try:
     import astra
@@ -43,7 +42,6 @@ except ImportError:
     ASTRA_VERSION = ''
 else:
     ASTRA_AVAILABLE = True
-
 
 # Make sure that ASTRA >= 1.7 is used
 if ASTRA_AVAILABLE:
@@ -60,21 +58,12 @@ if ASTRA_AVAILABLE:
                 'your version {}.{} of ASTRA is unsupported, please upgrade '
                 'to 1.7 or higher'.format(_maj, _min), RuntimeWarning)
 
-
-__all__ = (
-    'ASTRA_AVAILABLE',
-    'ASTRA_VERSION',
-    'astra_supports',
-    'astra_versions_supporting',
-    'astra_volume_geometry',
-    'astra_conebeam_3d_geom_to_vec',
-    'astra_conebeam_2d_geom_to_vec',
-    'astra_parallel_3d_geom_to_vec',
-    'astra_projection_geometry',
-    'astra_data',
-    'astra_projector',
-    'astra_algorithm',
-)
+__all__ = ('ASTRA_AVAILABLE', 'ASTRA_VERSION', 'astra_supports',
+           'astra_volume_geometry', 'astra_projection_geometry',
+           'astra_data', 'astra_projector', 'astra_algorithm',
+           'astra_conebeam_3d_geom_to_vec',
+           'astra_conebeam_2d_geom_to_vec',
+           'astra_parallel_3d_geom_to_vec')
 
 
 # ASTRA_FEATURES contains a set of features along with version specifiers
@@ -320,7 +309,7 @@ def astra_conebeam_3d_geom_to_vec(geometry):
 
     # Vectors from detector pixel (0, 0) to (1, 0) and (0, 0) to (0, 1)
     # `det_axes` gives shape (N, 2, 3), swap to get (2, N, 3)
-    det_axes = moveaxis(geometry.det_axes(angles), -2, 0)
+    det_axes = np.moveaxis(geometry.det_axes(angles), -2, 0)
     px_sizes = geometry.det_partition.cell_sides
     # Swap detector axes to have better memory layout in  projection data.
     # ASTRA produces `(v, theta, u)` layout, and to map to ODL layout
@@ -448,7 +437,7 @@ def astra_parallel_3d_geom_to_vec(geometry):
 
     # Vectors from detector pixel (0, 0) to (1, 0) and (0, 0) to (0, 1)
     # `det_axes` gives shape (N, 2, 3), swap to get (2, N, 3)
-    det_axes = moveaxis(geometry.det_axes(angles), -2, 0)
+    det_axes = np.moveaxis(geometry.det_axes(angles), -2, 0)
     px_sizes = geometry.det_partition.cell_sides
     # Swap detector axes to have better memory layout in  projection data.
     # ASTRA produces `(v, theta, u)` layout, and to map to ODL layout

--- a/odl/tomo/backends/astra_setup.py
+++ b/odl/tomo/backends/astra_setup.py
@@ -58,12 +58,20 @@ if ASTRA_AVAILABLE:
                 'your version {}.{} of ASTRA is unsupported, please upgrade '
                 'to 1.7 or higher'.format(_maj, _min), RuntimeWarning)
 
-__all__ = ('ASTRA_AVAILABLE', 'ASTRA_VERSION', 'astra_supports',
-           'astra_volume_geometry', 'astra_projection_geometry',
-           'astra_data', 'astra_projector', 'astra_algorithm',
-           'astra_conebeam_3d_geom_to_vec',
-           'astra_conebeam_2d_geom_to_vec',
-           'astra_parallel_3d_geom_to_vec')
+__all__ = (
+    'ASTRA_AVAILABLE',
+    'ASTRA_VERSION',
+    'astra_supports',
+    'astra_versions_supporting',
+    'astra_volume_geometry',
+    'astra_conebeam_3d_geom_to_vec',
+    'astra_conebeam_2d_geom_to_vec',
+    'astra_parallel_3d_geom_to_vec',
+    'astra_projection_geometry',
+    'astra_data',
+    'astra_projector',
+    'astra_algorithm',
+)
 
 
 # ASTRA_FEATURES contains a set of features along with version specifiers

--- a/odl/tomo/geometry/detector.py
+++ b/odl/tomo/geometry/detector.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2017 The ODL contributors
+# Copyright 2014-2019 The ODL contributors
 #
 # This file is part of ODL.
 #
@@ -8,16 +8,16 @@
 
 """Detectors for tomographic imaging."""
 
-from __future__ import print_function, division, absolute_import
+from __future__ import absolute_import, division, print_function
+
 from builtins import object
+
 import numpy as np
 
 from odl.discr import RectPartition
-from odl.tomo.util import perpendicular_vector, is_inside_bounds
-from odl.util import indent, signature_string, array_str
-from odl.util.npy_compat import moveaxis
+from odl.tomo.util import is_inside_bounds, perpendicular_vector
 from odl.tomo.util.utility import rotation_matrix_from_to
-
+from odl.util import array_str, indent, signature_string
 
 __all__ = ('Detector',
            'Flat1dDetector', 'Flat2dDetector', 'CircularDetector',
@@ -189,7 +189,7 @@ class Detector(object):
             deriv = self.surface_deriv(param)
             if deriv.ndim > 2:
                 # Vectorized, need to reshape (N, 2, 3) to (2, N, 3)
-                deriv = moveaxis(deriv, -2, 0)
+                deriv = np.moveaxis(deriv, -2, 0)
             normal = np.cross(*deriv, axis=-1)
             normal /= np.linalg.norm(normal, axis=-1, keepdims=True)
             return normal
@@ -245,7 +245,7 @@ class Detector(object):
             deriv = self.surface_deriv(param)
             if deriv.ndim > 2:
                 # Vectorized, need to reshape (N, 2, 3) to (2, N, 3)
-                deriv = moveaxis(deriv, -2, 0)
+                deriv = np.moveaxis(deriv, -2, 0)
             cross = np.cross(*deriv, axis=-1)
             measure = np.linalg.norm(cross, axis=-1)
             if scalar_out:

--- a/odl/util/npy_compat.py
+++ b/odl/util/npy_compat.py
@@ -6,72 +6,14 @@
 # v. 2.0. If a copy of the MPL was not distributed with this file, You can
 # obtain one at https://mozilla.org/MPL/2.0/.
 
-"""Numpy functions not available in the minimal required version."""
+"""Numpy functions not available in the minimal required version.
 
-from __future__ import print_function, division, absolute_import
-import numpy as np
+Current minimum Numpy version: 1.13.3
+"""
 
+from __future__ import absolute_import, division, print_function
 
-__all__ = ('moveaxis', 'flip')
-
-
-# TODO: Remove when Numpy 1.11 is an ODL dependency
-def moveaxis(a, source, destination):
-    """Move axes of an array to new positions.
-
-    Other axes remain in their original order.
-
-    This function is a backport of `numpy.moveaxis` introduced in
-    NumPy 1.11.
-
-    See Also
-    --------
-    numpy.moveaxis
-    """
-    import numpy
-    if hasattr(numpy, 'moveaxis'):
-        return numpy.moveaxis(a, source, destination)
-
-    try:
-        source = list(source)
-    except TypeError:
-        source = [source]
-    try:
-        destination = list(destination)
-    except TypeError:
-        destination = [destination]
-
-    source = [ax + a.ndim if ax < 0 else ax for ax in source]
-    destination = [ax + a.ndim if ax < 0 else ax for ax in destination]
-
-    order = [n for n in range(a.ndim) if n not in source]
-
-    for dest, src in sorted(zip(destination, source)):
-        order.insert(dest, src)
-
-    return a.transpose(order)
-
-
-# TODO: Remove when Numpy 1.12 is an ODL dependency
-def flip(a, axis):
-    """Reverse the order of elements in an array along the given axis.
-
-    This function is a backport of `numpy.flip` introduced in NumPy 1.12.
-
-    See Also
-    --------
-    numpy.flip
-    """
-    if not hasattr(a, 'ndim'):
-        a = np.asarray(a)
-    indexer = [slice(None)] * a.ndim
-    try:
-        indexer[axis] = slice(None, None, -1)
-    except IndexError:
-        raise ValueError('axis={} is invalid for the {}-dimensional input '
-                         'array'.format(axis, a.ndim))
-    return a[tuple(indexer)]
-
+__all__ = ()
 
 if __name__ == '__main__':
     from odl.util.testutils import run_doctests

--- a/odl/util/testutils.py
+++ b/odl/util/testutils.py
@@ -9,19 +9,18 @@
 """Testing utilities."""
 
 from __future__ import absolute_import, division, print_function
-from future.moves.itertools import zip_longest
 
-from contextlib import contextmanager
 import os
 import sys
 import warnings
 from builtins import object
+from contextlib import contextmanager
 from time import time
 
 import numpy as np
+from future.moves.itertools import zip_longest
 
 from odl.util.utility import is_string, run_from_ipython
-
 
 __all__ = (
     'dtype_ndigits',
@@ -340,8 +339,7 @@ def noise_array(space):
         return np.array([noise_array(si) for si in space])
     else:
         if space.dtype == bool:
-            # TODO(kohr-h): use `randint(..., dtype=bool)` from Numpy 1.11 on
-            arr = np.random.randint(0, 2, size=space.shape).astype(bool)
+            arr = np.random.randint(0, 2, size=space.shape, dtype=bool)
         elif np.issubdtype(space.dtype, np.unsignedinteger):
             arr = np.random.randint(0, 10, space.shape)
         elif np.issubdtype(space.dtype, np.signedinteger):

--- a/setup.cfg
+++ b/setup.cfg
@@ -41,7 +41,7 @@ install_requires =
     setuptools >=39.2.0
     future >=0.14
     packaging >=15.0
-    numpy >=1.10, !=1.14.0, !=1.14.1, !=1.14.2
+    numpy >=1.13.3, !=1.14.0, !=1.14.1, !=1.14.2
     scipy >=0.14
 python_requires = >=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*
 # pytest upper limit due to https://github.com/odlgroup/odl/issues/1514
@@ -153,4 +153,3 @@ ignore_errors = True
 
 [coverage:html]
 directory = htmlcov
-


### PR DESCRIPTION
(Hopefully) a fix for our current CI issue with new versions of SciPy. I went for the variant where we require `numpy >=1.13.3`, which is available on Ubuntu 18.04LTS, for instance.

I'll check if the docs refer to old versions of Numpy.

Closes: #1500 