### PR TITLE
Fix error in projection in L1-ball

### DIFF
--- a/odl/solvers/nonsmooth/proximal_operators.py
+++ b/odl/solvers/nonsmooth/proximal_operators.py
@@ -1608,9 +1608,12 @@ def proj_l1(x, radius=1, out=None):
         out = x.space.element()
 
     u = x.ufuncs.absolute()
-    v = x.ufuncs.sign()
-    proj_simplex(u, radius, out)
-    out *= v
+    if u.ufuncs.sum() <= radius:
+        out[:] = x
+    else:
+        v = x.ufuncs.sign()
+        proj_simplex(u, radius, out)
+        out *= v
 
     return out
 


### PR DESCRIPTION
The modified code follows the paragraph below equation (7) in 
[1] J. Duchi, S. Shalev-Shwartz, Y. Singer, and T. Chandra, “Efficient Projections onto the L1 -ball for Learning in High dimensions,” in Proceedings of the 25th International Conference on Machine Learning - ICML, 2008, pp. 272–279.

The bug was probably an oversight by myself when I coded this a couple of years back.