### PR TITLE
Replace obsolete `future.moves` imports with the standard library version.

### DIFF
--- a/odl/util/testutils.py
+++ b/odl/util/testutils.py
@@ -20,7 +20,7 @@ from time import time
 import numpy as np
 from odl.util.npy_compat import AVOID_UNNECESSARY_COPY
 
-from future.moves.itertools import zip_longest
+from itertools import zip_longest
 
 from odl.util.utility import is_string, run_from_ipython
 

--- a/odl/util/utility.py
+++ b/odl/util/utility.py
@@ -9,7 +9,7 @@
 """Utilities mainly for internal use."""
 
 from __future__ import absolute_import, division, print_function
-from future.moves.itertools import zip_longest
+from itertools import zip_longest
 
 import contextlib
 from collections import OrderedDict


### PR DESCRIPTION
These imports were once upon a time needed for compatibility with old Python versions, but this is not necessary anymore and anyways those old versions are also not compatible with other dependencies ODL now carries.

Besides general awkwardness, the `future.moves` modules also have strange side-effects, as reported in https://github.com/odlgroup/odl/issues/1693.

In Python 3, the simpler `import itertools` seems to work exactly the same. Test suite passes.