### PR TITLE
Fixing issues related to dtype=object arrays in interpolation routines

### DIFF
--- a/odl/discr/discr_utils.py
+++ b/odl/discr/discr_utils.py
@@ -1355,7 +1355,8 @@ def _make_dual_use_func(func_ip, func_oop, domain, out_dtype):
                             if shp and shp[0] == 1:
                                 res = res.reshape(res.shape[1:])
                         bcast_res.append(
-                            np.broadcast_to(res, scalar_out_shape).astype(scalar_out_dtype))
+                            np.broadcast_to(res, scalar_out_shape)
+                              .astype(scalar_out_dtype))
 
                     out_arr = np.array(bcast_res, dtype=scalar_out_dtype)
                 else:

--- a/odl/discr/discr_utils.py
+++ b/odl/discr/discr_utils.py
@@ -933,10 +933,9 @@ def _func_out_type(func):
 
     return has_out, out_optional
 
-def _broadcast_nested_list(arr_lists, element_shape):
+def _broadcast_nested_list(arr_lists, element_shape, ndim):
     """ A generalisation of `np.broadcast_to`, applied to an arbitrarily
     deep list (or tuple) eventually containing arrays or scalars. """
-    ndim = len(element_shape)
     if isinstance(arr_lists, np.ndarray) or np.isscalar(arr_lists):
         if ndim == 1:
             # As usual, 1d is tedious to deal with. This
@@ -949,7 +948,7 @@ def _broadcast_nested_list(arr_lists, element_shape):
                 arr_lists = arr_lists.reshape(arr_lists.shape[1:])
         return np.broadcast_to(arr_lists, element_shape)
     else:
-        return [_broadcast_nested_list(row, element_shape) for row in arr_lists]
+        return [_broadcast_nested_list(row, element_shape, ndim) for row in arr_lists]
 
 
 def sampling_function(func_or_arr, domain, out_dtype=None):
@@ -1027,7 +1026,7 @@ def sampling_function(func_or_arr, domain, out_dtype=None):
             else:
                 raise TypeError('invalid input `x`')
 
-            bcast_results = _broadcast_nested_list(result, scalar_out_shape)
+            bcast_results = _broadcast_nested_list(result, scalar_out_shape, domain.ndim)
 
             # New array that is flat in the `out_shape` axes, reshape it
             # to the final `out_shape + scalar_shape`, using the same
@@ -1364,7 +1363,7 @@ def _make_dual_use_func(func_ip, func_oop, domain, out_dtype):
                 try:
                     out_arr = np.asarray(out)
                 except ValueError:
-                    out_arr = np.asarray(_broadcast_nested_list(out, scalar_out_shape))
+                    out_arr = np.asarray(_broadcast_nested_list(out, scalar_out_shape, ndim=ndim))
 
                 if out_arr.dtype != scalar_out_dtype:
                     raise ValueError(

--- a/odl/discr/discr_utils.py
+++ b/odl/discr/discr_utils.py
@@ -20,6 +20,7 @@ import sys
 from builtins import object
 from functools import partial
 from itertools import product
+from warnings import warn
 
 import numpy as np
 
@@ -624,6 +625,8 @@ class _Interpolator(object):
             try:
                 xi = np.asarray(xi).astype(self.values.dtype, casting='safe')
             except TypeError:
+                warn("Unable to infer accurate dtype for"
+                  +" interpolation coefficients, defaulting to `float`.")
                 xi = np.asarray(xi, dtype=float)
 
             idcs = np.searchsorted(cvec, xi) - 1

--- a/odl/discr/discr_utils.py
+++ b/odl/discr/discr_utils.py
@@ -801,7 +801,7 @@ class _PerAxisInterpolator(_Interpolator):
         # axis, resulting in a loop of length 2**ndim
         for lo_hi, edge in zip(product(*([['l', 'h']] * len(indices))),
                                product(*edge_indices)):
-            weight = 1.0
+            weight = np.array([1.0], dtype = self.values.dtype)
             # TODO(kohr-h): determine best summation order from array strides
             for lh, w_lo, w_hi in zip(lo_hi, low_weights, high_weights):
 

--- a/odl/discr/discr_utils.py
+++ b/odl/discr/discr_utils.py
@@ -706,6 +706,8 @@ def _compute_nearest_weights_edge(idcs, ndist):
 
 def _compute_linear_weights_edge(idcs, ndist):
     """Helper for linear interpolation."""
+    ndist = np.asarray(ndist)
+
     # Get out-of-bounds indices from the norm_distances. Negative
     # means "too low", larger than or equal to 1 means "too high"
     lo = np.where(ndist < 0)

--- a/odl/discr/discr_utils.py
+++ b/odl/discr/discr_utils.py
@@ -1361,7 +1361,10 @@ def _make_dual_use_func(func_ip, func_oop, domain, out_dtype):
             elif tensor_valued:
                 # The out object can be any array-like of objects with shapes
                 # that should all be broadcastable to scalar_out_shape.
-                out_arr = np.asarray(_broadcast_nested_list(out, scalar_out_shape))
+                try:
+                    out_arr = np.asarray(out)
+                except ValueError:
+                    out_arr = np.asarray(_broadcast_nested_list(out, scalar_out_shape))
 
                 if out_arr.dtype != scalar_out_dtype:
                     raise ValueError(

--- a/odl/discr/discr_utils.py
+++ b/odl/discr/discr_utils.py
@@ -621,7 +621,10 @@ class _Interpolator(object):
 
         # iterate through dimensions
         for xi, cvec in zip(x, self.coord_vecs):
-            xi = np.asarray(xi, dtype=self.values.dtype)
+            try:
+                xi = np.asarray(xi).astype(self.values.dtype, casting='safe')
+            except TypeError:
+                xi = np.asarray(xi, dtype=float)
 
             idcs = np.searchsorted(cvec, xi) - 1
 

--- a/odl/discr/discr_utils.py
+++ b/odl/discr/discr_utils.py
@@ -621,7 +621,7 @@ class _Interpolator(object):
 
         # iterate through dimensions
         for xi, cvec in zip(x, self.coord_vecs):
-            xi = np.asarray(xi, dtype = self.values.dtype)
+            xi = np.asarray(xi, dtype=self.values.dtype)
 
             idcs = np.searchsorted(cvec, xi) - 1
 
@@ -803,7 +803,7 @@ class _PerAxisInterpolator(_Interpolator):
         # axis, resulting in a loop of length 2**ndim
         for lo_hi, edge in zip(product(*([['l', 'h']] * len(indices))),
                                product(*edge_indices)):
-            weight = np.array([1.0], dtype = self.values.dtype)
+            weight = np.array([1.0], dtype=self.values.dtype)
             # TODO(kohr-h): determine best summation order from array strides
             for lh, w_lo, w_hi in zip(lo_hi, low_weights, high_weights):
 

--- a/odl/discr/discr_utils.py
+++ b/odl/discr/discr_utils.py
@@ -120,7 +120,7 @@ def point_collocation(func, points, out=None, **kwargs):
     >>> ys = [3, 4]
     >>> mesh = sparse_meshgrid(xs, ys)
     >>> def vec_valued(x):
-    ...     return (x[0] - 1, 0, x[0] + x[1])  # broadcasting
+    ...     return (x[0] - 1., 0., x[0] + x[1])  # broadcasting
     >>> # For a function with several output components, we must specify the
     >>> # shape explicitly in the `out_dtype` parameter
     >>> func1 = sampling_function(

--- a/odl/discr/discr_utils.py
+++ b/odl/discr/discr_utils.py
@@ -621,6 +621,8 @@ class _Interpolator(object):
 
         # iterate through dimensions
         for xi, cvec in zip(x, self.coord_vecs):
+            xi = np.asarray(xi, dtype = self.values.dtype)
+
             idcs = np.searchsorted(cvec, xi) - 1
 
             idcs[idcs < 0] = 0

--- a/odl/discr/grid.py
+++ b/odl/discr/grid.py
@@ -1111,8 +1111,8 @@ def uniform_grid_fromintv(intv_prod, shape, nodes_on_bdry=True):
 
     shape = normalized_scalar_param_list(shape, intv_prod.ndim, safe_int_conv)
 
-    if np.shape(nodes_on_bdry) == ():
-        nodes_on_bdry = ([(bool(nodes_on_bdry), bool(nodes_on_bdry))] *
+    if isinstance(nodes_on_bdry, bool):
+        nodes_on_bdry = ([(nodes_on_bdry, nodes_on_bdry)] *
                          intv_prod.ndim)
     elif intv_prod.ndim == 1 and len(nodes_on_bdry) == 2:
         nodes_on_bdry = [nodes_on_bdry]

--- a/odl/test/discr/discr_space_test.py
+++ b/odl/test/discr/discr_space_test.py
@@ -897,7 +897,7 @@ def test_ufunc_corner_cases(odl_tspace_impl):
 
     # --- UFuncs with nin = 1, nout = 1 --- #
 
-    wrong_argcount_error = ValueError if np.__version__<"1.21" else TypeError
+    wrong_argcount_error = ValueError if np.__version__ < "1.21" else TypeError
 
     with pytest.raises(wrong_argcount_error):
         # Too many arguments

--- a/odl/test/discr/discr_space_test.py
+++ b/odl/test/discr/discr_space_test.py
@@ -897,7 +897,9 @@ def test_ufunc_corner_cases(odl_tspace_impl):
 
     # --- UFuncs with nin = 1, nout = 1 --- #
 
-    with pytest.raises(ValueError):
+    wrong_argcount_error = ValueError if np.__version__<"1.21" else TypeError
+
+    with pytest.raises(wrong_argcount_error):
         # Too many arguments
         x.__array_ufunc__(np.sin, '__call__', x, np.ones((2, 3)))
 
@@ -928,7 +930,7 @@ def test_ufunc_corner_cases(odl_tspace_impl):
 
     # --- UFuncs with nin = 2, nout = 1 --- #
 
-    with pytest.raises(ValueError):
+    with pytest.raises(wrong_argcount_error):
         # Too few arguments
         x.__array_ufunc__(np.add, '__call__', x)
 

--- a/odl/test/discr/discr_utils_test.py
+++ b/odl/test/discr/discr_utils_test.py
@@ -355,7 +355,8 @@ def func_tens_dual(x, out=None):
 
 
 func_tens_params = [(func_tens_ref, f)
-                    for f in [func_tens_oop, func_tens_oop_seq,
+                    for f in [ # func_tens_oop,
+                              func_tens_oop_seq,
                               func_tens_ip, func_tens_ip_seq]]
 func_tens = simple_fixture('func_tens', func_tens_params,
                            fmt=' {name} = {value[1].__name__} ')

--- a/odl/test/discr/discr_utils_test.py
+++ b/odl/test/discr/discr_utils_test.py
@@ -355,9 +355,9 @@ def func_tens_dual(x, out=None):
 
 
 func_tens_params = [(func_tens_ref, f)
-                    for f in [ # func_tens_oop,
-                              func_tens_oop_seq,
-                              func_tens_ip, func_tens_ip_seq]]
+                    for f in [  # func_tens_oop,
+                             func_tens_oop_seq,
+                             func_tens_ip, func_tens_ip_seq]]
 func_tens = simple_fixture('func_tens', func_tens_params,
                            fmt=' {name} = {value[1].__name__} ')
 

--- a/odl/test/discr/discr_utils_test.py
+++ b/odl/test/discr/discr_utils_test.py
@@ -355,9 +355,8 @@ def func_tens_dual(x, out=None):
 
 
 func_tens_params = [(func_tens_ref, f)
-                    for f in [  # func_tens_oop,
-                             func_tens_oop_seq,
-                             func_tens_ip, func_tens_ip_seq]]
+                    for f in [func_tens_oop, func_tens_oop_seq,
+                              func_tens_ip, func_tens_ip_seq]]
 func_tens = simple_fixture('func_tens', func_tens_params,
                            fmt=' {name} = {value[1].__name__} ')
 

--- a/odl/test/space/tensors_test.py
+++ b/odl/test/space/tensors_test.py
@@ -1530,7 +1530,9 @@ def test_ufunc_corner_cases(odl_tspace_impl):
 
     # --- Ufuncs with nin = 1, nout = 1 --- #
 
-    with pytest.raises(ValueError):
+    wrong_argcount_error = ValueError if np.__version__<"1.21" else TypeError
+
+    with pytest.raises(wrong_argcount_error):
         # Too many arguments
         x.__array_ufunc__(np.sin, '__call__', x, np.ones((2, 3)))
 
@@ -1561,7 +1563,7 @@ def test_ufunc_corner_cases(odl_tspace_impl):
 
     # --- Ufuncs with nin = 2, nout = 1 --- #
 
-    with pytest.raises(ValueError):
+    with pytest.raises(wrong_argcount_error):
         # Too few arguments
         x.__array_ufunc__(np.add, '__call__', x)
 

--- a/odl/test/space/tensors_test.py
+++ b/odl/test/space/tensors_test.py
@@ -1530,7 +1530,7 @@ def test_ufunc_corner_cases(odl_tspace_impl):
 
     # --- Ufuncs with nin = 1, nout = 1 --- #
 
-    wrong_argcount_error = ValueError if np.__version__<"1.21" else TypeError
+    wrong_argcount_error = ValueError if np.__version__ < "1.21" else TypeError
 
     with pytest.raises(wrong_argcount_error):
         # Too many arguments

--- a/odl/util/normalize.py
+++ b/odl/util/normalize.py
@@ -279,7 +279,7 @@ def normalized_nodes_on_bdry(nodes_on_bdry, length):
     [(True, False), (False, False), (True, True)]
     """
     if isinstance(nodes_on_bdry, bool):
-        return [(bool(nodes_on_bdry), bool(nodes_on_bdry))] * length
+        return [(nodes_on_bdry, nodes_on_bdry)] * length
     elif (length == 1 and len(nodes_on_bdry) == 2
           and all(isinstance(d, bool) for d in nodes_on_bdry)):
         return [nodes_on_bdry[0], nodes_on_bdry[1]]

--- a/odl/util/normalize.py
+++ b/odl/util/normalize.py
@@ -278,11 +278,11 @@ def normalized_nodes_on_bdry(nodes_on_bdry, length):
     >>> normalized_nodes_on_bdry([[True, False], False, True], length=3)
     [(True, False), (False, False), (True, True)]
     """
-    shape = np.shape(nodes_on_bdry)
-    if shape == ():
-        out_list = [(bool(nodes_on_bdry), bool(nodes_on_bdry))] * length
-    elif length == 1 and shape == (2,):
-        out_list = [(bool(nodes_on_bdry[0]), bool(nodes_on_bdry[1]))]
+    if isinstance(nodes_on_bdry, bool):
+        return [(bool(nodes_on_bdry), bool(nodes_on_bdry))] * length
+    elif (length == 1 and len(nodes_on_bdry) == 2
+          and all(isinstance(d, bool) for d in nodes_on_bdry)):
+        return [nodes_on_bdry[0], nodes_on_bdry[1]]
     elif len(nodes_on_bdry) == length:
         out_list = []
 

--- a/odl/util/vectorization.py
+++ b/odl/util/vectorization.py
@@ -21,7 +21,10 @@ __all__ = ('is_valid_input_array', 'is_valid_input_meshgrid',
 
 def is_valid_input_array(x, ndim=None):
     """Test if ``x`` is a correctly shaped point array in R^d."""
-    x = np.asarray(x)
+    try:
+        x = np.asarray(x)
+    except ValueError:
+        return False
 
     if ndim is None or ndim == 1:
         return x.ndim == 1 and x.size > 1 or x.ndim == 2 and x.shape[0] == 1


### PR DESCRIPTION
In old versions of NumPy, ODL relied on its capability to represent ragged arrays automatically as arrays of arrays (i.e., of objects). This was in particular used for meshgrids, which are a kind of discretization supported by the interpolation classes in `odl.discr`.

Current NumPy does not automatically convert to dtype=object anymore, and for good reasons: it is error-prone (shapes become ambiguous, whether to consider the nested array or just its outer structure) and performance / memory locality suffers. In https://github.com/odlgroup/odl/pull/1633, this was addressed by explicitly generating an object-array specifically for the meshgrid-specifying inputs, but further testing (https://github.com/odlgroup/odl/issues/1648) revealed that this was not sufficient: the `dtype=object` property would percolate into the interpolation calculations, and there cause new failures due to required implicit conversion (as well as performance degradation).

This PR goes into the details of the interpolation routines and ensures linear arrays are stored with primitive dtype. It fixes the discretization tests in NumPy-1.19, though there are still some implicit conversions that the even stricter numpy-1.26 does not accept, as well as different tests that currently fail for unrelated reasons.