### PR TITLE
Import the new name for copy-avoiding flag to the torch contrib module.

### DIFF
--- a/odl/contrib/torch/operator.py
+++ b/odl/contrib/torch/operator.py
@@ -21,6 +21,7 @@ import numpy as np
 import torch
 from packaging.version import parse as parse_version
 
+from odl.util.npy_compat import AVOID_UNNECESSARY_COPY
 from odl import Operator
 
 if parse_version(torch.__version__) < parse_version('0.4'):


### PR DESCRIPTION
This is used since 63ea59c, but I forgot to add the import statement to the torch contrib module that makes it work.

Reported by user wuebbel in https://github.com/odlgroup/odl/issues/1690.