### PR TITLE
Skip 3d source shift test if no ASTRA CUDA available

### DIFF
--- a/odl/test/tomo/operators/ray_trafo_test.py
+++ b/odl/test/tomo/operators/ray_trafo_test.py
@@ -530,6 +530,7 @@ def test_detector_shifts_2d():
     rel_error = np.max(error[im > 0] / im[im > 0])
     assert rel_error < space.cell_volume
 
+
 def test_source_shifts_2d():
     """Check that source shifts are handled correctly.
 
@@ -618,8 +619,8 @@ def test_detector_shifts_3d():
     and back-projection with and without detector shifts are
     numerically close (the error depends on domain discretization).
     """
-    if not odl.tomo.ASTRA_AVAILABLE:
-        pytest.skip(msg='ASTRA not available, skipping 2d test')
+    if not odl.tomo.ASTRA_CUDA_AVAILABLE:
+        pytest.skip(msg='ASTRA CUDA required but not available')
 
     d = 100
     space = odl.uniform_discr([-1] * 3, [1] * 3, [d] * 3)

--- a/odl/test/tomo/operators/ray_trafo_test.py
+++ b/odl/test/tomo/operators/ray_trafo_test.py
@@ -489,7 +489,7 @@ def test_detector_shifts_2d():
 
     d = 10
     space = odl.uniform_discr([-1] * 2, [1] * 2, [d] * 2)
-    phantom = odl.phantom.cuboid(space, [-1/3] * 2, [1/3] * 2)
+    phantom = odl.phantom.cuboid(space, [-1 / 3] * 2, [1 / 3] * 2)
 
     full_angle = 2 * np.pi
     n_angles = 2 * 10
@@ -500,9 +500,10 @@ def test_detector_shifts_2d():
     geom = odl.tomo.FanBeamGeometry(apart, dpart, src_rad, det_rad)
     k = 3
     shift = k * dpart.cell_sides[0]
-    geom_shift = odl.tomo.FanBeamGeometry(apart, dpart, src_rad, det_rad,
-                                          det_shift_func=
-                                          lambda angle: [0.0, shift])
+    geom_shift = odl.tomo.FanBeamGeometry(
+        apart, dpart, src_rad, det_rad,
+        det_shift_func=lambda angle: [0.0, shift]
+    )
 
     assert all_almost_equal(geom.angles, geom_shift.angles)
     angles = geom.angles
@@ -545,7 +546,7 @@ def test_source_shifts_2d():
 
     d = 10
     space = odl.uniform_discr([-1] * 2, [1] * 2, [d] * 2)
-    phantom = odl.phantom.cuboid(space, [-1/3] * 2, [1/3] * 2)
+    phantom = odl.phantom.cuboid(space, [-1 / 3] * 2, [1 / 3] * 2)
 
     full_angle = 2 * np.pi
     n_angles = 2 * 10
@@ -624,7 +625,7 @@ def test_detector_shifts_3d():
 
     d = 100
     space = odl.uniform_discr([-1] * 3, [1] * 3, [d] * 3)
-    phantom = odl.phantom.cuboid(space, [-1/3] * 3, [1/3] * 3)
+    phantom = odl.phantom.cuboid(space, [-1 / 3] * 3, [1 / 3] * 3)
 
     full_angle = 2 * np.pi
     n_angles = 2 * 100
@@ -662,7 +663,7 @@ def test_detector_shifts_3d():
     # check back-projection
     im = op.adjoint(y).asarray()
     im_shift = op_shift.adjoint(y_shift).asarray()
-    error = np.max(np.abs(im_shift-im))
+    error = np.max(np.abs(im_shift - im))
     assert error < 1e-3
 
 
@@ -679,7 +680,7 @@ def test_source_shifts_3d():
 
     d = 10
     space = odl.uniform_discr([-1] * 3, [1] * 3, [d] * 3)
-    phantom = odl.phantom.cuboid(space, [-1/3] * 3, [1/3] * 3)
+    phantom = odl.phantom.cuboid(space, [-1 / 3] * 3, [1 / 3] * 3)
 
     full_angle = 2 * np.pi
     n_angles = 2 * 10


### PR DESCRIPTION
Fix for a wrong skipping behavior in the 3D source shift test: it should have been skipped if ASTRA CUDA is not available, but was only skipped if ASTRA wasn't available at all.