### PR TITLE
Fixing issues related to dtype=object arrays in interpolation routines

### DIFF
--- a/odl/discr/discr_utils.py
+++ b/odl/discr/discr_utils.py
@@ -20,6 +20,7 @@ import sys
 from builtins import object
 from functools import partial
 from itertools import product
+from warnings import warn
 
 import numpy as np
 
@@ -624,6 +625,8 @@ class _Interpolator(object):
             try:
                 xi = np.asarray(xi).astype(self.values.dtype, casting='safe')
             except TypeError:
+                warn("Unable to infer accurate dtype for"
+                  +" interpolation coefficients, defaulting to `float`.")
                 xi = np.asarray(xi, dtype=float)
 
             idcs = np.searchsorted(cvec, xi) - 1

--- a/odl/discr/discr_utils.py
+++ b/odl/discr/discr_utils.py
@@ -801,7 +801,7 @@ class _PerAxisInterpolator(_Interpolator):
         # axis, resulting in a loop of length 2**ndim
         for lo_hi, edge in zip(product(*([['l', 'h']] * len(indices))),
                                product(*edge_indices)):
-            weight = 1.0
+            weight = np.array([1.0], dtype=self.values.dtype)
             # TODO(kohr-h): determine best summation order from array strides
             for lh, w_lo, w_hi in zip(lo_hi, low_weights, high_weights):
 

--- a/odl/discr/discr_utils.py
+++ b/odl/discr/discr_utils.py
@@ -621,6 +621,8 @@ class _Interpolator(object):
 
         # iterate through dimensions
         for xi, cvec in zip(x, self.coord_vecs):
+            xi = np.asarray(xi, dtype=self.values.dtype)
+
             idcs = np.searchsorted(cvec, xi) - 1
 
             idcs[idcs < 0] = 0

--- a/odl/discr/discr_utils.py
+++ b/odl/discr/discr_utils.py
@@ -706,6 +706,8 @@ def _compute_nearest_weights_edge(idcs, ndist):
 
 def _compute_linear_weights_edge(idcs, ndist):
     """Helper for linear interpolation."""
+    ndist = np.asarray(ndist)
+
     # Get out-of-bounds indices from the norm_distances. Negative
     # means "too low", larger than or equal to 1 means "too high"
     lo = np.where(ndist < 0)

--- a/odl/discr/discr_utils.py
+++ b/odl/discr/discr_utils.py
@@ -621,7 +621,10 @@ class _Interpolator(object):
 
         # iterate through dimensions
         for xi, cvec in zip(x, self.coord_vecs):
-            xi = np.asarray(xi, dtype=self.values.dtype)
+            try:
+                xi = np.asarray(xi).astype(self.values.dtype, casting='safe')
+            except TypeError:
+                xi = np.asarray(xi, dtype=float)
 
             idcs = np.searchsorted(cvec, xi) - 1
 

--- a/odl/util/vectorization.py
+++ b/odl/util/vectorization.py
@@ -21,7 +21,10 @@ __all__ = ('is_valid_input_array', 'is_valid_input_meshgrid',
 
 def is_valid_input_array(x, ndim=None):
     """Test if ``x`` is a correctly shaped point array in R^d."""
-    x = np.asarray(x)
+    try:
+        x = np.asarray(x)
+    except ValueError:
+        return False
 
     if ndim is None or ndim == 1:
         return x.ndim == 1 and x.size > 1 or x.ndim == 2 and x.shape[0] == 1


### PR DESCRIPTION
_This is a cleaned-up version of parts of #1649._ See that PR for discussion.

In old versions of NumPy, ODL relied on its capability to represent ragged arrays automatically as arrays of arrays (i.e., of objects). This was in particular used for meshgrids, which are a kind of discretization supported by the interpolation classes in odl.discr.

Current NumPy does not automatically convert to dtype=object anymore, and for good reasons: it is error-prone (shapes become ambiguous, whether to consider the nested array or just its outer structure) and performance / memory locality suffers. In https://github.com/odlgroup/odl/pull/1633, this was addressed by explicitly generating an object-array specifically for the meshgrid-specifying inputs, but further testing (https://github.com/odlgroup/odl/issues/1648) revealed that this was not sufficient: the dtype=object property would percolate into the interpolation calculations, and there cause new failures due to required implicit conversion (as well as performance degradation).

This PR goes into the details of the interpolation routines and ensures linear arrays are stored with primitive dtype. It fixes the discretization tests in NumPy-1.19, though there are still some implicit conversions that the even stricter numpy-1.26 does not accept, as well as different tests that currently fail for unrelated reasons.