### PR TITLE
Small compatibility fixes.

### DIFF
--- a/odl/discr/discr_utils.py
+++ b/odl/discr/discr_utils.py
@@ -565,7 +565,11 @@ class _Interpolator(object):
             Interpolated values. If ``out`` was given, the returned
             object is a reference to it.
         """
-        x = np.asarray(x)
+        if isinstance(x, tuple):
+            # Given a meshgrid, the evaluation will be on a ragged array.
+            x = np.asarray(x, dtype=object)
+        else:
+            x = np.asarray(x)
         ndim = len(self.coord_vecs)
         scalar_out = False
 

--- a/odl/tomo/backends/skimage_radon.py
+++ b/odl/tomo/backends/skimage_radon.py
@@ -152,13 +152,19 @@ def skimage_radon_back_projector(sinogram, geometry, vol_space, out=None):
         # Only do asserts here since these are backend functions
         assert out in vol_space
 
+    # scikit-image changed the name of this parameter in version 0.17
+    if (skimage.__version__<'0.17'):
+        filter_disable = {"filter": None}
+    else:
+        filter_disable = {"filter_name": None}
+
     # Rotate back from (rows, cols) to (x, y), then back-project (no filter)
     backproj = iradon(
         skimage_sinogram.asarray().T,
         theta,
         output_size=vol_space.shape[0],
-        filter=None,
         circle=False,
+        **filter_disable
     )
     out[:] = np.rot90(backproj, -1)
 


### PR DESCRIPTION
This is mostly about the way ragged arrays are used in the scikit-based ray transform. Old numpy versions used to allow that automatically, but it is eschewed because it requires a object per row. Newer versions require explicitly requesting it.

A more idiomatic solution would be to avoid ragged arrays entirely.