### PR TITLE
Fix Fourier normalisation that was changed by PyFFTW-0.13

### DIFF
--- a/odl/trafos/backends/pyfftw_bindings.py
+++ b/odl/trafos/backends/pyfftw_bindings.py
@@ -203,7 +203,10 @@ def pyfftw_call(array_in, array_out, direction='forward', axes=None,
     else:
         fftw_plan = fftw_plan_in
 
-    fftw_plan(array_in, array_out, normalise_idft=normalise_idft)
+    if not normalise_idft and direction=='forward':
+        fftw_plan(array_in, array_out, normalise_idft=True)
+    else:
+        fftw_plan(array_in, array_out, normalise_idft=normalise_idft)
 
     if wexport:
         try:

--- a/odl/trafos/fourier.py
+++ b/odl/trafos/fourier.py
@@ -675,7 +675,8 @@ class DiscreteFourierTransformInverse(DiscreteFourierTransformBase):
             halfcomplex=self.halfcomplex, planning_effort=effort,
             fftw_plan=self._fftw_plan, normalise_idft=True)
 
-        # Need to normalize for 'forward', no way to force pyfftw
+        # Need to normalize for 'forward', pyfftw before version 0.13
+        # does not offer a way to do this.
         if self.sign == '-':
             out /= np.prod(np.take(self.domain.shape, self.axes))
 


### PR DESCRIPTION
As per https://github.com/odlgroup/odl/issues/1666, the Fourier trafo tests fail when using PyFFTW 0.13 or later as the backend.

In older versions of PyFFTW, the `normalise_idft` argument was only relevant for the inverse direction, else ignored. ODLs `pyfftw_call` wrapper was modelled around this behaviour.

Starting with PyFFTW-0.13, the new NumPy normalisation arguments `norm='forward'` and `norm='backward'` (https://github.com/numpy/numpy/pull/16476) were adopted for the high-level binders (https://github.com/pyFFTW/pyFFTW/pull/308, merged in https://github.com/pyFFTW/pyFFTW/pull/330).

They implemented this by pre-matching the `norm` argument and setting `normalise_idft` accordingly. In case of the 'forward' normalisation this involves using `normalise_idft=False` to signal that the normalisation should instead happen in the forward direction, which was previously not even possible. In other words, in PyFFTW<0.13 `normalise_idft=False` meant no normalisation at all was used (neither for fft nor ifft, with the consequence that they weren't inverses in this case), and that is the behaviour ODL expected.

Explicitly setting `normalise_idft=True` in this specific case restores the desired behaviour, and is backwards-compatible because PyFFTW<0.13 ignores the `normalise_idft` argument in the forward direction. With this in place, the Fourier tests succeed for both `pyfftw==0.12.0` and `pyfftw==0.13.0`.

Note that the manual normalisation in https://github.com/odlgroup/odl/blob/9b93c01ca66c75cf5ab03669e0777358c4aab3f5/odl/trafos/fourier.py#L678-L680 could instead be done by PyFFTW from 0.13 onwards, so for the future it would make sense to do that. This would however not be possible with older versions, and has no real benefit because PyFFTW itself just uses a NumPy multiplication for this case.