### PR TITLE
Relax tolerance for single-precision float constant-weighting test.

### DIFF
--- a/odl/test/space/tensors_test.py
+++ b/odl/test/space/tensors_test.py
@@ -1263,7 +1263,7 @@ def test_const_weighting_norm(tspace, exponent):
     if real_dtype == np.float16:
         tolerance = 1e-3
     elif real_dtype == np.float32:
-        tolerance = 1e-7
+        tolerance = 1e-6
     elif real_dtype == np.float64:
         tolerance = 1e-15
     elif real_dtype == np.float128:


### PR DESCRIPTION
The test succeeded most of the time, but since it depends on random initialisation there are some rare cases where the deviation is more than 1e-7 when using single-precision floats.
This is evidently not an ODL problem but simply a manifestation of the low precision on Float32 (the double precision test does not have the problem). So making the tolerance higher is appropriate.