### PR TITLE
Put __all__ amendments last in __init__.py files

### DIFF
--- a/odl/__init__.py
+++ b/odl/__init__.py
@@ -54,10 +54,10 @@ np.set_printoptions(linewidth=71)
 # Import all names from "core" subpackages into the top-level namespace;
 # the `__all__` collection is extended later to make import errors more
 # visible (otherwise one gets errors like "... has no attribute __all__")
+from .discr import *
+from .operator import *
 from .set import *
 from .space import *
-from .operator import *
-from .discr import *
 
 # More "advanced" subpackages keep their namespaces separate from top-level,
 # we only import the modules themselves
@@ -75,8 +75,8 @@ from . import util
 from .util import test
 
 # Amend `__all__`
+__all__ += discr.__all__
+__all__ += operator.__all__
 __all__ += set.__all__
 __all__ += space.__all__
-__all__ += operator.__all__
-__all__ += discr.__all__
 __all__ += ('test',)

--- a/odl/deform/__init__.py
+++ b/odl/deform/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2017 The ODL contributors
+# Copyright 2014-2020 The ODL contributors
 #
 # This file is part of ODL.
 #
@@ -6,13 +6,11 @@
 # v. 2.0. If a copy of the MPL was not distributed with this file, You can
 # obtain one at https://mozilla.org/MPL/2.0/.
 
-"""Operators and functions for linearized deformations in ODL."""
+"""Operators and functions for deformations."""
 
 from __future__ import absolute_import
 
+from .linearized import *
 
 __all__ = ()
-
-
-from .linearized import *
 __all__ += linearized.__all__

--- a/odl/diagnostics/__init__.py
+++ b/odl/diagnostics/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2017 The ODL contributors
+# Copyright 2014-2020 The ODL contributors
 #
 # This file is part of ODL.
 #
@@ -6,17 +6,15 @@
 # v. 2.0. If a copy of the MPL was not distributed with this file, You can
 # obtain one at https://mozilla.org/MPL/2.0/.
 
-"""Automated tests for ODL."""
+"""Automated diagnostic checks."""
 
 from __future__ import absolute_import
 
-__all__ = ()
-
 from .examples import *
-__all__ += examples.__all__
-
-from .space import *
-__all__ += space.__all__
-
 from .operator import *
+from .space import *
+
+__all__ = ()
+__all__ += examples.__all__
 __all__ += operator.__all__
+__all__ += space.__all__

--- a/odl/discr/__init__.py
+++ b/odl/discr/__init__.py
@@ -18,9 +18,8 @@ from .grid import *
 from .partition import *
 
 __all__ = ()
-
+__all__ += diff_ops.__all__
+__all__ += discr_ops.__all__
+__all__ += discr_space.__all__
 __all__ += grid.__all__
 __all__ += partition.__all__
-__all__ += discr_space.__all__
-__all__ += discr_ops.__all__
-__all__ += diff_ops.__all__

--- a/odl/operator/__init__.py
+++ b/odl/operator/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2019 The ODL contributors
+# Copyright 2014-2020 The ODL contributors
 #
 # This file is part of ODL.
 #
@@ -6,23 +6,19 @@
 # v. 2.0. If a copy of the MPL was not distributed with this file, You can
 # obtain one at https://mozilla.org/MPL/2.0/.
 
-"""Representation of mathematical operators."""
+"""Implementations of mathematical operators."""
 
 from __future__ import absolute_import
 
-__all__ = ()
-
-from .operator import *
-__all__ += operator.__all__
-
 from .default_ops import *
-__all__ += default_ops.__all__
-
-from .pspace_ops import *
-__all__ += pspace_ops.__all__
-
-from .tensor_ops import *
-__all__ += tensor_ops.__all__
-
+from .operator import *
 from .oputils import *
+from .pspace_ops import *
+from .tensor_ops import *
+
+__all__ = ()
+__all__ += default_ops.__all__
+__all__ += operator.__all__
 __all__ += oputils.__all__
+__all__ += pspace_ops.__all__
+__all__ += tensor_ops.__all__

--- a/odl/phantom/__init__.py
+++ b/odl/phantom/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2018 The ODL contributors
+# Copyright 2014-2020 The ODL contributors
 #
 # This file is part of ODL.
 #
@@ -10,21 +10,16 @@
 
 from __future__ import absolute_import
 
-__all__ = ()
-
 from . import phantom_utils
-
 from .emission import *
-__all__ += emission.__all__
-
 from .geometric import *
-__all__ += geometric.__all__
-
 from .misc_phantoms import *
-__all__ += misc_phantoms.__all__
-
 from .noise import *
-__all__ += noise.__all__
-
 from .transmission import *
+
+__all__ = ()
+__all__ += emission.__all__
+__all__ += geometric.__all__
+__all__ += misc_phantoms.__all__
+__all__ += noise.__all__
 __all__ += transmission.__all__

--- a/odl/set/__init__.py
+++ b/odl/set/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2019 The ODL contributors
+# Copyright 2014-2020 The ODL contributors
 #
 # This file is part of ODL.
 #
@@ -10,13 +10,11 @@
 
 from __future__ import absolute_import
 
-__all__ = ()
-
-from .sets import *
-__all__ += sets.__all__
-
 from .domain import *
-__all__ += domain.__all__
-
+from .sets import *
 from .space import *
+
+__all__ = ()
+__all__ += sets.__all__
+__all__ += domain.__all__
 __all__ += space.__all__

--- a/odl/solvers/__init__.py
+++ b/odl/solvers/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2017 The ODL contributors
+# Copyright 2014-2020 The ODL contributors
 #
 # This file is part of ODL.
 #
@@ -6,22 +6,20 @@
 # v. 2.0. If a copy of the MPL was not distributed with this file, You can
 # obtain one at https://mozilla.org/MPL/2.0/.
 
+"""Classes and routines for numerical optimization."""
+
 from __future__ import absolute_import
 
+from .functional import *
+from .iterative import *
+from .nonsmooth import *
+from .smooth import *
+from .util import *
 
 __all__ = ()
 
-from .functional import *
 __all__ += functional.__all__
-
-from .nonsmooth import *
-__all__ += nonsmooth.__all__
-
-from .smooth import *
-__all__ += smooth.__all__
-
-from .iterative import *
 __all__ += iterative.__all__
-
-from .util import *
+__all__ += nonsmooth.__all__
+__all__ += smooth.__all__
 __all__ += util.__all__

--- a/odl/solvers/functional/__init__.py
+++ b/odl/solvers/functional/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2017 The ODL contributors
+# Copyright 2014-2020 The ODL contributors
 #
 # This file is part of ODL.
 #
@@ -6,18 +6,17 @@
 # v. 2.0. If a copy of the MPL was not distributed with this file, You can
 # obtain one at https://mozilla.org/MPL/2.0/.
 
+"""Implementations of mathematical functionals."""
+
 from __future__ import absolute_import
 
-__all__ = ()
-
-from .functional import *
-__all__ += functional.__all__
-
 from .default_functionals import *
-__all__ += default_functionals.__all__
-
-from .example_funcs import *
-__all__ += example_funcs.__all__
-
 from .derivatives import *
+from .example_funcs import *
+from .functional import *
+
+__all__ = ()
+__all__ += functional.__all__
+__all__ += default_functionals.__all__
+__all__ += example_funcs.__all__
 __all__ += derivatives.__all__

--- a/odl/solvers/iterative/__init__.py
+++ b/odl/solvers/iterative/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2017 The ODL contributors
+# Copyright 2014-2020 The ODL contributors
 #
 # This file is part of ODL.
 #
@@ -10,10 +10,9 @@
 
 from __future__ import absolute_import
 
-__all__ = ()
-
 from .iterative import *
-__all__ += iterative.__all__
-
 from .statistical import *
+
+__all__ = ()
+__all__ += iterative.__all__
 __all__ += statistical.__all__

--- a/odl/solvers/nonsmooth/__init__.py
+++ b/odl/solvers/nonsmooth/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2017 The ODL contributors
+# Copyright 2014-2020 The ODL contributors
 #
 # This file is part of ODL.
 #
@@ -10,28 +10,21 @@
 
 from __future__ import absolute_import
 
-__all__ = ()
-
-from .proximal_operators import *
-__all__ += proximal_operators.__all__
-
 from .admm import *
-__all__ += admm.__all__
-
-from .primal_dual_hybrid_gradient import *
-__all__ += primal_dual_hybrid_gradient.__all__
-
-from .douglas_rachford import *
-__all__ += douglas_rachford.__all__
-
-from .forward_backward import *
-__all__ += forward_backward.__all__
-
-from .proximal_gradient_solvers import *
-__all__ += proximal_gradient_solvers.__all__
-
 from .alternating_dual_updates import *
-__all__ += alternating_dual_updates.__all__
-
 from .difference_convex import *
+from .douglas_rachford import *
+from .forward_backward import *
+from .primal_dual_hybrid_gradient import *
+from .proximal_gradient_solvers import *
+from .proximal_operators import *
+
+__all__ = ()
+__all__ += admm.__all__
+__all__ += alternating_dual_updates.__all__
 __all__ += difference_convex.__all__
+__all__ += douglas_rachford.__all__
+__all__ += forward_backward.__all__
+__all__ += primal_dual_hybrid_gradient.__all__
+__all__ += proximal_gradient_solvers.__all__
+__all__ += proximal_operators.__all__

--- a/odl/solvers/smooth/__init__.py
+++ b/odl/solvers/smooth/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2017 The ODL contributors
+# Copyright 2014-2020 The ODL contributors
 #
 # This file is part of ODL.
 #
@@ -10,13 +10,11 @@
 
 from __future__ import absolute_import
 
-__all__ = ()
-
 from .gradient import *
-__all__ += gradient.__all__
-
 from .newton import *
-__all__ += newton.__all__
-
 from .nonlinear_cg import *
+
+__all__ = ()
+__all__ += gradient.__all__
+__all__ += newton.__all__
 __all__ += nonlinear_cg.__all__

--- a/odl/solvers/util/__init__.py
+++ b/odl/solvers/util/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2017 The ODL contributors
+# Copyright 2014-2020 The ODL contributors
 #
 # This file is part of ODL.
 #
@@ -6,12 +6,13 @@
 # v. 2.0. If a copy of the MPL was not distributed with this file, You can
 # obtain one at https://mozilla.org/MPL/2.0/.
 
+"""Utilities for optimization."""
+
 from __future__ import absolute_import
 
-__all__ = ()
-
 from .callback import *
-__all__ += callback.__all__
-
 from .steplen import *
+
+__all__ = ()
+__all__ += callback.__all__
 __all__ += steplen.__all__

--- a/odl/space/__init__.py
+++ b/odl/space/__init__.py
@@ -10,17 +10,12 @@
 
 from __future__ import absolute_import
 
-__all__ = ()
-
-from . import base_tensors
-from . import entry_points
-from . import weighting
-
+from . import base_tensors, entry_points, weighting
 from .npy_tensors import *
-__all__ += npy_tensors.__all__
-
 from .pspace import *
-__all__ += pspace.__all__
-
 from .space_utils import *
+
+__all__ = ()
+__all__ += npy_tensors.__all__
+__all__ += pspace.__all__
 __all__ += space_utils.__all__

--- a/odl/tomo/__init__.py
+++ b/odl/tomo/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2017 The ODL contributors
+# Copyright 2014-2020 The ODL contributors
 #
 # This file is part of ODL.
 #
@@ -6,25 +6,21 @@
 # v. 2.0. If a copy of the MPL was not distributed with this file, You can
 # obtain one at https://mozilla.org/MPL/2.0/.
 
-"""Tomography related operators and geometries."""
-
+"""Tomography-related operators and geometries."""
 
 from __future__ import absolute_import
 
-__all__ = ()
-
-from .geometry import *
-__all__ += geometry.__all__
-
-from .operators import *
-__all__ += operators.__all__
-
 from .analytic import *
-__all__ += analytic.__all__
-
 from .backends import (
     ASTRA_AVAILABLE, ASTRA_CUDA_AVAILABLE, SKIMAGE_AVAILABLE,
     astra_conebeam_2d_geom_to_vec, astra_conebeam_3d_geom_to_vec)
+from .geometry import *
+from .operators import *
+
+__all__ = ()
+__all__ += analytic.__all__
+__all__ += geometry.__all__
+__all__ += operators.__all__
 __all__ += (
     'ASTRA_AVAILABLE',
     'ASTRA_CUDA_AVAILABLE',

--- a/odl/tomo/analytic/__init__.py
+++ b/odl/tomo/analytic/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2017 The ODL contributors
+# Copyright 2014-2020 The ODL contributors
 #
 # This file is part of ODL.
 #
@@ -8,10 +8,9 @@
 
 """Analytic (i.e. one-step) reconstruction methods."""
 
-
 from __future__ import absolute_import
 
-__all__ = ()
-
 from .filtered_back_projection import *
+
+__all__ = ()
 __all__ += filtered_back_projection.__all__

--- a/odl/tomo/backends/__init__.py
+++ b/odl/tomo/backends/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2017 The ODL contributors
+# Copyright 2014-2020 The ODL contributors
 #
 # This file is part of ODL.
 #
@@ -6,20 +6,17 @@
 # v. 2.0. If a copy of the MPL was not distributed with this file, You can
 # obtain one at https://mozilla.org/MPL/2.0/.
 
-"""Back-ends for other libraries."""
+"""Bindings to external libraries for tomography."""
 
 from __future__ import absolute_import
 
-__all__ = ()
-
-from .astra_setup import *
-__all__ += astra_setup.__all__
-
 from .astra_cpu import *
-__all__ += astra_cpu.__all__
-
 from .astra_cuda import *
-__all__ += astra_cuda.__all__
-
+from .astra_setup import *
 from .skimage_radon import *
+
+__all__ = ()
+__all__ += astra_cpu.__all__
+__all__ += astra_cuda.__all__
+__all__ += astra_setup.__all__
 __all__ += skimage_radon.__all__

--- a/odl/tomo/geometry/__init__.py
+++ b/odl/tomo/geometry/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2017 The ODL contributors
+# Copyright 2014-2020 The ODL contributors
 #
 # This file is part of ODL.
 #
@@ -6,22 +6,19 @@
 # v. 2.0. If a copy of the MPL was not distributed with this file, You can
 # obtain one at https://mozilla.org/MPL/2.0/.
 
+"""Tomographic geometries."""
+
 from __future__ import absolute_import
 
-__all__ = ()
-
-
-from .detector import *
-__all__ += detector.__all__
-
-from .geometry import *
-__all__ += geometry.__all__
-
-from .parallel import *
-__all__ += parallel.__all__
-
 from .conebeam import *
-__all__ += conebeam.__all__
-
+from .detector import *
+from .geometry import *
+from .parallel import *
 from .spect import *
+
+__all__ = ()
+__all__ += conebeam.__all__
+__all__ += detector.__all__
+__all__ += geometry.__all__
+__all__ += parallel.__all__
 __all__ += spect.__all__

--- a/odl/tomo/operators/__init__.py
+++ b/odl/tomo/operators/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2017 The ODL contributors
+# Copyright 2014-2020 The ODL contributors
 #
 # This file is part of ODL.
 #
@@ -6,10 +6,11 @@
 # v. 2.0. If a copy of the MPL was not distributed with this file, You can
 # obtain one at https://mozilla.org/MPL/2.0/.
 
+"""Tomography operators."""
+
 from __future__ import absolute_import
 
-__all__ = ()
-
-
 from .ray_trafo import *
+
+__all__ = ()
 __all__ += ray_trafo.__all__

--- a/odl/tomo/util/__init__.py
+++ b/odl/tomo/util/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2018 The ODL contributors
+# Copyright 2014-2020 The ODL contributors
 #
 # This file is part of ODL.
 #
@@ -6,11 +6,12 @@
 # v. 2.0. If a copy of the MPL was not distributed with this file, You can
 # obtain one at https://mozilla.org/MPL/2.0/.
 
+"""Utilities for tomography."""
+
 from __future__ import absolute_import
 
-__all__ = ()
-
-from .utility import *
-__all__ += utility.__all__
-
 from . import testutils
+from .utility import *
+
+__all__ = ()
+__all__ += utility.__all__

--- a/odl/trafos/__init__.py
+++ b/odl/trafos/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2017 The ODL contributors
+# Copyright 2014-2020 The ODL contributors
 #
 # This file is part of ODL.
 #
@@ -10,16 +10,12 @@
 
 from __future__ import absolute_import
 
-__all__ = ()
-
-from . import util
-
-from . import backends
+from . import backends, util
 from .backends import PYFFTW_AVAILABLE, PYWT_AVAILABLE
-__all__ += (PYFFTW_AVAILABLE, PYWT_AVAILABLE)
-
 from .fourier import *
-__all__ += fourier.__all__
-
 from .wavelet import *
+
+__all__ = ()
+__all__ += fourier.__all__
 __all__ += wavelet.__all__
+__all__ += ("PYFFTW_AVAILABLE", "PYWT_AVAILABLE")

--- a/odl/trafos/backends/__init__.py
+++ b/odl/trafos/backends/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2017 The ODL contributors
+# Copyright 2014-2020 The ODL contributors
 #
 # This file is part of ODL.
 #
@@ -6,14 +6,13 @@
 # v. 2.0. If a copy of the MPL was not distributed with this file, You can
 # obtain one at https://mozilla.org/MPL/2.0/.
 
-"""Bindings to external backends for transformations."""
+"""Bindings to external libraries for transformations."""
 
 from __future__ import absolute_import
 
+from .pyfftw_bindings import *
+from .pywt_bindings import *
+
 __all__ = ()
-
-from . pyfftw_bindings import *
 __all__ += pyfftw_bindings.__all__
-
-from . pywt_bindings import *
 __all__ += pywt_bindings.__all__

--- a/odl/trafos/util/__init__.py
+++ b/odl/trafos/util/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2017 The ODL contributors
+# Copyright 2014-2020 The ODL contributors
 #
 # This file is part of ODL.
 #
@@ -6,11 +6,11 @@
 # v. 2.0. If a copy of the MPL was not distributed with this file, You can
 # obtain one at https://mozilla.org/MPL/2.0/.
 
-"""Utility functions for transformations."""
+"""Utilities for transformations."""
 
 from __future__ import absolute_import
 
-__all__ = ()
-
 from .ft_utils import *
+
+__all__ = ()
 __all__ += ft_utils.__all__

--- a/odl/ufunc_ops/__init__.py
+++ b/odl/ufunc_ops/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2019 The ODL contributors
+# Copyright 2014-2020 The ODL contributors
 #
 # This file is part of ODL.
 #
@@ -10,7 +10,7 @@
 
 from __future__ import absolute_import
 
-__all__ = ()
-
 from .ufunc_ops import *
+
+__all__ = ()
 __all__ = ufunc_ops.__all__

--- a/odl/util/__init__.py
+++ b/odl/util/__init__.py
@@ -10,22 +10,19 @@
 
 from __future__ import absolute_import
 
-__all__ = ()
-
-from .utility import *
-from .npy_compat import *
-from .normalize import *
 from .graphics import *
+from .normalize import *
+from .npy_compat import *
 from .numerics import *
-from .vectorization import *
 from .testutils import *
+from .utility import *
+from .vectorization import *
 
-from . import ufuncs
-
-__all__ += utility.__all__
-__all__ += npy_compat.__all__
-__all__ += normalize.__all__
+__all__ = ()
 __all__ += graphics.__all__
+__all__ += normalize.__all__
+__all__ += npy_compat.__all__
 __all__ += numerics.__all__
-__all__ += vectorization.__all__
 __all__ += testutils.__all__
+__all__ += utility.__all__
+__all__ += vectorization.__all__


### PR DESCRIPTION
This PR puts the code mangling the `__all__` tuple last in each `__init__.py` file. This makes errors when `odl` cannot be imported easier to trace: before one would typically get an error like `AttributeError: set has no attribute __all__`. Now the traceback will contain the actual offending code.