### PR TITLE
Use pip 2020-resolver for dependencies in travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,6 +48,7 @@ install:
         wget -q https://repo.continuum.io/miniconda/Miniconda2-latest-Linux-x86_64.sh -O miniconda.sh;
       else
         wget -q https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
+        PIP_2020_DEPENDENCY_RESOLVER_FLAG='--use-feature=2020-resolver'
       fi
     - bash miniconda.sh -b -p $HOME/miniconda
     - export PATH="$HOME/miniconda/bin:$PATH"
@@ -61,7 +62,7 @@ install:
     - conda create -n testenv python=$TRAVIS_PYTHON_VERSION nomkl
     - source activate testenv
     # Install packages with pip if possible, it's way faster
-    - pip install --use-feature=2020-resolver "numpy==$NUMPY_VERSION" scipy future packaging scikit-image pywavelets;
+    - pip install "$PIP_2020_DEPENDENCY_RESOLVER_FLAG" "numpy==$NUMPY_VERSION" scipy future packaging scikit-image pywavelets;
     # Building pyfftw wheels sometimes fails, using a conda-forge version instead;
     # To avoid a lower version of NumPy being installed over the pip one, we exclude all dependencies
     # (PyFFTW only depends on NumPy)

--- a/.travis.yml
+++ b/.travis.yml
@@ -61,7 +61,7 @@ install:
     - conda create -n testenv python=$TRAVIS_PYTHON_VERSION nomkl
     - source activate testenv
     # Install packages with pip if possible, it's way faster
-    - pip install "$PIP_2020_DEPENDENCY_RESOLVER_FLAG" "numpy==$NUMPY_VERSION" scipy future packaging scikit-image pywavelets;
+    - pip install $PIP_2020_DEPENDENCY_RESOLVER_FLAG "numpy==$NUMPY_VERSION" scipy future packaging scikit-image pywavelets;
     # Building pyfftw wheels sometimes fails, using a conda-forge version instead;
     # To avoid a lower version of NumPy being installed over the pip one, we exclude all dependencies
     # (PyFFTW only depends on NumPy)

--- a/.travis.yml
+++ b/.travis.yml
@@ -61,7 +61,7 @@ install:
     - conda create -n testenv python=$TRAVIS_PYTHON_VERSION nomkl
     - source activate testenv
     # Install packages with pip if possible, it's way faster
-    - pip install "numpy==$NUMPY_VERSION" scipy future packaging scikit-image pywavelets;
+    - pip install --use-feature=2020-resolver "numpy==$NUMPY_VERSION" scipy future packaging scikit-image pywavelets;
     # Building pyfftw wheels sometimes fails, using a conda-forge version instead;
     # To avoid a lower version of NumPy being installed over the pip one, we exclude all dependencies
     # (PyFFTW only depends on NumPy)

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ matrix:
 
         # Using Python 3.6 as main version due to availability of wheels (SciPy, NumPy, ...)
         - python: 3.6
-          env: NUMPY_VERSION=1.13.3
+          env: NUMPY_VERSION='1.13.3' PIP_2020_DEPENDENCY_RESOLVER_FLAG='--use-feature=2020-resolver'
 
         - python: 3.6
           env: NUMPY_VERSION='1.14.*'
@@ -48,7 +48,6 @@ install:
         wget -q https://repo.continuum.io/miniconda/Miniconda2-latest-Linux-x86_64.sh -O miniconda.sh;
       else
         wget -q https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
-        PIP_2020_DEPENDENCY_RESOLVER_FLAG='--use-feature=2020-resolver'
       fi
     - bash miniconda.sh -b -p $HOME/miniconda
     - export PATH="$HOME/miniconda/bin:$PATH"


### PR DESCRIPTION
Hopefully the new dependency resolver will correctly identify that `NUMPY_VERSION=1.13.3` is incompatible with `scipy=1.5.2` and maybe even install the correct one