### PR TITLE
Fixing a typo that affected the 3D FBP.

### DIFF
--- a/odl/applications/tomo/analytic/filtered_back_projection.py
+++ b/odl/applications/tomo/analytic/filtered_back_projection.py
@@ -426,7 +426,7 @@ def fbp_filter_op(ray_trafo, padding=True, filter_type='Ram-Lak',
         def fourier_filter(x):
             # If axis is aligned to a coordinate axis, save some memory and
             # time by using broadcasting
-            x, backend = get_array_and_backend(x[0])
+            _, backend = get_array_and_backend(x[0])
             array_namespace = backend.array_namespace
             if not used_axes[0]:
                 abs_freq = array_namespace.abs(rot_dir[1] * x[2])


### PR DESCRIPTION
A call to  on one component of x (to get the data namepsace on the fly) was overwritting the value of x which led to zero-valued reconstructions. We should look into making the FBP an operator with explicit impl attribute to avoid choosing the namespace on the fly and write some tests for numerical consistency