### PR TITLE
Fixed off-by-one error in CallbackProgressBar

### DIFF
--- a/odl/solvers/util/callback.py
+++ b/odl/solvers/util/callback.py
@@ -1014,10 +1014,9 @@ class CallbackProgressBar(Callback):
 
     def __call__(self, _):
         """Update the progressbar."""
+        self.iter += 1
         if self.iter % self.step == 0:
             self.pbar.update(self.step)
-
-        self.iter += 1
 
     def reset(self):
         """Set `iter` to 0."""


### PR DESCRIPTION
After the first iteration tqdm is called even if e.g. `step=10` and tqdm assumes that already 10 iterations have taken place (so actually it is an off-by-(`step-1`) error). This overestimates the iteration speed and the process bar is wrong as well.