### PR TITLE
Meta-information for the v0.8 release

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -15,30 +15,30 @@ build:
 
 requirements:
     build:
-        - python
-        - setuptools
+        - python >=3.7
+        - setuptools >=65.6
 
     host:
         - python
         - setuptools
         - nomkl # [not win]
-        - future >=0.14
-        - numpy >=1.13.3
-        - scipy >=0.14
-        - packaging >=15.0
+        - future >=0.16
+        - numpy >=1.19
+        - scipy >=1.1
+        - packaging >=17.0
 
     run:
         - python
-        - future >=0.14
-        - numpy >=1.13.3
-        - scipy >=0.14
-        - packaging >=15.0
-        - matplotlib
+        - future >=0.16
+        - numpy >=1.19
+        - scipy >=1.1
+        - packaging >=17.0
+        - matplotlib >=3.4
 
 test:
     requires:
         - nomkl # [not win]
-        - pytest >=3.0.3,<5.1
+        - pytest >=5.4
     imports:
         - odl
     commands:

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -1,6 +1,6 @@
 package:
     name: odl
-    version: "1.0.0.dev"
+    version: "0.8.0"
 
 source:
     git_url: https://github.com/odlgroup/odl

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -52,5 +52,8 @@ about:
 
 extra:
     maintainers:
-        - Jonas Adler (@adler-j)
-        - Holger Kohr (@kohr-h)
+        - Ozan Öktem (@ozanoktem)
+        - Justus Sagemüller (@leftaroundabout)
+        - Emilien Valat (@Emvlt)
+        # - Jonas Adler (@adler-j)
+        # - Holger Kohr (@kohr-h)

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,26 +27,24 @@ classifiers =
     Topic :: Software Development :: Libraries
     Topic :: Software Development :: Libraries :: Python Modules
     License :: OSI Approved :: Mozilla Public License 2.0 (MPL 2.0)
-    Programming Language :: Python :: 2
-    Programming Language :: Python :: 2.7
-    Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.5
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
+    Programming Language :: Python :: 3.12
     Operating System :: OS Independent
 
 [options]
 packages = find:
 install_requires =
-    setuptools >=39.2.0
-    future >=0.14
-    packaging >=15.0
-    numpy >=1.13.3, !=1.14.0, !=1.14.1, !=1.14.2
-    scipy >=0.14
-python_requires = >=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*
+    setuptools >=65.6
+    future >=0.16
+    packaging >=17.0
+    numpy >=1.19
+    scipy >=1.1
+python_requires = >=3.7
 tests_require =
-    pytest >=3.1, <5.0 ; python_version <= "2.7"
     pytest >=5.4.0 ; python_version >= "3"
     coverage >=4.0
     coveralls


### PR DESCRIPTION
We are about to release a new version for easy Conda installation. Some parts of the information in `meta.yaml` is clearly outdated and should not be used for this.

Also, since this is _not_ a major release but rather a dependency-updated version of how ODL was around 2020, the version number is kept at 0.*. Version 1.0 will be the one that is stable in the sense that it will work for the storage/compute backends we intend to support, whereas this version is still largely hard-coded to NumPy.