### PR TITLE
Support for immutable LinearSpace elements

### DIFF
--- a/odl/discr/discr_space.py
+++ b/odl/discr/discr_space.py
@@ -517,15 +517,21 @@ class DiscretizedSpace(TensorSpace):
 
     def _lincomb(self, a, x1, b, x2, out):
         """Raw linear combination."""
-        self.tspace._lincomb(a, x1.tensor, b, x2.tensor, out.tensor)
+        return self.element(
+            self.tspace._lincomb(a, x1.tensor, b, x2.tensor,
+                                 out.tensor if out is not None else None))
 
     def _multiply(self, x1, x2, out):
         """Raw pointwise multiplication of two elements."""
-        self.tspace._multiply(x1.tensor, x2.tensor, out.tensor)
+        return self.element(
+                self.tspace._multiply(x1.tensor, x2.tensor,
+                                      out.tensor if out is not None else None))
 
     def _divide(self, x1, x2, out):
         """Raw pointwise multiplication of two elements."""
-        self.tspace._divide(x1.tensor, x2.tensor, out.tensor)
+        return self.element(
+                self.tspace._divide(x1.tensor, x2.tensor,
+                                    out.tensor if out is not None else None))
 
     # The inherited methods by default use a weighting by a constant
     # (the grid cell size). In dimensions where the partitioned set contains

--- a/odl/discr/discr_space.py
+++ b/odl/discr/discr_space.py
@@ -18,6 +18,7 @@ from odl.discr.discr_utils import point_collocation, sampling_function
 from odl.discr.partition import (
     RectPartition, uniform_partition, uniform_partition_fromintv)
 from odl.set import IntervalProd, RealNumbers
+from odl.set.space import SupportedNumOperationParadigms, NumOperationParadigmSupport
 from odl.space import ProductSpace
 from odl.space.base_tensors import Tensor, TensorSpace
 from odl.space.entry_points import tensor_space_impl
@@ -100,6 +101,12 @@ class DiscretizedSpace(TensorSpace):
     def element_type(self):
         """`DiscretizedSpaceElement`"""
         return DiscretizedSpaceElement
+
+    @property
+    def supported_num_operation_paradigms(self) -> NumOperationParadigmSupport:
+        """In-place vs out-of-place is not of much concern for the discretization
+        and only depends on the underlying arrays."""
+        return self.tspace.supported_num_operation_paradigms
 
     # --- Constructor args
 

--- a/odl/discr/discr_space.py
+++ b/odl/discr/discr_space.py
@@ -737,6 +737,11 @@ class DiscretizedSpaceElement(Tensor):
         """
         return self.space.astype(dtype).element(self.tensor.astype(dtype))
 
+    def _assign(self, other, avoid_deep_copy):
+        """Assign the values of ``other``, which is assumed to be in the
+        same discretized space, to ``self``."""
+        self.__tensor.assign(other.tensor, avoid_deep_copy=avoid_deep_copy)
+
     def __eq__(self, other):
         """Return ``self == other``.
 

--- a/odl/set/space.py
+++ b/odl/set/space.py
@@ -598,8 +598,7 @@ class LinearSpaceElement(object):
         elif self.space.field is None:
             return NotImplemented
         elif other in self.space:
-            tmp = self.space.element()
-            return self.space.lincomb(1, self, 1, other, out=tmp)
+            return self.space.lincomb(1, self, 1, other)
         elif isinstance(other, LinearSpaceElement):
             return NotImplemented
         elif other in self.space.field:
@@ -662,8 +661,7 @@ class LinearSpaceElement(object):
         elif self.space.field is None:
             return NotImplemented
         elif other in self.space:
-            tmp = self.space.element()
-            return self.space.lincomb(1, self, -1, other, out=tmp)
+            return self.space.lincomb(1, self, -1, other)
         elif isinstance(other, LinearSpaceElement):
             return NotImplemented
         elif other in self.space.field:
@@ -740,11 +738,9 @@ class LinearSpaceElement(object):
         elif self.space.field is None:
             return NotImplemented
         elif other in self.space.field:
-            tmp = self.space.element()
-            return self.space.lincomb(other, self, out=tmp)
+            return self.space.lincomb(other, self)
         elif other in self.space:
-            tmp = self.space.element()
-            return self.space.multiply(other, self, out=tmp)
+            return self.space.multiply(other, self)
         elif isinstance(other, LinearSpaceElement):
             return NotImplemented
         else:
@@ -794,11 +790,9 @@ class LinearSpaceElement(object):
         elif self.space.field is None:
             return NotImplemented
         elif other in self.space.field:
-            tmp = self.space.element()
-            return self.space.lincomb(1.0 / other, self, out=tmp)
+            return self.space.lincomb(1.0 / other, self)
         elif other in self.space:
-            tmp = self.space.element()
-            return self.space.divide(self, other, out=tmp)
+            return self.space.divide(self, other)
         elif isinstance(other, LinearSpaceElement):
             return NotImplemented
         else:

--- a/odl/set/space.py
+++ b/odl/set/space.py
@@ -24,13 +24,24 @@ class NumOperationParadigmSupport(Enum):
     NOT_SUPPORTED = 0
     SUPPORTED = 1
     PREFERRED = 2
-    def __bool__(self):
+
+    @property
+    def is_supported(self):
         return self.value > 0
+
+    @property
+    def is_preferred(self):
+        return self.value > 1
+
+    def __bool__(self):
+        return self.is_supported
+
 
 @dataclass
 class SupportedNumOperationParadigms:
     in_place: NumOperationParadigmSupport
     out_of_place: NumOperationParadigmSupport
+
 
 class LinearSpace(Set):
     """Abstract linear vector space.

--- a/odl/set/space.py
+++ b/odl/set/space.py
@@ -237,15 +237,23 @@ class LinearSpace(Set):
         def assert_x2_has_b():
             if b is None and x2 is not None:
                 raise ValueError('`x2` provided but not `b`')
+
+        def assert_x1_in_self():
+            if x1 not in self:
+                raise LinearSpaceTypeError('`x1` {!r} is not an element of '
+                                           '{!r}'.format(x1, self))
+
         def assert_x2_in_self():
             if x2 not in self:
                 raise LinearSpaceTypeError('`x2` {!r} is not an element of '
                                            '{!r}'.format(x2, self))
+
         def assert_a_in_field():
             if self.field is not None and a not in self.field:
                 raise LinearSpaceTypeError('`a` {!r} not an element of the field '
                                            '{!r} of {!r}'
                                            ''.format(a, self.field, self))
+
         def assert_b_in_field():
             if self.field is not None and b not in self.field:
                 raise LinearSpaceTypeError('`b` {!r} not an element of the '
@@ -257,29 +265,32 @@ class LinearSpace(Set):
                  or not paradigms.out_of_place.is_supported):
                 out = self.element()
             else:
+                assert_a_in_field()
+                assert_x1_in_self()
                 if b is None:  # Single element
                     assert_x2_has_b()
-                    return self._lincomb(a, x1, 0, x1, None)
+                    result = self._lincomb(a, x1, 0, x1, out=None)
+                    assert(result is not None)
+                    return result
                 else:  # Two elements
                     assert_b_in_field()
                     assert_x2_in_self()
-                    return self._lincomb(a, x1, b, x2, None)
-
-        elif (not paradigms.in_place.is_supported):
-            out.assign(self.lincomb(a, x1, b, x2, out=None), avoid_deep_copy=True)
-            return out
-
+                    result = self._lincomb(a, x1, b, x2, out=None)
+                    assert(result is not None)
+                    return result
         elif out not in self:
             raise LinearSpaceTypeError('`out` {!r} is not an element of {!r}'
                                        ''.format(out, self))
+
+        if (not paradigms.in_place.is_supported):
+            out.assign(self.lincomb(a, x1, b, x2, out=None), avoid_deep_copy=True)
+            return out
+
         assert_a_in_field()
-        if x1 not in self:
-            raise LinearSpaceTypeError('`x1` {!r} is not an element of {!r}'
-                                       ''.format(x1, self))
+        assert_x1_in_self()
 
         if b is None:  # Single element
-            if x2 is not None:
-                raise ValueError('`x2` provided but not `b`')
+            assert_x2_has_b()
             self._lincomb(a, x1, 0, x1, out)
 
         else:  # Two elements
@@ -369,16 +380,16 @@ class LinearSpace(Set):
             raise LinearSpaceTypeError('`x2` {!r} is not an element of '
                                        '{!r}'.format(x2, self))
 
+        if out is not None and out not in self:
+            raise LinearSpaceTypeError('`out` {!r} is not an element of '
+                                       '{!r}'.format(out, self))
+
         if (paradigms.in_place.is_preferred
              or not paradigms.out_of_place.is_supported
              or out is not None and paradigms.in_place.is_supported):
 
             if out is None:
                 out = self.element()
-
-            if out not in self:
-                raise LinearSpaceTypeError('`out` {!r} is not an element of '
-                                           '{!r}'.format(out, self))
 
             low_level_method(x1, x2, out=out)
 

--- a/odl/set/space.py
+++ b/odl/set/space.py
@@ -390,20 +390,7 @@ class LinearSpace(Set):
             Quotient of the elements. If ``out`` was provided, the
             returned object is a reference to it.
         """
-        if out is None:
-            out = self.element()
-
-        if out not in self:
-            raise LinearSpaceTypeError('`out` {!r} is not an element of '
-                                       '{!r}'.format(out, self))
-        if x1 not in self:
-            raise LinearSpaceTypeError('`x1` {!r} is not an element of '
-                                       '{!r}'.format(x1, self))
-        if x2 not in self:
-            raise LinearSpaceTypeError('`x2` {!r} is not an element of '
-                                       '{!r}'.format(x2, self))
-        self._divide(x1, x2, out)
-        return out
+        return self._binary_num_operation(self._divide, x1, x2, out)
 
     @property
     def element_type(self):

--- a/odl/set/space.py
+++ b/odl/set/space.py
@@ -333,12 +333,12 @@ class LinearSpace(Set):
         `x1` and `x2`.
         This is done either in in-place fashion or out-of-place, depending on
         which style is preferred for this space."""
-        if (self.supported_num_operation_paradigms.in_place
-                  == NumOperationParadigmSupport.PREFERRED
-             or self.supported_num_operation_paradigms.out_of_place
-                  == NumOperationParadigmSupport.NOT_SUPPORTED
-             or out is not None
-                 and self.supported_num_operation_paradigms.in_place):
+
+        paradigms = self.supported_num_operation_paradigms
+
+        if (paradigms.in_place.is_preferred
+             or not paradigms.out_of_place.is_supported
+             or out is not None and paradigms.in_place.is_supported):
 
             if out is None:
                 out = self.element()
@@ -358,7 +358,7 @@ class LinearSpace(Set):
             return out
 
         else:
-            assert(self.supported_num_operation_paradigms.out_of_place)
+            assert(paradigms.out_of_place.is_supported)
             if out is not None:
                 out[:] = low_level_method(x1, x2, out=None)
                 return out

--- a/odl/set/space.py
+++ b/odl/set/space.py
@@ -397,11 +397,12 @@ class LinearSpace(Set):
 
         else:
             assert(paradigms.out_of_place.is_supported)
+            result = self.element(low_level_method(x1, x2, out=None))
             if out is not None:
-                out[:] = low_level_method(x1, x2, out=None)
+                out.assign(result, avoid_deep_copy=True)
                 return out
             else:
-                return self.element(low_level_method(x1, x2, out=None))
+                return result
 
     def multiply(self, x1, x2, out=None):
         """Return the pointwise product of ``x1`` and ``x2``.

--- a/odl/set/space.py
+++ b/odl/set/space.py
@@ -362,6 +362,13 @@ class LinearSpace(Set):
 
         paradigms = self.supported_num_operation_paradigms
 
+        if x1 not in self:
+            raise LinearSpaceTypeError('`x1` {!r} is not an element of '
+                                       '{!r}'.format(x1, self))
+        if x2 not in self:
+            raise LinearSpaceTypeError('`x2` {!r} is not an element of '
+                                       '{!r}'.format(x2, self))
+
         if (paradigms.in_place.is_preferred
              or not paradigms.out_of_place.is_supported
              or out is not None and paradigms.in_place.is_supported):
@@ -372,12 +379,6 @@ class LinearSpace(Set):
             if out not in self:
                 raise LinearSpaceTypeError('`out` {!r} is not an element of '
                                            '{!r}'.format(out, self))
-            if x1 not in self:
-                raise LinearSpaceTypeError('`x1` {!r} is not an element of '
-                                           '{!r}'.format(x1, self))
-            if x2 not in self:
-                raise LinearSpaceTypeError('`x2` {!r} is not an element of '
-                                           '{!r}'.format(x2, self))
 
             low_level_method(x1, x2, out=out)
 

--- a/odl/set/space.py
+++ b/odl/set/space.py
@@ -317,6 +317,43 @@ class LinearSpace(Set):
         else:
             return self.field.element(self._inner(x1, x2))
 
+    def _binary_num_operation(self, low_level_method, x1, x2, out=None):
+        """Apply the numerical operation implemented by `low_level_method` to
+        `x1` and `x2`.
+        This is done either in in-place fashion or out-of-place, depending on
+        which style is preferred for this space."""
+        if (self.supported_num_operation_paradigms.in_place
+                  == NumOperationParadigmSupport.PREFERRED
+             or self.supported_num_operation_paradigms.out_of_place
+                  == NumOperationParadigmSupport.NOT_SUPPORTED
+             or out is not None
+                 and self.supported_num_operation_paradigms.in_place):
+
+            if out is None:
+                out = self.element()
+
+            if out not in self:
+                raise LinearSpaceTypeError('`out` {!r} is not an element of '
+                                           '{!r}'.format(out, self))
+            if x1 not in self:
+                raise LinearSpaceTypeError('`x1` {!r} is not an element of '
+                                           '{!r}'.format(x1, self))
+            if x2 not in self:
+                raise LinearSpaceTypeError('`x2` {!r} is not an element of '
+                                           '{!r}'.format(x2, self))
+
+            low_level_method(x1, x2, out=out)
+
+            return out
+
+        else:
+            assert(self.supported_num_operation_paradigms.out_of_place)
+            if out is not None:
+                out[:] = low_level_method(x1, x2, out=None)
+                return out
+            else:
+                return self.element(low_level_method(x1, x2, out=None))
+
     def multiply(self, x1, x2, out=None):
         """Return the pointwise product of ``x1`` and ``x2``.
 

--- a/odl/set/space.py
+++ b/odl/set/space.py
@@ -370,20 +370,7 @@ class LinearSpace(Set):
             Product of the elements. If ``out`` was provided, the
             returned object is a reference to it.
         """
-        if out is None:
-            out = self.element()
-
-        if out not in self:
-            raise LinearSpaceTypeError('`out` {!r} is not an element of '
-                                       '{!r}'.format(out, self))
-        if x1 not in self:
-            raise LinearSpaceTypeError('`x1` {!r} is not an element of '
-                                       '{!r}'.format(x1, self))
-        if x2 not in self:
-            raise LinearSpaceTypeError('`x2` {!r} is not an element of '
-                                       '{!r}'.format(x2, self))
-        self._multiply(x1, x2, out)
-        return out
+        return self._binary_num_operation(self._multiply, x1, x2, out)
 
     def divide(self, x1, x2, out=None):
         """Return the pointwise quotient of ``x1`` and ``x2``

--- a/odl/set/space.py
+++ b/odl/set/space.py
@@ -266,8 +266,8 @@ class LinearSpace(Set):
                     return self._lincomb(a, x1, b, x2, None)
 
         elif (not paradigms.in_place.is_supported):
-            raise LinearSpaceTypeError(
-              "This space does not support in-place operations, but an out argument was given.")
+            out.assign(self.lincomb(a, x1, b, x2, out=None), avoid_deep_copy=True)
+            return out
 
         elif out not in self:
             raise LinearSpaceTypeError('`out` {!r} is not an element of {!r}'

--- a/odl/space/npy_tensors.py
+++ b/odl/space/npy_tensors.py
@@ -889,6 +889,14 @@ class NumpyTensor(Tensor):
         """The `numpy.ndarray` representing the data of ``self``."""
         return self.__data
 
+    def _assign(self, other, avoid_deep_copy):
+        """Assign the values of ``other``, which is assumed to be in the
+        same space, to ``self``."""
+        if avoid_deep_copy:
+            self.__data = other.__data
+        else:
+            self.__data[:] = other.__data
+
     def asarray(self, out=None):
         """Extract the data of this array as a ``numpy.ndarray``.
 

--- a/odl/space/npy_tensors.py
+++ b/odl/space/npy_tensors.py
@@ -288,6 +288,8 @@ class NumpyTensorSpace(TensorSpace):
             # No weighting, i.e., weighting with constant 1.0
             self.__weighting = NumpyTensorSpaceConstWeighting(1.0, exponent)
 
+        self.__use_in_place_ops = kwargs.pop('use_in_place_ops', True)
+
         # Make sure there are no leftover kwargs
         if kwargs:
             raise TypeError('got unknown keyword arguments {}'.format(kwargs))
@@ -300,11 +302,18 @@ class NumpyTensorSpace(TensorSpace):
     @property
     def supported_num_operation_paradigms(self) -> NumOperationParadigmSupport:
         """NumPy has full support for in-place operation, which is usually
-        advantageous to reduce memory allocations."""
-        return SupportedNumOperationParadigms(
-                in_place = NumOperationParadigmSupport.PREFERRED,
-                out_of_place = NumOperationParadigmSupport.SUPPORTED)
-
+        advantageous to reduce memory allocations.
+        This can be deactivated, mostly for testing purposes, by setting
+        `use_in_place_ops = False` when constructing the space."""
+        if self.__use_in_place_ops:
+            return SupportedNumOperationParadigms(
+                    in_place = NumOperationParadigmSupport.PREFERRED,
+                    out_of_place = NumOperationParadigmSupport.SUPPORTED)
+        else:
+            return SupportedNumOperationParadigms(
+                    in_place = NumOperationParadigmSupport.NOT_SUPPORTED,
+                    out_of_place = NumOperationParadigmSupport.PREFERRED)
+    
     @property
     def default_order(self):
         """Default storage order for new elements in this space: ``'C'``."""

--- a/odl/space/npy_tensors.py
+++ b/odl/space/npy_tensors.py
@@ -564,7 +564,12 @@ class NumpyTensorSpace(TensorSpace):
         >>> result is out
         True
         """
-        _lincomb_impl(a, x1, b, x2, out)
+        if self.__use_in_place_ops:
+            assert(out is not None)
+            _lincomb_impl(a, x1, b, x2, out)
+        else:
+            assert(out is None)
+            return self.element(a * x1.data + b * x2.data)
 
     def _dist(self, x1, x2):
         """Return the distance between ``x1`` and ``x2``.

--- a/odl/space/npy_tensors.py
+++ b/odl/space/npy_tensors.py
@@ -20,7 +20,8 @@ import numpy as np
 from odl.util.npy_compat import AVOID_UNNECESSARY_COPY
 
 from odl.set.sets import ComplexNumbers, RealNumbers
-from odl.set.space import LinearSpaceTypeError
+from odl.set.space import (LinearSpaceTypeError,
+        SupportedNumOperationParadigms, NumOperationParadigmSupport)
 from odl.space.base_tensors import Tensor, TensorSpace
 from odl.space.weighting import (
     ArrayWeighting, ConstWeighting, CustomDist, CustomInner, CustomNorm,
@@ -295,6 +296,14 @@ class NumpyTensorSpace(TensorSpace):
     def impl(self):
         """Name of the implementation back-end: ``'numpy'``."""
         return 'numpy'
+
+    @property
+    def supported_num_operation_paradigms(self) -> NumOperationParadigmSupport:
+        """NumPy has full support for in-place operation, which is usually
+        advantageous to reduce memory allocations."""
+        return SupportedNumOperationParadigms(
+                in_place = NumOperationParadigmSupport.PREFERRED,
+                out_of_place = NumOperationParadigmSupport.SUPPORTED)
 
     @property
     def default_order(self):

--- a/odl/space/npy_tensors.py
+++ b/odl/space/npy_tensors.py
@@ -698,7 +698,10 @@ class NumpyTensorSpace(TensorSpace):
         >>> result is out
         True
         """
-        np.multiply(x1.data, x2.data, out=out.data)
+        if out is None:
+            return np.multiply(x1.data, x2.data)
+        else:
+            np.multiply(x1.data, x2.data, out=out.data)
 
     def _divide(self, x1, x2, out):
         """Compute the entry-wise quotient ``x1 / x2``.
@@ -727,7 +730,10 @@ class NumpyTensorSpace(TensorSpace):
         >>> result is out
         True
         """
-        np.divide(x1.data, x2.data, out=out.data)
+        if out is None:
+            return np.divide(x1.data, x2.data)
+        else:
+            np.divide(x1.data, x2.data, out=out.data)
 
     def __eq__(self, other):
         """Return ``self == other``.

--- a/odl/space/pspace.py
+++ b/odl/space/pspace.py
@@ -403,6 +403,9 @@ class ProductSpace(LinearSpace):
         ip_prefers = 0
         oop_supported = True
         oop_prefers = 0
+
+        # Check for all of the subspaces whether they support each paradigm,
+        # and count how many of them prefer each.
         for parad in paradigms:
             if parad.in_place == NumOperationParadigmSupport.NOT_SUPPORTED:
                 ip_supported = False
@@ -413,6 +416,8 @@ class ProductSpace(LinearSpace):
             elif parad.out_of_place == NumOperationParadigmSupport.PREFERRED:
                 oop_prefers += 1
 
+        # Support in-place updates if all subspaces support them.
+        # Prefer them if a majority of the subspaces do.
         if ip_supported:
             if ip_prefers > oop_prefers:
                 in_place_support = NumOperationParadigmSupport.PREFERRED
@@ -421,6 +426,8 @@ class ProductSpace(LinearSpace):
         else:
             in_place_support = NumOperationParadigmSupport.NOT_SUPPORTED
 
+        # Support out-of-place calculations if all subspaces support them.
+        # Prefer them if a majority of the subspaces do.
         if oop_supported:
             if oop_prefers > ip_prefers:
                 oo_place_support = NumOperationParadigmSupport.PREFERRED

--- a/odl/space/pspace.py
+++ b/odl/space/pspace.py
@@ -931,6 +931,12 @@ class ProductSpaceElement(LinearSpaceElement):
         """The data type of the space of this element."""
         return self.space.dtype
 
+    def _assign(self, other, avoid_deep_copy):
+        """Assign the values of ``other``, which is assumed to be in the
+        same product space, to ``self``."""
+        for tgt, src in zip(self.parts, other.parts):
+            tgt.assign(src, avoid_deep_copy=avoid_deep_copy)
+
     def __len__(self):
         """Return ``len(self)``."""
         return len(self.space)

--- a/odl/space/pspace.py
+++ b/odl/space/pspace.py
@@ -618,6 +618,10 @@ class ProductSpace(LinearSpace):
 
     def _lincomb(self, a, x, b, y, out):
         """Linear combination ``out = a*x + b*y``."""
+        if out is None:
+            return self.element([
+                space._lincomb(a, xp, b, yp, out=None)
+                  for space, xp, yp in zip(self.spaces, x.parts, y.parts)])
         for space, xp, yp, outp in zip(self.spaces, x.parts, y.parts,
                                        out.parts):
             space._lincomb(a, xp, b, yp, outp)
@@ -636,12 +640,20 @@ class ProductSpace(LinearSpace):
 
     def _multiply(self, x1, x2, out):
         """Product ``out = x1 * x2``."""
+        if out is None:
+            return self.element([
+                spc._multiply(xp, yp, out=None)
+                  for spc, xp, yp in zip(self.spaces, x1.parts, x2.parts)])
         for spc, xp, yp, outp in zip(self.spaces, x1.parts, x2.parts,
                                      out.parts):
             spc._multiply(xp, yp, outp)
 
     def _divide(self, x1, x2, out):
         """Quotient ``out = x1 / x2``."""
+        if out is None:
+            return self.element([
+                spc._divide(xp, yp, out=None)
+                  for spc, xp, yp in zip(self.spaces, x1.parts, x2.parts)])
         for spc, xp, yp, outp in zip(self.spaces, x1.parts, x2.parts,
                                      out.parts):
             spc._divide(xp, yp, outp)


### PR DESCRIPTION
Up until now, ODL has had a strong emphasis on carrying out operations in-place. This is similar to traditional application-specific software like solvers written in Fortran, even when the user writes code that looks more functional/declarative.

While this is in many instances a good tradeoff between high-level ease of use and low-level performance, it is not suitable for all use cases.

- The pre-allocation philosophy makes ODL overly rigid. It requires that it is known beforehand what storage every element of a space will take up. This interferes with things like adaptive resolution and batching.
- Often it is not clear that it is performance-advantageous at all to modify in-place. If a result array is allocated ad-hoc just to write to it, nothing is gained. On the other hand, immutable objects can _avoid_ allocation by reusing objects in place, simply sharing references.
- While in-place updates are efficient in backends that merely wrap around arrays (like NumPy), this is not the case for more advanced backends. Of particular interest is PyTorch, which can build up a computation graph for automatic-differentiation purposes. Though PyTorch also supports in-place updates, these complicate the process and as a result make performance much worse than for out-of-place calculations.

This pull request allows spaces to specify whether their elements can be handled as mutable or immutable objects, and/or which way is more appropriate. Based on this, the general arithmetic operations will either pre-allocate memory and use it in place, or give back results in a RAII- / move-semantics fashion.

I have tested that this works by confirming that the test suite succeeds also when (contrivedly) selecting `in_place = NumOperationParadigmSupport.NOT_SUPPORTED` for `NumPyTensorSpace`. Not sure whether it would make sense to include this into the test suite.

The PR does not yet guarantee that operators and solvers follow the style indicated by `supported_num_operation_paradigms`, though to some extend they inherit the behaviour of the arithmetic primitives.