### PR TITLE
Compatibility with NumPy-2

### DIFF
--- a/examples/space/simple_rn.py
+++ b/examples/space/simple_rn.py
@@ -45,7 +45,7 @@ class SimpleRn(TensorSpace):
                                                        self.dim,))
         else:
             return self.element(np.array(
-                *args, **kwargs).astype(np.float64, copy=False))
+                *args, **kwargs).astype(np.float64, copy=AVOID_UNNECESSARY_COPY))
         return self.element(np.empty(self.dim, dtype=np.float64))
 
 

--- a/odl/contrib/fom/util.py
+++ b/odl/contrib/fom/util.py
@@ -61,7 +61,7 @@ def filter_image_sep2d(image, fh, fv, impl='numpy', padding=None):
                          'ndim={}'.format(image.ndim))
     if image.size == 0:
         raise ValueError('`image` cannot have size 0')
-    if not np.issubsctype(image.dtype, np.floating):
+    if not np.issubdtype(image.dtype, np.floating):
         image = image.astype(float)
 
     fh = np.asarray(fh).astype(image.dtype)

--- a/odl/contrib/torch/operator.py
+++ b/odl/contrib/torch/operator.py
@@ -240,13 +240,13 @@ class OperatorFunction(torch.autograd.Function):
 
             # Stack results, reshape to the expected output shape and enforce
             # correct dtype
-            result_arr = np.stack(results).astype(op_out_dtype, copy=False)
+            result_arr = np.stack(results).astype(op_out_dtype, copy=AVOID_UNNECESSARY_COPY)
             result_arr = result_arr.reshape(extra_shape + op_out_shape)
         else:
             # Single input: evaluate directly
             result_arr = np.asarray(
                 operator(input_arr)
-            ).astype(op_out_dtype, copy=False)
+            ).astype(op_out_dtype, copy=AVOID_UNNECESSARY_COPY)
 
         # Convert back to tensor
         tensor = torch.from_numpy(result_arr).to(input.device)
@@ -370,18 +370,18 @@ class OperatorFunction(torch.autograd.Function):
 
             # Stack results, reshape to the expected output shape and enforce
             # correct dtype
-            result_arr = np.stack(results).astype(op_in_dtype, copy=False)
+            result_arr = np.stack(results).astype(op_in_dtype, copy=AVOID_UNNECESSARY_COPY)
             result_arr = result_arr.reshape(extra_shape + op_in_shape)
         else:
             # Single gradient: evaluate directly
             if operator.is_linear:
                 result_arr = np.asarray(
                     operator.adjoint(grad_output_arr)
-                ).astype(op_in_dtype, copy=False)
+                ).astype(op_in_dtype, copy=AVOID_UNNECESSARY_COPY)
             else:
                 result_arr = np.asarray(
                     operator.derivative(input_arr).adjoint(grad_output_arr)
-                ).astype(op_in_dtype, copy=False)
+                ).astype(op_in_dtype, copy=AVOID_UNNECESSARY_COPY)
 
         # Apply scaling, convert to tensor and return
         if scaling != 1.0:

--- a/odl/discr/discr_ops.py
+++ b/odl/discr/discr_ops.py
@@ -347,7 +347,7 @@ class ResizingOperator(Operator):
                                     dtype=ran.dtype)
 
         # padding mode 'constant' with `pad_const != 0` is not linear
-        linear = (self.pad_mode != 'constant' or self.pad_const == 0.0)
+        linear = (self.pad_mode != 'constant' or self.pad_const == 0.0 or self.pad_const == 0)
 
         super(ResizingOperator, self).__init__(domain, ran, linear=linear)
 

--- a/odl/discr/discr_utils.py
+++ b/odl/discr/discr_utils.py
@@ -24,6 +24,8 @@ from warnings import warn
 
 import numpy as np
 
+from odl.util.npy_compat import AVOID_UNNECESSARY_COPY
+
 from odl.util import (
     dtype_repr, is_real_dtype, is_string, is_valid_input_array,
     is_valid_input_meshgrid, out_shape_from_array, out_shape_from_meshgrid,
@@ -826,7 +828,7 @@ class _PerAxisInterpolator(_Interpolator):
                 else:
                     weight = weight * w_hi
             out += np.asarray(self.values[edge]) * weight[vslice]
-        return np.array(out, copy=False, ndmin=1)
+        return np.array(out, copy=AVOID_UNNECESSARY_COPY, ndmin=1)
 
 
 class _LinearInterpolator(_PerAxisInterpolator):
@@ -1021,7 +1023,7 @@ def sampling_function(func_or_arr, domain, out_dtype=None):
         """Default in-place variant of an out-of-place-only function."""
         result = func_oop(x, **kwargs)
         try:
-            result = np.array(result, copy=False)
+            result = np.array(result, copy=AVOID_UNNECESSARY_COPY)
         except ValueError:
             # Different shapes encountered, need to broadcast
             if is_valid_input_array(x, domain.ndim):

--- a/odl/discr/partition.py
+++ b/odl/discr/partition.py
@@ -18,6 +18,8 @@ from __future__ import print_function, division, absolute_import
 from builtins import object
 import numpy as np
 
+from odl.util.npy_compat import AVOID_UNNECESSARY_COPY
+
 from odl.discr.grid import RectGrid, uniform_grid_fromintv
 from odl.set import IntervalProd
 from odl.util import (
@@ -1403,7 +1405,7 @@ def nonuniform_partition(*coord_vecs, **kwargs):
                              '`nodes_on_bdry=True`'.format(i))
 
         # Handle length 1 inputs
-        coords = np.array(coords, copy=False, ndmin=1)
+        coords = np.array(coords, copy=AVOID_UNNECESSARY_COPY, ndmin=1)
 
         # Compute boundary position if not given by user
         if xmin is None:

--- a/odl/operator/tensor_ops.py
+++ b/odl/operator/tensor_ops.py
@@ -14,6 +14,8 @@ from numbers import Integral
 
 import numpy as np
 
+from odl.util.npy_compat import AVOID_UNNECESSARY_COPY
+
 from odl.operator.operator import Operator
 from odl.set import ComplexNumbers, RealNumbers
 from odl.space import ProductSpace, tensor_space
@@ -796,7 +798,7 @@ class MatrixOperator(Operator):
         if scipy.sparse.isspmatrix(matrix):
             self.__matrix = matrix
         else:
-            self.__matrix = np.array(matrix, copy=False, ndmin=2)
+            self.__matrix = np.array(matrix, copy=AVOID_UNNECESSARY_COPY, ndmin=2)
 
         self.__axis, axis_in = int(axis), axis
         if self.axis != axis_in:
@@ -984,14 +986,14 @@ def _normalize_sampling_points(sampling_points, ndim):
     """
     sampling_points_in = sampling_points
     if ndim == 0:
-        sampling_points = [np.array(sampling_points, dtype=int, copy=False)]
+        sampling_points = [np.array(sampling_points, dtype=int, copy=AVOID_UNNECESSARY_COPY)]
         if sampling_points[0].size != 0:
             raise ValueError('`sampling_points` must be empty for '
                              '0-dim. `domain`')
     elif ndim == 1:
         if isinstance(sampling_points, Integral):
             sampling_points = (sampling_points,)
-        sampling_points = np.array(sampling_points, dtype=int, copy=False,
+        sampling_points = np.array(sampling_points, dtype=int, copy=AVOID_UNNECESSARY_COPY,
                                    ndmin=1)
 
         # Handle possible list of length one
@@ -1014,7 +1016,7 @@ def _normalize_sampling_points(sampling_points, ndim):
                                    for p in sampling_points]
             else:
                 sampling_points = [
-                    np.array(pts, dtype=int, copy=False, ndmin=1)
+                    np.array(pts, dtype=int, copy=AVOID_UNNECESSARY_COPY, ndmin=1)
                     for pts in sampling_points]
                 if any(pts.ndim != 1 for pts in sampling_points):
                     raise ValueError(

--- a/odl/set/domain.py
+++ b/odl/set/domain.py
@@ -11,6 +11,8 @@
 from __future__ import print_function, division, absolute_import
 import numpy as np
 
+from odl.util.npy_compat import AVOID_UNNECESSARY_COPY
+
 from odl.set.sets import Set
 from odl.util import (
     array_str, is_valid_input_array, is_valid_input_meshgrid, safe_int_conv)
@@ -253,7 +255,7 @@ class IntervalProd(Set):
         """
         try:
             # Duck-typed check of type
-            point = np.array(point, dtype=float, copy=False, ndmin=1)
+            point = np.array(point, dtype=float, copy=AVOID_UNNECESSARY_COPY, ndmin=1)
         except (ValueError, TypeError):
             return False
 
@@ -279,7 +281,7 @@ class IntervalProd(Set):
         """
         try:
             # Duck-typed check of type
-            point = np.array(other, dtype=float, copy=False, ndmin=1)
+            point = np.array(other, dtype=float, copy=AVOID_UNNECESSARY_COPY, ndmin=1)
         except (ValueError, TypeError):
             return False
 

--- a/odl/solvers/nonsmooth/proximal_operators.py
+++ b/odl/solvers/nonsmooth/proximal_operators.py
@@ -1924,7 +1924,7 @@ def proximal_convex_conj_kl_cross_entropy(space, lam=1, g=None):
                 lambw = scipy.special.lambertw(
                     (self.sigma / lam) * g * np.exp(x / lam))
 
-            if not np.issubsctype(self.domain.dtype, np.complexfloating):
+            if not np.issubdtype(self.domain.dtype, np.complexfloating):
                 lambw = lambw.real
 
             lambw = x.space.element(lambw)

--- a/odl/space/base_tensors.py
+++ b/odl/space/base_tensors.py
@@ -14,6 +14,8 @@ from numbers import Integral
 
 import numpy as np
 
+from odl.util.npy_compat import AVOID_UNNECESSARY_COPY
+
 from odl.set.sets import ComplexNumbers, RealNumbers
 from odl.set.space import LinearSpace, LinearSpaceElement
 from odl.util import (
@@ -663,7 +665,7 @@ class Tensor(LinearSpaceElement):
         if dtype is None:
             return self.asarray()
         else:
-            return self.asarray().astype(dtype, copy=False)
+            return self.asarray().astype(dtype, copy=AVOID_UNNECESSARY_COPY)
 
     def __array_wrap__(self, array):
         """Return a new tensor wrapping the ``array``.

--- a/odl/space/npy_tensors.py
+++ b/odl/space/npy_tensors.py
@@ -17,6 +17,8 @@ from functools import partial
 
 import numpy as np
 
+from odl.util.npy_compat import AVOID_UNNECESSARY_COPY
+
 from odl.set.sets import ComplexNumbers, RealNumbers
 from odl.set.space import LinearSpaceTypeError
 from odl.space.base_tensors import Tensor, TensorSpace
@@ -426,7 +428,7 @@ class NumpyTensorSpace(TensorSpace):
 
             # Try to not copy but require dtype and order if given
             # (`order=None` is ok as np.array argument)
-            arr = np.array(inp, copy=False, dtype=self.dtype, ndmin=self.ndim,
+            arr = np.array(inp, copy=AVOID_UNNECESSARY_COPY, dtype=self.dtype, ndmin=self.ndim,
                            order=order)
             # Make sure the result is writeable, if not make copy.
             # This happens for e.g. results of `np.broadcast_to()`.

--- a/odl/space/npy_tensors.py
+++ b/odl/space/npy_tensors.py
@@ -472,18 +472,17 @@ class NumpyTensorSpace(TensorSpace):
 
         Notes
         -----
-        This is all dtypes available in Numpy. See ``numpy.sctypes``
+        This is all dtypes available in Numpy. See ``numpy.sctypeDict``
         for more information.
 
         The available dtypes may depend on the specific system used.
         """
         all_dtypes = []
-        for lst in np.sctypes.values():
-            for dtype in lst:
-                if dtype not in (object, np.void):
-                    all_dtypes.append(np.dtype(dtype))
-        # Need to add these manually since np.sctypes['others'] will only
-        # contain one of them (depending on Python version)
+        for dtype in np.sctypeDict.values():
+            if dtype not in (object, np.void):
+                all_dtypes.append(np.dtype(dtype))
+        # Need to add these manually since they are not contained
+        # in np.sctypeDict.
         all_dtypes.extend([np.dtype('S'), np.dtype('U')])
         return tuple(sorted(set(all_dtypes)))
 

--- a/odl/space/space_utils.py
+++ b/odl/space/space_utils.py
@@ -11,6 +11,8 @@
 from __future__ import print_function, division, absolute_import
 import numpy as np
 
+from odl.util.npy_compat import AVOID_UNNECESSARY_COPY
+
 from odl.set import RealNumbers, ComplexNumbers
 from odl.space.entry_points import tensor_space_impl
 
@@ -74,7 +76,7 @@ def vector(array, dtype=None, order=None, impl='numpy'):
     )
     """
     # Sanitize input
-    arr = np.array(array, copy=False, order=order, ndmin=1)
+    arr = np.array(array, copy=AVOID_UNNECESSARY_COPY, order=order, ndmin=1)
     if arr.dtype is object:
         raise ValueError('invalid input data resulting in `dtype==object`')
 

--- a/odl/test/discr/discr_ops_test.py
+++ b/odl/test/discr/discr_ops_test.py
@@ -216,7 +216,10 @@ def test_resizing_op_inverse(padding, odl_tspace_impl):
         if pad_mode == 'order1' and (
                 np.issubdtype(dtype, np.unsignedinteger)
                 or np.issubdtype(dtype, np.timedelta64()) ):
-            # Linear continuation can create negative values, exempt from test.
+            # Extrapolating a trend might lead to negative values, which  
+            # will raise an error for unsigned integers. For timedeltas, 
+            # it would involve a multiplication of two times which was 
+            # allowed by numpy 1 but is not allowed in numpy 2.
             continue
 
         space = odl.uniform_discr([0, -1], [1, 1], (4, 5), dtype=dtype,

--- a/odl/test/discr/discr_ops_test.py
+++ b/odl/test/discr/discr_ops_test.py
@@ -212,6 +212,13 @@ def test_resizing_op_inverse(padding, odl_tspace_impl):
               if is_numeric_dtype(dt)]
 
     for dtype in dtypes:
+
+        if pad_mode == 'order1' and (
+                np.issubdtype(dtype, np.unsignedinteger)
+                or np.issubdtype(dtype, np.timedelta64()) ):
+            # Linear continuation can create negative values, exempt from test.
+            continue
+
         space = odl.uniform_discr([0, -1], [1, 1], (4, 5), dtype=dtype,
                                   impl=impl)
         res_space = odl.uniform_discr([0, -1.4], [1.5, 1.4], (6, 7),

--- a/odl/test/discr/discr_space_test.py
+++ b/odl/test/discr/discr_space_test.py
@@ -728,7 +728,7 @@ def test_ufuncs(odl_tspace_impl, odl_ufunc):
     npy_ufunc = getattr(np, name)
     nin = npy_ufunc.nin
     nout = npy_ufunc.nout
-    if (np.issubsctype(space.dtype, np.floating) and
+    if (np.issubdtype(space.dtype, np.floating) and
             name in ['bitwise_and',
                      'bitwise_or',
                      'bitwise_xor',

--- a/odl/test/largescale/tomo/ray_transform_slow_test.py
+++ b/odl/test/largescale/tomo/ray_transform_slow_test.py
@@ -236,7 +236,7 @@ def test_reconstruction(projector):
 
     # Make sure the result is somewhat close to the actual result
     maxerr = vol.norm() * 0.5
-    if np.issubsctype(projector.domain.dtype, np.complexfloating):
+    if np.issubdtype(projector.domain.dtype, np.complexfloating):
         # Error has double the amount of components practically
         maxerr *= np.sqrt(2)
     assert recon.dist(vol) < maxerr

--- a/odl/test/operator/tensor_ops_test.py
+++ b/odl/test/operator/tensor_ops_test.py
@@ -29,9 +29,9 @@ matrix_dtype = simple_fixture(
 @pytest.fixture(scope='module')
 def matrix(matrix_dtype):
     dtype = np.dtype(matrix_dtype)
-    if np.issubsctype(dtype, np.floating):
+    if np.issubdtype(dtype, np.floating):
         return np.ones((3, 4), dtype=dtype)
-    elif np.issubsctype(dtype, np.complexfloating):
+    elif np.issubdtype(dtype, np.complexfloating):
         return np.ones((3, 4), dtype=dtype) * (1 + 1j)
     else:
         assert 0

--- a/odl/test/set/domain_test.py
+++ b/odl/test/set/domain_test.py
@@ -330,7 +330,7 @@ def test_dist():
         assert set_.dist(exterior) == min(abs(set_.min_pt - exterior),
                                           abs(exterior - set_.max_pt))
 
-    assert set_.dist(np.NaN) == np.inf
+    assert set_.dist(np.nan) == np.inf
 
 
 # Set arithmetic

--- a/odl/test/space/tensors_test.py
+++ b/odl/test/space/tensors_test.py
@@ -854,10 +854,22 @@ def test_transpose(odl_tspace_impl):
 def test_multiply_by_scalar(tspace):
     """Verify that mult. with NumPy scalars preserves the element type."""
     x = tspace.zero()
+
+    # Simple scalar multiplication, as often performed in user code.
+    # This invokes the __mul__ and __rmul__ methods of the ODL space classes.
+    # Strictly speaking this operation loses precision if `tspace.dtype` has
+    # fewer than 64 bits (Python decimal literals are double precision), but
+    # it would be too cumbersome to force a change in the space's dtype.
     assert x * 1.0 in tspace
-    assert x * np.float32(1.0) in tspace
     assert 1.0 * x in tspace
-    assert np.float32(1.0) * x in tspace
+    
+    # Multiplying with NumPy scalars is (since NumPy-2) more restrictive:
+    # multiplying a scalar on the left that has a higher precision than can
+    # be represented in the space would upcast `x` to another space that has
+    # the required precision.
+    if np.can_cast(np.float32, tspace.dtype):
+        assert x * np.float32(1.0) in tspace
+        assert np.float32(1.0) * x in tspace
 
 
 def test_member_copy(odl_tspace_impl):

--- a/odl/test/space/tensors_test.py
+++ b/odl/test/space/tensors_test.py
@@ -1365,8 +1365,8 @@ def test_ufuncs(tspace, odl_ufunc):
     nin = npy_ufunc.nin
     nout = npy_ufunc.nout
 
-    if (np.issubsctype(tspace.dtype, np.floating) or
-            np.issubsctype(tspace.dtype, np.complexfloating) and
+    if (np.issubdtype(tspace.dtype, np.floating) or
+            np.issubdtype(tspace.dtype, np.complexfloating) and
             name in ['bitwise_and',
                      'bitwise_or',
                      'bitwise_xor',
@@ -1376,7 +1376,7 @@ def test_ufuncs(tspace, odl_ufunc):
         # Skip integer only methods for floating point data types
         return
 
-    if (np.issubsctype(tspace.dtype, np.complexfloating) and
+    if (np.issubdtype(tspace.dtype, np.complexfloating) and
             name in ['remainder',
                      'floor_divide',
                      'trunc',

--- a/odl/test/space/tensors_test.py
+++ b/odl/test/space/tensors_test.py
@@ -1253,10 +1253,25 @@ def test_const_weighting_norm(tspace, exponent):
         factor = constant
     else:
         factor = constant ** (1 / exponent)
+
     true_norm = factor * np.linalg.norm(xarr.ravel(), ord=exponent)
 
     w_const = NumpyTensorSpaceConstWeighting(constant, exponent=exponent)
-    assert w_const.norm(x) == pytest.approx(true_norm)
+
+    real_dtype = tspace.dtype.type(0).real.dtype
+
+    if real_dtype == np.float16:
+        tolerance = 1e-3
+    elif real_dtype == np.float32:
+        tolerance = 1e-7
+    elif real_dtype == np.float64:
+        tolerance = 1e-15
+    elif real_dtype == np.float128:
+        tolerance = 1e-19
+    else:
+        raise TypeError(f"No known tolerance for dtype {tspace.dtype}")
+    
+    assert w_const.norm(x) == pytest.approx(true_norm, rel=tolerance)
 
 
 def test_const_weighting_dist(tspace, exponent):

--- a/odl/test/util/numerics_test.py
+++ b/odl/test/util/numerics_test.py
@@ -540,7 +540,7 @@ def test_resize_array_raise():
 
     # padding constant cannot be cast to output data type
     with pytest.raises(ValueError):
-        resize_array(arr_1d, (10,), pad_const=1.0)  # arr_1d has dtype int
+        resize_array(arr_1d, (10,), pad_const=1.5)  # arr_1d has dtype int
     with pytest.raises(ValueError):
         arr_1d_float = arr_1d.astype(float)
         resize_array(arr_1d_float, (10,), pad_const=1.0j)

--- a/odl/test/util/utility_test.py
+++ b/odl/test/util/utility_test.py
@@ -12,12 +12,12 @@ import numpy as np
 
 from odl.util.utility import (
     is_numeric_dtype, is_real_dtype, is_real_floating_dtype,
-    is_complex_floating_dtype)
+    is_complex_floating_dtype, SCTYPES)
 
 
-real_float_dtypes = np.core.sctypes['float']
-complex_float_dtypes = np.core.sctypes['complex']
-nonfloat_numeric_dtypes = np.core.sctypes['uint'] + np.core.sctypes['int']
+real_float_dtypes = SCTYPES['float']
+complex_float_dtypes = SCTYPES['complex']
+nonfloat_numeric_dtypes = SCTYPES['uint'] + SCTYPES['int']
 numeric_dtypes = (real_float_dtypes + complex_float_dtypes +
                   nonfloat_numeric_dtypes)
 real_dtypes = real_float_dtypes + nonfloat_numeric_dtypes

--- a/odl/test/util/utility_test.py
+++ b/odl/test/util/utility_test.py
@@ -15,9 +15,9 @@ from odl.util.utility import (
     is_complex_floating_dtype)
 
 
-real_float_dtypes = np.sctypes['float']
-complex_float_dtypes = np.sctypes['complex']
-nonfloat_numeric_dtypes = np.sctypes['uint'] + np.sctypes['int']
+real_float_dtypes = np.core.sctypes['float']
+complex_float_dtypes = np.core.sctypes['complex']
+nonfloat_numeric_dtypes = np.core.sctypes['uint'] + np.core.sctypes['int']
 numeric_dtypes = (real_float_dtypes + complex_float_dtypes +
                   nonfloat_numeric_dtypes)
 real_dtypes = real_float_dtypes + nonfloat_numeric_dtypes

--- a/odl/tomo/backends/astra_cuda.py
+++ b/odl/tomo/backends/astra_cuda.py
@@ -152,7 +152,7 @@ class AstraCudaImpl:
             datatype='volume',
             ndim=self.vol_space.ndim,
             data=self.vol_array,
-            allow_copy=False,
+            allow_copy=AVOID_UNNECESSARY_COPY,
         )
 
         proj_type = 'cuda' if proj_ndim == 2 else 'cuda3d'
@@ -165,7 +165,7 @@ class AstraCudaImpl:
             datatype='projection',
             ndim=proj_ndim,
             data=self.proj_array,
-            allow_copy=False,
+            allow_copy=AVOID_UNNECESSARY_COPY,
         )
 
         # Create algorithm

--- a/odl/tomo/backends/astra_cuda.py
+++ b/odl/tomo/backends/astra_cuda.py
@@ -16,6 +16,7 @@ from multiprocessing import Lock
 import numpy as np
 from packaging.version import parse as parse_version
 
+from odl.util.npy_compat import AVOID_UNNECESSARY_COPY
 from odl.discr import DiscretizedSpace
 from odl.tomo.backends.astra_setup import (
     ASTRA_VERSION, astra_algorithm, astra_data, astra_projection_geometry,

--- a/odl/tomo/backends/astra_setup.py
+++ b/odl/tomo/backends/astra_setup.py
@@ -29,6 +29,8 @@ import warnings
 
 import numpy as np
 
+from odl.util.npy_compat import AVOID_UNNECESSARY_COPY
+
 from odl.discr import DiscretizedSpace, DiscretizedSpaceElement
 from odl.tomo.geometry import (
     DivergentBeamGeometry, Flat1dDetector, Flat2dDetector, Geometry,
@@ -543,7 +545,7 @@ def astra_projection_geometry(geometry):
     return proj_geom
 
 
-def astra_data(astra_geom, datatype, data=None, ndim=2, allow_copy=False):
+def astra_data(astra_geom, datatype, data=None, ndim=2, allow_copy=AVOID_UNNECESSARY_COPY):
     """Create an ASTRA data object.
 
     Parameters

--- a/odl/tomo/geometry/conebeam.py
+++ b/odl/tomo/geometry/conebeam.py
@@ -12,6 +12,8 @@ from __future__ import absolute_import, division, print_function
 
 import numpy as np
 
+from odl.util.npy_compat import AVOID_UNNECESSARY_COPY
+
 from odl.discr import uniform_partition
 from odl.tomo.geometry.detector import (
     CircularDetector, CylindricalDetector, Flat1dDetector, Flat2dDetector,
@@ -492,7 +494,7 @@ class FanBeamGeometry(DivergentBeamGeometry):
                [ 0.1, -1. ]])
         """
         squeeze_out = (np.shape(angle) == ())
-        angle = np.array(angle, dtype=float, copy=False, ndmin=1)
+        angle = np.array(angle, dtype=float, copy=AVOID_UNNECESSARY_COPY, ndmin=1)
         src_shifts = self.src_shift_func(angle)
 
         # Initial vector from the rotation center to the source. It can be
@@ -588,7 +590,7 @@ class FanBeamGeometry(DivergentBeamGeometry):
                [ 0.1, -1. ]])
         """
         squeeze_out = (np.shape(angle) == ())
-        angle = np.array(angle, dtype=float, copy=False, ndmin=1)
+        angle = np.array(angle, dtype=float, copy=AVOID_UNNECESSARY_COPY, ndmin=1)
         det_shifts = np.array(self.det_shift_func(angle), dtype=float, ndmin=2)
 
         # Initial vector from the rotation center to the detector. It can be
@@ -635,7 +637,7 @@ class FanBeamGeometry(DivergentBeamGeometry):
             shape ``(2, 2)``, otherwise ``angle.shape + (2, 2)``.
         """
         squeeze_out = (np.shape(angle) == ())
-        angle = np.array(angle, dtype=float, copy=False, ndmin=1)
+        angle = np.array(angle, dtype=float, copy=AVOID_UNNECESSARY_COPY, ndmin=1)
         if (self.check_bounds
                 and not is_inside_bounds(angle, self.motion_params)):
             raise ValueError('`angle` {} not in the valid range {}'
@@ -1315,7 +1317,7 @@ class ConeBeamGeometry(DivergentBeamGeometry, AxisOrientedGeometry):
                [ 0.1, -1. , -0.1]])
         """
         squeeze_out = (np.shape(angle) == ())
-        angle = np.array(angle, dtype=float, copy=False, ndmin=1)
+        angle = np.array(angle, dtype=float, copy=AVOID_UNNECESSARY_COPY, ndmin=1)
         rot_matrix = self.rotation_matrix(angle)
         extra_dims = angle.ndim
         det_shifts = np.array(self.det_shift_func(angle), dtype=float, ndmin=2)
@@ -1433,7 +1435,7 @@ class ConeBeamGeometry(DivergentBeamGeometry, AxisOrientedGeometry):
                [-0. , -1. ,  0.1]])
         """
         squeeze_out = (np.shape(angle) == ())
-        angle = np.array(angle, dtype=float, copy=False, ndmin=1)
+        angle = np.array(angle, dtype=float, copy=AVOID_UNNECESSARY_COPY, ndmin=1)
         rot_matrix = self.rotation_matrix(angle)
         extra_dims = angle.ndim
         src_shifts = self.src_shift_func(angle)

--- a/odl/tomo/geometry/detector.py
+++ b/odl/tomo/geometry/detector.py
@@ -14,6 +14,8 @@ from builtins import object
 
 import numpy as np
 
+from odl.util.npy_compat import AVOID_UNNECESSARY_COPY
+
 from odl.discr import RectPartition
 from odl.tomo.util import is_inside_bounds, perpendicular_vector
 from odl.tomo.util.utility import rotation_matrix_from_to
@@ -343,7 +345,7 @@ class Flat1dDetector(Detector):
         (4, 5, 2)
         """
         squeeze_out = (np.shape(param) == ())
-        param = np.array(param, dtype=float, copy=False, ndmin=1)
+        param = np.array(param, dtype=float, copy=AVOID_UNNECESSARY_COPY, ndmin=1)
         if self.check_bounds and not is_inside_bounds(param, self.params):
             raise ValueError('`param` {} not in the valid range '
                              '{}'.format(param, self.params))
@@ -395,7 +397,7 @@ class Flat1dDetector(Detector):
         (4, 5, 2)
         """
         squeeze_out = (np.shape(param) == ())
-        param = np.array(param, dtype=float, copy=False, ndmin=1)
+        param = np.array(param, dtype=float, copy=AVOID_UNNECESSARY_COPY, ndmin=1)
         if self.check_bounds and not is_inside_bounds(param, self.params):
             raise ValueError('`param` {} not in the valid range '
                              '{}'.format(param, self.params))
@@ -524,7 +526,7 @@ class Flat2dDetector(Detector):
         """
         squeeze_out = (np.broadcast(*param).shape == ())
         param_in = param
-        param = tuple(np.array(p, dtype=float, copy=False, ndmin=1)
+        param = tuple(np.array(p, dtype=float, copy=AVOID_UNNECESSARY_COPY, ndmin=1)
                       for p in param)
         if self.check_bounds and not is_inside_bounds(param, self.params):
             raise ValueError('`param` {} not in the valid range '
@@ -603,7 +605,7 @@ class Flat2dDetector(Detector):
         """
         squeeze_out = (np.broadcast(*param).shape == ())
         param_in = param
-        param = tuple(np.array(p, dtype=float, copy=False, ndmin=1)
+        param = tuple(np.array(p, dtype=float, copy=AVOID_UNNECESSARY_COPY, ndmin=1)
                       for p in param)
         if self.check_bounds and not is_inside_bounds(param, self.params):
             raise ValueError('`param` {} not in the valid range '
@@ -752,7 +754,7 @@ class CircularDetector(Detector):
         (4, 5, 2)
         """
         squeeze_out = (np.shape(param) == ())
-        param = np.array(param, dtype=float, copy=False, ndmin=1)
+        param = np.array(param, dtype=float, copy=AVOID_UNNECESSARY_COPY, ndmin=1)
         if self.check_bounds and not is_inside_bounds(param, self.params):
             raise ValueError('`param` {} not in the valid range '
                              '{}'.format(param, self.params))
@@ -815,7 +817,7 @@ class CircularDetector(Detector):
         (4, 5, 2)
         """
         squeeze_out = (np.shape(param) == ())
-        param = np.array(param, dtype=float, copy=False, ndmin=1)
+        param = np.array(param, dtype=float, copy=AVOID_UNNECESSARY_COPY, ndmin=1)
         if self.check_bounds and not is_inside_bounds(param, self.params):
             raise ValueError('`param` {} not in the valid range '
                              '{}'.format(param, self.params))
@@ -873,7 +875,7 @@ class CircularDetector(Detector):
         (4, 5)
         """
         scalar_out = (np.shape(param) == ())
-        param = np.array(param, dtype=float, copy=False, ndmin=1)
+        param = np.array(param, dtype=float, copy=AVOID_UNNECESSARY_COPY, ndmin=1)
         if self.check_bounds and not is_inside_bounds(param, self.params):
             raise ValueError('`param` {} not in the valid range '
                              '{}'.format(param, self.params))
@@ -1042,7 +1044,7 @@ class CylindricalDetector(Detector):
         """
         squeeze_out = (np.broadcast(*param).shape == ())
         param_in = param
-        param = tuple(np.array(p, dtype=float, copy=False, ndmin=1)
+        param = tuple(np.array(p, dtype=float, copy=AVOID_UNNECESSARY_COPY, ndmin=1)
                       for p in param)
         if self.check_bounds and not is_inside_bounds(param, self.params):
             raise ValueError('`param` {} not in the valid range '
@@ -1118,7 +1120,7 @@ class CylindricalDetector(Detector):
         """
         squeeze_out = (np.broadcast(*param).shape == ())
         param_in = param
-        param = tuple(np.array(p, dtype=float, copy=False, ndmin=1)
+        param = tuple(np.array(p, dtype=float, copy=AVOID_UNNECESSARY_COPY, ndmin=1)
                       for p in param)
         if self.check_bounds and not is_inside_bounds(param, self.params):
             raise ValueError('`param` {} not in the valid range '
@@ -1303,7 +1305,7 @@ class SphericalDetector(Detector):
         """
         squeeze_out = (np.broadcast(*param).shape == ())
         param_in = param
-        param = tuple(np.array(p, dtype=float, copy=False, ndmin=1)
+        param = tuple(np.array(p, dtype=float, copy=AVOID_UNNECESSARY_COPY, ndmin=1)
                       for p in param)
         if self.check_bounds and not is_inside_bounds(param, self.params):
             raise ValueError('`param` {} not in the valid range '
@@ -1381,7 +1383,7 @@ class SphericalDetector(Detector):
         """
         squeeze_out = (np.broadcast(*param).shape == ())
         param_in = param
-        param = tuple(np.array(p, dtype=float, copy=False, ndmin=1)
+        param = tuple(np.array(p, dtype=float, copy=AVOID_UNNECESSARY_COPY, ndmin=1)
                       for p in param)
         if self.check_bounds and not is_inside_bounds(param, self.params):
             raise ValueError('`param` {} not in the valid range '

--- a/odl/tomo/geometry/geometry.py
+++ b/odl/tomo/geometry/geometry.py
@@ -12,6 +12,8 @@ from __future__ import print_function, division, absolute_import
 from builtins import object
 import numpy as np
 
+from odl.util.npy_compat import AVOID_UNNECESSARY_COPY
+
 from odl.discr import RectPartition
 from odl.tomo.geometry.detector import Detector
 from odl.tomo.util import axis_rotation_matrix, is_inside_bounds
@@ -357,20 +359,20 @@ class Geometry(object):
         # to be able to reliably manipulate the final axes of the result
         if self.motion_params.ndim == 1:
             squeeze_mparam = (np.shape(mparam) == ())
-            mparam = np.array(mparam, dtype=float, copy=False, ndmin=1)
+            mparam = np.array(mparam, dtype=float, copy=AVOID_UNNECESSARY_COPY, ndmin=1)
             matrix = self.rotation_matrix(mparam)  # shape (m, ndim, ndim)
         else:
             squeeze_mparam = (np.broadcast(*mparam).shape == ())
-            mparam = tuple(np.array(a, dtype=float, copy=False, ndmin=1)
+            mparam = tuple(np.array(a, dtype=float, copy=AVOID_UNNECESSARY_COPY, ndmin=1)
                            for a in mparam)
             matrix = self.rotation_matrix(mparam)  # shape (m, ndim, ndim)
 
         if self.det_params.ndim == 1:
             squeeze_dparam = (np.shape(dparam) == ())
-            dparam = np.array(dparam, dtype=float, copy=False, ndmin=1)
+            dparam = np.array(dparam, dtype=float, copy=AVOID_UNNECESSARY_COPY, ndmin=1)
         else:
             squeeze_dparam = (np.broadcast(*dparam).shape == ())
-            dparam = tuple(np.array(p, dtype=float, copy=False, ndmin=1)
+            dparam = tuple(np.array(p, dtype=float, copy=AVOID_UNNECESSARY_COPY, ndmin=1)
                            for p in dparam)
 
         surf = self.detector.surface(dparam)  # shape (d, ndim)
@@ -529,18 +531,18 @@ class DivergentBeamGeometry(Geometry):
         # to be able to reliably manipulate the final axes of the result
         if self.motion_params.ndim == 1:
             squeeze_angle = (np.shape(angle) == ())
-            angle = np.array(angle, dtype=float, copy=False, ndmin=1)
+            angle = np.array(angle, dtype=float, copy=AVOID_UNNECESSARY_COPY, ndmin=1)
         else:
             squeeze_angle = (np.broadcast(*angle).shape == ())
-            angle = tuple(np.array(a, dtype=float, copy=False, ndmin=1)
+            angle = tuple(np.array(a, dtype=float, copy=AVOID_UNNECESSARY_COPY, ndmin=1)
                           for a in angle)
 
         if self.det_params.ndim == 1:
             squeeze_dparam = (np.shape(dparam) == ())
-            dparam = np.array(dparam, dtype=float, copy=False, ndmin=1)
+            dparam = np.array(dparam, dtype=float, copy=AVOID_UNNECESSARY_COPY, ndmin=1)
         else:
             squeeze_dparam = (np.broadcast(*dparam).shape == ())
-            dparam = tuple(np.array(p, dtype=float, copy=False, ndmin=1)
+            dparam = tuple(np.array(p, dtype=float, copy=AVOID_UNNECESSARY_COPY, ndmin=1)
                            for p in dparam)
 
         det_to_src = (self.src_position(angle) -
@@ -606,7 +608,7 @@ class AxisOrientedGeometry(object):
             shape ``(3, 3)``, otherwise ``angle.shape + (3, 3)``.
         """
         squeeze_out = (np.shape(angle) == ())
-        angle = np.array(angle, dtype=float, copy=False, ndmin=1)
+        angle = np.array(angle, dtype=float, copy=AVOID_UNNECESSARY_COPY, ndmin=1)
         if (self.check_bounds and
                 not is_inside_bounds(angle, self.motion_params)):
             raise ValueError('`angle` {} not in the valid range {}'

--- a/odl/tomo/geometry/parallel.py
+++ b/odl/tomo/geometry/parallel.py
@@ -12,6 +12,8 @@ from __future__ import absolute_import, division, print_function
 
 import numpy as np
 
+from odl.util.npy_compat import AVOID_UNNECESSARY_COPY
+
 from odl.discr import uniform_partition
 from odl.tomo.geometry.detector import Flat1dDetector, Flat2dDetector
 from odl.tomo.geometry.geometry import AxisOrientedGeometry, Geometry
@@ -168,12 +170,12 @@ class ParallelBeamGeometry(Geometry):
         """
         if self.motion_params.ndim == 1:
             squeeze_out = (np.shape(angle) == ())
-            angle = np.array(angle, dtype=float, copy=False, ndmin=1)
+            angle = np.array(angle, dtype=float, copy=AVOID_UNNECESSARY_COPY, ndmin=1)
             rot_matrix = self.rotation_matrix(angle)
             extra_dims = angle.ndim
         elif self.motion_params.ndim in (2, 3):
             squeeze_out = (np.broadcast(*angle).shape == ())
-            angle = tuple(np.array(a, dtype=float, copy=False, ndmin=1)
+            angle = tuple(np.array(a, dtype=float, copy=AVOID_UNNECESSARY_COPY, ndmin=1)
                           for a in angle)
             rot_matrix = self.rotation_matrix(angle)
             extra_dims = len(np.broadcast(*angle).shape)
@@ -288,20 +290,20 @@ class ParallelBeamGeometry(Geometry):
         # to be able to reliably manipulate the final axes of the result
         if self.motion_params.ndim == 1:
             squeeze_angle = (np.shape(angle) == ())
-            angle = np.array(angle, dtype=float, copy=False, ndmin=1)
+            angle = np.array(angle, dtype=float, copy=AVOID_UNNECESSARY_COPY, ndmin=1)
             matrix = self.rotation_matrix(angle)  # shape (m, ndim, ndim)
         else:
             squeeze_angle = (np.broadcast(*angle).shape == ())
-            angle = tuple(np.array(a, dtype=float, copy=False, ndmin=1)
+            angle = tuple(np.array(a, dtype=float, copy=AVOID_UNNECESSARY_COPY, ndmin=1)
                           for a in angle)
             matrix = self.rotation_matrix(angle)  # shape (m, ndim, ndim)
 
         if self.det_params.ndim == 1:
             squeeze_dparam = (np.shape(dparam) == ())
-            dparam = np.array(dparam, dtype=float, copy=False, ndmin=1)
+            dparam = np.array(dparam, dtype=float, copy=AVOID_UNNECESSARY_COPY, ndmin=1)
         else:
             squeeze_dparam = (np.broadcast(*dparam).shape == ())
-            dparam = tuple(np.array(p, dtype=float, copy=False, ndmin=1)
+            dparam = tuple(np.array(p, dtype=float, copy=AVOID_UNNECESSARY_COPY, ndmin=1)
                            for p in dparam)
 
         normal = self.detector.surface_normal(dparam)  # shape (d, ndim)
@@ -629,7 +631,7 @@ class Parallel2dGeometry(ParallelBeamGeometry):
             shape ``(2, 2)``, otherwise ``angle.ndim + (2, 2)``.
         """
         squeeze_out = (np.shape(angle) == ())
-        angle = np.array(angle, dtype=float, copy=False, ndmin=1)
+        angle = np.array(angle, dtype=float, copy=AVOID_UNNECESSARY_COPY, ndmin=1)
         if (self.check_bounds and
                 not is_inside_bounds(angle, self.motion_params)):
             raise ValueError('`angle` {} not in the valid range {}'
@@ -1037,7 +1039,7 @@ class Parallel3dEulerGeometry(ParallelBeamGeometry):
         """
         squeeze_out = (np.broadcast(*angles).shape == ())
         angles_in = angles
-        angles = tuple(np.array(angle, dtype=float, copy=False, ndmin=1)
+        angles = tuple(np.array(angle, dtype=float, copy=AVOID_UNNECESSARY_COPY, ndmin=1)
                        for angle in angles)
         if (self.check_bounds and
                 not is_inside_bounds(angles, self.motion_params)):

--- a/odl/tomo/util/source_detector_shifts.py
+++ b/odl/tomo/util/source_detector_shifts.py
@@ -10,6 +10,7 @@
 
 from __future__ import print_function, division, absolute_import
 import numpy as np
+from odl.util.npy_compat import AVOID_UNNECESSARY_COPY
 from odl.discr.discr_utils import nearest_interpolator
 
 __all__ = ('flying_focal_spot',)
@@ -36,7 +37,7 @@ def flying_focal_spot(angle, apart, shifts):
     """
     assert apart.ndim == 1
 
-    angle = np.array(angle, dtype=float, copy=False, ndmin=1)
+    angle = np.array(angle, dtype=float, copy=AVOID_UNNECESSARY_COPY, ndmin=1)
     assert angle.ndim == 1
 
     shifts = np.array(shifts, dtype=float, ndmin=2)

--- a/odl/tomo/util/utility.py
+++ b/odl/tomo/util/utility.py
@@ -9,6 +9,9 @@
 from __future__ import print_function, division, absolute_import
 import numpy as np
 
+from odl.util.npy_compat import AVOID_UNNECESSARY_COPY
+
+
 __all__ = ('euler_matrix', 'axis_rotation', 'axis_rotation_matrix',
            'rotation_matrix_from_to', 'transform_system',
            'perpendicular_vector', 'is_inside_bounds')
@@ -51,19 +54,19 @@ def euler_matrix(phi, theta=None, psi=None):
     if theta is None and psi is None:
         squeeze_out = (np.shape(phi) == ())
         ndim = 2
-        phi = np.array(phi, dtype=float, copy=False, ndmin=1)
+        phi = np.array(phi, dtype=float, copy=AVOID_UNNECESSARY_COPY, ndmin=1)
         theta = psi = 0.0
     else:
         # `None` broadcasts like a scalar
         squeeze_out = (np.broadcast(phi, theta, psi).shape == ())
         ndim = 3
-        phi = np.array(phi, dtype=float, copy=False, ndmin=1)
+        phi = np.array(phi, dtype=float, copy=AVOID_UNNECESSARY_COPY, ndmin=1)
         if theta is None:
             theta = 0.0
         if psi is None:
             psi = 0.0
-        theta = np.array(theta, dtype=float, copy=False, ndmin=1)
-        psi = np.array(psi, dtype=float, copy=False, ndmin=1)
+        theta = np.array(theta, dtype=float, copy=AVOID_UNNECESSARY_COPY, ndmin=1)
+        psi = np.array(psi, dtype=float, copy=AVOID_UNNECESSARY_COPY, ndmin=1)
         ndim = 3
 
     cph = np.cos(phi)
@@ -219,7 +222,7 @@ def axis_rotation_matrix(axis, angle):
         raise ValueError('`axis` shape must be (3,), got {}'
                          ''.format(axis.shape))
 
-    angle = np.array(angle, dtype=float, copy=False, ndmin=1)
+    angle = np.array(angle, dtype=float, copy=AVOID_UNNECESSARY_COPY, ndmin=1)
 
     cross_mat = np.array([[0, -axis[2], axis[1]],
                           [axis[2], 0, -axis[0]],
@@ -600,7 +603,7 @@ def perpendicular_vector(vec):
             [-1.,  0.,  0.]]])
     """
     squeeze_out = (np.ndim(vec) == 1)
-    vec = np.array(vec, dtype=float, copy=False, ndmin=2)
+    vec = np.array(vec, dtype=float, copy=AVOID_UNNECESSARY_COPY, ndmin=2)
 
     if np.any(np.all(vec == 0, axis=-1)):
         raise ValueError('zero vector')

--- a/odl/trafos/fourier.py
+++ b/odl/trafos/fourier.py
@@ -12,6 +12,8 @@ from __future__ import absolute_import, division, print_function
 
 import numpy as np
 
+from odl.util.npy_compat import AVOID_UNNECESSARY_COPY
+
 from odl.discr import DiscretizedSpace, uniform_discr
 from odl.operator import Operator
 from odl.set import ComplexNumbers, RealNumbers
@@ -1323,7 +1325,9 @@ class FourierTransform(FourierTransformBase):
             out = np.fft.rfftn(preproc, axes=self.axes)
         else:
             if self.sign == '-':
-                out = np.fft.fftn(preproc, axes=self.axes)
+                out = ( np.fft.fftn(preproc, axes=self.axes)
+                       .astype(complex_dtype(preproc.dtype), copy=AVOID_UNNECESSARY_COPY)
+                       )
             else:
                 out = np.fft.ifftn(preproc, axes=self.axes)
                 # Numpy's FFT normalizes by 1 / prod(shape[axes]), we

--- a/odl/trafos/util/ft_utils.py
+++ b/odl/trafos/util/ft_utils.py
@@ -12,6 +12,8 @@ from __future__ import absolute_import, division, print_function
 
 import numpy as np
 
+from odl.util.npy_compat import AVOID_UNNECESSARY_COPY
+
 from odl.discr import (
     DiscretizedSpace, uniform_discr_frompartition, uniform_grid,
     uniform_partition_fromgrid)
@@ -342,7 +344,7 @@ def dft_preprocess_data(arr, shift=True, axes=None, sign='-', out=None):
             factor = np.arange(length, dtype=out.dtype)
             factor *= -imag * np.pi * (1 - 1.0 / length)
             np.exp(factor, out=factor)
-        return factor.astype(out.dtype, copy=False)
+        return factor.astype(out.dtype, copy=AVOID_UNNECESSARY_COPY)
 
     onedim_arrs = []
     for axis, shift in zip(axes, shift_list):
@@ -540,7 +542,7 @@ def dft_postprocess_data(arr, real_grid, recip_grid, shift, axes,
         else:
             onedim_arr /= interp_kernel
 
-        onedim_arrs.append(onedim_arr.astype(out.dtype, copy=False))
+        onedim_arrs.append(onedim_arr.astype(out.dtype, copy=AVOID_UNNECESSARY_COPY))
 
     fast_1d_tensor_mult(out, onedim_arrs, axes=axes, out=out)
     return out

--- a/odl/ufunc_ops/ufunc_ops.py
+++ b/odl/ufunc_ops/ufunc_ops.py
@@ -11,6 +11,8 @@
 from __future__ import print_function, division, absolute_import
 import numpy as np
 
+from odl.util.npy_compat import AVOID_UNNECESSARY_COPY
+
 from odl.set import LinearSpace, RealNumbers, Field
 from odl.space import ProductSpace, tensor_space
 from odl.operator import Operator, MultiplyOperator

--- a/odl/util/npy_compat.py
+++ b/odl/util/npy_compat.py
@@ -9,7 +9,23 @@
 """Numpy functionality that is not uniform across the supported versions.
 """
 
-__all__ = ()
+import numpy as np
+
+# This is supposed to be used as the `copy=AVOID_UNNECESSARY_COPY` argument to
+# the `np.array` constructor when a copy is not desired but may not be avoidable
+# (for example because a conversion to a different `dtype` is performed).
+# ODL uses this in many places, since it gives usually good performance but
+# also still offers flexibility.
+# In NumPy-1, the `copy` argument could only be `True` or `False`, the latter
+# being merely a request which NumPy-1 ignored if necessary.
+# By contrast, NumPy-2 makes `False` binding: if a copy cannot be avoided,
+# an error is raised. For the old weak request, NumPy-2 offers `copy=None`
+# as the value, which is thus what ODL shall use forward-facing.
+# NumPy-1 does however not understand this, which is why the following definition
+# is needed for compatibility with both.
+AVOID_UNNECESSARY_COPY = None if np.__version__>='2' else False
+
+__all__ = ("AVOID_UNNECESSARY_COPY",)
 
 if __name__ == '__main__':
     from odl.util.testutils import run_doctests

--- a/odl/util/npy_compat.py
+++ b/odl/util/npy_compat.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2019 The ODL contributors
+# Copyright 2014-2025 The ODL contributors
 #
 # This file is part of ODL.
 #
@@ -6,12 +6,8 @@
 # v. 2.0. If a copy of the MPL was not distributed with this file, You can
 # obtain one at https://mozilla.org/MPL/2.0/.
 
-"""Numpy functions not available in the minimal required version.
-
-Current minimum Numpy version: 1.13.3
+"""Numpy functionality that is not uniform across the supported versions.
 """
-
-from __future__ import absolute_import, division, print_function
 
 __all__ = ()
 

--- a/odl/util/numerics.py
+++ b/odl/util/numerics.py
@@ -456,12 +456,15 @@ def resize_array(arr, newshp, offset=None, pad_mode='constant', pad_const=0,
         raise ValueError("`pad_mode` '{}' not understood".format(pad_mode_in))
 
     if (pad_mode == 'constant' and
-        not np.can_cast(pad_const, out.dtype) and
         any(n_new > n_orig
             for n_orig, n_new in zip(arr.shape, out.shape))):
-        raise ValueError('`pad_const` {} cannot be safely cast to the data '
-                         'type {} of the output array'
-                         ''.format(pad_const, out.dtype))
+        try:
+            pad_const_scl = np.array([pad_const], out.dtype)
+            assert(pad_const_scl == np.array([pad_const]))
+        except Exception as e:
+            raise ValueError('`pad_const` {} cannot be safely cast to the data '
+                             'type {} of the output array'
+                             ''.format(pad_const, out.dtype))
 
     # Handle direction
     direction, direction_in = str(direction).lower(), direction

--- a/odl/util/pytest_config.py
+++ b/odl/util/pytest_config.py
@@ -132,6 +132,12 @@ def pytest_ignore_collect(path, config):
 odl_tspace_impl = simple_fixture(name='tspace_impl',
                                  params=tensor_space_impl_names())
 
+real_floating_dtypes = np.core.sctypes['float']
+real_floating_dtype_params = [np.dtype(dt) for dt in real_floating_dtypes]
+odl_real_floating_dtype = simple_fixture(name='dtype',
+                                    params=real_floating_dtype_params,
+                                    fmt=' {name} = np.{value.name} ')
+
 floating_dtypes = np.core.sctypes['float'] + np.core.sctypes['complex']
 floating_dtype_params = [np.dtype(dt) for dt in floating_dtypes]
 odl_floating_dtype = simple_fixture(name='dtype',

--- a/odl/util/pytest_config.py
+++ b/odl/util/pytest_config.py
@@ -20,6 +20,7 @@ import odl
 from odl.space.entry_points import tensor_space_impl_names
 from odl.trafos.backends import PYFFTW_AVAILABLE, PYWT_AVAILABLE
 from odl.util.testutils import simple_fixture
+from odl.util.utility import SCTYPES
 
 try:
     import pytest
@@ -132,19 +133,19 @@ def pytest_ignore_collect(path, config):
 odl_tspace_impl = simple_fixture(name='tspace_impl',
                                  params=tensor_space_impl_names())
 
-real_floating_dtypes = np.core.sctypes['float']
+real_floating_dtypes = SCTYPES['float']
 real_floating_dtype_params = [np.dtype(dt) for dt in real_floating_dtypes]
 odl_real_floating_dtype = simple_fixture(name='dtype',
                                     params=real_floating_dtype_params,
                                     fmt=' {name} = np.{value.name} ')
 
-floating_dtypes = np.core.sctypes['float'] + np.core.sctypes['complex']
+floating_dtypes = SCTYPES['float'] + SCTYPES['complex']
 floating_dtype_params = [np.dtype(dt) for dt in floating_dtypes]
 odl_floating_dtype = simple_fixture(name='dtype',
                                     params=floating_dtype_params,
                                     fmt=' {name} = np.{value.name} ')
 
-scalar_dtypes = floating_dtype_params + np.core.sctypes['int'] + np.core.sctypes['uint']
+scalar_dtypes = floating_dtype_params + SCTYPES['int'] + SCTYPES['uint']
 scalar_dtype_params = [np.dtype(dt) for dt in floating_dtypes]
 odl_scalar_dtype = simple_fixture(name='dtype',
                                   params=scalar_dtype_params,

--- a/odl/util/pytest_config.py
+++ b/odl/util/pytest_config.py
@@ -132,13 +132,13 @@ def pytest_ignore_collect(path, config):
 odl_tspace_impl = simple_fixture(name='tspace_impl',
                                  params=tensor_space_impl_names())
 
-floating_dtypes = np.sctypes['float'] + np.sctypes['complex']
+floating_dtypes = np.core.sctypes['float'] + np.core.sctypes['complex']
 floating_dtype_params = [np.dtype(dt) for dt in floating_dtypes]
 odl_floating_dtype = simple_fixture(name='dtype',
                                     params=floating_dtype_params,
                                     fmt=' {name} = np.{value.name} ')
 
-scalar_dtypes = floating_dtype_params + np.sctypes['int'] + np.sctypes['uint']
+scalar_dtypes = floating_dtype_params + np.core.sctypes['int'] + np.core.sctypes['uint']
 scalar_dtype_params = [np.dtype(dt) for dt in floating_dtypes]
 odl_scalar_dtype = simple_fixture(name='dtype',
                                   params=scalar_dtype_params,

--- a/odl/util/testutils.py
+++ b/odl/util/testutils.py
@@ -18,6 +18,8 @@ from contextlib import contextmanager
 from time import time
 
 import numpy as np
+from odl.util.npy_compat import AVOID_UNNECESSARY_COPY
+
 from future.moves.itertools import zip_longest
 
 from odl.util.utility import is_string, run_from_ipython
@@ -365,7 +367,7 @@ def noise_array(space):
         else:
             raise ValueError('bad dtype {}'.format(space.dtype))
 
-        return arr.astype(space.dtype, copy=False)
+        return arr.astype(space.dtype, copy=AVOID_UNNECESSARY_COPY)
 
 
 def noise_element(space):

--- a/odl/util/utility.py
+++ b/odl/util/utility.py
@@ -332,14 +332,14 @@ def cache_arguments(function):
 def is_numeric_dtype(dtype):
     """Return ``True`` if ``dtype`` is a numeric type."""
     dtype = np.dtype(dtype)
-    return np.issubsctype(getattr(dtype, 'base', None), np.number)
+    return np.issubdtype(getattr(dtype, 'base', None), np.number)
 
 
 @cache_arguments
 def is_int_dtype(dtype):
     """Return ``True`` if ``dtype`` is an integer type."""
     dtype = np.dtype(dtype)
-    return np.issubsctype(getattr(dtype, 'base', None), np.integer)
+    return np.issubdtype(getattr(dtype, 'base', None), np.integer)
 
 
 @cache_arguments
@@ -358,14 +358,14 @@ def is_real_dtype(dtype):
 def is_real_floating_dtype(dtype):
     """Return ``True`` if ``dtype`` is a real floating point type."""
     dtype = np.dtype(dtype)
-    return np.issubsctype(getattr(dtype, 'base', None), np.floating)
+    return np.issubdtype(getattr(dtype, 'base', None), np.floating)
 
 
 @cache_arguments
 def is_complex_floating_dtype(dtype):
     """Return ``True`` if ``dtype`` is a complex floating point type."""
     dtype = np.dtype(dtype)
-    return np.issubsctype(getattr(dtype, 'base', None), np.complexfloating)
+    return np.issubdtype(getattr(dtype, 'base', None), np.complexfloating)
 
 
 def real_dtype(dtype, default=None):

--- a/odl/util/utility.py
+++ b/odl/util/utility.py
@@ -53,7 +53,7 @@ __all__ = (
 
 REPR_PRECISION = 4  # For printing scalars and array entries
 TYPE_MAP_R2C = {np.dtype(dtype): np.result_type(dtype, 1j)
-                for dtype in np.sctypes['float']}
+                for dtype in np.core.sctypes['float']}
 
 TYPE_MAP_C2R = {cdt: np.empty(0, dtype=cdt).real.dtype
                 for rdt, cdt in TYPE_MAP_R2C.items()}

--- a/odl/util/utility.py
+++ b/odl/util/utility.py
@@ -50,10 +50,20 @@ __all__ = (
     'unique',
 )
 
+try:
+    SCTYPES = np.core.sctypes
+    assert isinstance(SCTYPES, dict)
+except AttributeError:
+    # As of 29/04/25, we are aware that the module 
+    # np.core might be removed in future versions. If that happens, the
+    # npy types will have to be queried in a different way. We advise to
+    # install the npy version listed in the odl/conda/meta.yaml
+    raise ImportError('You are using a numpy version that was not tested with ' \
+    'ODL. Please install the npy version listed in the odl/conda/meta.yaml')
 
 REPR_PRECISION = 4  # For printing scalars and array entries
 TYPE_MAP_R2C = {np.dtype(dtype): np.result_type(dtype, 1j)
-                for dtype in np.core.sctypes['float']}
+                for dtype in SCTYPES['float']}
 
 TYPE_MAP_C2R = {cdt: np.empty(0, dtype=cdt).real.dtype
                 for rdt, cdt in TYPE_MAP_R2C.items()}


### PR DESCRIPTION
NumPy version 2 makes some changes that broke ODL tests. The main ones concern copying semantics and dtype conversions.

These checks make the standard ODL test suite green when running against NumPy-2.2, and they also still succeed in NumPy-1.26.

The biggest change that needed to be made was the introduction of the `AVOID_UNNECESSARY_COPY` flag. It is a replacement for the paradigm of passing `copy=False` to the NumPy array conversion functions that has a too strict behaviour in NumPy-2.