### PR TITLE
Modifications to the python-publish workflow to run numpy test suite

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -31,6 +31,12 @@ jobs:
           # NOTE: put your own distribution build steps here.
           python -m pip install build
           python -m build
+      
+      - name: Run test suite
+        run: |
+          pip install pytest
+          pip install dist/*.whl
+          pytest odl/test
 
       - name: Upload distributions
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
We want to avoid pushing a buggy version to pip so we set up a workflow that runs the minimal test suite before publishing a new version on pypi.