### PR TITLE
Correct prox for LInfty functional

### DIFF
--- a/odl/solvers/nonsmooth/proximal_operators.py
+++ b/odl/solvers/nonsmooth/proximal_operators.py
@@ -1494,7 +1494,7 @@ def proximal_linfty(space):
         def _call(self, x, out):
             """Return ``self(x)``."""
 
-            radius = 1
+            radius = self.sigma
 
             if x is out:
                 x = x.copy()


### PR DESCRIPTION
I believe the radius was wrong in the prox of the LInfty functional. I have checked that with pen and paper. Is there a way to verify this otherwise? Perhaps another human could have a look?