### PR TITLE
fix broken url

### DIFF
--- a/odl/contrib/datasets/images/cambridge.py
+++ b/odl/contrib/datasets/images/cambridge.py
@@ -26,7 +26,7 @@ __all__ = ('brain_phantom', 'resolution_phantom', 'building', 'rings',
 
 
 DATA_SUBSET = 'images_cambridge'
-URL_CAM = 'http://store.maths.cam.ac.uk/DAMTP/me404/data_sets/'
+URL_CAM = 'https://raw.github.com/mehrhardt/spdhg/master/data/'
 
 
 def convert(image, shape, gray=False, dtype='float64', normalize='max'):


### PR DESCRIPTION
Cambridge made some internal changes what servers can be accessed remotely, see mehrhardt/spdhg#1. Thus, the "Cambridge_images" are no longer available there. I transferred them to the github repository of the paper where they belong to https://github.com/mehrhardt/spdhg.

