### PR TITLE
Relax the dependency bounds to allow NumPy-2.

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -20,7 +20,7 @@ requirements:
     - python >=3.7
     - setuptools <76.0
     - future >=0.16
-    - numpy >=1.19, <1.27
+    - numpy >=1.19, <2.2
     - scipy >=1.1
     - packaging >=17.0
     - matplotlib-base >=3.4

--- a/setup.cfg
+++ b/setup.cfg
@@ -41,7 +41,7 @@ install_requires =
     setuptools >=65.6
     future >=0.16
     packaging >=17.0
-    numpy >=1.19, <1.27
+    numpy >=1.19, <2.2
     scipy >=1.1
 python_requires = >=3.7
 tests_require =


### PR DESCRIPTION
Support for NumPy 2 was already added in 4e47e9b, but the package meta-information did not yet reflect it.