### PR TITLE
Add scaling factors for ASTRA >= 1.9.9.dev

### DIFF
--- a/odl/tomo/backends/astra_cuda.py
+++ b/odl/tomo/backends/astra_cuda.py
@@ -376,6 +376,7 @@ def astra_cuda_bp_scaling_factor(proj_space, reco_space, geometry):
                        reco_space.cell_volume)
 
     if parse_version(ASTRA_VERSION) < parse_version('1.8rc1'):
+        # Scaling for the old, pre-1.8 behaviour
         if isinstance(geometry, Parallel2dGeometry):
             # Scales with 1 / cell_volume
             scaling_factor *= float(reco_space.cell_volume)
@@ -403,6 +404,7 @@ def astra_cuda_bp_scaling_factor(proj_space, reco_space, geometry):
             det_radius = geometry.det_radius
             scaling_factor *= ((src_radius + det_radius) / src_radius) ** 2
     elif parse_version(ASTRA_VERSION) < parse_version('1.9.0dev'):
+        # Scaling for the 1.8.x releases
         if isinstance(geometry, Parallel2dGeometry):
             # Scales with 1 / cell_volume
             scaling_factor *= float(reco_space.cell_volume)
@@ -435,6 +437,7 @@ def astra_cuda_bp_scaling_factor(proj_space, reco_space, geometry):
             scaling_factor *= (src_radius ** 2 * det_px_area ** 2 /
                                reco_space.cell_volume ** 2)
     elif parse_version(ASTRA_VERSION) < parse_version('1.9.9.dev'):
+        # Scaling for intermediate dev releases between 1.8.3 and 1.9.9.dev
         if isinstance(geometry, Parallel2dGeometry):
             # Scales with 1 / cell_volume
             scaling_factor *= float(reco_space.cell_volume)
@@ -466,6 +469,7 @@ def astra_cuda_bp_scaling_factor(proj_space, reco_space, geometry):
             det_px_area = geometry.det_partition.cell_volume
             scaling_factor *= (src_radius ** 2 * det_px_area ** 2)
     else:
+        # Scaling for versions since 1.9.9.dev
         scaling_factor /= float(reco_space.cell_volume)
         scaling_factor *= float(geometry.det_partition.cell_volume)
 

--- a/odl/tomo/backends/astra_cuda.py
+++ b/odl/tomo/backends/astra_cuda.py
@@ -116,7 +116,7 @@ class AstraCudaProjectorImpl(object):
 
             # Fix scaling to weight by pixel size
             if (isinstance(self.geometry, Parallel2dGeometry) and
-                parse_version(ASTRA_VERSION) < parse_version('1.9.9.dev')):
+                    parse_version(ASTRA_VERSION) < parse_version('1.9.9.dev')):
                 # parallel2d scales with pixel stride
                 out *= 1 / float(self.geometry.det_partition.cell_volume)
 

--- a/odl/tomo/backends/astra_cuda.py
+++ b/odl/tomo/backends/astra_cuda.py
@@ -375,10 +375,7 @@ def astra_cuda_bp_scaling_factor(proj_space, reco_space, geometry):
     scaling_factor /= (reco_space.weighting.const /
                        reco_space.cell_volume)
 
-    if parse_version(ASTRA_VERSION) >= parse_version('1.9.9.dev'):
-        scaling_factor /= float(reco_space.cell_volume)
-        scaling_factor *= float(geometry.det_partition.cell_volume)
-    elif parse_version(ASTRA_VERSION) < parse_version('1.8rc1'):
+    if parse_version(ASTRA_VERSION) < parse_version('1.8rc1'):
         if isinstance(geometry, Parallel2dGeometry):
             # Scales with 1 / cell_volume
             scaling_factor *= float(reco_space.cell_volume)
@@ -405,39 +402,7 @@ def astra_cuda_bp_scaling_factor(proj_space, reco_space, geometry):
             src_radius = geometry.src_radius
             det_radius = geometry.det_radius
             scaling_factor *= ((src_radius + det_radius) / src_radius) ** 2
-    # Check if an intermediate development version of astra is used
-    elif parse_version(ASTRA_VERSION) == parse_version('1.9.0dev'):
-        if isinstance(geometry, Parallel2dGeometry):
-            # Scales with 1 / cell_volume
-            scaling_factor *= float(reco_space.cell_volume)
-        elif (isinstance(geometry, FanBeamGeometry)
-              and geometry.det_curvature_radius is None):
-            # Scales with 1 / cell_volume
-            scaling_factor *= float(reco_space.cell_volume)
-            # Magnification correction
-            src_radius = geometry.src_radius
-            det_radius = geometry.det_radius
-            scaling_factor *= ((src_radius + det_radius) / src_radius)
-        elif isinstance(geometry, Parallel3dAxisGeometry):
-            # Scales with cell volume
-            # currently only square voxels are supported
-            scaling_factor /= reco_space.cell_volume
-        elif (isinstance(geometry, ConeBeamGeometry)
-              and geometry.det_curvature_radius is None):
-            # Scales with cell volume
-            scaling_factor /= reco_space.cell_volume
-            # Magnification correction (scaling = 1 / magnification ** 2)
-            src_radius = geometry.src_radius
-            det_radius = geometry.det_radius
-            scaling_factor *= ((src_radius + det_radius) / src_radius) ** 2
-
-            # Correction for scaled 1/r^2 factor in ASTRA's density weighting.
-            # This compensates for scaled voxels and pixels, as well as a
-            # missing factor src_radius ** 2 in the ASTRA BP with
-            # density weighting.
-            det_px_area = geometry.det_partition.cell_volume
-            scaling_factor *= (src_radius ** 2 * det_px_area ** 2)
-    else:
+    elif parse_version(ASTRA_VERSION) < parse_version('1.9.0dev'):
         if isinstance(geometry, Parallel2dGeometry):
             # Scales with 1 / cell_volume
             scaling_factor *= float(reco_space.cell_volume)
@@ -469,8 +434,40 @@ def astra_cuda_bp_scaling_factor(proj_space, reco_space, geometry):
             det_px_area = geometry.det_partition.cell_volume
             scaling_factor *= (src_radius ** 2 * det_px_area ** 2 /
                                reco_space.cell_volume ** 2)
+    elif parse_version(ASTRA_VERSION) < parse_version('1.9.9.dev'):
+        if isinstance(geometry, Parallel2dGeometry):
+            # Scales with 1 / cell_volume
+            scaling_factor *= float(reco_space.cell_volume)
+        elif (isinstance(geometry, FanBeamGeometry)
+              and geometry.det_curvature_radius is None):
+            # Scales with 1 / cell_volume
+            scaling_factor *= float(reco_space.cell_volume)
+            # Magnification correction
+            src_radius = geometry.src_radius
+            det_radius = geometry.det_radius
+            scaling_factor *= ((src_radius + det_radius) / src_radius)
+        elif isinstance(geometry, Parallel3dAxisGeometry):
+            # Scales with cell volume
+            # currently only square voxels are supported
+            scaling_factor /= reco_space.cell_volume
+        elif (isinstance(geometry, ConeBeamGeometry)
+              and geometry.det_curvature_radius is None):
+            # Scales with cell volume
+            scaling_factor /= reco_space.cell_volume
+            # Magnification correction (scaling = 1 / magnification ** 2)
+            src_radius = geometry.src_radius
+            det_radius = geometry.det_radius
+            scaling_factor *= ((src_radius + det_radius) / src_radius) ** 2
 
-        # TODO: add case with new ASTRA release
+            # Correction for scaled 1/r^2 factor in ASTRA's density weighting.
+            # This compensates for scaled voxels and pixels, as well as a
+            # missing factor src_radius ** 2 in the ASTRA BP with
+            # density weighting.
+            det_px_area = geometry.det_partition.cell_volume
+            scaling_factor *= (src_radius ** 2 * det_px_area ** 2)
+    else:
+        scaling_factor /= float(reco_space.cell_volume)
+        scaling_factor *= float(geometry.det_partition.cell_volume)
 
     return scaling_factor
 

--- a/odl/tomo/backends/astra_setup.py
+++ b/odl/tomo/backends/astra_setup.py
@@ -107,7 +107,7 @@ ASTRA_FEATURES = {
     # Approximate version of ray-density weighting in cone beam
     # backprojection for constant source-detector distance, see
     # https://github.com/astra-toolbox/astra-toolbox/pull/84
-    'cone3d_approx_density_weighting': '>=1.8',
+    'cone3d_approx_density_weighting': '>=1.8,<1.9.9.dev',
 
     # General case not supported yet, see the discussion in
     # https://github.com/astra-toolbox/astra-toolbox/issues/71

--- a/odl/tomo/backends/astra_setup.py
+++ b/odl/tomo/backends/astra_setup.py
@@ -699,7 +699,7 @@ def astra_projector(astra_proj_type, astra_vol_geom, astra_proj_geom, ndim):
     # Add the approximate 1/r^2 weighting exposed in intermediate versions of
     # ASTRA
     if (
-        astra_proj_type in ('cone', 'cone_vec')
+        astra_geom in ('cone', 'cone_vec')
         and astra_supports('cone3d_approx_density_weighting')
     ):
         proj_cfg['options']['DensityWeighting'] = True


### PR DESCRIPTION
This adapts the ODL astra_cuda backend scaling factors to the new adjoint scaling in astra-1.9.9.dev (current astra-toolbox master since a few days ago, astra-toolbox/astra-toolbox@54af7e8e22a3f1c9d90b13291b28d39778c05564), as announced in #1415 .

It is probably possible to clean things up further now, using a feature flag for example, but I'll leave that to you.