### PR TITLE
Update docs and metadata in the light of the Conda-Forge release.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-[![PyPI version](https://badge.fury.io/py/odl.svg)](https://badge.fury.io/py/odl)
+[![Anaconda-Server Badge](https://anaconda.org/conda-forge/odl/badges/version.svg)](https://anaconda.org/conda-forge/odl) <!-- [![PyPI version](https://badge.fury.io/py/odl.svg)](https://badge.fury.io/py/odl)
 [![Build Status](https://travis-ci.org/odlgroup/odl.svg?branch=master)](https://travis-ci.org/odlgroup/odl?branch=master)
-[![Coverage Status](https://coveralls.io/repos/github/odlgroup/odl/badge.svg)](https://coveralls.io/github/odlgroup/odl)
+[![Coverage Status](https://coveralls.io/repos/github/odlgroup/odl/badge.svg)](https://coveralls.io/github/odlgroup/odl) -->
 [![license](https://img.shields.io/badge/license-MPL--2.0-orange.svg)](https://opensource.org/licenses/MPL-2.0)
 [![DOI](https://zenodo.org/badge/45596393.svg)](https://zenodo.org/badge/latestdoi/45596393)
 

--- a/README.md
+++ b/README.md
@@ -20,11 +20,7 @@ Installation
 ============
 Installing ODL should be as easy as
 
-    conda install -c odlgroup odl
-
-or
-
-    pip install odl
+    conda install conda-forge::odl
 
 For more detailed instructions, check out the [Installation guide](https://odlgroup.github.io/odl/getting_started/installing.html).
 

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -10,39 +10,31 @@ source:
     # path: ..  # for builds from local source (no download)
 
 build:
+    noarch: python
     number: 0
-    # noarch_python: True
 
 requirements:
-    build:
-        - python >=3.7
-        - setuptools >=65.6
+  host:
+    - python >=3.7
+    - pip
+    - setuptools >=65.6
 
-    host:
-        - python
-        - setuptools
-        - nomkl # [not win]
-        - future >=0.16
-        - numpy >=1.19
-        - scipy >=1.1
-        - packaging >=17.0
-
-    run:
-        - python
-        - future >=0.16
-        - numpy >=1.19
-        - scipy >=1.1
-        - packaging >=17.0
-        - matplotlib >=3.4
+  run:
+    - python >=3.7
+    - setuptools <76.0
+    - future >=0.16
+    - numpy >=1.19, <1.27
+    - scipy >=1.1
+    - packaging >=17.0
+    - matplotlib-base >=3.4
 
 test:
-    requires:
-        - nomkl # [not win]
-        - pytest >=5.4
-    imports:
-        - odl
-    commands:
-        - python -c "import odl; odl.test()"
+  requires:
+    - pytest >=5.4
+  imports:
+    - odl
+  commands:
+    - python -c "import odl; odl.test()"
 
 about:
     home: https://github.com/odlgroup/odl

--- a/doc/source/getting_started/installing.rst
+++ b/doc/source/getting_started/installing.rst
@@ -65,9 +65,11 @@ Which Python version to use?
 ============================
 Any modern Python distribution supporting `NumPy`_ and `SciPy`_ should work for the core library, but some extensions require CPython (the standard Python distribution).
 
-ODL fully supports both Python 2 and Python 3.
+ODL fully supports most recent Python versions.
 If you choose to use your system Python interpreter (the "pip install as user" variant), it may be a good idea to stick with the default one, i.e. the one invoked by the ``python`` command on the command line.
-Otherwise, we recommend using Python 3, since Python 2 support will be discontinued in 2020.
+Otherwise, we recommend using Python 3.10.
+
+Python 2 and early versions of Python 3 are not supported anymore, but you may be able to use them with old releases of odl.
 
 
 .. _installing_odl__development_environment:

--- a/doc/source/getting_started/installing.rst
+++ b/doc/source/getting_started/installing.rst
@@ -21,7 +21,7 @@ or conda:
 
 .. code-block:: bash
 
-    $ conda install -c odlgroup odl matplotlib pytest scikit-image spyder
+    $ conda install conda-forge::odl matplotlib pytest scikit-image spyder
 
 After installation, the installation can be verified by running the tests:
 

--- a/doc/source/getting_started/installing_conda.rst
+++ b/doc/source/getting_started/installing_conda.rst
@@ -20,7 +20,7 @@ Instructions for the impatient:
 
   .. code-block:: bash
 
-    $ conda create -c odlgroup -n odl-py35 python=3.5 odl matplotlib pytest scikit-image spyder
+    $ conda create -n odl-py310 python=3.10 conda-forge::odl matplotlib pytest scikit-image spyder
 
 - Activate the conda enviroment and start working!
 
@@ -54,9 +54,9 @@ This is a very convenient way to have several "ecosystems" of Python packages in
 
 .. code-block:: bash
 
-    $ conda create --name odl-py35 python=3.5
+    $ conda create --name odl-py310 python=3.10
 
-Enter the newly created conda environment by running ``source activate odl-py35`` (Linux/MacOS) or ``activate odl-py35`` (Windows).
+Enter the newly created conda environment by running ``source activate odl-py310`` (Linux/MacOS) or ``activate odl-py310`` (Windows).
 If you want to exit later on, run ``source deactivate`` (Linux/MacOS) or ``deactivate`` (Windows), respectively.
 See the `Managing conda environments`_ documentation for further information.
 
@@ -72,7 +72,7 @@ See the `Managing conda environments`_ documentation for further information.
     To do this, open Spyder and use the navigation bar to open "Tools -> Preferences".
     Click on "Python interpreter" and change the first setting "Select the Python interpreter for all Spyder consoles" from the default setting to "Use the following Python interpreter:".
     In the text field, fill in the path to the Python executable in your newly created conda environment.
-    For example, if you installed Miniconda (or Anaconda) in ``C:\Programs\Miniconda3``, then the environment's Python interpreter is ``C:\Programs\Miniconda3\envs\odl-py35\bin\python.exe``.
+    For example, if you installed Miniconda (or Anaconda) in ``C:\Programs\Miniconda3``, then the environment's Python interpreter is ``C:\Programs\Miniconda3\envs\odl-py310\bin\python.exe``.
     You can use the file system browser (symbol to the right of the text field) to find the interpreter on your system.
 
 
@@ -82,16 +82,20 @@ Install ODL and all its (minimal) dependencies in a ``conda`` environment of you
 
 .. code-block:: bash
 
-    $ conda install -c odlgroup odl
+    $ conda install -c conda-forge odl
 
 .. note::
-    To skip the ``-c odlgroup`` option in the future, you can permanently add the ``odlgroup`` conda channel (see `Managing conda channels`_):
+    To skip the ``-c conda-forge`` option in the future, you can permanently add the ``conda-forge`` conda channel (see `Managing conda channels`_):
 
     .. code-block:: bash
 
-        $ conda config --append channels odlgroup
+        $ conda config --append channels conda-forge
 
     After that, ``conda install odl`` and ``conda update odl`` work without the ``-c`` option.
+
+    Alternatively, you can always directly refer to the conda-forge version of odl by writing
+
+    $ conda install conda-forge::odl
 
 
 .. _installing_odl_conda__extensions:

--- a/doc/source/getting_started/installing_pip.rst
+++ b/doc/source/getting_started/installing_pip.rst
@@ -37,16 +37,16 @@ Otherwise, you need to install it.
 
 On Linux:
 ---------
-In the unlikely event that Python is not installed, consult your distro package manager.
+In the unlikely event that Python 3 is not installed, consult your distro package manager.
 
 On MacOS:
 ---------
-Get the latest release (2 or 3) for MacOS `here <https://www.python.org/downloads/mac-osx/>`_ and install it.
+Get the latest release for MacOS `here <https://www.python.org/downloads/mac-osx/>`_ and install it.
 
 On Windows:
 -----------
 Python installers can be downloaded from `this link <https://www.python.org/downloads/windows/>`_.
-Pick the latest release for your favorite version (2 or 3).
+Pick the latest release for your favorite version.
 
 
 .. _installing_odl_pip__installing:
@@ -54,7 +54,7 @@ Pick the latest release for your favorite version (2 or 3).
 Installing ODL and its dependencies
 ===================================
 You may need to `install pip`_ to be able to install ODL and its dependencies from the `Python Package Index`_ (PyPI).
-If running ``pip`` (alternatively: ``pip2`` or ``pip3``) shows a help message, it is installed -- otherwise you need to install it first.
+If running ``pip`` (alternatively: ``pip3``) shows a help message, it is installed -- otherwise you need to install it first.
 
 For basic installation without extra dependencies, run
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -41,8 +41,9 @@ install_requires =
     setuptools >=65.6
     future >=0.16
     packaging >=17.0
-    numpy >=1.19
+    numpy >=1.19, <1.27
     scipy >=1.1
+    matplotlib-base >=3.4
 python_requires = >=3.7
 tests_require =
     pytest >=5.4.0 ; python_version >= "3"


### PR DESCRIPTION
ODL-0.8 [is now in the Conda-Forge](https://anaconda.org/conda-forge/odl) channel. This should now be the official way to install ODL, though a PyPI release is also still planned.

This PR changes the installation advice in the documentation accordingly, and updates the metadata to reflect the status of the Conda-Forge release.