### PR TITLE
Fix a memory leak in the Operator base class

### DIFF
--- a/odl/operator/operator.py
+++ b/odl/operator/operator.py
@@ -418,7 +418,7 @@ class Operator(object):
 
     def __new__(cls, *args, **kwargs):
         """Create a new instance."""
-        if not hasattr(cls, '_call_out_of_place'):
+        if '_call_out_of_place' not in cls.__dict__:
             call_has_out, call_out_optional, _ = _dispatch_call_args(cls)
             cls._call_has_out = call_has_out
             cls._call_out_optional = call_out_optional

--- a/odl/operator/operator.py
+++ b/odl/operator/operator.py
@@ -17,7 +17,6 @@ from numbers import Integral, Number
 
 from odl.set import Field, LinearSpace, Set
 from odl.set.space import LinearSpaceElement
-from odl.util import cache_arguments
 
 __all__ = (
     'Operator',
@@ -122,7 +121,6 @@ def _function_signature(func):
     return '{}({})'.format(func.__name__, argstr)
 
 
-@cache_arguments
 def _dispatch_call_args(cls=None, bound_call=None, unbound_call=None,
                         attr='_call'):
     """Check the arguments of ``_call()`` or similar for conformity.
@@ -420,20 +418,21 @@ class Operator(object):
 
     def __new__(cls, *args, **kwargs):
         """Create a new instance."""
-        call_has_out, call_out_optional, _ = _dispatch_call_args(cls)
-        cls._call_has_out = call_has_out
-        cls._call_out_optional = call_out_optional
-        if not call_has_out:
-            # Out-of-place _call
-            cls._call_in_place = _default_call_in_place
-            cls._call_out_of_place = cls._call
-        elif call_out_optional:
-            # Dual-use _call
-            cls._call_in_place = cls._call_out_of_place = cls._call
-        else:
-            # In-place-only _call
-            cls._call_in_place = cls._call
-            cls._call_out_of_place = _default_call_out_of_place
+        if not hasattr(cls, '_call_out_of_place'):
+            call_has_out, call_out_optional, _ = _dispatch_call_args(cls)
+            cls._call_has_out = call_has_out
+            cls._call_out_optional = call_out_optional
+            if not call_has_out:
+                # Out-of-place _call
+                cls._call_in_place = _default_call_in_place
+                cls._call_out_of_place = cls._call
+            elif call_out_optional:
+                # Dual-use _call
+                cls._call_in_place = cls._call_out_of_place = cls._call
+            else:
+                # In-place-only _call
+                cls._call_in_place = cls._call
+                cls._call_out_of_place = _default_call_out_of_place
 
         return object.__new__(cls)
 


### PR DESCRIPTION
References to operator *class* definitions were cached in the argument cache of `_dispatch_call_args` function, hence GC couldn't collect them. Normally that wouldn't be an issue, as class definitions don't consume much memory. However, a typical pattern of defining adjoint operators in ODL is using nested classes with references back to their encapsulating *objects*. Depending on the Operator, it may cause considerable memory leaks. 

For example, the `adjoint` method of `RayTransform` objects defines `RayBackProjection` nested class, which [holds a reference](https://github.com/odlgroup/odl/blob/139e7967e85927f9d1dd39da3942c04035eb81e3/odl/tomo/operators/ray_trafo.py#L337) back to `RayTransform`, which in turn references [geometry objects](https://github.com/odlgroup/odl/blob/139e7967e85927f9d1dd39da3942c04035eb81e3/odl/tomo/operators/ray_trafo.py#L200), preventing them from being reaped by GC and leading to considerable memory leaks.

Here's a reproducer of the leak:

```python
import gc
import odl


def iter():
    reco_space = odl.uniform_discr(min_pt=[-20, -20], max_pt=[20, 20],
                                   shape=[128, 128], dtype='float32')
    geometry = odl.tomo.parallel_beam_geometry(reco_space, num_angles=100)
    ray_trafo = odl.tomo.RayTransform(reco_space, geometry)
    ray_trafo.adjoint # This line causes a memory leak


def main():
    n = 150
    for i in range(1, 1 + n):
        iter()
        gc.collect()
        print("There are ", len(gc.get_objects()), " python objects")


if __name__ == '__main__':
    main()
```

Running the code without this fix leaks objects on each iteration.
```
After iter 1 there are 49945 python objects
After iter 2 there are 50002 python objects
After iter 3 there are 50059 python objects
[..]
After iter 126 there are 57070 python objects
After iter 127 there are 57127 python objects
After iter 128 there are 57127 python objects # further leaking stops here because the lru_cache() [1] used to implement cache_arguments() is limited to 128 objects by default
[..]
After iter 150 there are 57127 python objects
```

With fix the object count after each iteration remains constant.
```
After iter 1 there are 49872 python objects
After iter 2 there are 49872 python objects
After iter 3 there are 49872 python objects
[..]
After iter 150 there are 49872 python objects
```

The fix I've implemented is moving away from an argument cache in favor of caching
the returned values on the class itself. This ensures no class object references are
held permanently in the `cache_arguments()` decorator.

----

[1] https://docs.python.org/3/library/functools.html#functools.lru_cache