### PR TITLE
Configure GPU index for 'astra_cuda', select GPU currently used by PyTorch in OperatorModule 

### DIFF
--- a/odl/contrib/torch/operator.py
+++ b/odl/contrib/torch/operator.py
@@ -230,7 +230,7 @@ class OperatorFunction(torch.autograd.Function):
         ctx.op_in_dtype = operator.domain.dtype
         ctx.op_out_dtype = op_out_dtype
 
-        if hasattr(operator, 'gpu_index'):
+        if hasattr(operator, 'gpu_index') and torch.cuda.is_available():
             try:
                 operator.gpu_index = torch.cuda.current_device()
             except AttributeError:
@@ -352,7 +352,7 @@ class OperatorFunction(torch.autograd.Function):
                 ''.format(extra_shape + op_out_shape, grad_output_arr.shape)
             )
 
-        if hasattr(operator, 'gpu_index'):
+        if hasattr(operator, 'gpu_index') and torch.cuda.is_available():
             try:
                 operator.gpu_index = torch.cuda.current_device()
             except AttributeError:

--- a/odl/tomo/backends/astra_cuda.py
+++ b/odl/tomo/backends/astra_cuda.py
@@ -46,7 +46,7 @@ class AstraCudaProjectorImpl(object):
     sino_id = None
     proj_id = None
 
-    def __init__(self, geometry, reco_space, proj_space):
+    def __init__(self, geometry, reco_space, proj_space, gpu_index=0):
         """Initialize a new instance.
 
         Parameters
@@ -58,6 +58,9 @@ class AstraCudaProjectorImpl(object):
             projected.
         proj_space : `DiscreteLp`
             Projection space, the space of the result.
+        gpu_index : int, optional
+            Index of GPU to use.
+            Default: ``0``
         """
         assert isinstance(geometry, Geometry)
         assert isinstance(reco_space, DiscreteLp)
@@ -66,6 +69,7 @@ class AstraCudaProjectorImpl(object):
         self.geometry = geometry
         self.reco_space = reco_space
         self.proj_space = proj_space
+        self.gpu_index = gpu_index
 
         self.create_ids()
 
@@ -159,7 +163,8 @@ class AstraCudaProjectorImpl(object):
 
         proj_type = 'cuda' if proj_ndim == 2 else 'cuda3d'
         self.proj_id = astra_projector(
-            proj_type, vol_geom, proj_geom, proj_ndim
+            proj_type, vol_geom, proj_geom, proj_ndim,
+            gpu_index=self.gpu_index
         )
 
         self.sino_id = astra_data(proj_geom,
@@ -171,7 +176,7 @@ class AstraCudaProjectorImpl(object):
         # Create algorithm
         self.algo_id = astra_algorithm(
             'forward', proj_ndim, self.vol_id, self.sino_id,
-            proj_id=self.proj_id, impl='cuda')
+            proj_id=self.proj_id, impl='cuda', gpu_index=self.gpu_index)
 
     def __del__(self):
         """Delete ASTRA objects."""
@@ -203,7 +208,7 @@ class AstraCudaBackProjectorImpl(object):
     sino_id = None
     proj_id = None
 
-    def __init__(self, geometry, reco_space, proj_space):
+    def __init__(self, geometry, reco_space, proj_space, gpu_index=0):
         """Initialize a new instance.
 
         Parameters
@@ -214,6 +219,9 @@ class AstraCudaBackProjectorImpl(object):
             Reconstruction space, the space to which the backprojection maps.
         proj_space : `DiscreteLp`
             Projection space, the space from which the backprojection maps.
+        gpu_index : int, optional
+            Index of GPU to use.
+            Default: ``0``
         """
         assert isinstance(geometry, Geometry)
         assert isinstance(reco_space, DiscreteLp)
@@ -222,6 +230,8 @@ class AstraCudaBackProjectorImpl(object):
         self.geometry = geometry
         self.reco_space = reco_space
         self.proj_space = proj_space
+        self.gpu_index = gpu_index
+
         self.create_ids()
 
         # Create a mutually exclusive lock so that two callers cant use the
@@ -311,7 +321,8 @@ class AstraCudaBackProjectorImpl(object):
 
         proj_type = 'cuda' if proj_ndim == 2 else 'cuda3d'
         self.proj_id = astra_projector(
-            proj_type, vol_geom, proj_geom, proj_ndim
+            proj_type, vol_geom, proj_geom, proj_ndim,
+            gpu_index=self.gpu_index
         )
 
         self.vol_id = astra_data(vol_geom,
@@ -323,7 +334,7 @@ class AstraCudaBackProjectorImpl(object):
         # Create algorithm
         self.algo_id = astra_algorithm(
             'backward', proj_ndim, self.vol_id, self.sino_id,
-            proj_id=self.proj_id, impl='cuda')
+            proj_id=self.proj_id, impl='cuda', gpu_index=self.gpu_index)
 
     def __del__(self):
         """Delete ASTRA objects."""

--- a/odl/tomo/backends/astra_setup.py
+++ b/odl/tomo/backends/astra_setup.py
@@ -615,7 +615,8 @@ def astra_data(astra_geom, datatype, data=None, ndim=2, allow_copy=False):
         return create(astra_dtype_str, astra_geom)
 
 
-def astra_projector(astra_proj_type, astra_vol_geom, astra_proj_geom, ndim):
+def astra_projector(astra_proj_type, astra_vol_geom, astra_proj_geom, ndim,
+                    gpu_index=0):
     """Create an ASTRA projector configuration dictionary.
 
     Parameters
@@ -630,6 +631,9 @@ def astra_projector(astra_proj_type, astra_vol_geom, astra_proj_geom, ndim):
         ASTRA projection geometry.
     ndim : {2, 3}
         Number of dimensions of the projector.
+    gpu_index : int, optional
+        Index of GPU to use.
+        Default: ``0``
 
     Returns
     -------
@@ -691,7 +695,7 @@ def astra_projector(astra_proj_type, astra_vol_geom, astra_proj_geom, ndim):
     proj_cfg['type'] = astra_proj_type
     proj_cfg['VolumeGeometry'] = astra_vol_geom
     proj_cfg['ProjectionGeometry'] = astra_proj_geom
-    proj_cfg['options'] = {}
+    proj_cfg['options'] = {'GPUindex': gpu_index}
 
     # Add the approximate 1/r^2 weighting exposed in intermediate versions of
     # ASTRA
@@ -707,7 +711,8 @@ def astra_projector(astra_proj_type, astra_vol_geom, astra_proj_geom, ndim):
         return astra.projector3d.create(proj_cfg)
 
 
-def astra_algorithm(direction, ndim, vol_id, sino_id, proj_id, impl):
+def astra_algorithm(direction, ndim, vol_id, sino_id, proj_id, impl,
+                    gpu_index=0):
     """Create an ASTRA algorithm object to run the projector.
 
     Parameters
@@ -725,6 +730,9 @@ def astra_algorithm(direction, ndim, vol_id, sino_id, proj_id, impl):
         Handle for the ASTRA projector object.
     impl : {'cpu', 'cuda'}
         Implementation of the projector.
+    gpu_index : int, optional
+        Index of GPU to use for ``impl=='cuda'``.
+        Default: ``0``
 
     Returns
     -------
@@ -757,6 +765,8 @@ def astra_algorithm(direction, ndim, vol_id, sino_id, proj_id, impl):
         algo_cfg['VolumeDataId'] = vol_id
     else:
         algo_cfg['ReconstructionDataId'] = vol_id
+    if impl == 'cuda':
+        algo_cfg['option'] = {'GPUindex': gpu_index}
 
     # Create ASTRA algorithm object
     return astra.algorithm.create(algo_cfg)

--- a/odl/tomo/operators/ray_trafo.py
+++ b/odl/tomo/operators/ray_trafo.py
@@ -11,6 +11,7 @@
 from __future__ import absolute_import, division, print_function
 
 import warnings
+from copy import copy
 
 import numpy as np
 
@@ -356,6 +357,16 @@ class RayTransformBase(Operator):
 
         else:
             raise RuntimeError('bad domain {!r}'.format(self.domain))
+
+    def _replicate(self):
+        """Return replica that can be configured independently.
+
+        Useful to create multiple instances on different GPUs."""
+        replica = copy(self)
+        # Clear cached properties
+        replica._adjoint = None
+        replica._astra_wrapper = None
+        return replica
 
 
 class RayTransform(RayTransformBase):


### PR DESCRIPTION
This pull request implements two new features:

- Choice of GPU for 'astra_cuda' via settable property ``'gpu_index'`` in ``RayTransformBase``
- Automatically select GPU currently used by PyTorch in ``OperatorModule`` by setting ``'gpu_index'``

The second feature feels a little hacky, since it assumes the special role of the ``'gpu_index'`` property if existing for any ``Operator`` instance that is wrapped by the ``OperatorModule``. However this seems to me to be the most non-invasive way to implement this behaviour, since otherwise probably ``RayTransformBase`` would have to know about torch, e.g. offering ``gpu_index = 'torch_current'``.