### PR TITLE
Product space unit tests compatible with modern NumPy

### DIFF
--- a/odl/test/space/pspace_test.py
+++ b/odl/test/space/pspace_test.py
@@ -997,50 +997,62 @@ def test_real_imag_and_conj():
 
 
 def test_real_setter_product_space(space, newpart):
-    """Verify that the setter for the real part of an element works."""
+    """Verify that the setter for the real part of an element works.
+    What setting the real part means depends on the inputs; we perform a
+    recursive deconstruction to cover the possible cases."""
+
+    def verify_result(x, expected_result, recursion_limit=4):
+        if recursion_limit<=0:
+            return False
+        try:
+            # Catch scalar argument
+            iter(expected_result)
+        except TypeError:
+            return verify_result(x, expected_result * space.one(), recursion_limit-1)
+        if expected_result in space:
+            return all_equal(x.real, expected_result.real)
+        elif all_equal(x.real, expected_result):
+            return True
+        elif space.is_power_space:
+            return verify_result(x, [expected_result for _ in space], recursion_limit-1)
+
     x = noise_element(space)
     x.real = newpart
 
-    try:
-        # Catch the scalar
-        iter(newpart)
-    except TypeError:
-        expected_result = newpart * space.one()
-    else:
-        if newpart in space:
-            expected_result = newpart.real
-        elif np.shape(newpart) == (3,):
-            expected_result = [newpart, newpart]
-        else:
-            expected_result = newpart
-
     assert x in space
-    assert all_equal(x.real, expected_result)
+    assert(verify_result(x, newpart))
+
+    return
 
 
 def test_imag_setter_product_space(space, newpart):
-    """Verify that the setter for the imaginary part of an element works."""
-    x = noise_element(space)
-    x.imag = newpart
+    """Like test_real_setter_product_space but for imaginary part."""
 
-    try:
-        # Catch the scalar
-        iter(newpart)
-    except TypeError:
-        expected_result = newpart * space.one()
-    else:
-        if newpart in space:
+    def verify_result(x, expected_result, recursion_limit=4):
+        if recursion_limit<=0:
+            return False
+        try:
+            # Catch scalar argument
+            iter(expected_result)
+        except TypeError:
+            return verify_result(x, expected_result * space.one(), recursion_limit-1)
+        if expected_result in space:
             # The imaginary part is by definition real, and thus the new
             # imaginary part is thus the real part of the element we try to set
             # the value to
-            expected_result = newpart.real
-        elif np.shape(newpart) == (3,):
-            expected_result = [newpart, newpart]
-        else:
-            expected_result = newpart
+            return all_equal(x.imag, expected_result.real)
+        elif all_equal(x.imag, expected_result):
+            return True
+        elif space.is_power_space:
+            return verify_result(x, [expected_result for _ in space], recursion_limit-1)
+
+    x = noise_element(space)
+    x.imag = newpart
 
     assert x in space
-    assert all_equal(x.imag, expected_result)
+    assert(verify_result(x, newpart))
+
+    return
 
 
 if __name__ == '__main__':

--- a/odl/test/space/pspace_test.py
+++ b/odl/test/space/pspace_test.py
@@ -1002,19 +1002,21 @@ def test_real_setter_product_space(space, newpart):
     recursive deconstruction to cover the possible cases."""
 
     def verify_result(x, expected_result, recursion_limit=4):
-        if recursion_limit<=0:
+        if recursion_limit <= 0:
             return False
         try:
             # Catch scalar argument
             iter(expected_result)
         except TypeError:
-            return verify_result(x, expected_result * space.one(), recursion_limit-1)
+            return verify_result(x, expected_result * space.one(),
+                                 recursion_limit - 1)
         if expected_result in space:
             return all_equal(x.real, expected_result.real)
         elif all_equal(x.real, expected_result):
             return True
         elif space.is_power_space:
-            return verify_result(x, [expected_result for _ in space], recursion_limit-1)
+            return verify_result(x, [expected_result for _ in space],
+                                 recursion_limit - 1)
 
     x = noise_element(space)
     x.real = newpart
@@ -1029,13 +1031,14 @@ def test_imag_setter_product_space(space, newpart):
     """Like test_real_setter_product_space but for imaginary part."""
 
     def verify_result(x, expected_result, recursion_limit=4):
-        if recursion_limit<=0:
+        if recursion_limit <= 0:
             return False
         try:
             # Catch scalar argument
             iter(expected_result)
         except TypeError:
-            return verify_result(x, expected_result * space.one(), recursion_limit-1)
+            return verify_result(x, expected_result * space.one(),
+                                 recursion_limit - 1)
         if expected_result in space:
             # The imaginary part is by definition real, and thus the new
             # imaginary part is thus the real part of the element we try to set
@@ -1044,7 +1047,8 @@ def test_imag_setter_product_space(space, newpart):
         elif all_equal(x.imag, expected_result):
             return True
         elif space.is_power_space:
-            return verify_result(x, [expected_result for _ in space], recursion_limit-1)
+            return verify_result(x, [expected_result for _ in space],
+                                 recursion_limit - 1)
 
     x = noise_element(space)
     x.imag = newpart

--- a/odl/test/space/pspace_test.py
+++ b/odl/test/space/pspace_test.py
@@ -999,7 +999,11 @@ def test_real_imag_and_conj():
 def test_real_setter_product_space(space, newpart):
     """Verify that the setter for the real part of an element works.
     What setting the real part means depends on the inputs; we perform a
-    recursive deconstruction to cover the possible cases."""
+    recursive deconstruction to cover the possible cases.
+    Barring deeply nested products, the recursion will only be shallow
+    (depth 2 for a simple product space). We limit it to a depth of at
+    most 4, to avoid that if some bug causes an infinite recursion,
+    the user would get a cryptic stack-overflow error."""
 
     def verify_result(x, expected_result, recursion_limit=4):
         if recursion_limit <= 0:

--- a/odl/util/testutils.py
+++ b/odl/util/testutils.py
@@ -323,7 +323,22 @@ def noise_array(space):
     """
     from odl.space import ProductSpace
     if isinstance(space, ProductSpace):
-        return np.array([noise_array(si) for si in space])
+
+        if space.is_power_space:
+            return np.array([noise_array(si) for si in space])
+
+        # Non-power–product-space elements are represented as arrays of arrays, each in
+        # general with a different shape. These cannot be monolithic NumPy arrays.
+        # NumPy allows non-rectangular arrays when explicitly requesting dtype=object, but
+        # these behave different from ordinary arrays in several ways. The following is a
+        # hack to have only the outer array with dtype=object but store the inner elements
+        # as for the constituent spaces. The resulting ragged arrays support some, but not
+        # all numerical operations.
+        result = np.array([None for si in space], dtype=object)
+        for i, si in enumerate(space):
+            result[i] = noise_array(si)
+        return result
+
     else:
         if space.dtype == bool:
             arr = np.random.randint(0, 2, size=space.shape, dtype=bool)

--- a/odl/util/testutils.py
+++ b/odl/util/testutils.py
@@ -149,14 +149,14 @@ def all_almost_equal_array(v1, v2, ndigits):
     if v1.dtype is np.dtype(object) or v2.dtype is np.dtype(object):
         if len(v1) != len(v2):
             return False
-        for w1,w2 in zip(v1,v2):
+        for w1, w2 in zip(v1, v2):
             if not all_almost_equal(w1, w2, ndigits):
                 return False
         return True
     else:
         return np.allclose(v1, v2,
-                       rtol=10 ** -ndigits, atol=10 ** -ndigits,
-                       equal_nan=True)
+                           rtol=10 ** -ndigits, atol=10 ** -ndigits,
+                           equal_nan=True)
 
 
 def all_almost_equal(iter1, iter2, ndigits=None):
@@ -335,12 +335,13 @@ def noise_array(space):
         if space.is_power_space:
             return np.array([noise_array(si) for si in space])
 
-        # Non-power–product-space elements are represented as arrays of arrays, each in
-        # general with a different shape. These cannot be monolithic NumPy arrays.
-        # NumPy allows non-rectangular arrays when explicitly requesting dtype=object, but
-        # these behave different from ordinary arrays in several ways. The following is a
-        # hack to have only the outer array with dtype=object but store the inner elements
-        # as for the constituent spaces. The resulting ragged arrays support some, but not
+        # Non-power–product-space elements are represented as arrays of arrays,
+        # each in general with a different shape. These cannot be monolithic
+        # NumPy arrays. NumPy allows non-rectangular arrays when explicitly
+        # requesting dtype=object, but these behave different from ordinary
+        # arrays in several ways. The following is a hack to have only the
+        # outer array with dtype=object but store the inner elements as for the
+        # constituent spaces. The resulting ragged arrays support some, but not
         # all numerical operations.
         result = np.array([None for si in space], dtype=object)
         for i, si in enumerate(space):

--- a/odl/util/testutils.py
+++ b/odl/util/testutils.py
@@ -146,7 +146,15 @@ def all_equal(iter1, iter2):
 
 
 def all_almost_equal_array(v1, v2, ndigits):
-    return np.allclose(v1, v2,
+    if v1.dtype is np.dtype(object) or v2.dtype is np.dtype(object):
+        if len(v1) != len(v2):
+            return False
+        for w1,w2 in zip(v1,v2):
+            if not all_almost_equal(w1, w2, ndigits):
+                return False
+        return True
+    else:
+        return np.allclose(v1, v2,
                        rtol=10 ** -ndigits, atol=10 ** -ndigits,
                        equal_nan=True)
 


### PR DESCRIPTION
As per https://github.com/odlgroup/odl/issues/1639, the unit tests for product spaces have been failing.

This is mostly due to the more restrictive way NumPy nowadays handles arrays with non-rectangular /tensor structure (basically, it _doesn't_).

The way most of these tests work is by comparing an ODL operation to its plain NumPy pendant, but specifically with product spaces this means in general ragged arrays.

This pull request introduces some special case handling, with arrays of dtype=object (in the outer layer only) as heterogeneous arrays, to get those tests working again.