### PR TITLE
Tighten NumPy dependency to version 2.1

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -20,7 +20,7 @@ requirements:
     - python >=3.7
     - setuptools <76.0
     - future >=0.16
-    - numpy >=1.19, <2.2
+    - numpy >=2.1, <2.2
     - scipy >=1.1
     - packaging >=17.0
     - matplotlib-base >=3.4

--- a/setup.cfg
+++ b/setup.cfg
@@ -41,7 +41,7 @@ install_requires =
     setuptools >=65.6
     future >=0.16
     packaging >=17.0
-    numpy >=1.19, <2.2
+    numpy >=2.1, <2.2
     scipy >=1.1
 python_requires = >=3.7
 tests_require =

--- a/setup.cfg
+++ b/setup.cfg
@@ -54,6 +54,8 @@ include_package_data = True
 exclude =
     doc
     examples
+    conda
+    tools
 
 [options.package_data]
 tests = odl/test, odl/pytest.ini


### PR DESCRIPTION
This is necessary to take full leverage of the Python Array API, which is needed for ODL 1.0.

Users who want to build against NumPy-1.26 can stick to the 0.8.x versions, which will however not get the advantage of seemless multi-backend support.