### PR TITLE
Remove some type-inconsistent tests.

### DIFF
--- a/odl/test/discr/discr_space_test.py
+++ b/odl/test/discr/discr_space_test.py
@@ -852,11 +852,21 @@ def test_ufuncs(odl_tspace_impl, odl_ufunc):
 
     assert all_almost_equal(odl_result, npy_result)
 
-    # Check `ufunc.reduce`
-    if nin == 2 and nout == 1:
-        in_array = in_arrays[0]
-        in_elem = in_elems_new[0]
+    # Most ufuncs are type-preserving and can therefore be applied iteratively
+    # for reductions. This is not the case for equalities or logical operators,
+    # which can only be iterated over an array that was boolean to start with.
+    boolean_ufuncs = ['equal', 'not_equal',
+                      'greater', 'greater_equal',
+                      'less', 'less_equal',
+                      'logical_and', 'logical_or',
+                      'logical_xor']
 
+    in_array = in_arrays[0]
+    in_elem = in_elems_new[0]
+
+    # Check `ufunc.reduce`
+    if (nin == 2 and nout == 1
+          and (odl_ufunc not in boolean_ufuncs or in_array.dtype is bool)):
         # We only test along one axis since some binary ufuncs are not
         # re-orderable, in which case Numpy raises a ValueError
         with np.errstate(all='ignore'):  # avoid pytest warnings

--- a/odl/test/space/tensors_test.py
+++ b/odl/test/space/tensors_test.py
@@ -1378,6 +1378,7 @@ def test_ufuncs(tspace, odl_ufunc):
 
     if (np.issubsctype(tspace.dtype, np.complexfloating) and
             name in ['remainder',
+                     'floor_divide',
                      'trunc',
                      'signbit',
                      'invert',

--- a/odl/test/space/tensors_test.py
+++ b/odl/test/space/tensors_test.py
@@ -1487,10 +1487,21 @@ def test_ufuncs(tspace, odl_ufunc):
 
     assert all_almost_equal(odl_result, npy_result)
 
+    # Most ufuncs are type-preserving and can therefore be applied iteratively
+    # for reductions. This is not the case for equalities or logical operators,
+    # which can only be iterated over an array that was boolean to start with.
+    boolean_ufuncs = ['equal', 'not_equal',
+                      'greater', 'greater_equal',
+                      'less', 'less_equal',
+                      'logical_and', 'logical_or',
+                      'logical_xor']
+
+    in_array = in_arrays[0]
+    in_elem = in_elems_new[0]
+
     # Check `ufunc.reduce`
-    if nin == 2 and nout == 1:
-        in_array = in_arrays[0]
-        in_elem = in_elems_new[0]
+    if (nin == 2 and nout == 1
+          and (odl_ufunc not in boolean_ufuncs or in_array.dtype is bool)):
 
         # We only test along one axis since some binary ufuncs are not
         # re-orderable, in which case Numpy raises a ValueError

--- a/odl/test/tomo/operators/ray_trafo_test.py
+++ b/odl/test/tomo/operators/ray_trafo_test.py
@@ -16,7 +16,7 @@ from packaging.version import parse as parse_version
 from functools import partial
 
 import odl
-from odl.tomo.backends import ASTRA_VERSION
+from odl.tomo.backends import ASTRA_AVAILABLE, ASTRA_VERSION
 from odl.tomo.util.testutils import (
     skip_if_no_astra, skip_if_no_astra_cuda, skip_if_no_skimage)
 from odl.util.testutils import all_almost_equal, simple_fixture
@@ -235,7 +235,8 @@ def test_adjoint(projector):
     # Relative tolerance, still rather high due to imperfectly matched
     # adjoint in the cone beam case
     if (
-        parse_version(ASTRA_VERSION) < parse_version('1.8rc1')
+        ASTRA_AVAILABLE
+        and parse_version(ASTRA_VERSION) < parse_version('1.8rc1')
         and isinstance(projector.geometry, odl.tomo.ConeBeamGeometry)
     ):
         rtol = 0.1


### PR DESCRIPTION
Reducing (aka folding) an operation like `==` over an array of e.g. floating-point numbers does not really make any sense, because after the first application one has a boolean which to compare to a number is ill-typed.

This only ever worked because old NumPy would apply implicit type widening, but newer versions rightfully do not support this anymore. Since the test only checked whether ODL gave the same results as NumPy, but NumPy does _not_ give results for these cases anymore, it is only reasonable to remove the tests.

All these were done both for `discr_space` and `tensor_space`, with unfortunate redundancy in the testing code, so I also needed to apply the patch twice.