### PR TITLE
Slightly relax coding-style checks

### DIFF
--- a/.pep8speaks.yml
+++ b/.pep8speaks.yml
@@ -12,7 +12,23 @@ scanner:
 
 pycodestyle:
     show-source: True
+    max-line-length: 90 # Default is 80, but a little bit more is hardly a
+                        # problem on any modern device and can aid readability
+                        # by avoiding splits in self-contained lines.
+
     ignore:  # Errors and warnings to ignore
+
+        - E126 # Limits split-line continuations to be indented only by 4 spaces.
+               # This is not required by PEP8 and is often counterproductive for
+               # readability, particularly when the following line is indented
+               # to the same level and thus does not stand out as a new statement.
+
+        - E225 # Whitespace around all infix operators. PEP8 requires only
+               # that the whitespace should be the same on both sides of the
+               # operator, but often it is more compact and readable to just
+               # not have whitespace at all, particularly when writing
+               # something like a*b + c.
+
         - E402
         - E741
         - W503


### PR DESCRIPTION
This topic is up for debate.

It is certainly good to adhere to a style guide and [PEP 8](https://peps.python.org/pep-0008/) is established and mostly sensible. However, I find myself repeatedly clashing with the pep8speaks linter, particularly its very narrow understanding of where whitespace is and isn't allowed. In some cases I find the "fixed" version (according to these rules) to have significantly worse readability, because they require e.g. breaking lines in inconvenient spots and disallow aligning code in an eye-intuitive way.

This can be avoided by ignoring some of the linter rules. I would suggest reflecting that in the pep8speaks configuration, so it isn't a sticking point in every single pull request. 

Particularly debatable is the 80-characters limit. In my opinion it is good to _aim_ for 80 characters, but not to be dogmatic about it and to introduce a line break just to avoid having 3 characters too many in a line (especially when the line break also requires extra parentheses, and more indentation).