### PR TITLE
Have numpydoc submodule track (fixed) version branch

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "doc/sphinxext"]
 	path = doc/numpydoc
 	url = https://github.com/odlgroup/numpydoc
+	branch = v0.9.2-odl


### PR DESCRIPTION
Another quick fix.

- Make git submodule for numpydoc point to a branch in our fork (`v0.9.2-odl`)
- Fix handling of parameter in our patch (`param` is now a `namedtuple` instance and the name must be retrieved with `param.name`)

I'll merge immediately after successful CI to fix the docs and the now broken submodule link.