### PR TITLE
Fix bug in sparse matrix indexing

### DIFF
--- a/odl/util/sparse.py
+++ b/odl/util/sparse.py
@@ -51,4 +51,4 @@ class COOMatrix():
         return self.__data
 
     def __repr__(self):
-        return f"COO matrix({self.data}, {self.index})"
+        return f"COO matrix({self.data}, {self.__index}, {self.shape})"

--- a/odl/util/sparse.py
+++ b/odl/util/sparse.py
@@ -3,6 +3,8 @@
 Sparse matrix representation for creating product space operators.
 """
 
+import numpy as np
+
 __all__ = ('COOMatrix',)
 
 
@@ -27,18 +29,19 @@ class COOMatrix():
             raise ValueError('data and index must have the same length')
 
         self.__data = data
-        self.__index = index
+        self.__row_index = np.asarray(index[0])
+        self.__col_index = np.asarray(index[1])
         self.__shape = shape
 
     @property
     def row(self):
         """Return the row indices of the matrix."""
-        return self.__index[0]
+        return self.__row_index
 
     @property
     def col(self):
         """Return the column indices of the matrix."""
-        return self.__index[1]
+        return self.__col_index
 
     @property
     def shape(self):
@@ -51,4 +54,5 @@ class COOMatrix():
         return self.__data
 
     def __repr__(self):
-        return f"COO matrix({self.data}, {self.__index}, {self.shape})"
+        return ( f"COO matrix({self.data},"
+                + f"({self.__row_index}, {self.__col_index}), {self.shape})" )


### PR DESCRIPTION
As per https://github.com/odlgroup/odl/issues/1650, the new implementation of `ProductSpaceOperator` after https://github.com/odlgroup/odl/pull/1642 has a problem with element-wise accessing of the constituent operators, specifically with the indexing into the matrix of these operators.

I traced the problem to Python's lack of type safety - specifically the fact that the new `COOMatrix` class does not guarantee its row- and column indices are stored as NumPy arrays as `ProductSpaceOperator` requires.

A simple explicit conversion through `np.asarray` fixes this problem.