### PR TITLE
It turns out `matplotlib-base` is not a package pip can track.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -43,7 +43,6 @@ install_requires =
     packaging >=17.0
     numpy >=1.19, <1.27
     scipy >=1.1
-    matplotlib-base >=3.4
 python_requires = >=3.7
 tests_require =
     pytest >=5.4.0 ; python_version >= "3"


### PR DESCRIPTION
It is only a Conda that splits up matplotlib into a base and a full part, which differ in the latter pulling in the Qt widget TK.

For pip this does not apply since is only installs Python modules anyway, and merely uses Qt if already present on the system.

Partially reverts 7443b3c036875e23cecd4a9fd3c0015441706114.