### PR TITLE
Fix in _resize_discr for min_pt and max_pt of non-affected axes

### DIFF
--- a/odl/discr/discr_ops.py
+++ b/odl/discr/discr_ops.py
@@ -507,18 +507,16 @@ def _resize_discr(discr, newshp, offset, discr_kwargs):
     for axis, (n_orig, n_new, off, on_bdry) in enumerate(zip(
             discr.shape, newshp, offset, nodes_on_bdry)):
 
-        if not affected[axis]:
-            new_minpt.append(discr.min_pt[axis])
-            new_maxpt.append(discr.max_pt[axis])
-            continue
-
-        n_diff = n_new - n_orig
-        if off is None:
-            num_r = n_diff // 2
-            num_l = n_diff - num_r
+        if affected[axis]:
+            n_diff = n_new - n_orig
+            if off is None:
+                num_r = n_diff // 2
+                num_l = n_diff - num_r
+            else:
+                num_r = n_diff - off
+                num_l = off
         else:
-            num_r = n_diff - off
-            num_l = off
+            num_l, num_r = 0, 0
 
         try:
             on_bdry_l, on_bdry_r = on_bdry


### PR DESCRIPTION
`min_pt` and `max_pt` were just copied for axes that are not affected by the resizing. This lead to inconsistent `cell_sides` if `nodes_on_bdry` did not match between the original discr and the resized discr (for the latter it is by default `False`, but can be configured via `kwargs`).

This should fix #1497.

Another MWE that works with this fix but does not without:
```
import numpy as np
from odl.discr import uniform_discr, ResizingOperator

d = uniform_discr([0.], [np.pi], (10,), nodes_on_bdry=[(True, False)])

r = ResizingOperator(d, ran_shp=(10,))
r_inv = r.inverse
```