### PR TITLE
Avoid sporadic test failures due to nondeterminism

### DIFF
--- a/odl/test/discr/discr_ops_test.py
+++ b/odl/test/discr/discr_ops_test.py
@@ -259,8 +259,8 @@ def test_resizing_op_adjoint(padding, odl_tspace_impl):
         inner1 = res_op(elem).inner(res_elem)
         inner2 = elem.inner(res_op.adjoint(res_elem))
         assert inner1 == pytest.approx(
-            inner2, rel=space.size * dtype_tol(dtype)
-        )
+            inner2,
+            abs = 1e-2 * space.size * dtype_tol(dtype) * elem.norm() * res_elem.norm())
 
 
 def test_resizing_op_mixed_uni_nonuni():

--- a/odl/test/operator/oputils_test.py
+++ b/odl/test/operator/oputils_test.py
@@ -149,10 +149,25 @@ def test_power_method_opnorm_symm():
 
     op = odl.MatrixOperator(mat)
     true_opnorm = 1.2
-    opnorm_est = power_method_opnorm(op, maxiter=100)
-    assert opnorm_est == pytest.approx(true_opnorm, rel=1e-2)
 
-    # Start at a different point
+    # Run with a random starting point. This should give the right
+    # result most of the time, but can fail if the random point fell
+    # very close to the lesser eigenvector. To confirm that the probability
+    # is low, we run the method three times (they will have different
+    # random starting points). Usually all three should give the right
+    # result, but one of them may occasionally fail (and give the other
+    # singular value instead). Two wrong ones out of three should
+    # be exeedingly rare though, so we treat this as a test failure.
+    n_failures = 0
+    for _ in range(3):
+        opnorm_est = power_method_opnorm(op, maxiter=100)
+        if n_failures<1:
+            if opnorm_est != pytest.approx(true_opnorm, rel=1e-2):
+                n_failures += 1
+        else:
+            assert opnorm_est == pytest.approx(true_opnorm, rel=1e-2)
+
+    # Start at a deterministic point. This should _always_ succeed.
     xstart = odl.rn(2).element([0.8, 0.5])
     opnorm_est = power_method_opnorm(op, xstart=xstart, maxiter=100)
     assert opnorm_est == pytest.approx(true_opnorm, rel=1e-2)

--- a/odl/test/solvers/nonsmooth/douglas_rachford_test.py
+++ b/odl/test/solvers/nonsmooth/douglas_rachford_test.py
@@ -90,7 +90,7 @@ def test_primal_dual_l1():
 
     # Solve with f term dominating
     x = space.zero()
-    douglas_rachford_pd(x, f, g, L, tau=3.0, sigma=[1.0], niter=10)
+    douglas_rachford_pd(x, f, g, L, tau=3.0, sigma=[1.0], niter=15)
 
     assert all_almost_equal(x, data_1, ndigits=2)
 

--- a/odl/test/space/tensors_test.py
+++ b/odl/test/space/tensors_test.py
@@ -656,8 +656,22 @@ def test_norm(tspace):
     xarr, x = noise_elements(tspace)
 
     correct_norm = np.linalg.norm(xarr.ravel())
-    assert tspace.norm(x) == pytest.approx(correct_norm)
-    assert x.norm() == pytest.approx(correct_norm)
+
+    real_dtype = tspace.dtype.type(0).real.dtype
+
+    if real_dtype == np.float16:
+        tolerance = 1e-3
+    elif real_dtype == np.float32:
+        tolerance = 2e-7
+    elif real_dtype == np.float64:
+        tolerance = 1e-15
+    elif real_dtype == np.float128:
+        tolerance = 1e-19
+    else:
+        raise TypeError(f"No known tolerance for dtype {tspace.dtype}")
+    
+    assert tspace.norm(x) == pytest.approx(correct_norm, rel=tolerance)
+    assert x.norm() == pytest.approx(correct_norm, rel=tolerance)
 
 
 def test_norm_exceptions(tspace):
@@ -685,8 +699,22 @@ def test_dist(tspace):
     [xarr, yarr], [x, y] = noise_elements(tspace, n=2)
 
     correct_dist = np.linalg.norm((xarr - yarr).ravel())
-    assert tspace.dist(x, y) == pytest.approx(correct_dist)
-    assert x.dist(y) == pytest.approx(correct_dist)
+
+    real_dtype = tspace.dtype.type(0).real.dtype
+
+    if real_dtype == np.float16:
+        tolerance = 5e-3
+    elif real_dtype == np.float32:
+        tolerance = 2e-7
+    elif real_dtype == np.float64:
+        tolerance = 1e-15
+    elif real_dtype == np.float128:
+        tolerance = 1e-19
+    else:
+        raise TypeError(f"No known tolerance for dtype {tspace.dtype}")
+    
+    assert tspace.dist(x, y) == pytest.approx(correct_dist, rel=tolerance)
+    assert x.dist(y) == pytest.approx(correct_dist, rel=tolerance)
 
 
 def test_dist_exceptions(tspace):
@@ -1261,7 +1289,7 @@ def test_const_weighting_norm(tspace, exponent):
     real_dtype = tspace.dtype.type(0).real.dtype
 
     if real_dtype == np.float16:
-        tolerance = 1e-3
+        tolerance = 5e-2
     elif real_dtype == np.float32:
         tolerance = 1e-6
     elif real_dtype == np.float64:
@@ -1286,7 +1314,21 @@ def test_const_weighting_dist(tspace, exponent):
     true_dist = factor * np.linalg.norm((xarr - yarr).ravel(), ord=exponent)
 
     w_const = NumpyTensorSpaceConstWeighting(constant, exponent=exponent)
-    assert w_const.dist(x, y) == pytest.approx(true_dist)
+
+    real_dtype = tspace.dtype.type(0).real.dtype
+
+    if real_dtype == np.float16:
+        tolerance = 5e-2
+    elif real_dtype == np.float32:
+        tolerance = 5e-7
+    elif real_dtype == np.float64:
+        tolerance = 1e-15
+    elif real_dtype == np.float128:
+        tolerance = 1e-19
+    else:
+        raise TypeError(f"No known tolerance for dtype {tspace.dtype}")
+
+    assert w_const.dist(x, y) == pytest.approx(true_dist, rel=tolerance)
 
 
 def test_custom_inner(tspace):

--- a/odl/test/tomo/geometry/geometry_test.py
+++ b/odl/test/tomo/geometry/geometry_test.py
@@ -1026,7 +1026,7 @@ def test_source_detector_shifts():
             i = j
 
     # shifts define ffs at partition points
-    n_shifts = np.random.randint(1, n_angles)
+    n_shifts = np.random.randint(1, n_angles+1)
     shift_dim = 3
     shifts = np.random.uniform(size=(n_shifts, shift_dim))
     ffs = odl.tomo.flying_focal_spot(part_angles, apart, shifts)


### PR DESCRIPTION
@Emvlt and me have been running tests many times lately, to ensure the changes towards Python Array API are safe.

Besides the ones related to actual bugs, we also encountered some sporadic failures that happen only occasionally. These are due to randomness in either the test suite itself, or the methods being tested. 93e6d61 and 249a573 already addressed this partially, but not completely.

I have fixed all of these occurences that I encountered when running the entire test suite several hundred times. The tests in question I have run even more often.

There is no guarantee that there are not more, even rarer, nondeterminism problems, but at least they are now very unlikely to turn up in a debugging session or when a user attempts to get ODL running.