### PR TITLE
Fix reStructuredText problems in the Sphinx docstrings

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -51,9 +51,9 @@ else:
 
 # Add external links to GitHub
 extlinks = {
-    'pull': ('https://github.com/odlgroup/odl/pull/%s', 'PR '),
-    'issue': ('https://github.com/odlgroup/odl/issues/%s', 'issue '),
-    'commit': ('https://github.com/odlgroup/odl/commit/%s', 'commit ')
+    'pull': ('https://github.com/odlgroup/odl/pull/%s', 'PR %s'),
+    'issue': ('https://github.com/odlgroup/odl/issues/%s', 'issue %s'),
+    'commit': ('https://github.com/odlgroup/odl/commit/%s', 'commit %s')
 }
 
 
@@ -90,7 +90,7 @@ def setup(app):
     app.connect("autodoc-skip-member", skip)
     # TODO(kohr-h): Remove when upstream issue in sphinx-rtd-theme is solved
     # https://github.com/readthedocs/sphinx_rtd_theme/issues/746
-    app.add_stylesheet('custom.css')
+    app.add_css_file('custom.css')
 
 
 # Autosummary
@@ -135,7 +135,7 @@ release = version
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = 'english'
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.

--- a/odl/discr/discr_utils.py
+++ b/odl/discr/discr_utils.py
@@ -251,7 +251,10 @@ def nearest_interpolator(f, coord_vecs):
     Given points ``x[1] < x[2] < ... < x[N]``, and function values
     ``f[1], ..., f[N]``, nearest neighbor interpolation at ``x`` is defined
     as ::
-        I(x) = f[j]  with j such that |x - x[j]| is minimal.
+
+        I(x) = f[j]
+
+    with ``j`` such that ``|x - x[j]|`` is minimal.
     The ambiguity at the midpoints is resolved by preferring the right
     neighbor. In higher dimensions, this principle is applied per axis.
     The returned interpolator is the piecewise constant function ``x -> I(x)``.

--- a/odl/solvers/functional/default_functionals.py
+++ b/odl/solvers/functional/default_functionals.py
@@ -2246,6 +2246,7 @@ class IndicatorSimplex(Functional):
         sum_rtol : float, optional
             Relative tolerance for sum comparison.
             Default:
+
                 - ``space.dtype == 'float64'``: ``1e-10 * space.size``
                 - Otherwise: ``1e-6 * space.size``
 

--- a/odl/solvers/functional/default_functionals.py
+++ b/odl/solvers/functional/default_functionals.py
@@ -2489,8 +2489,7 @@ class MoreauEnvelope(Functional):
 
     References
     ----------
-    .. _Proximal Algorithms: \
-https://web.stanford.edu/~boyd/papers/pdf/prox_algs.pdf
+    .. _Proximal Algorithms: <https://web.stanford.edu/~boyd/papers/pdf/prox_algs.pdf>
     """
 
     def __init__(self, functional, sigma=1.0):

--- a/odl/solvers/functional/default_functionals.py
+++ b/odl/solvers/functional/default_functionals.py
@@ -438,10 +438,10 @@ class IndicatorLpUnitBall(Functional):
     This functional is defined as
 
         .. math::
-            f(x) = \left\{ \begin{array}{ll}
-            0 & \text{if } ||x||_{L_p} \leq 1, \
-            \infty & \text{else,}
-            \end{array} \right.
+            f(x) = \begin{cases}
+                0       & \text{if } ||x||_{L_p} \leq 1,
+             \\ +\infty & \text{else}
+            \end{cases}
 
     where :math:`||x||_{L_p}` is the :math:`L_p`-norm, which for finite values
     of :math:`p` is defined as
@@ -2227,8 +2227,8 @@ class IndicatorSimplex(Functional):
         F(x)
         =
         \begin{cases}
-            0 & \text{if } x_i \geq 0 \forall i \text{ and } \sum_i x_i = r \
-            +\infty & \text{else.}
+             0   & \text{if } x_i \geq 0 \forall i \text{ and } \sum_i x_i = r
+         \\ +\infty & \text{else.}
         \end{cases}
 
     where :math:`r` is the diameter.
@@ -2349,8 +2349,8 @@ class IndicatorSumConstraint(Functional):
         F(x)
         =
         \begin{cases}
-            0 & \text{if } \sum_i x_i = 1 \
-            +\infty & \text{else.}
+            0 & \text{if } \sum_i x_i = 1
+         \\ +\infty & \text{else.}
         \end{cases}
     """
 

--- a/odl/solvers/functional/derivatives.py
+++ b/odl/solvers/functional/derivatives.py
@@ -152,7 +152,7 @@ class NumericalGradient(Operator):
     """
 
     def __init__(self, functional, method='forward', step=None):
-        """Initialize a new instance.
+        r"""Initialize a new instance.
 
         Parameters
         ----------

--- a/odl/solvers/iterative/statistical.py
+++ b/odl/solvers/iterative/statistical.py
@@ -16,7 +16,7 @@ __all__ = ('mlem', 'osmlem', 'poisson_log_likelihood')
 
 def mlem(op, x, data, niter, callback=None, **kwargs):
 
-    """Maximum Likelihood Expectation Maximation algorithm.
+    r"""Maximum Likelihood Expectation Maximation algorithm.
 
     Attempts to solve::
 

--- a/odl/solvers/smooth/newton.py
+++ b/odl/solvers/smooth/newton.py
@@ -247,10 +247,10 @@ def bfgs_method(f, x, line_search=1.0, maxiter=1000, tol=1e-15, num_store=None,
                 hessinv_estimate=None, callback=None):
     r"""Quasi-Newton BFGS method to minimize a differentiable function.
 
-    Can use either the regular BFGS method, or the limited memory BFGS method.
-
     Notes
     -----
+    Can use either the regular BFGS method, or the limited memory BFGS method.
+
     This is a general and optimized implementation of a quasi-Newton
     method with BFGS update for solving a general unconstrained
     optimization problem

--- a/odl/solvers/smooth/newton.py
+++ b/odl/solvers/smooth/newton.py
@@ -272,8 +272,7 @@ def bfgs_method(f, x, line_search=1.0, maxiter=1000, tol=1e-15, num_store=None,
 
     The algorithm is described in [GNS2009], Section 12.3 and in the
     `BFGS Wikipedia article
-    <https://en.wikipedia.org/wiki/Broyden%E2%80%93Fletcher%E2%80%93\
-Goldfarb%E2%80%93Shanno_algorithm>`_
+    <https://en.wikipedia.org/wiki/BFGS_algorithm>`_.
 
     Parameters
     ----------

--- a/odl/solvers/util/callback.py
+++ b/odl/solvers/util/callback.py
@@ -1057,27 +1057,25 @@ def save_animation(filename,
     writer : str
         Back-end for generating the movie file. Available writers can be
         checked with the command ``matplotlib.animation.writers.list()``.
-        See the `matplotlib animation writers doc`_ for details.
-        For the default ``None``, the first writer from the list of available
-        ones is chosen.
+        See the `matplotlib animation writers doc
+        <https://matplotlib.org/api/animation_api.html#writer-classes>`_ for
+        details. For the default ``None``, the first writer from the list of
+        available ones is chosen.
     writer_kwargs : dict
         Keyword arguments passed to the writer class constructor.
-        See the `matplotlib animation writers doc`_ for details.
+        See the matplotlib animation writers doc for details.
     dpi : float, optional
         Resolution of the saved frames in DPI. For ``None``, the figure
         resolution ``fig.dpi`` is used, which is the default resolution if
         ``fig is None``.
     saving_kwargs : dict
         Keyword arguments passed to the ``saving`` method of the writer
-        instance. See the `matplotlib animation writers doc`_ for details.
+        instance. See the matplotlib animation writers doc for details.
     fig : matplotlib.figure.Figure, optional
         Matplotlib figure used for plotting. For the default ``None``, a new
         figure is created.
     step : positive int, optional
         Number of iterations between frames.
-
-    .. _matplotlib animation writers doc:
-       https://matplotlib.org/api/animation_api.html#writer-classes
     """
     import matplotlib.animation
     import matplotlib.pyplot as plt

--- a/odl/tomo/geometry/conebeam.py
+++ b/odl/tomo/geometry/conebeam.py
@@ -422,10 +422,12 @@ class FanBeamGeometry(DivergentBeamGeometry):
                        source_shift(phi)
 
         where ``src_to_det_init`` is the initial unit vector pointing
-        from source to detector and
+        from source to detector and ::
+
             source_shift(phi) = rot_matrix(phi) *
                                 (shift[0] * (-src_to_det_init) +
                                 shift[1] * tangent)
+
         where ``tangent`` is a vector tangent to the trajectory
 
         where ``src_to_det_init`` is the initial unit vector pointing
@@ -522,10 +524,12 @@ class FanBeamGeometry(DivergentBeamGeometry):
                            detector_shift(phi)
 
         where ``src_to_det_init`` is the initial unit vector pointing
-        from source to detector and
+        from source to detector and ::
+
             detector_shift(phi) = rot_matrix(phi) *
                                   (shift[0] * src_to_det_init +
                                   shift[1] * tangent)
+
         where ``tangent`` is a vector tangent to the trajectory
 
         Parameters
@@ -1244,7 +1248,8 @@ class ConeBeamGeometry(DivergentBeamGeometry, AxisOrientedGeometry):
                            detector_shift(phi)
 
         where ``src_to_det_init`` is the initial unit vector pointing
-        from source to detector and
+        from source to detector and ::
+
             detector_shift(phi) = rot_matrix(phi) *
                                   (shift1 * src_to_det_init +
                                   shift2 * cross(-src_to_det_init, axis))
@@ -1360,7 +1365,8 @@ class ConeBeamGeometry(DivergentBeamGeometry, AxisOrientedGeometry):
                        source_shift(phi)
 
         where ``src_to_det_init`` is the initial unit vector pointing
-        from source to detector and
+        from source to detector and ::
+
             source_shift(phi) = rot_matrix(phi) *
                                 (shift1 * (-src_to_det_init) +
                                 shift2 * cross(src_to_det_init, axis))


### PR DESCRIPTION
The docs currently do not build. It turns out a number of errors WRT reStructuredText had accumulated in the last years, as well as incompatibilities with how current versions of Sphinx are configured.

This PR fixes the errors encountered with Sphinx v7.3.7.

There are still many warnings, but most of them of the form
```
/home/justussa/progwrit/python/odl/doc/source/generated/odl.deform.linearized.LinDeformFixedDisp.adjoint.rst: WARNING: document isn't included in any toctree
/home/justussa/progwrit/python/odl/doc/source/generated/odl.deform.linearized.LinDeformFixedDisp.displacement.rst: WARNING: document isn't included in any toctree
/home/justussa/progwrit/python/odl/doc/source/generated/odl.deform.linearized.LinDeformFixedDisp.domain.rst: WARNING: document isn't included in any toctree
/home/justussa/progwrit/python/odl/doc/source/generated/odl.deform.linearized.LinDeformFixedDisp.interp.rst: WARNING: document isn't included in any toctree
/home/justussa/progwrit/python/odl/doc/source/generated/odl.deform.linearized.LinDeformFixedDisp.interp_byaxis.rst: WARNING: document isn't included in any toctree
/home/justussa/progwrit/python/odl/doc/source/generated/odl.deform.linearized.LinDeformFixedDisp.inverse.rst: WARNING: document isn't included in any toctree
...
```
which seems to mean only that these are not indexed, and [was also a known issue](https://odlgroup.github.io/odl/dev/release.html#make-sure-tests-succeed-and-docs-are-built-properly).