### PR TITLE
Astra curved detector

### DIFF
--- a/src/odl/applications/tomo/backends/astra_cuda.py
+++ b/src/odl/applications/tomo/backends/astra_cuda.py
@@ -318,7 +318,7 @@ class AstraCudaImpl:
             if self.proj_ndim == 2:
                 proj_data = proj_data.data[None]
             elif self.proj_ndim == 3:
-                proj_data = proj_data.data.__array_namespace__().permute_dims(proj_data, self.transpose_tuple)
+                proj_data = proj_data.data.__array_namespace__().permute_dims(proj_data.data, self.transpose_tuple)
             else:
                 raise NotImplementedError
 

--- a/src/odl/applications/tomo/backends/astra_cuda.py
+++ b/src/odl/applications/tomo/backends/astra_cuda.py
@@ -245,7 +245,7 @@ class AstraCudaImpl:
             proj_data = (
                 proj_data[0]
                 if self.geometry.ndim == 2
-                else self._proj_space.array_namespace.permute_dims(proj_data, self.invserse_transpose_tuple)
+                else self._proj_space.array_namespace.permute_dims(proj_data, self.inverse_transpose_tuple)
             )
 
             if out is not None:

--- a/src/odl/applications/tomo/backends/astra_cuda.py
+++ b/src/odl/applications/tomo/backends/astra_cuda.py
@@ -208,7 +208,7 @@ class AstraCudaImpl:
                     )
                 proj_data = out.data[None] if self.proj_ndim == 2 else out.data
                 if self.geometry.ndim == 3:
-                    proj_data = proj_data.__array_namespace__().permute_dims(proj_data, self.transpose_tuple)
+                    proj_data = self._proj_space.array_namespace.permute_dims(proj_data, self.transpose_tuple)
 
             else:
                 proj_data = empty(
@@ -244,7 +244,7 @@ class AstraCudaImpl:
             proj_data = (
                 proj_data[0]
                 if self.geometry.ndim == 2
-                else proj_data.__array_namespace__().permute_dims(proj_data, self.transpose_tuple)
+                else self._proj_space.array_namespace.permute_dims(proj_data, self.transpose_tuple)
             )
 
             if out is not None:
@@ -318,7 +318,7 @@ class AstraCudaImpl:
             if self.proj_ndim == 2:
                 proj_data = proj_data.data[None]
             elif self.proj_ndim == 3:
-                proj_data = proj_data.data.__array_namespace__().permute_dims(proj_data.data, self.transpose_tuple)
+                proj_data = self._proj_space.array_namespace.permute_dims(proj_data.data, self.transpose_tuple)
             else:
                 raise NotImplementedError
 

--- a/src/odl/applications/tomo/backends/astra_cuda.py
+++ b/src/odl/applications/tomo/backends/astra_cuda.py
@@ -112,16 +112,7 @@ class AstraCudaImpl:
         ), f"Volume space ({vol_space.impl}) != Projection space ({proj_space.impl})"
 
         if self.geometry.ndim == 3:
-            if vol_space.impl == 'numpy':
-                self.transpose_tuple = (1,0,2) if self.geometry.det_curvature_radius is None else (2, 0, 1)
-            elif vol_space.impl == 'pytorch':
-                # FIXME: if self.geometry.det_curvature_radius is None
-                # We can't use a single PyTorch transpose...
-                if self.geometry.det_curvature_radius is not None:
-                    raise NotImplementedError("Curved detectors currently do not support pytorch")
-                self.transpose_tuple = (1,0)
-            else:
-                raise NotImplementedError("Not implemented for another backend")
+            self.transpose_tuple = (1,0,2) if self.geometry.det_curvature_radius is None else (2, 0, 1)
 
         self.fp_scaling_factor = astra_cuda_fp_scaling_factor(self.geometry)
         self.bp_scaling_factor = astra_cuda_bp_scaling_factor(
@@ -217,7 +208,7 @@ class AstraCudaImpl:
                     )
                 proj_data = out.data[None] if self.proj_ndim == 2 else out.data
                 if self.geometry.ndim == 3:
-                    proj_data = proj_data.transpose(*self.transpose_tuple)
+                    proj_data = proj_data.__array_namespace__().permute_dims(proj_data, self.transpose_tuple)
 
             else:
                 proj_data = empty(
@@ -253,7 +244,7 @@ class AstraCudaImpl:
             proj_data = (
                 proj_data[0]
                 if self.geometry.ndim == 2
-                else proj_data.transpose(*self.transpose_tuple)
+                else proj_data.__array_namespace__().permute_dims(proj_data, self.transpose_tuple)
             )
 
             if out is not None:
@@ -327,7 +318,7 @@ class AstraCudaImpl:
             if self.proj_ndim == 2:
                 proj_data = proj_data.data[None]
             elif self.proj_ndim == 3:
-                proj_data = proj_data.data.transpose(*self.transpose_tuple)
+                proj_data = proj_data.data.__array_namespace__().permute_dims(proj_data, self.transpose_tuple)
             else:
                 raise NotImplementedError
 

--- a/src/odl/applications/tomo/backends/astra_cuda.py
+++ b/src/odl/applications/tomo/backends/astra_cuda.py
@@ -113,6 +113,7 @@ class AstraCudaImpl:
 
         if self.geometry.ndim == 3:
             self.transpose_tuple = (1,0,2) if self.geometry.det_curvature_radius is None else (2, 0, 1)
+            self.inverse_transpose_tuple = (1,0,2) if self.geometry.det_curvature_radius is None else (1, 2, 0)
 
         self.fp_scaling_factor = astra_cuda_fp_scaling_factor(self.geometry)
         self.bp_scaling_factor = astra_cuda_bp_scaling_factor(
@@ -244,7 +245,7 @@ class AstraCudaImpl:
             proj_data = (
                 proj_data[0]
                 if self.geometry.ndim == 2
-                else self._proj_space.array_namespace.permute_dims(proj_data, self.transpose_tuple)
+                else self._proj_space.array_namespace.permute_dims(proj_data, self.invserse_transpose_tuple)
             )
 
             if out is not None:

--- a/src/odl/applications/tomo/backends/astra_cuda.py
+++ b/src/odl/applications/tomo/backends/astra_cuda.py
@@ -113,8 +113,12 @@ class AstraCudaImpl:
 
         if self.geometry.ndim == 3:
             if vol_space.impl == 'numpy':
-                self.transpose_tuple = (1,0,2)
+                self.transpose_tuple = (1,0,2) if self.geometry.det_curvature_radius is None else (2, 0, 1)
             elif vol_space.impl == 'pytorch':
+                # FIXME: if self.geometry.det_curvature_radius is None
+                # We can't use a single PyTorch transpose...
+                if self.geometry.det_curvature_radius is not None:
+                    raise NotImplementedError("Curved detectors currently do not support pytorch")
                 self.transpose_tuple = (1,0)
             else:
                 raise NotImplementedError("Not implemented for another backend")

--- a/src/odl/applications/tomo/backends/astra_setup.py
+++ b/src/odl/applications/tomo/backends/astra_setup.py
@@ -423,7 +423,7 @@ def astra_cyl_conebeam_3d_geom_to_vec(geometry:DivergentBeamGeometry):
 
     # ASTRA has (z, y, x) axis convention, in contrast to (x, y, z) in ODL,
     # so we need to adapt to this by changing the order.
-    vectors = vectors[:, ODL_TO_ASTRA_INDEX_PERMUTATIONS]
+    vectors = vectors[:, [*ODL_TO_ASTRA_INDEX_PERMUTATIONS, 12]]
 
     return vectors
 

--- a/src/odl/applications/tomo/backends/astra_setup.py
+++ b/src/odl/applications/tomo/backends/astra_setup.py
@@ -30,7 +30,7 @@ import numpy as np
 
 from odl.core.discr import DiscretizedSpace, DiscretizedSpaceElement
 from odl.applications.tomo.geometry import (
-    DivergentBeamGeometry, Flat1dDetector, Flat2dDetector, Geometry,
+    ConeBeamGeometry, CylindricalDetector, DivergentBeamGeometry, Flat1dDetector, Flat2dDetector, Geometry,
     ParallelBeamGeometry)
 from odl.applications.tomo.util.utility import euler_matrix
 from odl.core.array_API_support import get_array_and_backend
@@ -124,6 +124,10 @@ ASTRA_FEATURES = {
     # next release after 1.8.3, see
     # https://github.com/astra-toolbox/astra-toolbox/pull/183
     'par2d_distance_driven_proj': '>1.8.3',
+
+    # Cylidrical detector geometry, see
+    # https://github.com/astra-toolbox/astra-toolbox/pull/444
+    'cyl_cone_vec': ">= 2.4.0"
 }
 
 ODL_TO_ASTRA_INDEX_PERMUTATIONS = [
@@ -347,6 +351,75 @@ def astra_conebeam_3d_geom_to_vec(geometry:Geometry):
     # keeps at least contiguous blocks in `v`.
     vectors[:, 9:12] = det_axes[0] * px_sizes[0]
     vectors[:, 6:9] = det_axes[1] * px_sizes[1]
+
+    # ASTRA has (z, y, x) axis convention, in contrast to (x, y, z) in ODL,
+    # so we need to adapt to this by changing the order.
+    vectors = vectors[:, ODL_TO_ASTRA_INDEX_PERMUTATIONS]
+
+    return vectors
+
+def astra_cyl_conebeam_3d_geom_to_vec(geometry:DivergentBeamGeometry):
+    """Create vectors for ASTRA projection geometries from ODL geometry.
+
+    The 3D vectors are used to create an ASTRA projection geometry for
+    cone beam geometries with a cylindrical detector, see ``'cyl_cone_vec'``
+    in the `ASTRA projection geometry documentation`_.
+
+    Each row of the returned vectors corresponds to a single projection
+    and consists of ::
+
+        (srcX, srcY, srcZ, dX, dY, dZ, uX, uY, uZ, vX, vY, vZ, R)
+
+    with
+
+        - ``src``: the ray source position
+        - ``d``  : the center of the detector
+        - ``u``  : tangential direction at center of detector;
+                   the length of u is the arc length of a detector pixel
+        - ``v``  : the vector from detector pixel ``(0,0)`` to ``(1,0)``
+        - ``R``  : the radius of the detector cylinder
+
+    Parameters
+    ----------
+    geometry : `Geometry`
+        ODL projection geometry from which to create the ASTRA geometry.
+
+    Returns
+    -------
+    vectors : `numpy.ndarray`
+        Array of shape ``(num_angles, 13)`` containing the vectors.
+
+    References
+    ----------
+    .. _ASTRA projection geometry documentation:
+       http://www.astra-toolbox.com/docs/geom3d.html#projection-geometries
+    """
+    angles = geometry.angles
+    vectors = np.zeros((angles.size, 13))
+
+    # Source position
+    vectors[:, 0:3] = geometry.src_position(angles)
+
+    # Center of detector in 3D space
+    # FIXME: This is not correct: det_point_position returns the zero-point of 
+    # the detector, and not the center of the detector. For quarter-pixel-shifted
+    # detector these two do not coincide.
+    mid_pt = geometry.det_params.mid_pt
+    vectors[:, 3:6] = geometry.det_point_position(angles, mid_pt)
+
+    # `det_axes` gives shape (N, 2, 3), swap to get (2, N, 3)
+    det_axes = np.moveaxis(geometry.det_axes(angles), -2, 0)
+    px_sizes = geometry.det_partition.cell_sides
+
+    # `px_sizes[0]` is angular partition; scale by radius to get arc length
+    # NB: For flat panel detector we swap the u and v axes to get a better
+    # memory layout. For cylindrical detectors this is (currently) not possible
+    # since both ODL and Astra have the v direction along the axial direction.
+    vectors[:, 6:9] = det_axes[0] * px_sizes[0] * geometry.det_curvature_radius
+    vectors[:, 9:12] = det_axes[1] * px_sizes[1]
+
+    # detector curvature radius
+    vectors[:, 12] = geometry.det_curvature_radius
 
     # ASTRA has (z, y, x) axis convention, in contrast to (x, y, z) in ODL,
     # so we need to adapt to this by changing the order.
@@ -609,6 +682,23 @@ def astra_projection_geometry(geometry: Geometry, astra_impl: str):
         vec = astra_conebeam_3d_geom_to_vec(geometry)
         proj_geom = astra.create_proj_geom('cone_vec', det_row_count,
                                            det_col_count, vec)
+        
+    elif (isinstance(geometry, DivergentBeamGeometry) and
+          isinstance(geometry.detector, CylindricalDetector) and
+          geometry.ndim == 3):
+        
+        if not astra_supports('cyl_cone_vec'):
+            req_ver = astra_versions_supporting('cyl_cone_vec')
+            raise NotImplementedError(
+                f"support for cylindrical detector geometry requires ASTRA {req_ver}"
+            )
+        # Do NOT swap detector axes (see astra_cyl_conebeam_3d_geom_to_vec)
+        det_row_count = geometry.det_partition.shape[1]
+        det_col_count = geometry.det_partition.shape[0]
+        vec = astra_cyl_conebeam_3d_geom_to_vec(geometry)
+        proj_geom = astra.create_proj_geom('cyl_cone_vec', det_row_count,
+                                           det_col_count, vec)
+
     else:
         raise NotImplementedError(f"unknown ASTRA geometry type {geometry}")
 
@@ -750,6 +840,8 @@ def astra_projector(
         valid_proj_types = ['linear3d', 'cuda3d']
     elif astra_geom in {'cone', 'cone_vec'}:
         valid_proj_types = ['linearcone', 'cuda3d']
+    elif astra_geom in {'cyl_cone_vec'}:
+        valid_proj_types = ['cuda3d']
     else:
         raise ValueError(f"invalid geometry type {astra_geom}")
 

--- a/src/odl/applications/tomo/geometry/conebeam.py
+++ b/src/odl/applications/tomo/geometry/conebeam.py
@@ -1471,6 +1471,7 @@ class ConeBeamGeometry(DivergentBeamGeometry, AxisOrientedGeometry):
         posargs = [self.motion_partition, self.det_partition]
         optargs = [('src_radius', self.src_radius, -1),
                    ('det_radius', self.det_radius, -1),
+                   ('det_curvature_radius', self.det_curvature_radius, None),
                    ('pitch', self.pitch, 0)
                    ]
 


### PR DESCRIPTION
This PR is based on #1634 but remade for odl 1.0.0.

This PR uses `cyl_cone_vec` from ASTRA 2.4.0 to allow curved cone beam detectors.

From #1634 there was a note about a off-by-half bug related to pixel centers that I'm not sure if it still applies.
> Known bug: there is a misinterpretion of the detector center if the detector partition isn't centered around 0, which is the case for quarter-pixel-shifted detectors. Fixing this needs to be coordinated with the Mayo CT data loader, which currently is assuming the presence of this bug.

~~There is also a FIXME in astra_cuda.py related to not being able to arbitrarily transposing pytorch tensors. Not sure what the best solution for that is, guidance is appreciated. :)~~ This is fixed by using [`permute_dims`](https://data-apis.org/array-api/latest/API_specification/generated/array_api.permute_dims.html#permute-dims).

@leftaroundabout could you take a look at and see if you can see anything that is obviously wrong that I could fix? You can do a full review when you have time.