### PR TITLE
Compatibility with matplotlib-3.8.

### DIFF
--- a/odl/util/graphics.py
+++ b/odl/util/graphics.py
@@ -436,14 +436,14 @@ def show_discrete_data(values, grid, title=None, method='',
                 plt.colorbar(mappable=csub, ticks=ticks, format=fmt)
             elif update_in_place:
                 # If it exists and we should update it
-                csub.colorbar.set_clim(minval, maxval)
+                csub.set_clim(minval, maxval)
                 csub.colorbar.set_ticks(ticks)
                 if '%' not in fmt:
                     labels = [fmt] * len(ticks)
                 else:
                     labels = [fmt % t for t in ticks]
                 csub.colorbar.set_ticklabels(labels)
-                csub.colorbar.draw_all()
+                fig.canvas.draw_idle()
 
     # Set title of window
     if title is not None:


### PR DESCRIPTION
The update methods for colorbars have been removed in favour of more global updates.

Applying the change to the `clim`s simply on the `csub` was suggested by paulhausner in https://github.com/odlgroup/odl/pull/1635 and seems to work fine.

Actually updating the drawing of the colorbar (specifically, the ticks on it) did not work with the fix suggested in the Matplotlib documentation, but `canvas.draw_idle()` does seem to have the intended effect.

Fixes https://github.com/odlgroup/odl/issues/1636.