### PR TITLE
TST: Fix largescale pytest mark issue

### DIFF
--- a/doc/source/dev/testing.rst
+++ b/doc/source/dev/testing.rst
@@ -116,7 +116,7 @@ Examples
 Examples, while not technically tests in the traditional sense, still constitute a part of the test framework for ODL by showing how different parts of ODL work together and by ensuring that functions that depend on each other work as expected.
 The main purpose of the examples is however to show ODL from a users perspective and particular care should be taken to keep them readable and working since this is often the first thing users see when they start using ODL.
 
-It is even possible to run all examples as part of the test suite by running ``pytest -S examples``, but be aware that this requires all ODL dependencies to be installed and that plotting windows can be opened during execution.
+It is even possible to run all examples as part of the test suite by running ``pytest -S examples``, but be aware that this requires all ODL dependencies to be installed and can take a long time.
 
 Consult the `examples`_ directory for an impression of the style in which ODL examples are written.
 

--- a/doc/source/dev/testing.rst
+++ b/doc/source/dev/testing.rst
@@ -11,7 +11,7 @@ ODL tests are run using pytest_, and there are several types:
 Name            Command                    Description
 ==============  =========================  =======
 Unit tests      ``pytest``                 Test "micro-features" of the code
-Large-scale     ``pytest --largescale``    Unit tests with large inputs and more cases
+Large-scale     ``pytest -S largescale``   Unit tests with large inputs and more cases
 Doctests        ``pytest``                 Validate usage examples in docstrings
 Examples        ``pytest --examples``      Run all examples in the `examples`_ folder
 Documentation   ``pytest --doctest-doc``   Run the doctest examples in the Sphinx documentation
@@ -33,7 +33,7 @@ For more information consult the `pytest`_ documentation and look at existing te
 
 
     def myfunction(x):
-        """Convert ``x`` to a integer and add 1"""
+        """Convert ``x`` to a integer and add 1."""
         return int(x) + 1
 
 

--- a/doc/source/dev/testing.rst
+++ b/doc/source/dev/testing.rst
@@ -7,15 +7,15 @@ Testing in ODL
 ODL tests are run using pytest_, and there are several types:
 
 
-==============  =========================  =======
-Name            Command                    Description
-==============  =========================  =======
-Unit tests      ``pytest``                 Test "micro-features" of the code
-Large-scale     ``pytest -S largescale``   Unit tests with large inputs and more cases
-Doctests        ``pytest``                 Validate usage examples in docstrings
-Examples        ``pytest --examples``      Run all examples in the `examples`_ folder
-Documentation   ``pytest --doctest-doc``   Run the doctest examples in the Sphinx documentation
-==============  =========================  =======
+==============  ==========================  =======
+Name            Command                     Description
+==============  ==========================  =======
+Unit tests      ``pytest``                  Test "micro-features" of the code
+Large-scale     ``pytest -S largescale``    Unit tests with large inputs and more cases
+Doctests        ``pytest``                  Validate usage examples in docstrings
+Examples        ``pytest -S examples``      Run all examples in the `examples`_ folder
+Documentation   ``pytest -S doc_doctests``  Run the doctest examples in the Sphinx documentation
+==============  ==========================  =======
 
 Unit tests
 ~~~~~~~~~~
@@ -116,7 +116,7 @@ Examples
 Examples, while not technically tests in the traditional sense, still constitute a part of the test framework for ODL by showing how different parts of ODL work together and by ensuring that functions that depend on each other work as expected.
 The main purpose of the examples is however to show ODL from a users perspective and particular care should be taken to keep them readable and working since this is often the first thing users see when they start using ODL.
 
-It is even possible to run all examples as part of the test suite by running ``pytest --examples``, but be aware that this requires all ODL dependencies to be installed and that plotting windows can be opened during execution.
+It is even possible to run all examples as part of the test suite by running ``pytest -S examples``, but be aware that this requires all ODL dependencies to be installed and that plotting windows can be opened during execution.
 
 Consult the `examples`_ directory for an impression of the style in which ODL examples are written.
 

--- a/odl/pytest.ini
+++ b/odl/pytest.ini
@@ -1,5 +1,4 @@
 [pytest]
-minversion = 5.4.0
 testpaths = odl
 doctest_optionflags = NORMALIZE_WHITESPACE IGNORE_EXCEPTION_DETAIL ELLIPSIS
 addopts = --doctest-modules --strict-markers

--- a/odl/pytest.ini
+++ b/odl/pytest.ini
@@ -1,15 +1,11 @@
 [pytest]
-minversion = 3.0.3
-markers = not benchmark and not largescale
+minversion = 5.4.0
 testpaths = odl
 doctest_optionflags = NORMALIZE_WHITESPACE IGNORE_EXCEPTION_DETAIL ELLIPSIS
-addopts = --doctest-modules
+addopts = --doctest-modules --strict-markers
 xfail_strict=true
 
 # PEP8
 pep8ignore =
     E402
 pep8maxlinelength = 79
-# Temporary fix for https://github.com/odlgroup/odl/issues/1514, works with pytest<5.1
-filterwarnings =
-    ignore::pytest.PytestDeprecationWarning

--- a/odl/test/largescale/solvers/nonsmooth/default_functionals_slow_test.py
+++ b/odl/test/largescale/solvers/nonsmooth/default_functionals_slow_test.py
@@ -282,4 +282,4 @@ def test_proximal_convex_conj_kl_cross_entropy_solving_opt_problem():
 
 
 if __name__ == '__main__':
-    odl.util.test_file(__file__, ['-S', 'slow'])
+    odl.util.test_file(__file__, ['-S', 'largescale'])

--- a/odl/test/largescale/solvers/nonsmooth/default_functionals_slow_test.py
+++ b/odl/test/largescale/solvers/nonsmooth/default_functionals_slow_test.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2019 The ODL contributors
+# Copyright 2014-2020 The ODL contributors
 #
 # This file is part of ODL.
 #
@@ -16,14 +16,13 @@ import scipy.special
 
 import odl
 from odl.solvers.functional.functional import FunctionalDefaultConvexConjugate
-from odl.util.testutils import (
-    all_almost_equal, noise_element, simple_fixture, skip_if_no_largescale)
-
+from odl.util.testutils import all_almost_equal, noise_element, simple_fixture
 
 # --- pytest fixtures --- #
 
 
-pytestmark = skip_if_no_largescale
+# Global pytest mark
+pytestmark = pytest.mark.suite('largescale')
 
 
 stepsize = simple_fixture('stepsize', [0.1, 1.0, 10.0])
@@ -72,8 +71,11 @@ def functional(request, linear_offset, quadratic_offset, dual):
                                        outer_exp=outer_exp,
                                        singular_vector_exp=singular_vector_exp)
     elif name == 'quadratic':
-        func = odl.solvers.QuadraticForm(operator=odl.IdentityOperator(space),
-                                         vector=space.one(), constant=0.623)
+        func = odl.solvers.QuadraticForm(
+            operator=odl.IdentityOperator(space),
+            vector=space.one(),
+            constant=0.623,
+        )
     elif name == 'linear':
         func = odl.solvers.QuadraticForm(vector=space.one(), constant=0.623)
     elif name == 'huber':
@@ -91,7 +93,8 @@ def functional(request, linear_offset, quadratic_offset, dual):
 
         quadratic_coeff = 1.32
         func = odl.solvers.FunctionalQuadraticPerturb(
-            func, quadratic_coeff=quadratic_coeff, linear_term=g)
+            func, quadratic_coeff=quadratic_coeff, linear_term=g
+        )
 
     elif linear_offset:
         g = noise_element(space)
@@ -279,4 +282,4 @@ def test_proximal_convex_conj_kl_cross_entropy_solving_opt_problem():
 
 
 if __name__ == '__main__':
-    odl.util.test_file(__file__, ['--largescale'])
+    odl.util.test_file(__file__, ['-S', 'slow'])

--- a/odl/test/largescale/space/tensor_space_slow_test.py
+++ b/odl/test/largescale/space/tensor_space_slow_test.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2019 The ODL contributors
+# Copyright 2014-2020 The ODL contributors
 #
 # This file is part of ODL.
 #
@@ -14,14 +14,13 @@ import numpy as np
 import pytest
 
 import odl
-from odl.util.testutils import (
-    all_almost_equal, dtype_tol, noise_elements, skip_if_no_largescale)
-
+from odl.util.testutils import all_almost_equal, dtype_tol, noise_elements
 
 # --- pytest fixtures --- #
 
 
-pytestmark = skip_if_no_largescale
+# Global pytest mark
+pytestmark = pytest.mark.suite('largescale')
 
 
 spc_params = ['rn', '1d', '3d']
@@ -333,4 +332,4 @@ def test_operators(tspace):
 
 
 if __name__ == '__main__':
-    odl.util.test_file(__file__)
+    odl.util.test_file(__file__, ['-S', 'largescale'])

--- a/odl/test/largescale/tomo/analytic_slow_test.py
+++ b/odl/test/largescale/tomo/analytic_slow_test.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2017 The ODL contributors
+# Copyright 2014-2020 The ODL contributors
 #
 # This file is part of ODL.
 #
@@ -17,13 +17,13 @@ import odl
 import odl.tomo as tomo
 from odl.tomo.util.testutils import (
     skip_if_no_astra, skip_if_no_astra_cuda, skip_if_no_skimage)
-from odl.util.testutils import simple_fixture, skip_if_no_largescale
-
+from odl.util.testutils import simple_fixture
 
 # --- pytest fixtures --- #
 
 
-pytestmark = skip_if_no_largescale
+# Global pytest mark
+pytestmark = pytest.mark.suite('largescale')
 
 
 filter_type = simple_fixture(
@@ -230,4 +230,4 @@ def test_fbp_reconstruction_filters(filter_type, frequency_scaling, weighting):
 
 
 if __name__ == '__main__':
-    odl.util.test_file(__file__, ['--largescale'])
+    odl.util.test_file(__file__, ['-S', 'largescale'])

--- a/odl/test/largescale/tomo/ray_transform_slow_test.py
+++ b/odl/test/largescale/tomo/ray_transform_slow_test.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2019 The ODL contributors
+# Copyright 2014-2020 The ODL contributors
 #
 # This file is part of ODL.
 #
@@ -17,13 +17,13 @@ from packaging.version import parse as parse_version
 import odl
 from odl.tomo.util.testutils import (
     skip_if_no_astra, skip_if_no_astra_cuda, skip_if_no_skimage)
-from odl.util.testutils import simple_fixture, skip_if_no_largescale
-
+from odl.util.testutils import all_almost_equal, simple_fixture
 
 # --- pytest fixtures --- #
 
 
-pytestmark = skip_if_no_largescale
+# Global pytest mark
+pytestmark = pytest.mark.suite('largescale')
 
 
 dtype_params = ['float32', 'float64', 'complex64']
@@ -212,7 +212,7 @@ def test_adjoint_of_adjoint(projector):
     proj_adj_adj_adj = projector.adjoint.adjoint.adjoint(proj)
 
     # Verify A^*(y) == ((A^*)^*)^*(x)
-    assert proj_adj == proj_adj_adj_adj
+    assert all_almost_equal(proj_adj, proj_adj_adj_adj)
 
 
 def test_reconstruction(projector):
@@ -243,4 +243,4 @@ def test_reconstruction(projector):
 
 
 if __name__ == '__main__':
-    odl.util.test_file(__file__, ['--largescale'])
+    odl.util.test_file(__file__, ['-S', 'largescale'])

--- a/odl/test/largescale/trafos/fourier_slow_test.py
+++ b/odl/test/largescale/trafos/fourier_slow_test.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2019 The ODL contributors
+# Copyright 2014-2020 The ODL contributors
 #
 # This file is part of ODL.
 #
@@ -18,14 +18,13 @@ import numpy as np
 import pytest
 
 import odl
-from odl.util.testutils import (
-    simple_fixture, skip_if_no_largescale, skip_if_no_pyfftw)
-
+from odl.util.testutils import simple_fixture, skip_if_no_pyfftw
 
 # --- pytest fixtures --- #
 
 
-pytestmark = skip_if_no_largescale
+# Global pytest mark
+pytestmark = pytest.mark.suite('largescale')
 
 
 impl = simple_fixture(
@@ -85,4 +84,4 @@ def test_fourier_trafo_forward_complex(domain, impl):
 
 
 if __name__ == '__main__':
-    odl.util.test_file(__file__, ['--largescale'])
+    odl.util.test_file(__file__, ['-S', 'largescale'])

--- a/odl/test/space/tensors_test.py
+++ b/odl/test/space/tensors_test.py
@@ -93,10 +93,7 @@ weight_params = [1.0, 0.5, _pos_array(odl.tensor_space((3, 4)))]
 weight_ids = [' weight=1.0 ', ' weight=0.5 ', ' weight=<array> ']
 
 
-# scope='module' removed due to pytest issue, see
-# https://github.com/pytest-dev/pytest/issues/6497
-# TODO: re-introduce when fixed
-@pytest.fixture(params=weight_params, ids=weight_ids)
+@pytest.fixture(scope='module', params=weight_params, ids=weight_ids)
 def weight(request):
     return request.param
 
@@ -108,7 +105,7 @@ def tspace(odl_floating_dtype, odl_tspace_impl):
     return odl.tensor_space(shape=(3, 4), dtype=dtype, impl=impl)
 
 
-# --- Space classes --- #
+# --- Tests --- #
 
 
 def test_init_npy_tspace():
@@ -451,8 +448,8 @@ def test_lincomb_discontig(odl_tspace_impl):
             _test_lincomb(tspace, a, b, discontig=True)
 
 
-def test_lincomb_raise(tspace):
-    """Test if lincomb raises correctly for bad input."""
+def test_lincomb_exceptions(tspace):
+    """Test whether lincomb raises correctly for bad output element."""
     other_space = odl.rn((4, 3), impl=tspace.impl)
 
     other_x = other_space.zero()

--- a/odl/test/test_doc.py
+++ b/odl/test/test_doc.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2018 The ODL contributors
+# Copyright 2014-2020 The ODL contributors
 #
 # This file is part of ODL.
 #
@@ -16,26 +16,26 @@ This test file assumes that all dependencies are installed.
 """
 
 from __future__ import division
+
 import doctest
-from doctest import IGNORE_EXCEPTION_DETAIL, ELLIPSIS, NORMALIZE_WHITESPACE
 import os
+from doctest import ELLIPSIS, IGNORE_EXCEPTION_DETAIL, NORMALIZE_WHITESPACE
+
+import numpy
 import pytest
+
+import odl
+from odl.util.testutils import simple_fixture
+
 try:
     import matplotlib
-    matplotlib.use('Agg')  # To avoid the backend freezing
+    matplotlib.use('agg')  # prevent backend from freezing
     import matplotlib.pyplot as plt
 except ImportError:
     pass
 
-# Modules to be added to testing globals
-import numpy
-import odl
-try:
-    import proximal
-except ImportError:
-    proximal = None
 
-doctest_extraglobs = {'odl': odl, 'np': numpy, 'proximal': proximal}
+doctest_extraglobs = {'odl': odl, 'np': numpy}
 
 root_dir = os.path.join(os.path.abspath(os.path.dirname(__file__)),
                         os.pardir, os.pardir, 'doc', 'source')
@@ -55,13 +55,10 @@ for test_dir in test_dirs:
                 doc_src_files.append(os.path.join(path, filename))
 
 
-@pytest.fixture(scope="module", ids=doc_src_files, params=doc_src_files)
-def doc_src_file(request):
-    return request.param
+doc_src_file = simple_fixture("doc_src_file", doc_src_files)
 
 
-@pytest.mark.skipif("not pytest.config.getoption('--doctest-doc')",
-                    reason='Need --doctest-doc option to run')
+@pytest.mark.suite("doc_doctests")
 def test_file(doc_src_file):
     # FIXXXME: This doesn't seem to actually test the file :-(
     doctest.testfile(doc_src_file, module_relative=False, report=True,

--- a/odl/test/test_examples.py
+++ b/odl/test/test_examples.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2017 The ODL contributors
+# Copyright 2014-2020 The ODL contributors
 #
 # This file is part of ODL.
 #
@@ -19,10 +19,14 @@ This package assumes that all dependencies are installed.
 """
 
 from __future__ import division
+
 import os
-import pytest
 import sys
+
+import pytest
+
 import odl
+from odl.util.testutils import simple_fixture
 
 try:
     import matplotlib
@@ -36,23 +40,18 @@ ignore_prefix = ['proximal_lang']
 # Make a fixture for all examples
 here = os.path.dirname(os.path.abspath(__file__))
 examples_path = os.path.join(here, os.path.pardir, os.path.pardir, 'examples')
-example_ids = []
 example_params = []
 for dirpath, dirnames, filenames in os.walk(examples_path):
     for filename in [f for f in filenames
                      if f.endswith('.py') and
                      not any(f.startswith(pre) for pre in ignore_prefix)]:
         example_params.append(os.path.join(dirpath, filename))
-        example_ids.append(filename[:-3])  # skip .py
 
 
-@pytest.fixture(scope="module", ids=example_ids, params=example_params)
-def example(request):
-    return request.param
+example = simple_fixture("example", example_params)
 
 
-@pytest.mark.skipif("not pytest.config.getoption('--examples')",
-                    reason='Need --examples option to run')
+@pytest.mark.suite("examples")
 def test_example(example):
     if (sys.version_info.major, sys.version_info.minor) <= (3, 3):
         # The `imp` module is deprecated since 3.4

--- a/odl/test/util/normalize_test.py
+++ b/odl/test/util/normalize_test.py
@@ -22,10 +22,6 @@ from odl.util.testutils import simple_fixture
 length = simple_fixture('length', [1, 2])
 
 
-# For this and other fixtures below:
-# scope='module' removed due to pytest issue, see
-# https://github.com/pytest-dev/pytest/issues/6497
-# TODO: re-introduce when fixed
 single_conv_params = [(-1.0, float),
                       (2, float),
                       ('10', float),
@@ -41,7 +37,7 @@ single_conv_ids = [' input = {0[0]}, conv = {0[1]} '.format(p)
                    for p in single_conv_params]
 
 
-@pytest.fixture(ids=single_conv_ids, params=single_conv_params)
+@pytest.fixture(scope='module', ids=single_conv_ids, params=single_conv_params)
 def single_conv(request):
     return request.param
 
@@ -64,7 +60,7 @@ seq_conv_ids = [' input = {0[0]}, conv = {0[1]} '.format(p)
                 for p in seq_conv_params]
 
 
-@pytest.fixture(ids=seq_conv_ids, params=seq_conv_params)
+@pytest.fixture(scope='module', ids=seq_conv_ids, params=seq_conv_params)
 def seq_conv(request):
     return request.param
 
@@ -82,7 +78,7 @@ axes_conv_ids = [' axes={0[0]}, conv={0[1]} '.format(axis)
                  for axis in axes_conv_params]
 
 
-@pytest.fixture(ids=axes_conv_ids, params=axes_conv_params)
+@pytest.fixture(scope='module', ids=axes_conv_ids, params=axes_conv_params)
 def axes_conv(request):
     return request.param
 

--- a/odl/util/pytest_config.py
+++ b/odl/util/pytest_config.py
@@ -87,7 +87,13 @@ def pytest_addoption(parser):
         'Available suites: largescale, examples, doc_doctests'
     )
     parser.addoption(
-        '-S', '--suite', nargs='*', metavar='NAME', type=str, help=suite_help
+        '-S',
+        '--suite',
+        nargs='*',
+        metavar='NAME',
+        type=str,
+        default=[],
+        help=suite_help,
     )
 
 

--- a/odl/util/pytest_config.py
+++ b/odl/util/pytest_config.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2019 The ODL contributors
+# Copyright 2014-2020 The ODL contributors
 #
 # This file is part of ODL.
 #
@@ -8,10 +8,13 @@
 
 """Test configuration file."""
 
-from __future__ import print_function, division, absolute_import
-import numpy as np
+from __future__ import absolute_import, division, print_function
+
 import operator
 import os
+from os import path
+
+import numpy as np
 
 import odl
 from odl.space.entry_points import tensor_space_impl_names
@@ -19,10 +22,16 @@ from odl.trafos.backends import PYFFTW_AVAILABLE, PYWT_AVAILABLE
 from odl.util.testutils import simple_fixture
 
 try:
+    import pytest
     from pytest import fixture
 except ImportError:
-    # Make fixture the identity decorator (default of OptionalArgDecorator)
-    from odl.util.utility import OptionalArgDecorator as fixture
+    pytest = None
+
+    # Identity fixture
+    def fixture(*arg, **kw):
+        if arg and callable(arg[0]):
+            return arg[0]
+        return fixture
 
 
 # --- Add numpy and ODL to all doctests ---
@@ -34,26 +43,13 @@ def _add_doctest_np_odl(doctest_namespace):
     doctest_namespace['odl'] = odl
 
 
-def pytest_addoption(parser):
-    parser.addoption('--largescale', action='store_true',
-                     help='Run large and slow tests')
-
-    parser.addoption('--benchmark', action='store_true',
-                     help='Run benchmarks')
-
-    parser.addoption('--examples', action='store_true',
-                     help='Run examples')
-
-    parser.addoption('--doctest-doc', action='store_true',
-                     help='Run doctests in the documentation')
-
-
 # --- Ignored tests due to missing modules ---
 
-this_dir = os.path.dirname(__file__)
-odl_root = os.path.abspath(os.path.join(this_dir, os.pardir, os.pardir))
-collect_ignore = [os.path.join(odl_root, 'setup.py'),
-                  os.path.join(odl_root, 'odl', 'contrib')]
+
+this_dir = path.dirname(__file__)
+odl_root = path.abspath(path.join(this_dir, '..', '..'))
+collect_ignore = [path.join(odl_root, 'setup.py'),
+                  path.join(odl_root, 'odl', 'contrib')]
 
 
 # Add example directories to `collect_ignore`
@@ -61,7 +57,7 @@ def find_example_dirs():
     dirs = []
     for dirpath, dirnames, _ in os.walk(odl_root):
         if 'examples' in dirnames:
-            dirs.append(os.path.join(dirpath, 'examples'))
+            dirs.append(path.join(dirpath, 'examples'))
     return dirs
 
 
@@ -70,22 +66,55 @@ collect_ignore.extend(find_example_dirs())
 
 if not PYFFTW_AVAILABLE:
     collect_ignore.append(
-        os.path.join(odl_root, 'odl', 'trafos', 'backends',
-                     'pyfftw_bindings.py'))
+        path.join(odl_root, 'odl', 'trafos', 'backends', 'pyfftw_bindings.py')
+    )
 if not PYWT_AVAILABLE:
     collect_ignore.append(
-        os.path.join(odl_root, 'odl', 'trafos', 'backends',
-                     'pywt_bindings.py'))
+        path.join(odl_root, 'odl', 'trafos', 'backends', 'pywt_bindings.py')
+    )
     # Currently `pywt` is the only implementation
     collect_ignore.append(
-        os.path.join(odl_root, 'odl', 'trafos', 'wavelet.py'))
+        path.join(odl_root, 'odl', 'trafos', 'wavelet.py')
+    )
+
+
+# --- Command-line options --- #
+
+
+def pytest_addoption(parser):
+    suite_help = (
+        'enable an opt-in test suite NAME. Available suites: largescale'
+    )
+    parser.addoption(
+        '-S', '--suite', action='store', metavar='NAME', help=suite_help
+    )
+    parser.addoption('--examples', action='store_true', help='Run examples')
+    doctest_help = 'Run doctests in the documentation'
+    parser.addoption(
+        '--doctest-doc', action='store_true', help=doctest_help
+    )
+
+
+def pytest_configure(config):
+    # Register an additional marker
+    config.addinivalue_line(
+        'markers', 'suite(name): mark test to belong to an opt-in suite'
+    )
+
+
+def pytest_runtest_setup(item):
+    suites = [mark.args[0] for mark in item.iter_markers(name='suite')]
+    if suites:
+        if item.config.getoption("-S") not in suites:
+            pytest.skip('test not in suites {!r}'.format(suites))
 
 
 # Remove duplicates
 collect_ignore = list(set(collect_ignore))
-collect_ignore = [os.path.normcase(ignored) for ignored in collect_ignore]
+collect_ignore = [path.normcase(ignored) for ignored in collect_ignore]
 
 
+# NB: magical `path` param name is needed
 def pytest_ignore_collect(path, config):
     normalized = os.path.normcase(str(path))
     return any(normalized.startswith(ignored) for ignored in collect_ignore)

--- a/odl/util/pytest_config.py
+++ b/odl/util/pytest_config.py
@@ -88,11 +88,6 @@ def pytest_addoption(parser):
     parser.addoption(
         '-S', '--suite', action='store', metavar='NAME', help=suite_help
     )
-    parser.addoption('--examples', action='store_true', help='Run examples')
-    doctest_help = 'Run doctests in the documentation'
-    parser.addoption(
-        '--doctest-doc', action='store_true', help=doctest_help
-    )
 
 
 def pytest_configure(config):

--- a/odl/util/pytest_config.py
+++ b/odl/util/pytest_config.py
@@ -83,10 +83,11 @@ if not PYWT_AVAILABLE:
 
 def pytest_addoption(parser):
     suite_help = (
-        'enable an opt-in test suite NAME. Available suites: largescale'
+        'enable an opt-in test suite NAME. '
+        'Available suites: largescale, examples, doc_doctests'
     )
     parser.addoption(
-        '-S', '--suite', action='store', metavar='NAME', help=suite_help
+        '-S', '--suite', nargs='*', metavar='NAME', type=str, help=suite_help
     )
 
 
@@ -100,7 +101,7 @@ def pytest_configure(config):
 def pytest_runtest_setup(item):
     suites = [mark.args[0] for mark in item.iter_markers(name='suite')]
     if suites:
-        if item.config.getoption("-S") not in suites:
+        if not any(val in suites for val in item.config.getoption('-S')):
             pytest.skip('test not in suites {!r}'.format(suites))
 
 

--- a/odl/util/testutils.py
+++ b/odl/util/testutils.py
@@ -30,8 +30,6 @@ __all__ = (
     'is_subdict',
     'skip_if_no_pyfftw',
     'skip_if_no_pywavelets',
-    'skip_if_no_largescale',
-    'skip_if_no_benchmark',
     'simple_fixture',
     'noise_array',
     'noise_element',
@@ -201,7 +199,6 @@ def is_subdict(subdict, dictionary):
 
 
 try:
-    # Try catch in case user does not have pytest
     import pytest
 
 except ImportError:
@@ -214,8 +211,6 @@ except ImportError:
 
     skip_if_no_pyfftw = identity
     skip_if_no_pywavelets = identity
-    skip_if_no_largescale = identity
-    skip_if_no_benchmark = identity
 
 else:
     # Mark decorators for test parameters
@@ -226,14 +221,6 @@ else:
     skip_if_no_pywavelets = pytest.mark.skipif(
         'not odl.trafos.PYWT_AVAILABLE',
         reason='PyWavelets not available',
-    )
-    skip_if_no_largescale = pytest.mark.skipif(
-        "not pytest.config.getoption('--largescale')",
-        reason='--largescale option not given',
-    )
-    skip_if_no_benchmark = pytest.mark.skipif(
-        "not pytest.config.getoption('--benchmark')",
-        reason='--benchmark option not given',
     )
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -45,7 +45,8 @@ install_requires =
     scipy >=0.14
 python_requires = >=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*
 tests_require =
-    pytest >=5.4.0
+    pytest >=3.1, <5.0 ; python_version <= "2.7"
+    pytest >=5.4.0 ; python_version >= "3"
     coverage >=4.0
     coveralls
 include_package_data = True
@@ -60,11 +61,13 @@ tests = odl/test, odl/pytest.ini
 
 [options.extras_require]
 testing =
-    pytest >=5.4.0
+    pytest >=3.1, <5.0 ; python_version <= "2.7"
+    pytest >=5.4.0 ; python_version >= "3"
     coverage >=4.0
     coveralls
 all =
-    pytest >=5.4.0
+    pytest >=3.1, <5.0 ; python_version <= "2.7"
+    pytest >=5.4.0 ; python_version >= "3"
     coverage >=4.0
     coveralls
     matplotlib
@@ -80,7 +83,6 @@ pytest11 = odl_plugins=odl.util.pytest_config
 universal = 1
 
 [tool:pytest]
-minversion = 5.4.0
 testpaths = odl
 doctest_optionflags = NORMALIZE_WHITESPACE IGNORE_EXCEPTION_DETAIL ELLIPSIS
 addopts = --doctest-modules --strict-markers

--- a/setup.cfg
+++ b/setup.cfg
@@ -44,9 +44,8 @@ install_requires =
     numpy >=1.13.3, !=1.14.0, !=1.14.1, !=1.14.2
     scipy >=0.14
 python_requires = >=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*
-# pytest upper limit due to https://github.com/odlgroup/odl/issues/1514
 tests_require =
-    pytest >=3.0.3, <5.1
+    pytest >=5.4.0
     coverage >=4.0
     coveralls
 include_package_data = True
@@ -60,13 +59,12 @@ exclude =
 tests = odl/test, odl/pytest.ini
 
 [options.extras_require]
-# pytest upper limit due to https://github.com/odlgroup/odl/issues/1514
 testing =
-    pytest >=3.0.3, <5.1
+    pytest >=5.4.0
     coverage >=4.0
     coveralls
 all =
-    pytest >=3.0.3, <5.1
+    pytest >=5.4.0
     coverage >=4.0
     coveralls
     matplotlib
@@ -82,16 +80,11 @@ pytest11 = odl_plugins=odl.util.pytest_config
 universal = 1
 
 [tool:pytest]
-minversion = 3.0.3
-markers = not benchmark and not largescale
+minversion = 5.4.0
 testpaths = odl
 doctest_optionflags = NORMALIZE_WHITESPACE IGNORE_EXCEPTION_DETAIL ELLIPSIS
-addopts = --doctest-modules
+addopts = --doctest-modules --strict-markers
 xfail_strict=true
-# Temporary fix for https://github.com/odlgroup/odl/issues/1514 and
-# https://github.com/odlgroup/odl/issues/1532. Works with pytest<5.1
-filterwarnings =
-    ignore::pytest.PytestDeprecationWarning
 
 [tool:isort]
 # Options: https://github.com/timothycrosley/isort#configuring-isort

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,6 +33,7 @@ classifiers =
     Programming Language :: Python :: 3.5
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
     Operating System :: OS Independent
 
 [options]


### PR DESCRIPTION
We change the command-line option to a version recommended in
the pytest docs:
https://docs.pytest.org/en/latest/example/markers.html#custom-marker-and-command-line-option-to-control-test-runs

- A global `suite(name)` mark is registered, that takes a
  name and marks a test as belonging to a specific suite.
- These special suites are opt-in, i.e., not run by default.
- To enable a suite, one adds `-S name` to the pytest
  command-line options.
- Since function-scoped fixtures are handled stricter now,
  the workaround in tensors_test.py didn't work any longer
  (see https://github.com/pytest-dev/pytest/issues/6497).
- We thus set the minimum pytest version to 5.4.0, where the
  fix for the issue is implemented.

Closes: #1514