### PR TITLE
Create custom COO matrix representation for product operators, with updated product spaces

### DIFF
--- a/odl/operator/pspace_ops.py
+++ b/odl/operator/pspace_ops.py
@@ -175,7 +175,8 @@ class ProductSpaceOperator(Operator):
             # scipy sparse matrix not supported (deprecated due to API changes)
             # keep now for backward compatibility
             print('Warning: scipy.sparse.spmatrix is deprecated.')
-            self.__ops = COOMatrix(operators.data, (operators.row, operators.col),
+            self.__ops = COOMatrix(operators.data,
+                                   (operators.row, operators.col),
                                    operators.shape)
 
         elif isinstance(operators, COOMatrix):

--- a/odl/operator/pspace_ops.py
+++ b/odl/operator/pspace_ops.py
@@ -15,6 +15,7 @@ import numpy as np
 from odl.operator.operator import Operator
 from odl.operator.default_ops import ZeroOperator
 from odl.space import ProductSpace
+from odl.util import COOMatrix
 
 
 __all__ = ('ProductSpaceOperator',
@@ -166,12 +167,20 @@ class ProductSpaceOperator(Operator):
                                 ''.format(range))
             if range.is_weighted:
                 raise NotImplementedError('weighted spaces not supported')
-
+        
         if isinstance(operators, scipy.sparse.spmatrix):
             if not all(isinstance(op, Operator) for op in operators.data):
                 raise ValueError('sparse matrix `operator` contains non-'
                                  '`Operator` entries')
+            # scipy sparse matrix not supported (deprecated due to API changes)
+            # keep now for backward compatibility
+            print('Warning: scipy.sparse.spmatrix is deprecated.')
+            self.__ops = COOMatrix(operators.data, (operators.row, operators.col),
+                                   operators.shape)
+        
+        elif isinstance(operators, COOMatrix):
             self.__ops = operators
+        
         else:
             self.__ops = self._convert_to_spmatrix(operators)
 
@@ -229,8 +238,9 @@ class ProductSpaceOperator(Operator):
     @staticmethod
     def _convert_to_spmatrix(operators):
         """Convert an array-like object of operators to a sparse matrix."""
+        
         # Lazy import to improve `import odl` time
-        import scipy.sparse
+        # import scipy.sparse
 
         # Convert ops to sparse representation. This is not trivial because
         # operators can be indexable themselves and give the wrong impression
@@ -279,8 +289,8 @@ class ProductSpaceOperator(Operator):
         # in `coo_matrix.__init__`
         data_arr = np.empty(len(data), dtype=object)
         data_arr[:] = data
-        return scipy.sparse.coo_matrix((data_arr, (irow, icol)),
-                                       shape=(nrows, ncols))
+        
+        return COOMatrix(data_arr, (irow, icol), (nrows, ncols))
 
     @property
     def ops(self):
@@ -382,7 +392,7 @@ class ProductSpaceOperator(Operator):
         data[:] = deriv_ops
         indices = [self.ops.row, self.ops.col]
         shape = self.ops.shape
-        deriv_matrix = scipy.sparse.coo_matrix((data, indices), shape)
+        deriv_matrix = COOMatrix(data, indices, shape)
         return ProductSpaceOperator(deriv_matrix, self.domain, self.range)
 
     @property
@@ -431,7 +441,7 @@ class ProductSpaceOperator(Operator):
         data[:] = adjoint_ops
         indices = [self.ops.col, self.ops.row]  # Swap col/row -> transpose
         shape = (self.ops.shape[1], self.ops.shape[0])
-        adj_matrix = scipy.sparse.coo_matrix((data, indices), shape)
+        adj_matrix = COOMatrix(data, indices, shape)
         return ProductSpaceOperator(adj_matrix, self.range, self.domain)
 
     def __getitem__(self, index):
@@ -1145,7 +1155,7 @@ class DiagonalOperator(ProductSpaceOperator):
         data = np.empty(n_ops, dtype=object)
         data[:] = operators
         shape = (n_ops, n_ops)
-        op_matrix = scipy.sparse.coo_matrix((data, (irow, icol)), shape)
+        op_matrix = COOMatrix(data, (irow, icol), shape)
         super(DiagonalOperator, self).__init__(op_matrix, **kwargs)
 
         self.__operators = tuple(operators)

--- a/odl/operator/pspace_ops.py
+++ b/odl/operator/pspace_ops.py
@@ -167,7 +167,7 @@ class ProductSpaceOperator(Operator):
                                 ''.format(range))
             if range.is_weighted:
                 raise NotImplementedError('weighted spaces not supported')
-        
+
         if isinstance(operators, scipy.sparse.spmatrix):
             if not all(isinstance(op, Operator) for op in operators.data):
                 raise ValueError('sparse matrix `operator` contains non-'
@@ -177,10 +177,10 @@ class ProductSpaceOperator(Operator):
             print('Warning: scipy.sparse.spmatrix is deprecated.')
             self.__ops = COOMatrix(operators.data, (operators.row, operators.col),
                                    operators.shape)
-        
+
         elif isinstance(operators, COOMatrix):
             self.__ops = operators
-        
+
         else:
             self.__ops = self._convert_to_spmatrix(operators)
 
@@ -238,7 +238,7 @@ class ProductSpaceOperator(Operator):
     @staticmethod
     def _convert_to_spmatrix(operators):
         """Convert an array-like object of operators to a sparse matrix."""
-        
+
         # Lazy import to improve `import odl` time
         # import scipy.sparse
 
@@ -289,7 +289,7 @@ class ProductSpaceOperator(Operator):
         # in `coo_matrix.__init__`
         data_arr = np.empty(len(data), dtype=object)
         data_arr[:] = data
-        
+
         return COOMatrix(data_arr, (irow, icol), (nrows, ncols))
 
     @property
@@ -741,6 +741,7 @@ class BroadcastOperator(Operator):
     ReductionOperator : Calculates sum of operator results.
     DiagonalOperator : Case where each operator should have its own argument.
     """
+
     def __init__(self, *operators):
         """Initialize a new instance
 
@@ -911,6 +912,7 @@ class ReductionOperator(Operator):
     DiagonalOperator : Case where each operator should have its own argument.
     SeparableSum : Corresponding construction for functionals.
     """
+
     def __init__(self, *operators):
         """Initialize a new instance.
 

--- a/odl/util/__init__.py
+++ b/odl/util/__init__.py
@@ -17,6 +17,7 @@ from .numerics import *
 from .testutils import *
 from .utility import *
 from .vectorization import *
+from .sparse import *
 
 __all__ = ()
 __all__ += graphics.__all__
@@ -26,3 +27,4 @@ __all__ += numerics.__all__
 __all__ += testutils.__all__
 __all__ += utility.__all__
 __all__ += vectorization.__all__
+__all__ += sparse.__all__

--- a/odl/util/sparse.py
+++ b/odl/util/sparse.py
@@ -10,16 +10,18 @@ __all__ = ('COOMatrix',)
 class COOMatrix():
     """
     Custom COO matrix representation for creating product space operators.
-    
-    The columns, rows and data are stored in separate lists such that A[i[k], j[k]] = data[k].
-    
+
+    The columns, rows and data are stored in separate lists such that
+    A[i[k], j[k]] = data[k].
+
     """
+
     def __init__(self, data, index, shape):
-        
+
         # type check
         if len(data) != len(index[0]) or len(data) != len(index[1]):
             raise ValueError('data and index must have the same length')
-        
+
         self.__data = data
         self.__index = index
         self.__shape = shape
@@ -27,18 +29,18 @@ class COOMatrix():
     @property
     def row(self):
         return self.__index[0]
-    
+
     @property
     def col(self):
         return self.__index[1]
-    
+
     @property
     def shape(self):
         return self.__shape
-    
+
     @property
     def data(self):
         return self.__data
-    
+
     def __repr__(self):
         return f"COO matrix({self.data}, {self.index})"

--- a/odl/util/sparse.py
+++ b/odl/util/sparse.py
@@ -1,0 +1,44 @@
+
+"""
+File containing a custom COO matrix representation.
+In contrast to scipy the container allows for arbitrary matrix elements.
+"""
+
+__all__ = ('COOMatrix',)
+
+
+class COOMatrix():
+    """
+    Custom COO matrix representation for creating product space operators.
+    
+    The columns, rows and data are stored in separate lists such that A[i[k], j[k]] = data[k].
+    
+    """
+    def __init__(self, data, index, shape):
+        
+        # type check
+        if len(data) != len(index[0]) or len(data) != len(index[1]):
+            raise ValueError('data and index must have the same length')
+        
+        self.__data = data
+        self.__index = index
+        self.__shape = shape
+
+    @property
+    def row(self):
+        return self.__index[0]
+    
+    @property
+    def col(self):
+        return self.__index[1]
+    
+    @property
+    def shape(self):
+        return self.__shape
+    
+    @property
+    def data(self):
+        return self.__data
+    
+    def __repr__(self):
+        return f"COO matrix({self.data}, {self.index})"

--- a/odl/util/sparse.py
+++ b/odl/util/sparse.py
@@ -1,7 +1,6 @@
 
 """
-File containing a custom COO matrix representation.
-In contrast to scipy the container allows for arbitrary matrix elements.
+Sparse matrix representation for creating product space operators.
 """
 
 __all__ = ('COOMatrix',)
@@ -9,10 +8,15 @@ __all__ = ('COOMatrix',)
 
 class COOMatrix():
     """
-    Custom COO matrix representation for creating product space operators.
+    Custom coo matrix representation for creating product space operators.
 
     The columns, rows and data are stored in separate lists such that
     A[i[k], j[k]] = data[k].
+
+    Note that, the class is only used as a container and does not provide
+    any matrix operations. Further, no checks are performed on the data thus
+    duplicate and out-of-order indices are allowed and the user is responsible
+    for ensuring the correct shape of the matrix.
 
     """
 
@@ -28,18 +32,22 @@ class COOMatrix():
 
     @property
     def row(self):
+        """Return the row indices of the matrix."""
         return self.__index[0]
 
     @property
     def col(self):
+        """Return the column indices of the matrix."""
         return self.__index[1]
 
     @property
     def shape(self):
+        """Return the shape of the matrix."""
         return self.__shape
 
     @property
     def data(self):
+        """Return the data of the matrix."""
         return self.__data
 
     def __repr__(self):


### PR DESCRIPTION
This is a rebased version of https://github.com/odlgroup/odl/pull/1635, including also the changes from https://github.com/odlgroup/odl/pull/1638 and https://github.com/odlgroup/odl/pull/1640