### PR TITLE
"sign error" in salt and pepper noise

### DIFF
--- a/odl/phantom/noise.py
+++ b/odl/phantom/noise.py
@@ -241,7 +241,7 @@ def salt_pepper_noise(vector, fraction=0.05, salt_vs_pepper=0.5,
                                int(fraction * vector.size)]
 
             values[salt_indices] = high_val
-            values[pepper_indices] = -low_val
+            values[pepper_indices] = low_val
             values = values.reshape(vector.space.shape)
 
     return vector.space.element(values)


### PR DESCRIPTION
The description of the functions says "Salt and pepper noise replaces random elements in ``vector`` with ``low_val`` or ``high_val``." but values are replaced by -low_val and high_val. Just corrected the sign mistake.