### PR TITLE
Flying Focal Spot for FanBeam and ConeBeam geometries

### DIFF
--- a/odl/test/tomo/geometry/geometry_test.py
+++ b/odl/test/tomo/geometry/geometry_test.py
@@ -15,6 +15,7 @@ import numpy as np
 
 import odl
 from odl.util.testutils import all_almost_equal, all_equal, simple_fixture
+from odl.tomo.util.source_detector_shifts import flying_focal_spot
 
 
 # --- pytest fixtures --- #
@@ -561,10 +562,13 @@ def test_fanbeam_flying_focal_spot():
     shift1 = np.array([2, -3])
     shift2 = np.array([-2, 3])
     init = np.array([1, 0], dtype=np.float32)
-    geom_ffs = odl.tomo.FanBeamGeometry(apart, dpart, src_rad, det_rad,
-                                        src_to_det_init=init,
-                                        flying_focal_spot=[shift1,
-                                                           shift2])
+    geom_ffs = odl.tomo.FanBeamGeometry(
+        apart, dpart,
+        src_rad, det_rad,
+        src_to_det_init=init,
+        src_shift_func=lambda angle: flying_focal_spot(
+            angle, apart=apart,
+            shifts=[shift1, shift2]))
     # angles must be shifted to match discretization of apart
     ang1 = -full_angle / 20
     apart1 = odl.uniform_partition(ang1, full_angle + ang1, 5)
@@ -583,7 +587,7 @@ def test_fanbeam_flying_focal_spot():
 
     sp1 = geom1.src_position(geom1.angles)
     sp2 = geom2.src_position(geom2.angles)
-    sp = geom_ffs.src_position(geom_ffs.angles, geom_ffs.flying_focal_spot)
+    sp = geom_ffs.src_position(geom_ffs.angles)
     assert all_almost_equal(sp[0::2], sp1)
     assert all_almost_equal(sp[1::2], sp2)
 
@@ -737,10 +741,13 @@ def test_conebeam_flying_focal_spot():
     shift1 = np.array([2, -3, 1])
     shift2 = np.array([-2, 3, -1])
     init = np.array([1, 0, 0], dtype=np.float32)
-    geom_ffs = odl.tomo.ConeBeamGeometry(apart, dpart, src_rad, det_rad,
-                                         src_to_det_init=init,
-                                         flying_focal_spot=[shift1,
-                                                            shift2])
+    geom_ffs = odl.tomo.ConeBeamGeometry(
+        apart, dpart,
+        src_rad, det_rad,
+        src_to_det_init=init,
+        src_shift_func=lambda angle: flying_focal_spot(
+            angle, apart=apart,
+            shifts=[shift1, shift2]))
     # angles must be shifted to match discretization of apart
     ang1 = -full_angle / 20
     apart1 = odl.uniform_partition(ang1, full_angle + ang1, 5)
@@ -761,7 +768,7 @@ def test_conebeam_flying_focal_spot():
 
     sp1 = geom1.src_position(geom1.angles)
     sp2 = geom2.src_position(geom2.angles)
-    sp = geom_ffs.src_position(geom_ffs.angles, geom_ffs.flying_focal_spot)
+    sp = geom_ffs.src_position(geom_ffs.angles)
     assert all_almost_equal(sp[0::2], sp1)
     assert all_almost_equal(sp[1::2], sp2)
 

--- a/odl/test/tomo/operators/ray_trafo_test.py
+++ b/odl/test/tomo/operators/ray_trafo_test.py
@@ -485,7 +485,6 @@ def test_source_detector_shifts_2d():
     (the detector must be large enough, not to be influenced by shifts)
     """
 
-    # If no implementation is available, skip
     if not odl.tomo.ASTRA_AVAILABLE:
         pytest.skip(msg='ASTRA not available, skipping 2d test')
 
@@ -554,7 +553,6 @@ def test_source_detector_shifts_3d():
     (the geometries are not completely equivalent)
     """
 
-    # If no implementation is available, skip
     if not odl.tomo.ASTRA_CUDA_AVAILABLE:
         pytest.skip(msg='ASTRA_CUDA not available, skipping 3d test')
 

--- a/odl/test/tomo/operators/ray_trafo_test.py
+++ b/odl/test/tomo/operators/ray_trafo_test.py
@@ -540,7 +540,7 @@ def test_source_shifts_2d():
     """
 
     if not odl.tomo.ASTRA_AVAILABLE:
-        pytest.skip(msg='ASTRA not available, skipping 2d test')
+        pytest.skip(msg='ASTRA required but not available')
 
     d = 10
     space = odl.uniform_discr([-1] * 2, [1] * 2, [d] * 2)
@@ -638,8 +638,9 @@ def test_detector_shifts_3d():
     geom_shift = odl.tomo.ConeBeamGeometry(apart, dpart, src_rad, det_rad,
                                            det_shift_func=lambda angle: shift)
 
-    assert all_almost_equal(geom.angles, geom_shift.angles)
     angles = geom.angles
+
+    assert all_almost_equal(angles, geom_shift.angles)
     assert all_almost_equal(geom.src_position(angles),
                             geom_shift.src_position(angles))
     assert all_almost_equal(geom.det_axes(angles),
@@ -672,7 +673,6 @@ def test_source_shifts_3d():
     geometries which mimic ffs by using initial angular offsets and
     detector shifts
     """
-
     if not odl.tomo.ASTRA_CUDA_AVAILABLE:
         pytest.skip(msg='ASTRA_CUDA not available, skipping 3d test')
 

--- a/odl/tomo/__init__.py
+++ b/odl/tomo/__init__.py
@@ -16,15 +16,17 @@ from .backends import (
     astra_conebeam_2d_geom_to_vec, astra_conebeam_3d_geom_to_vec)
 from .geometry import *
 from .operators import *
+from .util import *
 
 __all__ = ()
 __all__ += analytic.__all__
 __all__ += geometry.__all__
 __all__ += operators.__all__
+__all__ += util.source_detector_shifts.__all__
 __all__ += (
     'ASTRA_AVAILABLE',
     'ASTRA_CUDA_AVAILABLE',
     'SKIMAGE_AVAILABLE',
     'astra_conebeam_2d_geom_to_vec',
-    'astra_conebeam_3d_geom_to_vec',
+    'astra_conebeam_3d_geom_to_vec'
 )

--- a/odl/tomo/backends/astra_setup.py
+++ b/odl/tomo/backends/astra_setup.py
@@ -307,10 +307,9 @@ def astra_conebeam_3d_geom_to_vec(geometry):
     """
     angles = geometry.angles
     vectors = np.zeros((angles.size, 12))
-    ffs = geometry.flying_focal_spot
 
     # Source position
-    vectors[:, 0:3] = geometry.src_position(angles, ffs)
+    vectors[:, 0:3] = geometry.src_position(angles)
 
     # Center of detector in 3D space
     mid_pt = geometry.det_params.mid_pt
@@ -379,10 +378,9 @@ def astra_conebeam_2d_geom_to_vec(geometry):
     rot_minus_90 = euler_matrix(-np.pi / 2)
     angles = geometry.angles
     vectors = np.zeros((angles.size, 6))
-    ffs = geometry.flying_focal_spot
 
     # Source position
-    src_pos = geometry.src_position(angles, ffs)
+    src_pos = geometry.src_position(angles)
     vectors[:, 0:2] = rot_minus_90.dot(src_pos.T).T  # dot along 2nd axis
 
     # Center of detector
@@ -750,7 +748,6 @@ def astra_algorithm(direction, ndim, vol_id, sino_id, proj_id, impl):
     algo_map = {'forward': {2: {'cpu': 'FP', 'cuda': 'FP_CUDA'},
                             3: {'cpu': None, 'cuda': 'FP3D_CUDA'}},
                 'backward': {2: {'cpu': 'BP', 'cuda': 'BP_CUDA'},
-                             3: {'cpu': None, 'cuda': 'BP3D_CUDA'},
                              3: {'cpu': None, 'cuda': 'BP3D_CUDA'}}}
 
     algo_cfg = {'type': algo_map[direction][ndim][impl],

--- a/odl/tomo/backends/astra_setup.py
+++ b/odl/tomo/backends/astra_setup.py
@@ -307,9 +307,10 @@ def astra_conebeam_3d_geom_to_vec(geometry):
     """
     angles = geometry.angles
     vectors = np.zeros((angles.size, 12))
+    ffs = geometry.flying_focal_spot
 
     # Source position
-    vectors[:, 0:3] = geometry.src_position(angles)
+    vectors[:, 0:3] = geometry.src_position(angles, ffs)
 
     # Center of detector in 3D space
     mid_pt = geometry.det_params.mid_pt
@@ -378,9 +379,10 @@ def astra_conebeam_2d_geom_to_vec(geometry):
     rot_minus_90 = euler_matrix(-np.pi / 2)
     angles = geometry.angles
     vectors = np.zeros((angles.size, 6))
+    ffs = geometry.flying_focal_spot
 
     # Source position
-    src_pos = geometry.src_position(angles)
+    src_pos = geometry.src_position(angles, ffs)
     vectors[:, 0:2] = rot_minus_90.dot(src_pos.T).T  # dot along 2nd axis
 
     # Center of detector
@@ -748,6 +750,7 @@ def astra_algorithm(direction, ndim, vol_id, sino_id, proj_id, impl):
     algo_map = {'forward': {2: {'cpu': 'FP', 'cuda': 'FP_CUDA'},
                             3: {'cpu': None, 'cuda': 'FP3D_CUDA'}},
                 'backward': {2: {'cpu': 'BP', 'cuda': 'BP_CUDA'},
+                             3: {'cpu': None, 'cuda': 'BP3D_CUDA'},
                              3: {'cpu': None, 'cuda': 'BP3D_CUDA'}}}
 
     algo_cfg = {'type': algo_map[direction][ndim][impl],

--- a/odl/tomo/geometry/conebeam.py
+++ b/odl/tomo/geometry/conebeam.py
@@ -486,11 +486,13 @@ class FanBeamGeometry(DivergentBeamGeometry):
                      + np.multiply.outer(flying_focal_spot[:, 1], tangent))
         center_to_src_init = center_to_src_init + ffs_shift
         # broadcasting to perform matrix multiplication "manually",
-        # since existing numpy functions do cross product along the outer dimensions,
-        # which we don't need here
-        center_to_src_init = np.repeat(center_to_src_init, 2, axis=-2).reshape(-1, 2, 2)
+        # since existing numpy functions do cross product along the outer
+        # dimensions, which we don't need here
+        center_to_src_init = np.repeat(center_to_src_init, 2,
+                                       axis=-2).reshape(-1, 2, 2)
         pos_vec = (self.translation[None, :]
-                   + np.sum(self.rotation_matrix(angle) * center_to_src_init, axis=-1))
+                   + np.sum(self.rotation_matrix(angle) * center_to_src_init,
+                            axis=-1))
         if squeeze_out:
             pos_vec = pos_vec.squeeze()
 
@@ -1347,9 +1349,10 @@ class ConeBeamGeometry(DivergentBeamGeometry, AxisOrientedGeometry):
                      + np.multiply.outer(flying_focal_spot[:, 1], tangent))
         center_to_src_init = center_to_src_init + ffs_shift
         # broadcasting to perform matrix multiplication "manually",
-        # since existing numpy functions do cross product along the outer dimensions,
-        # which we don't need here
-        center_to_src_init = np.repeat(center_to_src_init, 3, axis=-2).reshape(-1, 3, 3)
+        # since existing numpy functions do cross product along the outer
+        # dimensions, which we don't need here
+        center_to_src_init = np.repeat(center_to_src_init, 3,
+                                       axis=-2).reshape(-1, 3, 3)
         # `circle_component` has shape (a, ndim)
         circle_component = np.sum(rot_matrix * center_to_src_init, axis=-1)
 

--- a/odl/tomo/geometry/conebeam.py
+++ b/odl/tomo/geometry/conebeam.py
@@ -51,7 +51,7 @@ class FanBeamGeometry(DivergentBeamGeometry):
 
     def __init__(self, apart, dpart, src_radius, det_radius,
                  det_curvature_radius=None, src_to_det_init=(0, 1),
-                 src_shift_func=None, **kwargs):
+                 src_shift_func=None, det_shift_func=None, **kwargs):
         """Initialize a new instance.
 
         Parameters
@@ -76,6 +76,12 @@ class FanBeamGeometry(DivergentBeamGeometry):
             returning a source shift for a given angle.
             Each shift is interpreted as a vector ``[shift_d, shift_t]``, where
             "d" and "t" denote shifts in the detector-to-source and
+            tangent directions, respectively.
+        det_shift_func : callable, optional
+            Function with signature ``det_shift_func(angle) -> shift``
+            returning a detector shift for a given angle.
+            Each shift is interpreted as a vector ``[shift_d, shift_t]``, where
+            "d" and "t" denote shifts in the source-to-detector and
             tangent directions, respectively.
 
         Other Parameters
@@ -167,21 +173,22 @@ class FanBeamGeometry(DivergentBeamGeometry):
         >>> np.allclose(geom.det_axis_init, e_y)
         True
 
-        Specifying a flying focal spot:
+        Specifying a flying focal spot and detector offset:
 
         >>> apart = odl.uniform_partition(0, 2 * np.pi, 4)
         >>> geom = FanBeamGeometry(
         ...     apart, dpart,
         ...     src_radius=1, det_radius=5,
         ...     src_shift_func=lambda angle: odl.tomo.flying_focal_spot(
-        ...             angle, apart=apart, shifts=[(0.1, 0), (0, 0.1)]
-        ...         )
-        ...     )
+        ...             angle, apart=apart, shifts=[(0.1, 0), (0, 0.1)]),
+        ...     det_shift_func=lambda angle: [0.0, 0.05])
         >>> geom.src_shift_func(geom.angles)
         array([[ 0.1, 0. ],
                [ 0. , 0.1],
                [ 0.1, 0. ],
                [ 0. , 0.1]])
+        >>> geom.det_shift_func(geom.angles)
+        [0.0, 0.05]
         """
         default_src_to_det_init = self._default_config['src_to_det_init']
         default_det_axis_init = self._default_config['det_axis_init']
@@ -238,12 +245,6 @@ class FanBeamGeometry(DivergentBeamGeometry):
                                         axis=det_axis_init,
                                         check_bounds=check_bounds)
 
-        if src_shift_func is None:
-            self.__src_shift_func = lambda x: np.array(
-                [0.0, 0.0], dtype=float, ndmin=2)
-        else:
-            self.__src_shift_func = src_shift_func
-
         translation = kwargs.pop('translation', None)
         super(FanBeamGeometry, self).__init__(
             ndim=2, motion_part=apart, detector=detector,
@@ -265,6 +266,18 @@ class FanBeamGeometry(DivergentBeamGeometry):
         if self.motion_partition.ndim != 1:
             raise ValueError('`apart` has dimension {}, expected 1'
                              ''.format(self.motion_partition.ndim))
+
+        if src_shift_func is None:
+            self.__src_shift_func = lambda x: np.array(
+                [0.0, 0.0], dtype=float, ndmin=2)
+        else:
+            self.__src_shift_func = src_shift_func
+
+        if det_shift_func is None:
+            self.__det_shift_func = lambda x: np.array(
+                [0.0, 0.0], dtype=float, ndmin=2)
+        else:
+            self.__det_shift_func = det_shift_func
 
     @classmethod
     def frommatrix(cls, apart, dpart, src_radius, det_radius, init_matrix,
@@ -394,6 +407,11 @@ class FanBeamGeometry(DivergentBeamGeometry):
         """Source shifts in the geometry."""
         return self.__src_shift_func
 
+    @property
+    def det_shift_func(self):
+        """Detector shifts in the geometry."""
+        return self.__det_shift_func
+
     def src_position(self, angle):
         """Return the source position at ``angle``.
 
@@ -401,13 +419,13 @@ class FanBeamGeometry(DivergentBeamGeometry):
 
             src(phi) = translation +
                        rot_matrix(phi) * (-src_rad * src_to_det_init) +
-                       source_shift
+                       source_shift(phi)
 
         where ``src_to_det_init`` is the initial unit vector pointing
         from source to detector and
-            source_shift = rot_matrix(phi) *
-                           (shift[0] * (-src_to_det_init) +
-                            shift[1] * tangent)
+            source_shift(phi) = rot_matrix(phi) *
+                                (shift[0] * (-src_to_det_init) +
+                                shift[1] * tangent)
         where ``tangent`` is a vector tangent to the trajectory
 
         where ``src_to_det_init`` is the initial unit vector pointing
@@ -500,10 +518,15 @@ class FanBeamGeometry(DivergentBeamGeometry):
         For an angle ``phi``, the detector position is given by ::
 
             det_ref(phi) = translation +
-                           rot_matrix(phi) * (det_rad * src_to_det_init)
+                           rot_matrix(phi) * (det_rad * src_to_det_init) +
+                           detector_shift(phi)
 
         where ``src_to_det_init`` is the initial unit vector pointing
-        from source to detector.
+        from source to detector and
+            detector_shift(phi) = rot_matrix(phi) *
+                                  (shift[0] * src_to_det_init +
+                                  shift[1] * tangent)
+        where ``tangent`` is a vector tangent to the trajectory
 
         Parameters
         ----------
@@ -543,16 +566,41 @@ class FanBeamGeometry(DivergentBeamGeometry):
         True
         >>> np.allclose(points[1], [-5, 0])
         True
+
+        Specifying detector offset:
+
+        >>> apart = odl.uniform_partition(0, 2 * np.pi, 4)
+        >>> geom = FanBeamGeometry(
+        ...     apart, dpart,
+        ...     src_radius=1, det_radius=1,
+        ...     det_shift_func=lambda angle: [0.0, 0.1],
+        ...     src_to_det_init=(0.71, -0.71))
+        >>> geom.angles
+        array([ 0.78539816,  2.35619449,  3.92699082,  5.49778714])
+        >>> np.round(geom.det_refpoint(geom.angles), 2)
+        array([[ 1. ,  0.1],
+               [-0.1,  1. ],
+               [-1. , -0.1],
+               [ 0.1, -1. ]])
         """
         squeeze_out = (np.shape(angle) == ())
         angle = np.array(angle, dtype=float, copy=False, ndmin=1)
+        det_shifts = np.array(self.det_shift_func(angle), dtype=float, ndmin=2)
 
         # Initial vector from the rotation center to the detector. It can be
         # computed this way since source and detector are at maximum distance,
         # i.e. the connecting line passes the origin.
         center_to_det_init = self.det_radius * self.src_to_det_init
+        # shifting the detector
+        tangent = np.array([-self.src_to_det_init[1], self.src_to_det_init[0]])
+        shift = (np.multiply.outer(det_shifts[:, 0],
+                                   self.src_to_det_init)
+                 + np.multiply.outer(det_shifts[:, 1], tangent))
+        center_to_det_init = center_to_det_init + shift
         refpt = (self.translation[None, :]
-                 + self.rotation_matrix(angle).dot(center_to_det_init))
+                 + np.einsum('...ij,...j->...i',
+                             self.rotation_matrix(angle),
+                             center_to_det_init))
         if squeeze_out:
             refpt = refpt.squeeze()
 
@@ -654,6 +702,8 @@ class FanBeamGeometry(DivergentBeamGeometry):
                                det_curvature_radius=self.det_curvature_radius,
                                src_to_det_init=self.src_to_det_init,
                                det_axis_init=self._det_axis_init_arg,
+                               src_shift_func=self.src_shift_func,
+                               det_shift_func=self.det_shift_func,
                                translation=self.translation)
 
 
@@ -684,7 +734,7 @@ class ConeBeamGeometry(DivergentBeamGeometry, AxisOrientedGeometry):
 
     def __init__(self, apart, dpart, src_radius, det_radius,
                  det_curvature_radius=None, pitch=0, axis=(0, 0, 1),
-                 src_shift_func=None, **kwargs):
+                 src_shift_func=None, det_shift_func=None, **kwargs):
         """Initialize a new instance.
 
         Parameters
@@ -717,6 +767,14 @@ class ConeBeamGeometry(DivergentBeamGeometry, AxisOrientedGeometry):
             is interpreted as a vector ``[shift_d, shift_t, shift_r]``, where
             "d", "t" and "r" denote shifts along the following directions:
             detector-to-source, tangent to the rotation
+            (projected on plane perpendicular to rotation axis),
+            rotation axis.
+        det_shift_func : callable, optional
+            Function with signature ``det_shift_func(angle) -> shift``
+            returning a detector shift for a given angle. Each shift
+            is interpreted as a vector ``[shift_d, shift_t, shift_r]``, where
+            "d", "t" and "r" denote shifts along the following directions:
+            source-to-detector, tangent to the rotation
             (projected on plane perpendicular to rotation axis),
             rotation axis.
 
@@ -847,21 +905,22 @@ class ConeBeamGeometry(DivergentBeamGeometry, AxisOrientedGeometry):
         >>> np.allclose(geom.det_axes_init, (e_y, e_z))
         True
 
-        Specifying a flying focal spot:
+        Specifying a flying focal spot and detector offset:
 
         >>> apart = odl.uniform_partition(0, 2 * np.pi, 4)
         >>> geom = ConeBeamGeometry(
         ...     apart, dpart,
         ...     src_radius=1, det_radius=5,
         ...     src_shift_func=lambda angle: odl.tomo.flying_focal_spot(
-        ...         angle,
-        ...         apart=apart,
-        ...         shifts=[(0, 0.1, 0), (0, 0, 0.1)]))
+        ...         angle, apart=apart, shifts=[(0, 0.1, 0), (0, 0, 0.1)]),
+        ...     det_shift_func=lambda angle: [0.0, 0.05, 0.03])
         >>> geom.src_shift_func(geom.angles)
         array([[ 0. , 0.1, 0. ],
                [ 0. , 0. , 0.1],
                [ 0. , 0.1, 0. ],
                [ 0. , 0. , 0.1]])
+        >>> geom.det_shift_func(geom.angles)
+        [0.0, 0.05, 0.03]
         """
         default_axis = self._default_config['axis']
         default_src_to_det_init = self._default_config['src_to_det_init']
@@ -945,12 +1004,6 @@ class ConeBeamGeometry(DivergentBeamGeometry, AxisOrientedGeometry):
             raise ValueError('det_curvature_radius {} must be a 2-tuple'
                              ''.format(det_curvature_radius))
 
-        if src_shift_func is None:
-            self.__src_shift_func = lambda x: np.array(
-                [0.0, 0.0, 0.0], dtype=float, ndmin=2)
-        else:
-            self.__src_shift_func = src_shift_func
-
         super(ConeBeamGeometry, self).__init__(
             ndim=3, motion_part=apart, detector=detector, **kwargs)
 
@@ -970,6 +1023,18 @@ class ConeBeamGeometry(DivergentBeamGeometry, AxisOrientedGeometry):
         if self.motion_partition.ndim != 1:
             raise ValueError('`apart` has dimension {}, expected 1'
                              ''.format(self.motion_partition.ndim))
+
+        if src_shift_func is None:
+            self.__src_shift_func = lambda x: np.array(
+                [0.0, 0.0, 0.0], dtype=float, ndmin=2)
+        else:
+            self.__src_shift_func = src_shift_func
+
+        if det_shift_func is None:
+            self.__det_shift_func = lambda x: np.array(
+                [0.0, 0.0, 0.0], dtype=float, ndmin=2)
+        else:
+            self.__det_shift_func = det_shift_func
 
     @classmethod
     def frommatrix(cls, apart, dpart, src_radius, det_radius, init_matrix,
@@ -1132,6 +1197,11 @@ class ConeBeamGeometry(DivergentBeamGeometry, AxisOrientedGeometry):
         """Source shifts in the geometry."""
         return self.__src_shift_func
 
+    @property
+    def det_shift_func(self):
+        """Detector shifts in the geometry."""
+        return self.__det_shift_func
+
     def det_axes(self, angle):
         """Return the detector axes tuple at ``angle``.
 
@@ -1170,10 +1240,15 @@ class ConeBeamGeometry(DivergentBeamGeometry, AxisOrientedGeometry):
 
             det_ref(phi) = translation +
                            rot_matrix(phi) * (det_rad * src_to_det_init) +
-                           (offset_along_axis + pitch * phi) * axis
+                           (offset_along_axis + pitch * phi) * axis +
+                           detector_shift(phi)
 
         where ``src_to_det_init`` is the initial unit vector pointing
-        from source to detector.
+        from source to detector and
+            detector_shift(phi) = rot_matrix(phi) *
+                                  (shift1 * src_to_det_init +
+                                  shift2 * cross(-src_to_det_init, axis))
+                                  shift3 * axis
 
         Parameters
         ----------
@@ -1217,24 +1292,49 @@ class ConeBeamGeometry(DivergentBeamGeometry, AxisOrientedGeometry):
         True
         >>> geom.det_refpoint(np.zeros((4, 5))).shape
         (4, 5, 3)
+
+        Specifying detector offset:
+
+        >>> apart = odl.uniform_partition(0, 2 * np.pi, 4)
+        >>> geom = ConeBeamGeometry(
+        ...     apart, dpart,
+        ...     src_radius=1, det_radius=1,
+        ...     det_shift_func=lambda angle:[0, 0.1, -0.1],
+        ...     src_to_det_init=(0.71, -0.71, 0))
+        >>> geom.angles
+        array([ 0.78539816,  2.35619449,  3.92699082,  5.49778714])
+        >>> np.round(geom.det_refpoint(geom.angles), 2)
+        array([[ 1. ,  0.1, -0.1],
+               [-0.1,  1. , -0.1],
+               [-1. , -0.1, -0.1],
+               [ 0.1, -1. , -0.1]])
         """
         squeeze_out = (np.shape(angle) == ())
         angle = np.array(angle, dtype=float, copy=False, ndmin=1)
         rot_matrix = self.rotation_matrix(angle)
         extra_dims = angle.ndim
+        det_shifts = np.array(self.det_shift_func(angle), dtype=float, ndmin=2)
 
         # Initial vector from center of rotation to detector.
         # It can be computed this way since source and detector are at
         # maximum distance, i.e. the connecting line passes the center.
         center_to_det_init = self.det_radius * self.src_to_det_init
+        # shifting the detector according to det_shift_func
+        tangent = -np.cross(self.src_to_det_init, self.axis)
+        tangent /= np.linalg.norm(tangent)
+        det_shift = (np.multiply.outer(det_shifts[:, 0], self.src_to_det_init)
+                     + np.multiply.outer(det_shifts[:, 1], tangent))
+        center_to_det_init = center_to_det_init + det_shift
         # `circle_component` has shape (a, ndim)
-        circle_component = rot_matrix.dot(center_to_det_init)
+        circle_component = np.einsum('...ij,...j->...i',
+                                     rot_matrix, center_to_det_init)
 
         # Increment along the rotation axis according to pitch and
         # offset_along_axis
         # `shift_along_axis` has shape angles.shape
         shift_along_axis = (self.offset_along_axis
-                            + self.pitch * angle / (2 * np.pi))
+                            + self.pitch * angle / (2 * np.pi)
+                            + det_shifts[:, 2])
         # Create outer product of `shift_along_axis` and `axis`, resulting
         # in shape (a, ndim)
         pitch_component = np.multiply.outer(shift_along_axis, self.axis)
@@ -1257,14 +1357,14 @@ class ConeBeamGeometry(DivergentBeamGeometry, AxisOrientedGeometry):
             src(phi) = translation +
                        rot_matrix(phi) * (-src_rad * src_to_det_init) +
                        (offset_along_axis + pitch * phi) * axis +
-                       source_shift
+                       source_shift(phi)
 
         where ``src_to_det_init`` is the initial unit vector pointing
         from source to detector and
-            source_shift = rot_matrix(phi) *
-                           (shift1 * (-src_to_det_init) +
-                            shift2 * cross(-src_to_det_init, axis))
-                            shift3 * axis
+            source_shift(phi) = rot_matrix(phi) *
+                                (shift1 * (-src_to_det_init) +
+                                shift2 * cross(src_to_det_init, axis))
+                                shift3 * axis
 
         Parameters
         ----------
@@ -1316,10 +1416,8 @@ class ConeBeamGeometry(DivergentBeamGeometry, AxisOrientedGeometry):
         ...     apart, dpart,
         ...     src_radius=1, det_radius=5,
         ...     src_shift_func=lambda angle: odl.tomo.flying_focal_spot(
-        ...         angle,
-        ...         apart=apart,
-        ...         shifts=[(0, 0.1, 0), (0, 0, 0.1)]),
-        ...         src_to_det_init=(-0.71, 0.71, 0))
+        ...         angle, apart=apart, shifts=[(0, 0.1, 0), (0, 0, 0.1)]),
+        ...     src_to_det_init=(-0.71, 0.71, 0))
         >>> geom.angles
         array([ 0.78539816,  2.35619449,  3.92699082,  5.49778714])
         >>> np.round(geom.src_position(geom.angles), 2)
@@ -1440,6 +1538,8 @@ class ConeBeamGeometry(DivergentBeamGeometry, AxisOrientedGeometry):
                                 offset_along_axis=self.offset_along_axis,
                                 src_to_det_init=self._src_to_det_init_arg,
                                 det_axes_init=self._det_axes_init_arg,
+                                src_shift_func=self.src_shift_func,
+                                det_shift_func=self.det_shift_func,
                                 translation=self.translation)
 
     # Manually override the abstract method in `Geometry` since it's found

--- a/odl/tomo/geometry/conebeam.py
+++ b/odl/tomo/geometry/conebeam.py
@@ -711,11 +711,12 @@ class ConeBeamGeometry(DivergentBeamGeometry, AxisOrientedGeometry):
             beam geometry.
         axis : `array-like`, shape ``(3,)``, optional
             Vector defining the fixed rotation axis of this geometry.
-        src_shift_func : a function of (angle), optional
-            Should return a 3 dimensional vector representing a shift
-            relative to the default source position. Vector elements
-            represent shifts along the following directions:
-            det_to_src, tangent to the rotation
+        src_shift_func : callable, optional
+            Function with signature ``src_shift_func(angle) -> shift``
+            returning a source shift for a given angle. Each shift
+            is interpreted as a vector ``[shift_d, shift_t, shift_r]``, where
+            "d", "t" and "r" denote shifts along the following directions:
+            detector-to-source, tangent to the rotation
             (projected on plane perpendicular to rotation axis),
             rotation axis.
 

--- a/odl/tomo/util/__init__.py
+++ b/odl/tomo/util/__init__.py
@@ -12,6 +12,8 @@ from __future__ import absolute_import
 
 from . import testutils
 from .utility import *
+from .source_detector_shifts import *
 
 __all__ = ()
 __all__ += utility.__all__
+__all__ += source_detector_shifts.__all__

--- a/odl/tomo/util/source_detector_shifts.py
+++ b/odl/tomo/util/source_detector_shifts.py
@@ -31,7 +31,8 @@ def flying_focal_spot(angle, apart, shifts):
         Each vectors in a sequence represent a subsequent shift
         relative to the default source position. Vector elements
         represent shifts along the following directions:
-        det_to_src, tangent to the rotation, rotation axis.
+        det_to_src, tangent to the rotation
+        (projected on a plane perpendicular to rotation axis), rotation axis.
     """
     assert apart.ndim == 1
 

--- a/odl/tomo/util/source_detector_shifts.py
+++ b/odl/tomo/util/source_detector_shifts.py
@@ -10,14 +10,15 @@
 
 from __future__ import print_function, division, absolute_import
 import numpy as np
-from odl.discr import uniform_discr_frompartition
 from odl.discr.discr_utils import nearest_interpolator
 
-__all__ = ('flying_focal_spot')
+__all__ = ('flying_focal_spot',)
 
 
 def flying_focal_spot(angle, apart, shifts):
     """Flying focal spot shifts for divergent beam geometries.
+    Shifts are defined only for grid points of angular partition.
+    For all other angles nearest neighbor interpolation is used.
 
     Parameters
     ----------
@@ -32,15 +33,20 @@ def flying_focal_spot(angle, apart, shifts):
         represent shifts along the following directions:
         det_to_src, tangent to the rotation, rotation axis.
     """
+    assert apart.ndim == 1
+
     angle = np.array(angle, dtype=float, copy=False, ndmin=1)
-    interpolator = nearest_interpolator(np.arange(apart.size),
-                                        apart.coord_vectors)
-    ind = interpolator(angle)
+    assert angle.ndim == 1
 
     shifts = np.array(shifts, dtype=float, ndmin=2)
     if shifts.shape[1] not in [2, 3]:
         raise ValueError('Flying focal spot shifts must have '
                          'shape (2,) or (3,), got {}'.format(shifts))
+
+    interpolator = nearest_interpolator(np.arange(apart.size),
+                                        apart.coord_vectors)
+    ind = interpolator(angle)
+
     k = len(shifts)
     result = [shifts[int(i) % k] for i in ind]
     return np.array(result, dtype=float, ndmin=2)

--- a/odl/tomo/util/source_detector_shifts.py
+++ b/odl/tomo/util/source_detector_shifts.py
@@ -1,0 +1,46 @@
+# Copyright 2014-2020 The ODL contributors
+#
+# This file is part of ODL.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file, You can
+# obtain one at https://mozilla.org/MPL/2.0/.
+
+"""Source and detector shifts for divergent beam geometries."""
+
+from __future__ import print_function, division, absolute_import
+import numpy as np
+from odl.discr import uniform_discr_frompartition
+from odl.discr.discr_utils import nearest_interpolator
+
+__all__ = ('flying_focal_spot')
+
+
+def flying_focal_spot(angle, apart, shifts):
+    """Flying focal spot shifts for divergent beam geometries.
+
+    Parameters
+    ----------
+    angle : float or `array-like`
+        Angle(s) in radians describing the counter-clockwise
+        rotation of source and detector.
+    apart : 1-dim. `RectPartition`
+        Partition of the angle interval.
+    shifts : sequence of `array-like`
+        Each vectors in a sequence represent a subsequent shift
+        relative to the default source position. Vector elements
+        represent shifts along the following directions:
+        det_to_src, tangent to the rotation, rotation axis.
+    """
+    angle = np.array(angle, dtype=float, copy=False, ndmin=1)
+    interpolator = nearest_interpolator(np.arange(apart.size),
+                                        apart.coord_vectors)
+    ind = interpolator(angle)
+
+    shifts = np.array(shifts, dtype=float, ndmin=2)
+    if shifts.shape[1] not in [2, 3]:
+        raise ValueError('Flying focal spot shifts must have '
+                         'shape (2,) or (3,), got {}'.format(shifts))
+    k = len(shifts)
+    result = [shifts[int(i) % k] for i in ind]
+    return np.array(result, dtype=float, ndmin=2)


### PR DESCRIPTION
Added possibility to arbitrary shift source positions. Since ASTRA allows to provide arbitrary source positions to projection and back-projection functions, it is possible now to do reconstruction with flying focal spot.

Implementation:
The sequence of unique shifts should be defined relative to the default source position and provided as an input to the geometry. Then this sequence is extended for all angles and returned when calling geometry.flying_focal_spot. However, one has to manually provide flying_focal_spot sequence to geometry.src_position() as an argument. This choice was made because FFS shifts correspond to discretization of angular partition and defining a FFS shift for any angle would introduce significant overhead in terms of work (moreover, in practice this is not needed). 